### PR TITLE
Retry npm install with relaxed engine checks when a dependency demands a newer Node

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -517,7 +517,13 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // demands a newer Node than Electron bundles, retries once with engine checks
 // relaxed. The first failure's output still reaches the log, so the real reason
 // stays visible instead of being silently papered over.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register }) {
+//
+// The automatic retry is opt-in and only npm:install enables it. Scripts
+// (build, grunt, …) can fail partway through with side effects already on
+// disk, and npm prints EBADENGINE as a mere warning when engine-strict is off
+// — so a warning followed by an unrelated non-zero exit would wrongly restart
+// a half-finished script. An install, by contrast, is idempotent to re-run.
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
 	const start = (relaxEngines) => {
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
@@ -534,7 +540,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register 
 		const forward = (stream, type) => {
 			stream.on('data', (data) => {
 				const text = data.toString();
-				if (!relaxEngines) detector.push(text);
+				if (retryOnEngineMismatch && !relaxEngines) detector.push(text);
 				onLog(type, text);
 			});
 		};
@@ -542,7 +548,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register 
 		forward(child.stderr, 'stderr');
 
 		child.on('close', (code, signal) => {
-			const retry = shouldRetryWithRelaxedEngines({
+			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
 				sawEngineMismatch: detector.found,
@@ -569,6 +575,7 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		runnerPath: path.join(__dirname, 'install-runner.js'),
 		args: [directoryPath],
 		cwd: directoryPath,
+		retryOnEngineMismatch: true,
 		register: (child) => {
 			runningInstalls[installId] = child;
 		},

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,12 @@ const JsDiff = require('diff');
 const { spawn } = require('child_process');
 const { SMTPServer } = require('smtp-server');
 const { simpleParser } = require('mailparser');
+const {
+	createEngineMismatchDetector,
+	shouldRetryWithRelaxedEngines,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+} = require('./npm-runner');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -89,6 +95,8 @@ function findAvailableDirName(rootDir, baseName) {
 const runningInstalls = {};
 /** @type {Record<string, import('child_process').ChildProcess>} */
 const runningScripts = {};
+// Children the user explicitly stopped, so a failed run is not retried.
+const cancelledChildren = new WeakSet();
 /** @type {Record<string, string>} */
 const runIdByDirectory = {};
 /** @type {Record<string, { child: import('child_process').ChildProcess, url?: string }>} */
@@ -503,42 +511,74 @@ ipcMain.handle('url:open', async (_e, url) => {
 	return true;
 });
 
+const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this app bundles.\n  Retrying with engine checks relaxed…\n\n';
+
+// Spawns an npm runner, and if it fails specifically because a dependency
+// demands a newer Node than Electron bundles, retries once with engine checks
+// relaxed. The first failure's output still reaches the log, so the real reason
+// stays visible instead of being silently papered over.
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register }) {
+	const start = (relaxEngines) => {
+		const child = spawn(process.execPath, [runnerPath, ...args], {
+			cwd,
+			env: buildChildEnv({
+				shimDir: ensureNodeShimDir(),
+				extraEnv: relaxEngines ? RELAXED_ENGINES_ENV : {}
+			}),
+			shell: false,
+			windowsHide: true
+		});
+		register(child);
+
+		const detector = createEngineMismatchDetector();
+		const forward = (stream, type) => {
+			stream.on('data', (data) => {
+				const text = data.toString();
+				if (!relaxEngines) detector.push(text);
+				onLog(type, text);
+			});
+		};
+		forward(child.stdout, 'stdout');
+		forward(child.stderr, 'stderr');
+
+		child.on('close', (code, signal) => {
+			const retry = shouldRetryWithRelaxedEngines({
+				code,
+				signal,
+				sawEngineMismatch: detector.found,
+				alreadyRelaxed: relaxEngines,
+				cancelled: cancelledChildren.has(child)
+			});
+			if (retry) {
+				onLog('stdout', ENGINE_RETRY_NOTICE);
+				start(true);
+				return;
+			}
+			onDone(code);
+		});
+	};
+	start(false);
+}
+
 ipcMain.handle('npm:install', async (event, directoryPath) => {
 	if (!directoryPath) throw new Error('directoryPath is required');
 
 	const installId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-	const runnerPath = path.join(__dirname, 'install-runner.js');
 
-	const child = spawn(process.execPath, [runnerPath, directoryPath], {
+	runNpmWithEngineRetry({
+		runnerPath: path.join(__dirname, 'install-runner.js'),
+		args: [directoryPath],
 		cwd: directoryPath,
-		env: {
-			...process.env,
-			ELECTRON_RUN_AS_NODE: '1',
-			NODE: process.execPath,
-			npm_config_production: 'false',
-			NODE_ENV: 'development',
-			// On Windows, ensure both PATH and Path are set, and PATHEXT includes .CMD/.BAT
-			PATH: process.platform === 'win32' ? `${ensureNodeShimDir()};${process.env.PATH || ''}` : `${ensureNodeShimDir()}:${process.env.PATH || ''}`,
-			Path: process.platform === 'win32' ? `${ensureNodeShimDir()};${process.env.Path || process.env.PATH || ''}` : undefined,
-			PATHEXT: process.platform === 'win32' ? [
-				'.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC'
-			].join(';') : process.env.PATHEXT
+		register: (child) => {
+			runningInstalls[installId] = child;
 		},
-		shell: false,
-		windowsHide: true
-	});
-
-	runningInstalls[installId] = child;
-
-	child.stdout.on('data', (data) => {
-		event.sender.send('npm:install:log', { installId, type: 'stdout', data: data.toString() });
-	});
-	child.stderr.on('data', (data) => {
-		event.sender.send('npm:install:log', { installId, type: 'stderr', data: data.toString() });
-	});
-	child.on('close', (code) => {
-		event.sender.send('npm:install:done', { installId, code });
-		delete runningInstalls[installId];
+		onLog: (type, data) => {
+			event.sender.send('npm:install:log', { installId, type, data });
+		},
+		onDone: (code) => {
+			event.sender.send('npm:install:done', { installId, code });
+			delete runningInstalls[installId];
+		}
 	});
 
 	return { installId };
@@ -549,40 +589,24 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 	if (!scriptName) throw new Error('scriptName is required');
 
 	const runId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-	const runnerPath = path.join(__dirname, 'script-runner.js');
 
-	const child = spawn(process.execPath, [runnerPath, directoryPath, scriptName, ...scriptArgs], {
+	runNpmWithEngineRetry({
+		runnerPath: path.join(__dirname, 'script-runner.js'),
+		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
-		env: {
-			...process.env,
-			ELECTRON_RUN_AS_NODE: '1',
-			NODE: process.execPath,
-			npm_config_production: 'false',
-			NODE_ENV: 'development',
-			PATH: process.platform === 'win32' ? `${ensureNodeShimDir()};${process.env.PATH || ''}` : `${ensureNodeShimDir()}:${process.env.PATH || ''}`,
-			Path: process.platform === 'win32' ? `${ensureNodeShimDir()};${process.env.Path || process.env.PATH || ''}` : undefined,
-			PATHEXT: process.platform === 'win32' ? [
-				'.COM','.EXE','.BAT','.CMD','.VBS','.VBE','.JS','.JSE','.WSF','.WSH','.MSC'
-			].join(';') : process.env.PATHEXT
+		register: (child) => {
+			runningScripts[runId] = child;
+			runIdByDirectory[directoryPath] = runId;
 		},
-		shell: false,
-		windowsHide: true
-	});
-
-	runningScripts[runId] = child;
-	runIdByDirectory[directoryPath] = runId;
-
-	child.stdout.on('data', (data) => {
-		event.sender.send('npm:run-script:log', { runId, type: 'stdout', data: data.toString() });
-	});
-	child.stderr.on('data', (data) => {
-		event.sender.send('npm:run-script:log', { runId, type: 'stderr', data: data.toString() });
-	});
-	child.on('close', (code) => {
-		event.sender.send('npm:run-script:done', { runId, code });
-		delete runningScripts[runId];
-		if (runIdByDirectory[directoryPath] === runId) {
-			delete runIdByDirectory[directoryPath];
+		onLog: (type, data) => {
+			event.sender.send('npm:run-script:log', { runId, type, data });
+		},
+		onDone: (code) => {
+			event.sender.send('npm:run-script:done', { runId, code });
+			delete runningScripts[runId];
+			if (runIdByDirectory[directoryPath] === runId) {
+				delete runIdByDirectory[directoryPath];
+			}
 		}
 	});
 
@@ -599,6 +623,7 @@ ipcMain.handle('npm:kill', async (_event, { runId, directoryPath }) => {
 	}
 	if (!child) return { ok: false, error: 'No running script' };
 	try {
+		cancelledChildren.add(child);
 		child.kill('SIGTERM');
 		setTimeout(() => child.kill('SIGKILL'), 3000);
 		return { ok: true };

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -66,17 +66,21 @@ function buildChildEnv({
 } = {}) {
 	const isWindows = platform === 'win32';
 	const separator = isWindows ? ';' : ':';
+	const basePath = isWindows
+		? (baseEnv.Path || baseEnv.PATH || '')
+		: (baseEnv.PATH || '');
+	const joinedPath = basePath ? `${shimDir}${separator}${basePath}` : String(shimDir);
 	const env = {
 		...baseEnv,
 		ELECTRON_RUN_AS_NODE: '1',
 		NODE: execPath,
 		npm_config_production: 'false',
 		NODE_ENV: 'development',
-		PATH: `${shimDir}${separator}${baseEnv.PATH || ''}`,
+		PATH: joinedPath,
 		PATHEXT: isWindows ? WINDOWS_PATHEXT : baseEnv.PATHEXT
 	};
 	if (isWindows) {
-		env.Path = `${shimDir};${baseEnv.Path || baseEnv.PATH || ''}`;
+		env.Path = joinedPath;
 	}
 	return { ...env, ...extraEnv };
 }

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -31,8 +31,11 @@ function createEngineMismatchDetector() {
 	let found = false;
 	return {
 		push(text) {
-			if (!found && isEngineMismatch(tail + text)) found = true;
-			tail = String(text || '').slice(-CHUNK_OVERLAP);
+			// The retained tail must be a suffix of the combined text, not of the
+			// newest chunk alone, or a marker spread over three+ chunks is lost.
+			const combined = tail + String(text || '');
+			if (!found && isEngineMismatch(combined)) found = true;
+			tail = combined.slice(-CHUNK_OVERLAP);
 			return found;
 		},
 		get found() {

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -1,0 +1,90 @@
+// Helpers for spawning npm on Electron's bundled Node runtime.
+// Deliberately free of Electron imports so it can be unit-tested.
+
+const WINDOWS_PATHEXT = [
+	'.COM', '.EXE', '.BAT', '.CMD', '.VBS', '.VBE', '.JS', '.JSE', '.WSF', '.WSH', '.MSC'
+].join(';');
+
+// Relaxes `engine-strict`, which wordpress-develop's .npmrc turns on. Passed as
+// an environment variable rather than a CLI flag so it also reaches nested npm
+// invocations made by WordPress's own scripts (e.g. the Gutenberg sync npm ci).
+const RELAXED_ENGINES_ENV = { npm_config_engine_strict: 'false' };
+
+// True when npm output blames an engines mismatch. Kept narrow on purpose: a
+// failure for any other reason must not trigger the relaxed-engines retry.
+// Note npm prints EBADENGINE as a warning too when engine-strict is off, so
+// callers must also require a non-zero exit code.
+function isEngineMismatch(text) {
+	if (!text) return false;
+	return /EBADENGINE/.test(text)
+		|| /Not compatible with your version of node/i.test(text);
+}
+
+// Longest phrase isEngineMismatch looks for is ~40 chars; 64 is a safe overlap.
+const CHUNK_OVERLAP = 64;
+
+// Stateful detector for streamed output. Child stdout/stderr arrives in
+// arbitrary chunks, so a marker can straddle a chunk boundary; carrying a short
+// tail across calls keeps it detectable without buffering the whole log.
+function createEngineMismatchDetector() {
+	let tail = '';
+	let found = false;
+	return {
+		push(text) {
+			if (!found && isEngineMismatch(tail + text)) found = true;
+			tail = String(text || '').slice(-CHUNK_OVERLAP);
+			return found;
+		},
+		get found() {
+			return found;
+		}
+	};
+}
+
+// Decides whether a finished npm run earns a second attempt with engine checks
+// relaxed. Retrying is only ever right for an engines failure that the process
+// reached on its own: a run the user cancelled (or the OS killed) must stay
+// dead, otherwise pressing "stop" would silently start the work over.
+function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alreadyRelaxed, cancelled }) {
+	if (alreadyRelaxed) return false;
+	if (cancelled) return false;
+	// A non-null signal means the process was terminated rather than exiting.
+	// Windows kills surface as a plain non-zero code, hence the `cancelled` flag.
+	if (signal != null) return false;
+	if (code === 0) return false;
+	return Boolean(sawEngineMismatch);
+}
+
+// The env block for a spawned npm runner. On Windows both PATH and Path are set
+// and PATHEXT is extended so child npm processes can find the node shim.
+function buildChildEnv({
+	shimDir,
+	extraEnv = {},
+	baseEnv = process.env,
+	platform = process.platform,
+	execPath = process.execPath
+} = {}) {
+	const isWindows = platform === 'win32';
+	const separator = isWindows ? ';' : ':';
+	const env = {
+		...baseEnv,
+		ELECTRON_RUN_AS_NODE: '1',
+		NODE: execPath,
+		npm_config_production: 'false',
+		NODE_ENV: 'development',
+		PATH: `${shimDir}${separator}${baseEnv.PATH || ''}`,
+		PATHEXT: isWindows ? WINDOWS_PATHEXT : baseEnv.PATHEXT
+	};
+	if (isWindows) {
+		env.Path = `${shimDir};${baseEnv.Path || baseEnv.PATH || ''}`;
+	}
+	return { ...env, ...extraEnv };
+}
+
+module.exports = {
+	isEngineMismatch,
+	createEngineMismatchDetector,
+	shouldRetryWithRelaxedEngines,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+};

--- a/test/fixtures/engine-strict/.npmrc
+++ b/test/fixtures/engine-strict/.npmrc
@@ -1,0 +1,3 @@
+# Mirrors wordpress-develop's .npmrc, which is what turns an engines mismatch
+# from a warning into a fatal error.
+engine-strict = true

--- a/test/fixtures/engine-strict/needs-future-node/package.json
+++ b/test/fixtures/engine-strict/needs-future-node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "needs-future-node",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Declares a Node version that will never exist, so this fixture keeps reproducing EBADENGINE no matter how new the Node running the tests is. A real registry package would stop failing once CI's Node caught up, silently turning the test green.",
+  "engines": {
+    "node": ">=99.0.0"
+  }
+}

--- a/test/fixtures/engine-strict/package.json
+++ b/test/fixtures/engine-strict/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "engine-strict-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reproduces the EBADENGINE failure from issue #37 without cloning wordpress-develop.",
+  "dependencies": {
+    "needs-future-node": "file:./needs-future-node"
+  }
+}

--- a/test/npm-install.integration.test.cjs
+++ b/test/npm-install.integration.test.cjs
@@ -1,0 +1,91 @@
+// Integration coverage for the engine-strict retry: runs the real install
+// runner against a synthetic project that reproduces issue #37's EBADENGINE.
+//
+// The value of this file is platform-specific. The unit tests in
+// npm-runner.test.cjs only check the strings buildChildEnv builds; these run
+// real npm, so on Windows they prove that npm's config precedence (env var
+// beating the project .npmrc) and npm's error wording are what the detector
+// expects — neither of which can be verified by injecting a platform name.
+//
+// Not covered here: ensureNodeShimDir()'s node/npm shims. Those live in
+// main.js, which requires electron and so cannot be imported by node --test.
+// The fixture has no lifecycle scripts, so nothing here needs to resolve `node`
+// off PATH.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const {
+	isEngineMismatch,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+} = require('../src/npm-runner.js');
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'engine-strict');
+const INSTALL_RUNNER = path.join(__dirname, '..', 'src', 'install-runner.js');
+
+// Keep npm quiet and offline: the fixture's only dependency is a local folder,
+// so an audit or funding lookup would add network flakiness for nothing.
+const QUIET_NPM = {
+	npm_config_loglevel: 'warn',
+	npm_config_audit: 'false',
+	npm_config_fund: 'false',
+	npm_config_progress: 'false'
+};
+
+function copyFixture() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-strict-'));
+	fs.cpSync(FIXTURE, dir, { recursive: true });
+	return dir;
+}
+
+// Runs the production install runner the same way main.js spawns it.
+function runInstall(dir, { relaxEngines }) {
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, [INSTALL_RUNNER, dir], {
+			cwd: dir,
+			env: buildChildEnv({
+				// Irrelevant for this fixture (no lifecycle scripts) — see header.
+				shimDir: path.join(dir, 'unused-shim'),
+				extraEnv: { ...QUIET_NPM, ...(relaxEngines ? RELAXED_ENGINES_ENV : {}) }
+			}),
+			shell: false,
+			windowsHide: true
+		});
+		let output = '';
+		child.stdout.on('data', (d) => { output += d.toString(); });
+		child.stderr.on('data', (d) => { output += d.toString(); });
+		child.on('close', (code) => resolve({ code, output }));
+	});
+}
+
+test('a real engine-strict install fails with output the detector recognises', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { code, output } = await runInstall(dir, { relaxEngines: false });
+
+	assert.notEqual(code, 0, `expected a non-zero exit, got ${code}. Output:\n${output}`);
+	// The whole retry hinges on recognising this output, so assert against what
+	// npm really printed rather than a copy pasted into the unit tests.
+	assert.equal(isEngineMismatch(output), true, `detector missed real npm output:\n${output}`);
+	assert.equal(fs.existsSync(path.join(dir, 'node_modules')), false, 'nothing should have been installed');
+});
+
+test('the same install succeeds once engine checks are relaxed', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { code, output } = await runInstall(dir, { relaxEngines: true });
+
+	assert.equal(code, 0, `expected a clean exit, got ${code}. Output:\n${output}`);
+	assert.equal(
+		fs.existsSync(path.join(dir, 'node_modules', 'needs-future-node')),
+		true,
+		`the dependency should have been installed. Output:\n${output}`
+	);
+});

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -1,0 +1,151 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+	isEngineMismatch,
+	createEngineMismatchDetector,
+	shouldRetryWithRelaxedEngines,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+} = require('../src/npm-runner.js');
+
+// A run that failed on its own with an engines complaint — the one case that
+// earns a retry. Individual tests override single fields from here.
+const ENGINE_FAILURE = {
+	code: 1,
+	signal: null,
+	sawEngineMismatch: true,
+	alreadyRelaxed: false,
+	cancelled: false
+};
+
+// Verbatim from the failure reported in issue #37.
+const EBADENGINE_OUTPUT = `npm error code EBADENGINE
+npm error engine Unsupported engine
+npm error engine Not compatible with your version of node/npm: @eslint/compat@2.1.0
+npm error notsup Not compatible with your version of node/npm: @eslint/compat@2.1.0
+npm error notsup Required: {"node":"^20.19.0 || ^22.13.0 || >=24"}
+npm error notsup Actual:   {"npm":"10.9.3","node":"v20.18.0"}`;
+
+test('isEngineMismatch detects a real engines failure', () => {
+	assert.equal(isEngineMismatch(EBADENGINE_OUTPUT), true);
+	// npm may emit only the warning form on stderr before the error block.
+	assert.equal(isEngineMismatch('npm warn EBADENGINE Unsupported engine'), true);
+});
+
+test('isEngineMismatch ignores failures with other causes', () => {
+	// These must not trigger the retry — retrying would waste a full install
+	// and hide the real problem behind a misleading "newer Node" message.
+	assert.equal(isEngineMismatch('npm error code ENOTFOUND\nnpm error network request failed'), false);
+	assert.equal(isEngineMismatch('npm error code ERESOLVE\nnpm error unable to resolve dependency tree'), false);
+	assert.equal(isEngineMismatch('npm error code ENOSPC\nnpm error nospc no space left on device'), false);
+	assert.equal(isEngineMismatch('npm error code E404\nnpm error 404 Not Found'), false);
+	assert.equal(isEngineMismatch('Error: build failed with 3 errors'), false);
+	assert.equal(isEngineMismatch(''), false);
+	assert.equal(isEngineMismatch(undefined), false);
+});
+
+test('createEngineMismatchDetector survives a marker split across chunks', () => {
+	// Child output arrives in arbitrary chunks, so the marker can straddle a
+	// boundary. Missing it here would mean never retrying.
+	const detector = createEngineMismatchDetector();
+	assert.equal(detector.push('npm error code EBADEN'), false);
+	assert.equal(detector.push('GINE\nnpm error engine Unsupported engine'), true);
+	assert.equal(detector.found, true);
+});
+
+test('createEngineMismatchDetector latches and stays quiet on clean output', () => {
+	const clean = createEngineMismatchDetector();
+	clean.push('added 1294 packages in 47s\n');
+	clean.push('found 0 vulnerabilities\n');
+	assert.equal(clean.found, false);
+
+	// Once seen, a later clean chunk must not clear the finding.
+	const latched = createEngineMismatchDetector();
+	latched.push(EBADENGINE_OUTPUT);
+	latched.push('npm verbose exit 1\n');
+	assert.equal(latched.found, true);
+});
+
+test('shouldRetryWithRelaxedEngines retries an engines failure once', () => {
+	assert.equal(shouldRetryWithRelaxedEngines(ENGINE_FAILURE), true);
+	// The retry itself must never spawn a third attempt.
+	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, alreadyRelaxed: true }), false);
+});
+
+test('shouldRetryWithRelaxedEngines never restarts a cancelled run', () => {
+	// Pressing "stop" makes the child exit non-zero with the engines warning
+	// already in the log. Retrying there would restart work the user stopped.
+	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, cancelled: true }), false);
+	// On POSIX a kill also surfaces as a signal with a null exit code.
+	assert.equal(
+		shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, code: null, signal: 'SIGTERM' }),
+		false
+	);
+	assert.equal(
+		shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, code: null, signal: 'SIGKILL' }),
+		false
+	);
+});
+
+test('shouldRetryWithRelaxedEngines leaves other outcomes alone', () => {
+	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, code: 0 }), false);
+	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, sawEngineMismatch: false }), false);
+});
+
+test('buildChildEnv points child processes at Electron\'s Node', () => {
+	const env = buildChildEnv({
+		shimDir: '/shims',
+		baseEnv: { PATH: '/usr/bin', HOME: '/home/test' },
+		platform: 'darwin',
+		execPath: '/Applications/App.app/Contents/MacOS/App'
+	});
+
+	assert.equal(env.ELECTRON_RUN_AS_NODE, '1');
+	assert.equal(env.NODE, '/Applications/App.app/Contents/MacOS/App');
+	assert.equal(env.NODE_ENV, 'development');
+	assert.equal(env.npm_config_production, 'false');
+	// The shim must come first, or the system node (if any) wins.
+	assert.equal(env.PATH, '/shims:/usr/bin');
+	// Unrelated variables are preserved.
+	assert.equal(env.HOME, '/home/test');
+	// Engine checks are left alone unless explicitly relaxed.
+	assert.equal(env.npm_config_engine_strict, undefined);
+});
+
+test('buildChildEnv sets both PATH casings and PATHEXT on Windows only', () => {
+	const win = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe'
+	});
+	assert.equal(win.PATH, 'C:\\shims;C:\\Windows');
+	assert.equal(win.Path, 'C:\\shims;C:\\Windows');
+	assert.match(win.PATHEXT, /\.CMD;/);
+	assert.match(win.PATHEXT, /\.BAT;/);
+
+	const posix = buildChildEnv({
+		shimDir: '/shims',
+		baseEnv: { PATH: '/usr/bin' },
+		platform: 'linux',
+		execPath: '/opt/app'
+	});
+	// A defined `Path` key on POSIX would shadow nothing but is misleading.
+	assert.equal('Path' in posix, false);
+	assert.equal(posix.PATHEXT, undefined);
+});
+
+test('buildChildEnv applies extraEnv last so the retry can relax engines', () => {
+	const env = buildChildEnv({
+		shimDir: '/shims',
+		baseEnv: { PATH: '/usr/bin' },
+		platform: 'darwin',
+		execPath: '/opt/app',
+		extraEnv: RELAXED_ENGINES_ENV
+	});
+	assert.equal(env.npm_config_engine_strict, 'false');
+	// Relaxing engines must not disturb the rest of the environment.
+	assert.equal(env.ELECTRON_RUN_AS_NODE, '1');
+	assert.equal(env.PATH, '/shims:/usr/bin');
+});

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -54,6 +54,16 @@ test('createEngineMismatchDetector survives a marker split across chunks', () =>
 	assert.equal(detector.found, true);
 });
 
+test('createEngineMismatchDetector survives a marker split across three chunks', () => {
+	// Regression: the retained tail must come from the combined text, not just
+	// the newest chunk, or a marker spread over three chunks is never seen.
+	const detector = createEngineMismatchDetector();
+	assert.equal(detector.push('EBA'), false);
+	assert.equal(detector.push('DEN'), false);
+	assert.equal(detector.push('GINE'), true);
+	assert.equal(detector.found, true);
+});
+
 test('createEngineMismatchDetector latches and stays quiet on clean output', () => {
 	const clean = createEngineMismatchDetector();
 	clean.push('added 1294 packages in 47s\n');


### PR DESCRIPTION
Fixes #37.

## Problem

"Install npm dependencies" fails for everyone with `EBADENGINE` before installing anything, on `trunk` and on the shipped v0.1.0. Nothing here regressed — `wordpress-develop`'s dependency floor rose while the Node version Electron bundles stayed put:

- Child `npm install` runs on Electron's bundled Node, which is **v20.18.1**.
- `@wordpress/eslint-plugin@25.0.0` (2026-04-15) pulled in `@eslint/compat@^2.0.0`, which requires Node `^20.19.0 || ^22.13.0 || >=24`.
- `wordpress-develop`'s `.npmrc` sets `engine-strict = true`, making the mismatch fatal rather than a warning.

Upgrading Electron raises the floor but doesn't remove the failure mode — it just resets the clock until the next upstream bump. This makes the app tolerant of the drift instead.

## Approach

Run the install normally. **Only** if it fails for an engines mismatch, retry once with `npm_config_engine_strict=false` and say so in the log:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^20.19.0 || ^22.13.0 || >=24"}

⚠ This site requires a newer Node.js than this app bundles.
  Retrying with engine checks relaxed…

added 2566 packages, and audited 2567 packages in 14s
```

The first failure still reaches the log, so the real reason stays visible rather than being permanently silenced. Relaxing the check is low-risk here: the packages raising the floor are all lint-only, and aren't needed to build WordPress, run the dev server, or produce a patch.

Two decisions worth a reviewer's attention:

- **`npm_config_engine_strict` is set in the child's environment, not passed on npm's command line.** Env vars are inherited, so it also reaches nested `npm` calls made by WordPress's own scripts; a flag would not. It may therefore fix #8 as well (unverified).
- **`npm:kill` records the cancellation before terminating the child.** Stopping a script exits non-zero with the engines warning already logged — which a naive retry would otherwise take as a reason to start the work over.

## Changes

- New `src/npm-runner.js` — spawn env and retry decision, free of Electron imports so it's unit-testable (same seam as `src/patch.js`). Also de-duplicates the two identical env blocks `npm:install` and `npm:run-script` each carried.
- `src/main.js` — `runNpmWithEngineRetry()` wraps both handlers, reusing the same `installId`/`runId` so the renderer's log stream stays continuous.
- Tests: 25/25 pass (13 existing + 12 new).

## Test plan

- [x] `npm test` — 25/25 pass
- [x] Verified end-to-end against a real `wordpress-develop` clone with an empty `node_modules`: first attempt fails, retry fires, **install completes** with 2566 packages and exit 0.
- [x] `node --test test/npm-install.integration.test.cjs` — runs the real install runner against a synthetic fixture reproducing the same `EBADENGINE`, in ~200ms with no network.

**Not covered:** verified on macOS only — `ensureNodeShimDir()`'s Windows shims stay untested, and `npm test` runs in no Buildkite step yet (#39).
