### PR TITLE
Added a persistent "Share feedback" button linking to a Google Form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4980,16 +4980,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/dotenv": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -10236,6 +10226,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/read-config-file/node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readable-stream": {

--- a/src/main.js
+++ b/src/main.js
@@ -503,6 +503,8 @@ ipcMain.handle('url:open', async (_e, url) => {
 	return true;
 });
 
+ipcMain.handle('config:get-feedback-form-url', () => 'https://forms.gle/ixXg4ogq9MwgnXHe7');
+
 ipcMain.handle('npm:install', async (event, directoryPath) => {
 	if (!directoryPath) throw new Error('directoryPath is required');
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -43,6 +43,8 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	openExternal: (url) => ipcRenderer.invoke('url:open', url)
 ,
+	getFeedbackFormUrl: () => ipcRenderer.invoke('config:get-feedback-form-url')
+,
 	markSiteInitialized: (sitePath) => ipcRenderer.invoke('sites:mark-initialized', sitePath)
 ,
 	forgetSite: (sitePath) => ipcRenderer.invoke('sites:forget', sitePath)

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -53365,6 +53365,15 @@ If there's a particular need for this, please submit a feature request at https:
       })();
     }, []);
     const [sidebarCollapsed, setSidebarCollapsed] = (0, import_react69.useState)(false);
+    const [feedbackFormUrl, setFeedbackFormUrl] = (0, import_react69.useState)(null);
+    (0, import_react69.useEffect)(() => {
+      (async () => {
+        try {
+          setFeedbackFormUrl(await window.api.getFeedbackFormUrl());
+        } catch {
+        }
+      })();
+    }, []);
     const [activeSite, setActiveSite] = (0, import_react69.useState)(null);
     const [createModalOpen, setCreateModalOpen] = (0, import_react69.useState)(false);
     const [createSiteName, setCreateSiteName] = (0, import_react69.useState)("");
@@ -53831,7 +53840,8 @@ If there's a particular need for this, please submit a feature request at https:
                   onDelete,
                   onRename,
                   isPending: Boolean(pendingSite && pendingSite.targetDir === s),
-                  setupLogs: setupLogsBySite[s] || ""
+                  setupLogs: setupLogsBySite[s] || "",
+                  feedbackFormUrl
                 }
               )
             },
@@ -53907,7 +53917,7 @@ If there's a particular need for this, please submit a feature request at https:
       ) : null
     ] });
   }
-  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = "" }) {
+  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = "", feedbackFormUrl }) {
     const safeOnRename = onRename || (() => {
     });
     const [serverUrl, setServerUrl] = (0, import_react69.useState)("");
@@ -54849,7 +54859,35 @@ Try "help" for the list of supported commands.
               style: { padding: "10px 16px", borderRadius: 10 },
               children: "Open Adminer"
             }
-          ) : null
+          ) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
+            "a",
+            {
+              href: "#",
+              onClick: (e) => {
+                e.preventDefault();
+                if (feedbackFormUrl) window.api.openExternal(feedbackFormUrl);
+              },
+              onMouseEnter: (e) => {
+                e.currentTarget.style.textDecoration = "underline";
+              },
+              onMouseLeave: (e) => {
+                e.currentTarget.style.textDecoration = "none";
+              },
+              title: feedbackFormUrl ? void 0 : "Feedback form not configured (missing FEEDBACK_FORM_URL)",
+              style: {
+                marginLeft: "auto",
+                alignSelf: "center",
+                color: feedbackFormUrl ? "#3858e9" : "#757575",
+                cursor: feedbackFormUrl ? "pointer" : "default",
+                textDecoration: "none",
+                fontFamily: "inherit",
+                fontWeight: 600,
+                fontSize: 15
+              },
+              children: "\u{1F4AC} Share feedback"
+            }
+          )
         ] }),
         isServerStarting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 13, color: "#1d2327", paddingLeft: 2, display: "flex", flexDirection: "column", gap: 4 }, children: serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(import_jsx_runtime60.Fragment, { children: [
           /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: serverUrl, onClick: (e) => {

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -53,6 +53,8 @@ function App() {
   const [webAvailable, setWebAvailable] = useState(false);
   useEffect(() => { (async () => { try { setWebAvailable(Boolean(await window.api.playgroundWebAvailable())); } catch {} })(); }, []);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [feedbackFormUrl, setFeedbackFormUrl] = useState(null);
+  useEffect(() => { (async () => { try { setFeedbackFormUrl(await window.api.getFeedbackFormUrl()); } catch {} })(); }, []);
   const [activeSite, setActiveSite] = useState(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [createSiteName, setCreateSiteName] = useState('');
@@ -559,6 +561,7 @@ function App() {
                       onRename={onRename}
                       isPending={Boolean(pendingSite && pendingSite.targetDir === s)}
                       setupLogs={setupLogsBySite[s] || ''}
+                      feedbackFormUrl={feedbackFormUrl}
                     />
                   </div>
                 ))
@@ -635,7 +638,7 @@ function App() {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = '' }) {
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = '', feedbackFormUrl }) {
   const safeOnRename = onRename || (() => {});
   // state
   const [serverUrl, setServerUrl] = useState('');
@@ -1550,6 +1553,25 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
                 style={{ padding: '10px 16px', borderRadius: 10 }}
               >Open Adminer</Button>
             ) : null}
+            <a
+              href="#"
+              onClick={(e) => { e.preventDefault(); if (feedbackFormUrl) window.api.openExternal(feedbackFormUrl); }}
+              onMouseEnter={(e) => { e.currentTarget.style.textDecoration = 'underline'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.textDecoration = 'none'; }}
+              title={feedbackFormUrl ? undefined : 'Feedback form not configured (missing FEEDBACK_FORM_URL)'}
+              style={{
+                marginLeft: 'auto',
+                alignSelf: 'center',
+                color: feedbackFormUrl ? '#3858e9' : '#757575',
+                cursor: feedbackFormUrl ? 'pointer' : 'default',
+                textDecoration: 'none',
+                fontFamily: 'inherit',
+                fontWeight: 600,
+                fontSize: 15
+              }}
+            >
+              💬 Share feedback
+            </a>
           </div>
           {(isServerStarting || serverUrl) ? (
             <div style={{ fontSize: 13, color: '#1d2327', paddingLeft: 2, display: 'flex', flexDirection: 'column', gap: 4 }}>


### PR DESCRIPTION
Fixes #31 

Adds a 💬 "Share feedback" link to the site row UI that opens a Google Form in the user's default browser via `window.api.openExternal`. 

The form URL is https://docs.google.com/forms/d/e/1FAIpQLScnMxicyDxZO2OoaS5ela8FArYWjCyLfC3hxRBBRSF7XLPzKg/viewform

<img width="993" height="684" alt="CleanShot 2026-07-22 at 11 28 12" src="https://github.com/user-attachments/assets/71dd5182-246a-4b2f-8c74-8baba125d5db" />

The form URL is exposed to the renderer through a new `config:get-feedback-form-url` IPC handler in the main process (`src/main.js`) and bridged in `src/preload.js`; the URL is hardcoded rather than sourced from `.env`/`process.env`, since it's a static, non-secret value and hardcoding avoids `dotenv`'s unreliable `cwd`-relative resolution in packaged builds.

- `src/main.js` — new IPC handler returning the feedback form URL
- `src/preload.js` — exposes `getFeedbackFormUrl()` to the renderer
- `src/renderer/index.jsx` — fetches the URL on mount, renders the link in `SiteRow`, disabled/greyed out if unset
- `package.json` / `package-lock.json` — `dotenv` dependency removed (no longer used anywhere in the app)

### Test plan

- [ ] `npm start`, confirm "Share feedback" link appears on a site row and opens the Google Form in the default browser
