### PR TITLE
Exclude coding-agent directories from generated patches

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,53 @@ const { parseEventName, buildProvenanceHeader, handoffFilename } = require('./pa
 const { describeRefused } = require('./safe-log');
 const { detectEditors, matchDetectedEditor, openSiteInEditor, REFUSAL_REASONS } = require('./editor-launch');
 
+const LOCAL_EXCLUDES_MARKER = '# WordPress Contributor Toolkit local excludes';
+const LOCAL_EXCLUDES = [
+	'/.claude/',
+	'/.cursor/',
+	'/.windsurf/',
+	'/.gemini/',
+	'/.cline/',
+	'/.clinerules/'
+];
+
+/**
+ * Seeds per-site ignores for machine-local files that must never become part
+ * of a contribution. This lives in `.git/info/exclude`, not the repository's
+ * `.gitignore`: the checkout stays unchanged and isomorphic-git reads these
+ * rules when it builds a status matrix (issue #19).
+ *
+ * The marker is the ownership boundary. Once present, the contributor may
+ * edit or remove the rules below it and the app will not restore them.
+ * Existing rules above or below the block are never rewritten.
+ *
+ * @param {string} dir Repository working directory.
+ * @return {Promise<boolean>} Whether the default block was appended.
+ */
+async function ensureLocalExcludes(dir) {
+	const gitDir = path.join(dir, '.git');
+	try {
+		if (!(await fs.promises.stat(gitDir)).isDirectory()) return false;
+	} catch {
+		return false;
+	}
+
+	const infoDir = path.join(gitDir, 'info');
+	const excludePath = path.join(infoDir, 'exclude');
+	let existing = '';
+	try {
+		existing = await fs.promises.readFile(excludePath, 'utf8');
+	} catch (error) {
+		if (!error || error.code !== 'ENOENT') throw error;
+	}
+	if (existing.split(/\r?\n/).includes(LOCAL_EXCLUDES_MARKER)) return false;
+
+	await fs.promises.mkdir(infoDir, { recursive: true });
+	const separator = existing && !existing.endsWith('\n') ? '\n' : '';
+	await fs.promises.appendFile(excludePath, `${separator}${LOCAL_EXCLUDES_MARKER}\n${LOCAL_EXCLUDES.join('\n')}\n`);
+	return true;
+}
+
 // Screenshot harness only (scripts/screenshots/): point userData at a throwaway
 // directory so a seeded settings.json is read instead of the contributor's real
 // site registry. Must run before `ready` — electron-store resolves its file path
@@ -1727,6 +1774,7 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		const hasBuilt = fs.existsSync(distDir);
 
 		const s = await getStore();
+		if ((s.get('sites') || []).includes(sitePath)) await ensureLocalExcludes(sitePath);
 		const meta = s.get('siteMeta') || {};
 		const m = meta[sitePath] || {};
 
@@ -1791,6 +1839,7 @@ ipcMain.handle('sites:add', async (_e, sitePath) => {
 	// A pre-existing dir was likely cloned by native git — exactly the case
 	// where CRLF checkouts break status/patch generation (see ensureAutocrlf).
 	await ensureAutocrlf(sitePath);
+	await ensureLocalExcludes(sitePath);
 	const s = await getStore();
 	const sites = s.get('sites');
 	if (!sites.includes(sitePath)) {
@@ -1851,6 +1900,7 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 			}
 		});
 		await ensureAutocrlf(siteDir);
+		await ensureLocalExcludes(siteDir);
 
 		const s = await getStore();
 		const sites = s.get('sites');

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,8 @@ const { detectEditors, matchDetectedEditor, openSiteInEditor, REFUSAL_REASONS } 
 const LOCAL_EXCLUDES_MARKER = '# WordPress Contributor Toolkit local excludes';
 const LOCAL_EXCLUDES = [
 	'/.claude/',
+	'/.codex/',
+	'/.agents/',
 	'/.cursor/',
 	'/.windsurf/',
 	'/.gemini/',

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -433,6 +433,44 @@ test('site:status reports the trunk snapshot trunk-update read, not its own gues
 	assert.equal(settings.values.siteMeta['/sites/wp'].trunkOid, 'abc123');
 });
 
+test('site:status does not seed excludes in an unregistered repository (issue #19)', async (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-unregistered-exclude-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	const excludePath = path.join(dir, '.git', 'info', 'exclude');
+	fs.writeFileSync(excludePath, 'existing-rule/\n');
+	const settings = fakeSettingsStore({ sites: [], siteMeta: {} });
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./trunk-update': { readTrunkInfo: async () => { throw new Error('not registered'); } }
+		}
+	});
+
+	await main.invoke('site:status', dir);
+
+	assert.equal(fs.readFileSync(excludePath, 'utf8'), 'existing-rule/\n');
+});
+
+test('git:get-patch does not seed excludes in an unregistered repository (issue #19)', async (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-unregistered-patch-exclude-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'README.md'), 'base\n');
+	await git.add({ fs, dir, filepath: 'README.md' });
+	await git.commit({ fs, dir, message: 'init', author: { name: 'test', email: 'test@example.com' } });
+	fs.appendFileSync(path.join(dir, 'README.md'), 'edit\n');
+	const excludePath = path.join(dir, '.git', 'info', 'exclude');
+	fs.writeFileSync(excludePath, 'existing-rule/\n');
+	const main = patchMain();
+
+	const result = await main.invoke('git:get-patch', dir);
+
+	assert.equal(result.ok, true);
+	assert.equal(fs.readFileSync(excludePath, 'utf8'), 'existing-rule/\n');
+});
+
 // --- git:* -> src/trunk-update.js ----------------------------------------
 
 test('git:worktree-dirty reports what trunk-update found, not its own guess', async () => {
@@ -807,6 +845,61 @@ test('git:get-patch includes an untracked file without staging it (issues #108, 
 		await git.statusMatrix({ fs, dir }),
 		before,
 		'generating a patch must not stage anything into the contributor\'s index (#85)'
+	);
+});
+
+test('git:get-patch excludes local coding-agent directories from a managed site (issue #19)', async (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-agent-exclude-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'README.md'), 'managed wordpress-develop site\n');
+	await git.add({ fs, dir, filepath: 'README.md' });
+	await git.commit({ fs, dir, message: 'init', author: { name: 'test', email: 'test@example.com' } });
+	fs.writeFileSync(path.join(dir, '.git', 'info', 'exclude'), 'build/\n');
+
+	const agentArtifacts = [
+		'.claude/settings.local.json',
+		'.cursor/rules/local.mdc',
+		'.windsurf/rules/local.md',
+		'.gemini/settings.json',
+		'.cline/rules/local.md',
+		'.clinerules/local.md'
+	];
+	for (const filepath of agentArtifacts) {
+		fs.mkdirSync(path.dirname(path.join(dir, filepath)), { recursive: true });
+		fs.writeFileSync(path.join(dir, filepath), 'local agent configuration\n');
+	}
+	fs.appendFileSync(path.join(dir, 'README.md'), 'real contributor edit\n');
+
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({ sites: [dir], siteMeta: { [dir]: {} } }).stubs,
+			'./trunk-update': { ensureAutocrlf: async () => {} }
+		}
+	});
+	await main.invoke('site:status', dir);
+	const seededExclude = fs.readFileSync(path.join(dir, '.git', 'info', 'exclude'), 'utf8');
+	for (const directory of ['.claude', '.cursor', '.windsurf', '.gemini', '.cline', '.clinerules']) {
+		assert.match(seededExclude, new RegExp(`^/${directory.replace('.', '\\.')}/$`, 'm'));
+	}
+
+	const result = await main.invoke('git:get-patch', dir);
+
+	assert.equal(result.ok, true);
+	assert.match(result.patch, /README\.md/, 'the contributor\'s WordPress change stays visible');
+	for (const filepath of agentArtifacts) {
+		assert.doesNotMatch(result.patch, new RegExp(filepath.split('/')[0].replace('.', '\\.')));
+	}
+	const exclude = fs.readFileSync(path.join(dir, '.git', 'info', 'exclude'), 'utf8');
+	assert.match(exclude, /^build\/$/m, 'existing per-site excludes survive');
+
+	await main.invoke('git:get-patch', dir);
+	const afterSecondPatch = fs.readFileSync(path.join(dir, '.git', 'info', 'exclude'), 'utf8');
+	assert.equal(
+		afterSecondPatch.split('# WordPress Contributor Toolkit local excludes').length - 1,
+		1,
+		'the managed block is added only once'
 	);
 });
 

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -859,6 +859,8 @@ test('git:get-patch excludes local coding-agent directories from a managed site 
 
 	const agentArtifacts = [
 		'.claude/settings.local.json',
+		'.codex/config.toml',
+		'.agents/skills/local/SKILL.md',
 		'.cursor/rules/local.mdc',
 		'.windsurf/rules/local.md',
 		'.gemini/settings.json',
@@ -880,7 +882,7 @@ test('git:get-patch excludes local coding-agent directories from a managed site 
 	});
 	await main.invoke('site:status', dir);
 	const seededExclude = fs.readFileSync(path.join(dir, '.git', 'info', 'exclude'), 'utf8');
-	for (const directory of ['.claude', '.cursor', '.windsurf', '.gemini', '.cline', '.clinerules']) {
+	for (const directory of ['.claude', '.codex', '.agents', '.cursor', '.windsurf', '.gemini', '.cline', '.clinerules']) {
 		assert.match(seededExclude, new RegExp(`^/${directory.replace('.', '\\.')}/$`, 'm'));
 	}
 


### PR DESCRIPTION
## Why

Coding agents create workspace directories such as `.claude/` inside the managed `wordpress-develop` checkout. Because these files are untracked and not ignored by that repository, the Toolkit includes them in patches and pull requests even though they are unrelated to the contributor's WordPress change.

## What changes

The Toolkit seeds a marked block in each managed site's `.git/info/exclude` for the project directories used by Claude Code, Codex, Cursor, Windsurf, Gemini CLI, and Cline:

- `/.claude/`
- `/.codex/`
- `/.agents/`
- `/.cursor/`
- `/.windsurf/`
- `/.gemini/`
- `/.cline/`
- `/.clinerules/`

The rules are installed after cloning or adopting a site. Existing registered sites receive them during their normal status read. Existing exclude rules are preserved, the block is written only once, and the marker lets advanced users take ownership of later edits. Generic dotfiles are deliberately not excluded.

## How to test this

Platforms: any. The behavior uses Git ignore semantics and platform-safe filesystem paths.

**Starting state:**

A Toolkit-managed site linked to a Trac ticket, with an ordinary uncommitted WordPress change.

1. Start the Toolkit with `npm start` and open the managed site.
   - Expected: the site loads normally.
2. In the managed site's directory, modify a tracked WordPress file such as `README.md`.
   - Expected: the Toolkit reports an unsubmitted change.
3. Create representative local agent files, for example `.claude/settings.local.json`, `.codex/config.toml`, `.agents/skills/local/SKILL.md`, and `.cursor/rules/local.mdc`.
4. Click **Review & submit changes**.
   - Expected: the patch contains the `README.md` change.
   - Expected: none of the agent directories appears in the patch.
5. Inspect `<site>/.git/info/exclude`.
   - Expected: existing rules remain and the eight agent-directory exclusions appear under `# WordPress Contributor Toolkit local excludes`.
6. Close and reopen **Review & submit changes**, then inspect the exclude file again.
   - Expected: the marked block appears exactly once.

**What must not have happened:**

- The agent files must still exist on disk; they are ignored, not deleted.
- The contributor's WordPress edit must not disappear from the patch.
- Unrelated dotfiles must not be excluded.
- A repository not registered with the Toolkit must not have its `.git/info/exclude` changed.

## Risks and limitations

No open review findings. A contributor who intentionally wants to add a new project configuration under one of these agent directories must edit the marked per-site exclude block first. Tracked upstream files remain visible under normal Git ignore semantics.

## Related

Fixes #19

---

<details>
<summary>Design decisions and alternatives considered</summary>

A broad `.*` rule was rejected because it would hide unrelated dotfiles. Filtering paths in patch-rendering code was also rejected because pull requests and other status consumers use the same Git walk. Per-repository excludes let isomorphic-git apply one consistent rule without changing the managed repository's tracked `.gitignore`.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up].

The fresh review initially found two instances where renderer-controlled paths could write exclusions outside the registered-site boundary. Both were fixed: `site:status` validates exact registry membership, patch collection performs no writes, and negative regression tests cover both entry points.

Deterministic checks: `npm run lint` passed; `npm test` passed 1,017/1,017; `git diff --check` passed.

</details>

<details>
<summary>Implementation notes</summary>

The exclusion helper uses asynchronous filesystem operations so routine status checks do not block Electron's main process. The regression test also verifies preservation of existing rules and idempotent block creation.

</details>

<details>
<summary>Screenshots or recording</summary>

No UI changed. The behavior is visible in the existing **Review & submit changes** patch pane.

</details>

