### PR TITLE
Harden npm engine retry behavior

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -513,11 +513,10 @@ ipcMain.handle('url:open', async (_e, url) => {
 
 const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this app bundles.\n  Retrying with engine checks relaxed…\n\n';
 
-// Spawns an npm runner, and if it fails specifically because a dependency
-// demands a newer Node than Electron bundles, retries once with engine checks
-// relaxed. The first failure's output still reaches the log, so the real reason
-// stays visible instead of being silently papered over.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register }) {
+// Spawns an npm runner. Callers may opt into one retry with engine checks
+// relaxed after an engines failure. npm scripts remain one-shot so a partially
+// executed build, test, or grunt task is never started over automatically.
+function runNpmRunner({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
 	const start = (relaxEngines) => {
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
@@ -530,11 +529,13 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register 
 		});
 		register(child);
 
-		const detector = createEngineMismatchDetector();
+		const detector = retryOnEngineMismatch && !relaxEngines
+			? createEngineMismatchDetector()
+			: null;
 		const forward = (stream, type) => {
 			stream.on('data', (data) => {
 				const text = data.toString();
-				if (!relaxEngines) detector.push(text);
+				if (detector) detector.push(text);
 				onLog(type, text);
 			});
 		};
@@ -545,9 +546,10 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register 
 			const retry = shouldRetryWithRelaxedEngines({
 				code,
 				signal,
-				sawEngineMismatch: detector.found,
+				sawEngineMismatch: detector?.found || false,
 				alreadyRelaxed: relaxEngines,
-				cancelled: cancelledChildren.has(child)
+				cancelled: cancelledChildren.has(child),
+				retryEnabled: retryOnEngineMismatch
 			});
 			if (retry) {
 				onLog('stdout', ENGINE_RETRY_NOTICE);
@@ -565,10 +567,11 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 
 	const installId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
-	runNpmWithEngineRetry({
+	runNpmRunner({
 		runnerPath: path.join(__dirname, 'install-runner.js'),
 		args: [directoryPath],
 		cwd: directoryPath,
+		retryOnEngineMismatch: true,
 		register: (child) => {
 			runningInstalls[installId] = child;
 		},
@@ -590,10 +593,11 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 
 	const runId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
-	runNpmWithEngineRetry({
+	runNpmRunner({
 		runnerPath: path.join(__dirname, 'script-runner.js'),
 		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
+		retryOnEngineMismatch: false,
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -31,8 +31,9 @@ function createEngineMismatchDetector() {
 	let found = false;
 	return {
 		push(text) {
-			if (!found && isEngineMismatch(tail + text)) found = true;
-			tail = String(text || '').slice(-CHUNK_OVERLAP);
+			const combined = tail + String(text || '');
+			if (!found && isEngineMismatch(combined)) found = true;
+			tail = combined.slice(-CHUNK_OVERLAP);
 			return found;
 		},
 		get found() {
@@ -45,7 +46,8 @@ function createEngineMismatchDetector() {
 // relaxed. Retrying is only ever right for an engines failure that the process
 // reached on its own: a run the user cancelled (or the OS killed) must stay
 // dead, otherwise pressing "stop" would silently start the work over.
-function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alreadyRelaxed, cancelled }) {
+function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alreadyRelaxed, cancelled, retryEnabled = true }) {
+	if (!retryEnabled) return false;
 	if (alreadyRelaxed) return false;
 	if (cancelled) return false;
 	// A non-null signal means the process was terminated rather than exiting.

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -16,7 +16,8 @@ const ENGINE_FAILURE = {
 	signal: null,
 	sawEngineMismatch: true,
 	alreadyRelaxed: false,
-	cancelled: false
+	cancelled: false,
+	retryEnabled: true
 };
 
 // Verbatim from the failure reported in issue #37.
@@ -51,6 +52,14 @@ test('createEngineMismatchDetector survives a marker split across chunks', () =>
 	const detector = createEngineMismatchDetector();
 	assert.equal(detector.push('npm error code EBADEN'), false);
 	assert.equal(detector.push('GINE\nnpm error engine Unsupported engine'), true);
+	assert.equal(detector.found, true);
+});
+
+test('createEngineMismatchDetector survives a marker split across three chunks', () => {
+	const detector = createEngineMismatchDetector();
+	assert.equal(detector.push('EBA'), false);
+	assert.equal(detector.push('DEN'), false);
+	assert.equal(detector.push('GINE'), true);
 	assert.equal(detector.found, true);
 });
 
@@ -91,6 +100,10 @@ test('shouldRetryWithRelaxedEngines never restarts a cancelled run', () => {
 test('shouldRetryWithRelaxedEngines leaves other outcomes alone', () => {
 	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, code: 0 }), false);
 	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, sawEngineMismatch: false }), false);
+});
+
+test('shouldRetryWithRelaxedEngines respects a caller opting out of retries', () => {
+	assert.equal(shouldRetryWithRelaxedEngines({ ...ENGINE_FAILURE, retryEnabled: false }), false);
 });
 
 test('buildChildEnv points child processes at Electron\'s Node', () => {


### PR DESCRIPTION
## Summary

- Preserve the streamed engine-mismatch detector’s rolling tail across any number of chunks.
- Keep relaxed-engine retries opt-in for dependency installation so `npm run` commands are never automatically restarted after partial execution.
- Add regression coverage for a marker split across three chunks and for callers disabling retries.

## Why

This follows up on the review of #38. The detector previously retained only the newest chunk, so an `EBADENGINE` marker split across three chunks could be missed. The shared retry wrapper also applied to arbitrary npm scripts, which could restart a partially completed build, test, or Grunt task and could misclassify warning-form `EBADENGINE` output followed by an unrelated failure.

This PR is intentionally stacked on #38 and targets `juanmaguitar/issue-37-npm-engine-retry`; merging it updates PR 38 directly.

## Validation

- `npm test` — 27/27 passing
- `node --check src/main.js`
- `node --check src/npm-runner.js`
- `git diff --check`
