### PR TITLE
Write an app log to disk and add a Help menu to open it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@wp-playground/cli": "^3.0.8",
         "@xterm/xterm": "^5.5.0",
         "diff": "^5.2.0",
+        "electron-log": "^5.4.4",
         "electron-store": "^10.0.1",
         "extract-zip": "^2.0.1",
         "fs-extra": "^11.2.0",
@@ -5138,6 +5139,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@wp-playground/cli": "^3.0.8",
     "@xterm/xterm": "^5.5.0",
     "diff": "^5.2.0",
+    "electron-log": "^5.4.4",
     "electron-store": "^10.0.1",
     "extract-zip": "^2.0.1",
     "fs-extra": "^11.2.0",

--- a/src/log-lines.js
+++ b/src/log-lines.js
@@ -1,0 +1,34 @@
+// Reassembles child-process stream chunks into whole lines for the app log.
+// Deliberately free of Electron imports so it can be unit-tested.
+
+// Child stdout/stderr arrives in arbitrary chunks: a single npm message can be
+// split across two reads, and one read can carry a dozen messages. Logging the
+// chunks verbatim would stamp a timestamp mid-sentence and interleave the two
+// streams mid-word, which is exactly what makes a log unreadable at the moment
+// someone needs it. Buffering to line boundaries costs one partial line of
+// latency and is why `flush` exists — the last line before a process exits
+// usually has no trailing newline, and it is often the interesting one.
+function createLineBuffer() {
+	let pending = '';
+	return {
+		// Returns the complete lines contained in `chunk`, retaining any partial
+		// trailing line for the next call.
+		push(chunk) {
+			pending += String(chunk ?? '');
+			// A trailing \n yields a final '' element, which is dropped as the new
+			// pending — so a chunk ending exactly on a boundary leaves nothing behind.
+			const parts = pending.split('\n');
+			pending = parts.pop();
+			// \r\n from Windows child processes would otherwise show as a stray CR.
+			return parts.map((line) => line.replace(/\r$/, ''));
+		},
+		// The unterminated remainder, if any. Call once when the stream closes.
+		flush() {
+			const rest = pending.replace(/\r$/, '');
+			pending = '';
+			return rest ? [rest] : [];
+		}
+	};
+}
+
+module.exports = { createLineBuffer };

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,0 +1,127 @@
+// The app's on-disk log. This is the only module that touches electron-log, so
+// the rest of the codebase depends on these four functions rather than on the
+// library.
+//
+// Why a file at all: in a packaged GUI build the main process has no terminal,
+// so every console.* call and every byte of child-process stdout/stderr goes
+// nowhere. Child output is forwarded to the renderer over IPC, which means a
+// spawn that fails before producing output — or a renderer that never renders
+// what it received — leaves no trace whatsoever. "Nothing happened" and "the
+// spawn failed with EPERM" then look identical, and there is nothing to attach
+// to a bug report.
+
+const path = require('path');
+const { app } = require('electron');
+const log = require('electron-log/main');
+const { createLineBuffer } = require('./log-lines');
+
+// Rotated to main.old.log past this size, so an app left running through many
+// npm installs cannot grow the file without bound.
+const MAX_LOG_SIZE = 5 * 1024 * 1024;
+
+let initialized = false;
+
+function initLogging() {
+	if (initialized) return;
+	initialized = true;
+
+	// Must run before the first BrowserWindow is constructed: this preloads the
+	// IPC bridge that lets renderer output reach this file. Called later it
+	// silently does nothing for windows that already exist. spyRendererConsole
+	// is what captures the renderer's own console.* — the blind spot behind the
+	// class of bug where the main process is fine and the UI simply never shows
+	// what it was sent.
+	log.initialize({ spyRendererConsole: true });
+
+	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), 'main.log');
+	log.transports.file.maxSize = MAX_LOG_SIZE;
+
+	// Redirects the existing console.* calls throughout the main process into
+	// the log without editing their call sites. They keep printing to stdout in
+	// development via the console transport.
+	Object.assign(console, log.functions);
+
+	// There were no uncaughtException/unhandledRejection handlers at all, so a
+	// main-process crash previously produced an empty log — the exact moment the
+	// log is most wanted. showDialog is off deliberately: at a Contributor Day a
+	// modal error box derails the session, and the stack is in the file anyway.
+	log.errorHandler.startCatching({ showDialog: false });
+
+	writeHeader();
+}
+
+// A version/platform block at the top of each run. Nearly every bug report needs
+// it and nearly no reporter thinks to include it; asking for the log file should
+// be enough on its own.
+function writeHeader() {
+	const scoped = log.scope('app');
+	scoped.info('--- session start ---');
+	scoped.info(`app ${app.getVersion()} (${app.getName()})`);
+	scoped.info(`electron ${process.versions.electron} · node ${process.versions.node} · chrome ${process.versions.chrome}`);
+	scoped.info(`platform ${process.platform} ${process.arch} · ${process.env.NODE_ENV || 'production'}`);
+	scoped.info(`log file ${getLogFilePath()}`);
+}
+
+// Absolute path to the current log file, for the Help menu entries. Resolving it
+// through the transport rather than recomputing it keeps the menu honest if the
+// path logic ever changes.
+function getLogFilePath() {
+	return log.transports.file.getFile().path;
+}
+
+// One line buffer per (scope, stream). Chunks arrive mid-line, so writing them
+// raw would fragment single messages across timestamped entries.
+const buffers = new Map();
+
+function bufferFor(scope, type) {
+	const key = `${scope}:${type}`;
+	if (!buffers.has(key)) buffers.set(key, createLineBuffer());
+	return buffers.get(key);
+}
+
+// Mirrors a chunk of child-process output into the log. Callers keep sending the
+// same chunk to the renderer over IPC as before — this is an addition, never a
+// replacement, so the UI is unaffected.
+function logChildOutput(scope, type, chunk) {
+	const scoped = log.scope(scope);
+	const write = type === 'stderr' ? scoped.warn : scoped.info;
+	for (const line of bufferFor(scope, type).push(chunk)) {
+		write(line);
+	}
+}
+
+// Call when the child closes, to emit any line it left unterminated and drop the
+// buffers — scopes are keyed by site path or run id and would otherwise
+// accumulate for the lifetime of the app.
+function flushChildOutput(scope) {
+	const scoped = log.scope(scope);
+	for (const type of ['stdout', 'stderr']) {
+		const key = `${scope}:${type}`;
+		const buf = buffers.get(key);
+		if (!buf) continue;
+		for (const line of buf.flush()) {
+			(type === 'stderr' ? scoped.warn : scoped.info)(line);
+		}
+		buffers.delete(key);
+	}
+}
+
+// Structured events around a child process: the spawn itself and its exit code.
+// These matter more than the output — a spawn that dies immediately (EPERM on
+// Windows) produces no stdout at all, and that silence is the bug.
+function logEvent(scope, message) {
+	log.scope(scope).info(message);
+}
+
+function logError(scope, message) {
+	log.scope(scope).error(message);
+}
+
+module.exports = {
+	initLogging,
+	getLogFilePath,
+	logChildOutput,
+	flushChildOutput,
+	logEvent,
+	logError
+};

--- a/src/logging.js
+++ b/src/logging.js
@@ -15,7 +15,26 @@ const { app } = require('electron');
 const log = require('electron-log/main');
 const { createLineBuffer } = require('./log-lines');
 
-// Rotated to main.old.log past this size, so an app left running through many
+// Friendly platform names rather than process.platform's own values: 'win32'
+// reads as 32-bit to most people, and this string ends up in front of
+// contributors rather than only in code.
+const PLATFORM_NAMES = {
+	darwin: 'macos',
+	win32: 'windows',
+	linux: 'linux'
+};
+
+// Not electron-log's default of main.log. The point of this file is that people
+// attach it to bug reports, at which moment it is separated from the app-named
+// folder that would otherwise identify it — so the name has to stand alone in a
+// list of attachments. The platform is in there because a single issue thread
+// often collects logs from several contributors, and which OS a log came from is
+// the first thing anyone reading it needs to know.
+function logFileName(platform = process.platform) {
+	return `wordpress-contributor-toolkit-${PLATFORM_NAMES[platform] || platform}.log`;
+}
+
+// Rotated to <name>.old.log past this size, so an app left running through many
 // npm installs cannot grow the file without bound.
 const MAX_LOG_SIZE = 5 * 1024 * 1024;
 
@@ -33,7 +52,7 @@ function initLogging() {
 	// what it was sent.
 	log.initialize({ spyRendererConsole: true });
 
-	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), 'main.log');
+	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), logFileName());
 	log.transports.file.maxSize = MAX_LOG_SIZE;
 
 	// Redirects the existing console.* calls throughout the main process into

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,5 +1,5 @@
 // The app's on-disk log. This is the only module that touches electron-log, so
-// the rest of the codebase depends on these four functions rather than on the
+// the rest of the codebase depends on this module's exports rather than on the
 // library.
 //
 // Why a file at all: in a packaged GUI build the main process has no terminal,

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, Menu, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const fs = require('fs');
 const fse = require('fs-extra');
 const https = require('https');
@@ -570,14 +571,44 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		forward(child.stdout, 'stdout');
 		forward(child.stderr, 'stderr');
 
+		// 'error' and 'close' are independent events, and Node documents that the
+		// exit events "may or may not" follow a spawn failure. In practice close
+		// does arrive (verified on Electron's Node 20: error, then close with code
+		// -2), so the normal path below is left to win — it is the one that knows
+		// about the engines retry. This only settles the request when close
+		// genuinely never comes, which would otherwise leave the caller waiting
+		// forever and the child registry never cleaned up.
+		let settled = false;
+		// The single exit point, so the caller is told exactly once no matter which
+		// event gets there first.
+		const settle = (code) => {
+			if (settled) return;
+			settled = true;
+			onDone(code);
+		};
+
 		child.on('error', (err) => {
 			logError(logScope, `spawn failed: ${String(err)}`);
+			// Deferred by a turn so that close — which knows about the engines
+			// retry — wins whenever it does arrive. A spawn failure is the very
+			// case this logging exists to expose, so it must not also become a
+			// silent hang with the request never settled.
+			setTimeout(() => {
+				if (settled) return;
+				flushChildOutput(logScope);
+				logEvent(logScope, 'never started; no exit reported');
+				settle(null);
+			}, 0);
 		});
 
 		child.on('close', (code, signal) => {
 			flushChildOutput(logScope);
 			logEvent(logScope, `exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
-			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
+			// `!settled` guards the case where the error path got there first: the
+			// caller has already been told the run finished, so starting a second
+			// attempt behind its back would report output for a run it considers
+			// over.
+			const retry = !settled && retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
 				sawEngineMismatch: detector.found,
@@ -589,7 +620,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 				start(true);
 				return;
 			}
-			onDone(code);
+			settle(code);
 		});
 	};
 	start(false);
@@ -672,6 +703,16 @@ ipcMain.handle('npm:kill', async (_event, { runId, directoryPath }) => {
 	}
 });
 
+// Servers for several sites can run at once, and two sites can share a folder
+// name under different parents. The log's line buffers are keyed by scope, so a
+// bare basename would let two servers' partial lines interleave into corrupted
+// ones. The path hash disambiguates without putting an absolute path on every
+// line; the full path is logged once at spawn.
+function playgroundLogScope(sitePath) {
+	const suffix = crypto.createHash('sha1').update(String(sitePath)).digest('hex').slice(0, 4);
+	return `playground:${path.basename(sitePath)}#${suffix}`;
+}
+
 ipcMain.handle('playground:start', async (event, sitePath) => {
 	// Ensure a per-site SMTP server is running alongside the dev server and get its port
 	const smtp = await ensureSmtpServerForSite(sitePath).catch(() => null);
@@ -680,7 +721,7 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		return { ok: true, url: playgroundServers[sitePath].url };
 	}
 	const runnerPath = path.join(__dirname, 'server-runner.js');
-	const logScope = `playground:${path.basename(sitePath)}`;
+	const logScope = playgroundLogScope(sitePath);
 	logEvent(logScope, `starting server for ${buildDir} (smtp port ${(smtp && smtp.port) ? smtp.port : 25})`);
 	const child = spawn(process.execPath, [runnerPath, buildDir], {
 		cwd: buildDir,

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
+const { app, BrowserWindow, Menu, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -18,6 +18,15 @@ const {
 	buildChildEnv,
 	RELAXED_ENGINES_ENV
 } = require('./npm-runner');
+const {
+	initLogging,
+	getLogFilePath,
+	logChildOutput,
+	flushChildOutput,
+	logEvent,
+	logError
+} = require('./logging');
+const { buildMenuTemplate } = require('./menu');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -346,6 +355,15 @@ ipcMain.handle('git:save-patch', async (_e, sitePath) => {
 });
 
 app.whenReady().then(() => {
+	// Before createWindow(): initLogging preloads the IPC bridge that carries
+	// renderer output into the log file, which only applies to windows created
+	// afterwards.
+	initLogging();
+	Menu.setApplicationMenu(Menu.buildFromTemplate(buildMenuTemplate({
+		onOpenLog: () => shell.openPath(getLogFilePath()),
+		onShowLogsFolder: () => shell.showItemInFolder(getLogFilePath())
+	})));
+
 	createWindow();
 
 	app.on('activate', function () {
@@ -523,8 +541,12 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // disk, and npm prints EBADENGINE as a mere warning when engine-strict is off
 // — so a warning followed by an unrelated non-zero exit would wrongly restart
 // a half-finished script. An install, by contrast, is idempotent to re-run.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, logScope, retryOnEngineMismatch = false }) {
 	const start = (relaxEngines) => {
+		// Logged before the spawn: a child that fails to start at all (EPERM on
+		// Windows) produces no output, so without this the log would show nothing
+		// where the failure was.
+		logEvent(logScope, `spawn ${path.basename(runnerPath)} ${args.join(' ')} in ${cwd}${relaxEngines ? ' (relaxed engines)' : ''}`);
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
 			env: buildChildEnv({
@@ -541,13 +563,20 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			stream.on('data', (data) => {
 				const text = data.toString();
 				if (retryOnEngineMismatch && !relaxEngines) detector.push(text);
+				logChildOutput(logScope, type, text);
 				onLog(type, text);
 			});
 		};
 		forward(child.stdout, 'stdout');
 		forward(child.stderr, 'stderr');
 
+		child.on('error', (err) => {
+			logError(logScope, `spawn failed: ${String(err)}`);
+		});
+
 		child.on('close', (code, signal) => {
+			flushChildOutput(logScope);
+			logEvent(logScope, `exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
 			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
@@ -575,6 +604,9 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		runnerPath: path.join(__dirname, 'install-runner.js'),
 		args: [directoryPath],
 		cwd: directoryPath,
+		// Suffixed with the correlation id so two installs running at once stay
+		// distinguishable in the log instead of interleaving.
+		logScope: `install#${installId.slice(-4)}`,
 		retryOnEngineMismatch: true,
 		register: (child) => {
 			runningInstalls[installId] = child;
@@ -601,6 +633,7 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 		runnerPath: path.join(__dirname, 'script-runner.js'),
 		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
+		logScope: `${scriptName}#${runId.slice(-4)}`,
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;
@@ -647,6 +680,8 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		return { ok: true, url: playgroundServers[sitePath].url };
 	}
 	const runnerPath = path.join(__dirname, 'server-runner.js');
+	const logScope = `playground:${path.basename(sitePath)}`;
+	logEvent(logScope, `starting server for ${buildDir} (smtp port ${(smtp && smtp.port) ? smtp.port : 25})`);
 	const child = spawn(process.execPath, [runnerPath, buildDir], {
 		cwd: buildDir,
 		env: {
@@ -671,13 +706,13 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 	child.stderr.setEncoding('utf8');
 	child.stdout.on('data', (data) => {
 		const text = String(data);
-		console.log("STDOUT", text);
+		logChildOutput(logScope, 'stdout', text);
 		event.sender.send('playground:log', { sitePath, type: 'stdout', data: text });
 		const match = text.match(/SERVER_URL:(.*)/);
 		if (match && !resolved) {
 			resolved = true;
 			playgroundServers[sitePath].url = match[1].trim();
-			console.log("URL", playgroundServers[sitePath].url);
+			logEvent(logScope, `server ready at ${playgroundServers[sitePath].url}`);
 			event.sender.send('playground:url', { sitePath, url: playgroundServers[sitePath].url });
 			if (typeof pendingResolve === 'function') {
 				clearTimeout(timeoutId);
@@ -687,14 +722,18 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		}
 	});
 	child.stderr.on('data', (data) => {
-		console.log("STDERR", data);
+		logChildOutput(logScope, 'stderr', String(data));
 		event.sender.send('playground:log', { sitePath, type: 'stderr', data: String(data) });
 	});
 	child.on('error', (err) => {
-		console.log("ERROR", err);
+		logError(logScope, `spawn failed: ${String(err)}`);
 		event.sender.send('playground:log', { sitePath, type: 'stderr', data: String(err) + '\n' });
 	});
-	child.on('close', (code) => {
+	// `signal` is logged as well as `code`: a killed process reports a null code,
+	// and "exited with code null" tells a reader nothing about why it stopped.
+	child.on('close', (code, signal) => {
+		flushChildOutput(logScope);
+		logEvent(logScope, `server exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
 		delete playgroundServers[sitePath];
 		event.sender.send('playground:stopped', { sitePath, code });
 		// Stop WP debug tail if running
@@ -727,6 +766,9 @@ ipcMain.handle('playground:stop', async (_event, sitePath) => {
 });
 
 // --- Global Playground web server (serves local-playground-web) ---
+// A single global server, so unlike the per-site ones its log scope is constant.
+const WEB_LOG_SCOPE = 'playground-web';
+
 ipcMain.handle('playground-web:available', async () => {
     const webDirCandidates = [
         path.join(app.getAppPath(), 'local-playground-web'),
@@ -767,6 +809,7 @@ ipcMain.handle('playground-web:start', async (event) => {
     }
 
     const runnerPath = path.join(__dirname, 'playground-web-runner.js');
+    logEvent(WEB_LOG_SCOPE, `starting web server for ${webDir} on port 39372`);
     const child = spawn(process.execPath, [runnerPath, webDir, '39372'], {
         cwd: webDir,
         env: {
@@ -786,11 +829,13 @@ ipcMain.handle('playground-web:start', async (event) => {
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (data) => {
         const text = String(data);
+        logChildOutput(WEB_LOG_SCOPE, 'stdout', text);
         try { broadcastToAll('playground-web:log', { type: 'stdout', data: text }); } catch {}
         const match = text.match(/WEB_SERVER_URL:(.*)/);
         if (match && !resolved) {
             resolved = true;
             playgroundWebServer.url = match[1].trim();
+            logEvent(WEB_LOG_SCOPE, `web server ready at ${playgroundWebServer.url}`);
             broadcastToAll('playground-web:url', { url: playgroundWebServer.url });
             if (typeof pendingResolve === 'function') {
                 clearTimeout(timeoutId);
@@ -801,12 +846,16 @@ ipcMain.handle('playground-web:start', async (event) => {
         }
     });
     child.stderr.on('data', (data) => {
+        logChildOutput(WEB_LOG_SCOPE, 'stderr', String(data));
         try { broadcastToAll('playground-web:log', { type: 'stderr', data: String(data) }); } catch {}
     });
     child.on('error', (err) => {
+        logError(WEB_LOG_SCOPE, `spawn failed: ${String(err)}`);
         try { broadcastToAll('playground-web:log', { type: 'stderr', data: String(err) + '\n' }); } catch {}
     });
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
+        flushChildOutput(WEB_LOG_SCOPE);
+        logEvent(WEB_LOG_SCOPE, `web server exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
         const stillPending = !resolved && typeof pendingResolve === 'function';
         playgroundWebServer = null;
         if (stillPending) {

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,0 +1,47 @@
+// The application menu.
+//
+// The app previously set no menu at all and inherited Electron's default one.
+// Setting a menu replaces that default wholesale, so the template below rebuilds
+// it out of Electron's built-in roles — anything dropped here is a feature the
+// user silently loses. The only real addition is the Help submenu, which is how
+// a contributor gets at the log file without knowing where their OS keeps it.
+//
+// Kept free of Electron imports and of the log module: the caller supplies the
+// click handlers, so this file is a plain data structure.
+
+const isMac = (platform = process.platform) => platform === 'darwin';
+
+function buildMenuTemplate({ onOpenLog, onShowLogsFolder, platform = process.platform } = {}) {
+	return [
+		// On macOS the first submenu is the app menu (About/Quit/Services). On
+		// Windows and Linux those items live under File instead, which `fileMenu`
+		// already handles, so this entry is omitted entirely.
+		...(isMac(platform) ? [{ role: 'appMenu' }] : []),
+		{ role: 'fileMenu' },
+		{ role: 'editMenu' },
+		{ role: 'viewMenu' },
+		{ role: 'windowMenu' },
+		{
+			role: 'help',
+			submenu: [
+				{
+					// "App Log" rather than "Log": the app also tails each site's
+					// WordPress debug.log, and confusing the two would send people
+					// to the wrong file.
+					label: 'Open App Log',
+					click: () => onOpenLog?.()
+				},
+				{
+					label: 'Show Logs Folder',
+					click: () => onShowLogsFolder?.()
+				},
+				{ type: 'separator' },
+				// Duplicates the View entry on purpose. Someone who does not know
+				// the shortcut looks under Help, not View.
+				{ role: 'toggleDevTools' }
+			]
+		}
+	];
+}
+
+module.exports = { buildMenuTemplate };

--- a/test/log-lines.test.cjs
+++ b/test/log-lines.test.cjs
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createLineBuffer } = require('../src/log-lines.js');
+
+test('emits complete lines and holds back a partial one', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('added 733 packages\nfound 0 vul'), ['added 733 packages']);
+	// The partial line only surfaces once its newline arrives.
+	assert.deepEqual(buf.push('nerabilities\n'), ['found 0 vulnerabilities']);
+});
+
+test('a chunk ending on a newline leaves nothing pending', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('one\ntwo\n'), ['one', 'two']);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('a line split across three chunks is reassembled', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('npm error code '), []);
+	assert.deepEqual(buf.push('EBAD'), []);
+	assert.deepEqual(buf.push('ENGINE\n'), ['npm error code EBADENGINE']);
+});
+
+test('strips the CR of Windows CRLF output', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('C:\\Users\\dev>npm install\r\ndone\r\n'), ['C:\\Users\\dev>npm install', 'done']);
+});
+
+test('flush returns the unterminated last line', () => {
+	// Servers commonly exit right after a prompt with no trailing newline, and
+	// that line is usually the one explaining why.
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('Error: listen EPERM'), []);
+	assert.deepEqual(buf.flush(), ['Error: listen EPERM']);
+	// Flushing twice must not repeat it.
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('blank lines are preserved but a trailing empty remainder is not', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('a\n\nb\n'), ['a', '', 'b']);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('empty and nullish chunks are no-ops', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push(''), []);
+	assert.deepEqual(buf.push(undefined), []);
+	assert.deepEqual(buf.push(null), []);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('buffers are independent so stdout and stderr do not interleave', () => {
+	const out = createLineBuffer();
+	const err = createLineBuffer();
+	assert.deepEqual(out.push('half of stdout'), []);
+	assert.deepEqual(err.push('a whole stderr line\n'), ['a whole stderr line']);
+	assert.deepEqual(out.push(' completed\n'), ['half of stdout completed']);
+});

--- a/test/menu.test.cjs
+++ b/test/menu.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildMenuTemplate } = require('../src/menu.js');
+
+const roles = (template) => template.map((item) => item.role);
+const helpItems = (template) => template.find((item) => item.role === 'help').submenu;
+
+test('rebuilds the default menu roles that setting a menu would otherwise drop', () => {
+	// Setting an application menu replaces Electron's default wholesale, so a
+	// missing role here is a silent regression in existing menu behaviour.
+	for (const platform of ['darwin', 'win32', 'linux']) {
+		const template = buildMenuTemplate({ platform });
+		for (const role of ['fileMenu', 'editMenu', 'viewMenu', 'windowMenu', 'help']) {
+			assert.ok(roles(template).includes(role), `${role} missing on ${platform}`);
+		}
+	}
+});
+
+test('the app menu is macOS-only', () => {
+	// On Windows and Linux those items belong under File, which fileMenu covers;
+	// an appMenu there would render as a stray empty submenu.
+	assert.ok(roles(buildMenuTemplate({ platform: 'darwin' })).includes('appMenu'));
+	assert.ok(!roles(buildMenuTemplate({ platform: 'win32' })).includes('appMenu'));
+	assert.ok(!roles(buildMenuTemplate({ platform: 'linux' })).includes('appMenu'));
+});
+
+test('Help exposes both log entries plus DevTools', () => {
+	const items = helpItems(buildMenuTemplate({}));
+	assert.deepEqual(
+		items.filter((i) => i.label).map((i) => i.label),
+		['Open App Log', 'Show Logs Folder']
+	);
+	assert.ok(items.some((i) => i.role === 'toggleDevTools'));
+});
+
+test('Help entries invoke the handlers they were given', () => {
+	let opened = 0;
+	let revealed = 0;
+	const items = helpItems(buildMenuTemplate({
+		onOpenLog: () => { opened++; },
+		onShowLogsFolder: () => { revealed++; }
+	}));
+	items.find((i) => i.label === 'Open App Log').click();
+	items.find((i) => i.label === 'Show Logs Folder').click();
+	assert.equal(opened, 1);
+	assert.equal(revealed, 1);
+});
+
+test('clicking without handlers does not throw', () => {
+	// The template is built before the log path is known in some call orders;
+	// a click must not take the whole main process down with it.
+	const items = helpItems(buildMenuTemplate());
+	assert.doesNotThrow(() => items.find((i) => i.label === 'Open App Log').click());
+});


### PR DESCRIPTION
> **Stack — 1 of 5** · `trunk` → **#50** → #51 → #52 → #56 → #58
> The diff below is only this PR's own changes. All five were verified together end to end on a Windows VM: clone → install → build → dev server → WordPress wizard → wp-admin.

Closes #49

## Problem

A packaged build has no terminal, so nothing the app does is recorded anywhere. Child-process output is only forwarded to the renderer over IPC — it exists as pixels in the UI, and only if the UI manages to draw it.

So a spawn that fails with `EPERM` and a spawn that never started look identical to the person in front of the app: nothing happens. Helping someone remotely becomes "describe what you saw", and at a Contributor Day that is where the session ends.

## Fix

The app writes a log file, and **Help → Open App Log** takes you to it. Everything that was previously invisible now lands there: child-process output, the command used to spawn each one and the code it exited with, renderer errors, and crashes with stack traces.

Asking for a bug report becomes "open Help, click Show Logs Folder, attach that file".

[<img width="2524" height="1614" alt="CleanShot 2026-07-29 at 11 14 25@2x" src="https://github.com/user-attachments/assets/73faeb1e-8cbe-4d85-8b53-ba525005b139" />
](https://www.youtube.com/watch?v=mJGF8S3cLhQ)
[see video](https://www.youtube.com/watch?v=mJGF8S3cLhQ)

## How to test

Run the app from this branch: `npm install && npm start`

1. Open **Help**. It has three entries: *Open App Log*, *Show Logs Folder*, *Toggle Developer Tools*.
2. Click **Open App Log**. The file opens in your default viewer and starts with a session header — app version, Electron, Node, Chrome, platform, arch.
3. Click **Show Logs Folder**. The file is revealed in Finder/Explorer, named `wordpress-contributor-toolkit-<platform>.log`.
4. Create a site and click **Install npm dependencies**. While it runs, the log fills with the same output you see in the Terminal panel, plus two lines the UI never shows: `spawn install-runner.js <path>` when it starts and `exited with code 0` when it ends.
5. Quit and reopen the app. A new `--- session start ---` header is appended; the previous session is still there.

Automated: `npm test` (13 new cases).


<details>
<summary><b>The menu, the file location, and what ends up in it</b></summary>

Under **Help**:

- **Open App Log** — opens the log in the system's default viewer
- **Show Logs Folder** — reveals it in Explorer/Finder, for attaching to an issue
- **Toggle Developer Tools** — the same item as under View, where someone who doesn't know the shortcut will actually look for it

The file is named `wordpress-contributor-toolkit-<platform>.log` so it still identifies itself once it has been detached from its folder and attached to a GitHub issue alongside logs from other contributors.

| Platform | Path |
| --- | --- |
| Windows | `%APPDATA%\WordPress Contributor Toolkit\logs\wordpress-contributor-toolkit-windows.log` |
| macOS | `~/Library/Logs/WordPress Contributor Toolkit/wordpress-contributor-toolkit-macos.log` |
| Linux | `~/.config/WordPress Contributor Toolkit/logs/wordpress-contributor-toolkit-linux.log` |

What ends up in it:

- every session starts with app, Electron, Node, Chrome, platform and architecture — the block every bug report needs and nobody remembers to include
- the full output of `npm install`, `npm run <script>` and both Playground servers, as whole lines rather than the fragments the streams actually arrive in
- the command used to spawn each child process and the code it exited with, so a child that dies before printing anything is still visible — that silence being precisely the bug on Windows today
- errors from the UI as well as the main process, so a failure where the app is working fine and the interface simply never shows it is no longer invisible
- crashes: uncaught exceptions and unhandled rejections in both processes, with stack traces, where previously a crash left an empty log

It rotates at 5 MB, so a long-lived session cannot fill someone's disk. It writes alongside the existing UI output rather than replacing it — the terminal panel behaves exactly as before.

</details>

<details>
<summary><b>Notes for reviewers</b></summary>

**The log is not redacted.** It contains local paths (`C:\Users\<name>\…`) and environment details, in a file users are directed to attach to public issues. That is the same information a bug report needs, so it seems the right trade, but it is a deliberate choice rather than an oversight.

**"App Log" is deliberately not "Log".** The app already tails each site's WordPress `debug.log` and shows it in the UI; these are different files for different purposes, and the wording is there to keep people from opening the wrong one.

**Setting an application menu replaces Electron's default wholesale.** The default submenus are rebuilt from built-in roles rather than dropped, so nothing that worked before disappears — worth a look on both platforms, since a mistake there presents as a missing or empty menu.

**Anyone on an earlier build of this branch has an orphaned `main.log`** in that folder from before the file was renamed. Nothing cleans it up, so two files in the folder is expected rather than a bug.

</details>
