### PR TITLE
Fix VS Code not detected in packaged app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -505,7 +505,10 @@ ipcMain.handle('dir:open', async (_e, directoryPath) => {
 
 const editorCommands = {
 	vscode: {
-		darwin: 'code',
+		// 'code' is only resolved as a fixed app-bundle path is not checked; the
+		// CLI shim path is added as a fallback since apps launched from Finder/Dock
+		// don't inherit the shell PATH where VS Code's "code" shim usually lives.
+		darwin: ['code', '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'],
 		linux: 'code',
 		win32: 'code.cmd'
 	},
@@ -521,32 +524,50 @@ const editorCommands = {
 	}
 };
 
+// GUI apps launched from Finder/Dock on macOS get a minimal default PATH and
+// don't inherit the shell-populated PATH (nvm, Homebrew, VS Code's own
+// "install 'code' command in PATH" shim, etc). Augment PATH with the common
+// install locations so `which` can still find these commands.
+const MAC_FALLBACK_BIN_DIRS = ['/usr/local/bin', '/opt/homebrew/bin', path.join(os.homedir(), '.local/bin')];
+
+async function commandExistsInPath(command, platform) {
+	return new Promise((resolve) => {
+		const which = platform === 'win32' ? 'where' : 'which';
+		const env = platform === 'darwin'
+			? { ...process.env, PATH: `${MAC_FALLBACK_BIN_DIRS.join(':')}:${process.env.PATH || ''}` }
+			: process.env;
+		const proc = spawn(which, [command], { stdio: 'ignore', env });
+		proc.on('close', (code) => resolve(code === 0));
+		proc.on('error', () => resolve(false));
+	});
+}
+
 async function checkEditorAvailable(editor) {
 	const platform = process.platform;
 	const editorConfig = editorCommands[editor];
 
 	if (!editorConfig) return false;
 
-	const command = editorConfig[platform];
-	if (!command) return false;
+	const commands = editorConfig[platform];
+	if (!commands) return false;
 
-	// For macOS app bundles, check if the path exists
-	if (platform === 'darwin' && command.startsWith('/Applications')) {
-		try {
-			await fs.promises.access(command, fs.constants.X_OK);
-			return true;
-		} catch {
-			return false;
+	const candidates = Array.isArray(commands) ? commands : [commands];
+
+	for (const command of candidates) {
+		// For macOS app bundles, check if the path exists directly
+		if (platform === 'darwin' && command.startsWith('/Applications')) {
+			try {
+				await fs.promises.access(command, fs.constants.X_OK);
+				return true;
+			} catch {
+				continue;
+			}
 		}
+
+		if (await commandExistsInPath(command, platform)) return true;
 	}
 
-	// For command-line tools, try to find them in PATH
-	return new Promise((resolve) => {
-		const which = platform === 'win32' ? 'where' : 'which';
-		const proc = spawn(which, [command], { stdio: 'ignore' });
-		proc.on('close', (code) => resolve(code === 0));
-		proc.on('error', () => resolve(false));
-	});
+	return false;
 }
 
 ipcMain.handle('editor:check-available', async (_e) => {


### PR DESCRIPTION
## Summary

Fixes #24 — VS Code was reported as "not installed" in the `Open directory in` dropdown when running the packaged/signed build, despite being installed and working correctly under `npm start`.

## Root cause

`checkEditorAvailable()` in `src/main.js` detects VS Code purely via `which code`, relying on `process.env.PATH` as inherited by the Electron main process:

- When run via `npm start` from a terminal, the process inherits the full shell PATH (populated by `.zshrc`/`.bash_profile`, nvm, Homebrew, etc.), where the `code` shim installed by VS Code's "Shell Command: Install 'code' command in PATH" typically lives (`/usr/local/bin`, `/opt/homebrew/bin`, or `~/.local/bin`).
- When launched from Finder/Dock (the packaged app's normal launch path), macOS gives the process a minimal default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include any of those locations, so `which code` fails.
- Unlike PHPStorm and Cursor, VS Code had no fixed `/Applications/*.app` path fallback to fall back on.

## Fix

- Augment the `PATH` used for the `which` lookup on macOS with the common shim install locations (`/usr/local/bin`, `/opt/homebrew/bin`, `~/.local/bin`).
- Add the VS Code CLI binary bundled inside the app (`/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`) as an additional fallback candidate, checked the same way PHPStorm/Cursor bundle paths are checked.
- Generalized `editorCommands` entries to accept either a single command/path or an array of candidates, tried in order.

Other platforms (Linux, Windows) and other editors (PHPStorm, Cursor) are unaffected — their detection logic is unchanged.

## Test plan

- [ ] On macOS, build/sign the app (or otherwise launch it outside a terminal so it gets the minimal default PATH) with VS Code installed via the standard `.app` + "Install 'code' command in PATH" flow, and confirm the "Open directory in" dropdown now detects VS Code.
- [ ] Confirm `npm start` still detects VS Code as before.
- [ ] Confirm PHPStorm and Cursor detection is unaffected.
- [ ] Confirm behavior on Linux/Windows is unchanged (command lookup unaffected by these changes).