### PR TITLE
Lock the "Install npm dependencies" step until the clone finishes

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -30964,6 +30964,44 @@ WARNING: This link could potentially be dangerous`)) {
     }
   });
 
+  // src/renderer/setup-steps.cjs
+  var require_setup_steps = __commonJS({
+    "src/renderer/setup-steps.cjs"(exports, module) {
+      "use strict";
+      function computeSetupStepState2(flags = {}) {
+        const isPending = Boolean(flags.isPending);
+        const statusLoading = Boolean(flags.statusLoading);
+        const hasNodeModules = Boolean(flags.hasNodeModules);
+        const hasBuilt = Boolean(flags.hasBuilt);
+        const installing = Boolean(flags.installing);
+        const building = Boolean(flags.building);
+        const starting = Boolean(flags.starting);
+        return {
+          download: {
+            done: !isPending,
+            ready: true
+          },
+          install: {
+            done: hasNodeModules,
+            ready: !isPending,
+            disabled: isPending || statusLoading || installing || hasNodeModules
+          },
+          build: {
+            done: hasBuilt,
+            ready: hasNodeModules,
+            disabled: statusLoading || building || !hasNodeModules || hasBuilt
+          },
+          dev: {
+            done: false,
+            ready: hasBuilt,
+            disabled: statusLoading || starting || !hasBuilt
+          }
+        };
+      }
+      module.exports = { computeSetupStepState: computeSetupStepState2 };
+    }
+  });
+
   // src/renderer/index.jsx
   var import_react69 = __toESM(require_react());
   var import_client2 = __toESM(require_client());
@@ -53327,6 +53365,7 @@ If there's a particular need for this, please submit a feature request at https:
 
   // src/renderer/index.jsx
   var import_xterm = __toESM(require_xterm());
+  var import_setup_steps = __toESM(require_setup_steps());
   var import_jsx_runtime61 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
@@ -53352,7 +53391,12 @@ If there's a particular need for this, please submit a feature request at https:
   function App() {
     const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
     const [downloadPhase, setDownloadPhase] = (0, import_react69.useState)("");
-    const [pendingSite, setPendingSite] = (0, import_react69.useState)(null);
+    const [pendingSites, setPendingSites] = (0, import_react69.useState)([]);
+    const addPendingSite = (0, import_react69.useCallback)((dir) => {
+      if (!dir) return;
+      setPendingSites((prev2) => prev2.includes(dir) ? prev2 : [...prev2, dir]);
+    }, []);
+    const clearPendingSites = (0, import_react69.useCallback)(() => setPendingSites([]), []);
     const [terminalMsgs, setTerminalMsgs] = (0, import_react69.useState)("");
     const termRef = (0, import_react69.useRef)(null);
     const createDirInputRef = (0, import_react69.useRef)(null);
@@ -53466,11 +53510,11 @@ If there's a particular need for this, please submit a feature request at https:
           appendSetupLog(p.target, `${p.message}
 `);
         }
-        if (p && p.target) setPendingSite({ targetDir: p.target });
+        if (p && p.target) addPendingSite(p.target);
       });
       const unsubStat = window.api.subscribeSetupStatus((s) => {
         if (!s) return;
-        if (s.target) setPendingSite({ targetDir: s.target });
+        if (s.target && s.phase !== "done") addPendingSite(s.target);
         const key = s.sitePath || s.target;
         if (key) {
           const phaseLabel = s.phase ? `Status: ${s.phase}` : "Status update";
@@ -53481,7 +53525,7 @@ If there's a particular need for this, please submit a feature request at https:
         if (s.phase === "cloning") setDownloadPhase("Cloning repository\u2026");
         else if (s.phase === "done") {
           setDownloadPhase("");
-          setPendingSite(null);
+          clearPendingSites();
           setTerminalMsgs("");
         }
       });
@@ -53489,7 +53533,7 @@ If there's a particular need for this, please submit a feature request at https:
         unsubProg && unsubProg();
         unsubStat && unsubStat();
       };
-    }, [appendSetupLog]);
+    }, [addPendingSite, appendSetupLog, clearPendingSites]);
     const chooseAndSetup = (0, import_react69.useCallback)(() => {
       setCreateSiteName("");
       setCreateSiteDir("");
@@ -53580,13 +53624,13 @@ If there's a particular need for this, please submit a feature request at https:
         setCreateSubmitting(true);
         setCreateSiteError("");
         setTerminalMsgs("");
-        setPendingSite({ targetDir });
+        addPendingSite(targetDir);
         appendSetupLog(targetDir, "Starting site setup\u2026\n");
         const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
         if (createdPath) {
           finalSitePath = createdPath;
           if (createdPath !== targetDir) {
-            setPendingSite({ targetDir: createdPath });
+            addPendingSite(createdPath);
             moveSetupLog(targetDir, createdPath);
             setSites((prev2) => {
               const filtered = prev2.filter((path) => path !== targetDir);
@@ -53610,7 +53654,6 @@ If there's a particular need for this, please submit a feature request at https:
         setActiveSite(finalSitePath);
         appendSetupLog(finalSitePath, "Site setup request completed.\n");
       } catch (e) {
-        setPendingSite(null);
         setCreateSiteError(String(e));
         appendSetupLog(targetDir, `Setup failed: ${String(e)}
 `);
@@ -53622,9 +53665,10 @@ If there's a particular need for this, please submit a feature request at https:
           return next2;
         });
       } finally {
+        clearPendingSites();
         setCreateSubmitting(false);
       }
-    }, [appendSetupLog, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+    }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
     const closeCreateModal = (0, import_react69.useCallback)(() => {
       if (createSubmitting) return;
       setCreateModalOpen(false);
@@ -53872,7 +53916,7 @@ If there's a particular need for this, please submit a feature request at https:
           /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { ref: webLogRef, style: { marginTop: 8, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: webLogs })
         ] }) }) : null,
         /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { id: "sites", children: [
-          pendingSite && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(component_default8, { children: [
+          pendingSites.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(component_default8, { children: [
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontWeight: 600 }, children: "Setting up new site\u2026" }),
             downloadPhase && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontSize: 12, color: "#555", marginBottom: 6 }, children: downloadPhase }),
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { ref: termRef, style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: terminalMsgs })
@@ -53893,7 +53937,7 @@ If there's a particular need for this, please submit a feature request at https:
                   onForget,
                   onDelete,
                   onRename,
-                  isPending: Boolean(pendingSite && pendingSite.targetDir === s),
+                  isPending: pendingSites.includes(s),
                   setupLogs: setupLogsBySite[s] || ""
                 }
               )
@@ -53970,7 +54014,7 @@ If there's a particular need for this, please submit a feature request at https:
       ) : null
     ] });
   }
-  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = "" }) {
+  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = "" }) {
     const safeOnRename = onRename || (() => {
     });
     const [serverUrl, setServerUrl] = (0, import_react69.useState)("");
@@ -54673,27 +54717,34 @@ Try "help" for the list of supported commands.
         indicatorContent: "\u2013"
       }
     };
+    const stepState = (0, import_setup_steps.computeSetupStepState)({
+      isPending,
+      statusLoading,
+      hasNodeModules,
+      hasBuilt,
+      installing,
+      building,
+      starting
+    });
     const baseSteps = [
       {
         key: "download",
         label: "Download WordPress development version",
-        description: "Clone the WordPress develop repository.",
-        done: true,
-        ready: true
+        description: isPending ? "Cloning the WordPress develop repository\u2026 the next step unlocks when it finishes." : "Clone the WordPress develop repository.",
+        ...stepState.download
       },
       {
         key: "install",
         label: "Install npm dependencies",
         description: "Install npm packages so commands can run.",
-        done: hasNodeModules,
-        ready: true,
+        ...stepState.install,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
           {
             isBusy: installing,
             variant: hasNodeModules ? "secondary" : "primary",
             onClick: runInstallWithTerminal,
-            disabled: statusLoading || installing || hasNodeModules,
+            disabled: stepState.install.disabled,
             children: hasNodeModules ? "Dependencies installed" : "Install npm dependencies"
           }
         )
@@ -54702,15 +54753,14 @@ Try "help" for the list of supported commands.
         key: "build",
         label: "Run first full build",
         description: "Compile WordPress Core once to generate the initial dist files.",
-        done: hasBuilt,
-        ready: hasNodeModules,
+        ...stepState.build,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
           {
             isBusy: building,
             variant: hasBuilt ? "secondary" : "primary",
             onClick: () => runScript("build"),
-            disabled: statusLoading || building || !hasNodeModules || hasBuilt,
+            disabled: stepState.build.disabled,
             children: hasBuilt ? "First build complete" : "Run first full build"
           }
         )
@@ -54719,8 +54769,7 @@ Try "help" for the list of supported commands.
         key: "dev",
         label: "Start dev server & finish wizard",
         description: "Launch the development server once to complete the WordPress setup wizard.",
-        done: false,
-        ready: hasBuilt,
+        ...stepState.dev,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
             button_default,
@@ -54731,7 +54780,7 @@ Try "help" for the list of supported commands.
                 await markSkipWizard();
                 await toggleDevServer();
               },
-              disabled: statusLoading || starting || !hasBuilt,
+              disabled: stepState.dev.disabled,
               children: running ? "Stop dev server" : "Start dev server and finish the wizard"
             }
           ),

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -16,6 +16,7 @@ import { plus, chevronLeft, chevronRight, copy as copyIcon, check as checkIcon, 
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
+import { computeSetupStepState } from './setup-steps.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
@@ -41,7 +42,15 @@ function useSites() {
 function App() {
   const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
   const [downloadPhase, setDownloadPhase] = useState('');
-  const [pendingSite, setPendingSite] = useState(null);
+  // Directories whose clone is still running. An array rather than a single
+  // path because the main process may settle on a different (deduplicated)
+  // directory than the one the renderer optimistically created a row for.
+  const [pendingSites, setPendingSites] = useState([]);
+  const addPendingSite = useCallback((dir) => {
+    if (!dir) return;
+    setPendingSites((prev) => (prev.includes(dir) ? prev : [...prev, dir]));
+  }, []);
+  const clearPendingSites = useCallback(() => setPendingSites([]), []);
   const [terminalMsgs, setTerminalMsgs] = useState('');
   const termRef = useRef(null);
   const createDirInputRef = useRef(null);
@@ -150,11 +159,11 @@ function App() {
         setTerminalMsgs((v) => v + p.message + '\n');
         appendSetupLog(p.target, `${p.message}\n`);
       }
-      if (p && p.target) setPendingSite({ targetDir: p.target });
+      if (p && p.target) addPendingSite(p.target);
     });
     const unsubStat = window.api.subscribeSetupStatus((s) => {
       if (!s) return;
-      if (s.target) setPendingSite({ targetDir: s.target });
+      if (s.target && s.phase !== 'done') addPendingSite(s.target);
       const key = s.sitePath || s.target;
       if (key) {
         const phaseLabel = s.phase ? `Status: ${s.phase}` : 'Status update';
@@ -162,10 +171,10 @@ function App() {
         if (s.phase === 'done') appendSetupLog(key, 'Setup finished.\n');
       }
       if (s.phase === 'cloning') setDownloadPhase('Cloning repository…');
-      else if (s.phase === 'done') { setDownloadPhase(''); setPendingSite(null); setTerminalMsgs(''); }
+      else if (s.phase === 'done') { setDownloadPhase(''); clearPendingSites(); setTerminalMsgs(''); }
     });
     return () => { unsubProg && unsubProg(); unsubStat && unsubStat(); };
-  }, [appendSetupLog]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites]);
 
   const chooseAndSetup = useCallback(() => {
     setCreateSiteName('');
@@ -274,13 +283,13 @@ function App() {
       setCreateSubmitting(true);
       setCreateSiteError('');
       setTerminalMsgs('');
-      setPendingSite({ targetDir });
+      addPendingSite(targetDir);
       appendSetupLog(targetDir, 'Starting site setup…\n');
       const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
       if (createdPath) {
         finalSitePath = createdPath;
         if (createdPath !== targetDir) {
-          setPendingSite({ targetDir: createdPath });
+          addPendingSite(createdPath);
           moveSetupLog(targetDir, createdPath);
           setSites((prev) => {
             const filtered = prev.filter((path) => path !== targetDir);
@@ -304,7 +313,6 @@ function App() {
       setActiveSite(finalSitePath);
       appendSetupLog(finalSitePath, 'Site setup request completed.\n');
     } catch (e) {
-      setPendingSite(null);
       setCreateSiteError(String(e));
       appendSetupLog(targetDir, `Setup failed: ${String(e)}\n`);
       setSites((prev) => prev.filter((path) => path !== targetDir));
@@ -315,9 +323,13 @@ function App() {
         return next;
       });
     } finally {
+      // `setupWordPress` resolving (or throwing) *is* the clone finishing, so
+      // clearing here guarantees the checklist can never stay locked even if
+      // the `done` status event is missed.
+      clearPendingSites();
       setCreateSubmitting(false);
     }
-  }, [appendSetupLog, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
 
   const closeCreateModal = useCallback(() => {
     if (createSubmitting) return;
@@ -579,7 +591,7 @@ function App() {
             ) : null}
 
             <div id="sites">
-              {pendingSite && (
+              {pendingSites.length > 0 && (
                 <Card style={{ marginBottom: 24 }}>
                   <CardBody>
                     <div style={{ fontWeight: 600 }}>Setting up new site…</div>
@@ -605,7 +617,7 @@ function App() {
                       onForget={onForget}
                       onDelete={onDelete}
                       onRename={onRename}
-                      isPending={Boolean(pendingSite && pendingSite.targetDir === s)}
+                      isPending={pendingSites.includes(s)}
                       setupLogs={setupLogsBySite[s] || ''}
                     />
                   </div>
@@ -683,7 +695,7 @@ function App() {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = '' }) {
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = '' }) {
   const safeOnRename = onRename || (() => {});
   // state
   const [serverUrl, setServerUrl] = useState('');
@@ -1366,26 +1378,36 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     }
   };
 
+  const stepState = computeSetupStepState({
+    isPending,
+    statusLoading,
+    hasNodeModules,
+    hasBuilt,
+    installing,
+    building,
+    starting
+  });
+
   const baseSteps = [
     {
       key: 'download',
       label: 'Download WordPress development version',
-      description: 'Clone the WordPress develop repository.',
-      done: true,
-      ready: true
+      description: isPending
+        ? 'Cloning the WordPress develop repository… the next step unlocks when it finishes.'
+        : 'Clone the WordPress develop repository.',
+      ...stepState.download
     },
     {
       key: 'install',
       label: 'Install npm dependencies',
       description: 'Install npm packages so commands can run.',
-      done: hasNodeModules,
-      ready: true,
+      ...stepState.install,
       action: (
         <Button
           isBusy={installing}
           variant={hasNodeModules ? 'secondary' : 'primary'}
           onClick={runInstallWithTerminal}
-          disabled={statusLoading || installing || hasNodeModules}
+          disabled={stepState.install.disabled}
         >{hasNodeModules ? 'Dependencies installed' : 'Install npm dependencies'}</Button>
       )
     },
@@ -1393,14 +1415,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       key: 'build',
       label: 'Run first full build',
       description: 'Compile WordPress Core once to generate the initial dist files.',
-      done: hasBuilt,
-      ready: hasNodeModules,
+      ...stepState.build,
       action: (
         <Button
           isBusy={building}
           variant={hasBuilt ? 'secondary' : 'primary'}
           onClick={()=>runScript('build')}
-          disabled={statusLoading || building || (!hasNodeModules) || hasBuilt}
+          disabled={stepState.build.disabled}
         >{hasBuilt ? 'First build complete' : 'Run first full build'}</Button>
       )
     },
@@ -1408,8 +1429,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       key: 'dev',
       label: 'Start dev server & finish wizard',
       description: 'Launch the development server once to complete the WordPress setup wizard.',
-      done: false,
-      ready: hasBuilt,
+      ...stepState.dev,
       action: (
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Button
@@ -1419,7 +1439,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               await markSkipWizard();
               await toggleDevServer();
             }}
-            disabled={statusLoading || starting || (!hasBuilt)}
+            disabled={stepState.dev.disabled}
           >{running ? 'Stop dev server' : 'Start dev server and finish the wizard'}</Button>
           {starting || serverUrl ? (
             <span style={{ fontSize: 12 }}>

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Derives the done/ready/disabled state of every step in the site setup
+ * checklist.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly.
+ *
+ * `isPending` means the `wordpress-develop` clone for this site is still
+ * running, so nothing that touches the working tree may be offered yet.
+ */
+function computeSetupStepState(flags = {}) {
+	const isPending = Boolean(flags.isPending);
+	const statusLoading = Boolean(flags.statusLoading);
+	const hasNodeModules = Boolean(flags.hasNodeModules);
+	const hasBuilt = Boolean(flags.hasBuilt);
+	const installing = Boolean(flags.installing);
+	const building = Boolean(flags.building);
+	const starting = Boolean(flags.starting);
+
+	return {
+		download: {
+			done: !isPending,
+			ready: true
+		},
+		install: {
+			done: hasNodeModules,
+			ready: !isPending,
+			disabled: isPending || statusLoading || installing || hasNodeModules
+		},
+		build: {
+			done: hasBuilt,
+			ready: hasNodeModules,
+			disabled: statusLoading || building || !hasNodeModules || hasBuilt
+		},
+		dev: {
+			done: false,
+			ready: hasBuilt,
+			disabled: statusLoading || starting || !hasBuilt
+		}
+	};
+}
+
+module.exports = { computeSetupStepState };

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { computeSetupStepState } = require('../src/renderer/setup-steps.cjs');
+
+test('while the clone is still running, the install step is locked (issue #47)', () => {
+	const steps = computeSetupStepState({ isPending: true });
+
+	assert.strictEqual(steps.download.done, false, 'download must not read as complete mid-clone');
+	assert.strictEqual(steps.install.ready, false, 'install must stay locked mid-clone');
+	assert.strictEqual(steps.install.disabled, true, 'install button must be disabled mid-clone');
+});
+
+test('a pending clone never unlocks the later steps', () => {
+	const steps = computeSetupStepState({ isPending: true, hasNodeModules: true, hasBuilt: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+	assert.strictEqual(steps.download.done, false);
+});
+
+test('once the clone finishes the install step becomes actionable', () => {
+	const steps = computeSetupStepState({ isPending: false });
+
+	assert.strictEqual(steps.download.done, true);
+	assert.strictEqual(steps.install.ready, true);
+	assert.strictEqual(steps.install.disabled, false);
+});
+
+test('the status probe still gates the install button', () => {
+	const steps = computeSetupStepState({ statusLoading: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+});
+
+test('an install in flight disables its own button', () => {
+	const steps = computeSetupStepState({ installing: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+	assert.strictEqual(steps.install.done, false);
+});
+
+test('installed dependencies complete the install step and unlock the build', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true });
+
+	assert.strictEqual(steps.install.done, true);
+	assert.strictEqual(steps.install.disabled, true, 'nothing left to install');
+	assert.strictEqual(steps.build.ready, true);
+	assert.strictEqual(steps.build.disabled, false);
+});
+
+test('the build stays locked without node_modules', () => {
+	const steps = computeSetupStepState({});
+
+	assert.strictEqual(steps.build.ready, false);
+	assert.strictEqual(steps.build.disabled, true);
+});
+
+test('a finished build completes its step and unlocks the dev server', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true });
+
+	assert.strictEqual(steps.build.done, true);
+	assert.strictEqual(steps.build.disabled, true, 'nothing left to build');
+	assert.strictEqual(steps.dev.ready, true);
+	assert.strictEqual(steps.dev.disabled, false);
+});
+
+test('the dev step is never marked done by the checklist', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true, starting: true });
+
+	assert.strictEqual(steps.dev.done, false);
+	assert.strictEqual(steps.dev.disabled, true, 'disabled while starting');
+});


### PR DESCRIPTION
> **Stack — 2 of 5** · `trunk` → #50 → **#51** → #52 → #56 → #58
> The diff below is only this PR's own changes. All five were verified together end to end on a Windows VM: clone → install → build → dev server → WordPress wizard → wp-admin.

Fixes #47

## Problem

The site detail view renders as soon as a site is created — **before** `git.clone` of `wordpress-develop` has finished. The checklist showed step 1 ("Download WordPress development version") as already complete and left step 2 ("Install npm dependencies") enabled, so `npm install` could run against a half-cloned working tree and break the setup.

Easiest to hit on Windows because the clone takes longer, but the bug is in the renderer and is cross-platform.

## Fix

While the clone runs, step 1 shows as *current* ("Cloning the WordPress develop repository…") and step 2 renders *locked* with a disabled button.

The signal already existed and was silently dropped: `App` passed `isPending` to `SiteRow`, and `SiteRow` never declared the prop.

## How to test

Run the app from this branch: `npm install && npm start`

1. Click **Create WordPress Core site**, give it a name and a location, submit.
2. **Immediately** — while the clone is still running — look at the checklist:
   - step 1 is *current*, described as "Cloning the WordPress develop repository…"
   - step 2 is *locked* and its button is disabled, so it cannot be clicked
3. Wait for the clone to finish. Step 1 flips to *completed* and step 2's button becomes enabled.
4. Regression check: open a site that was already set up. Its checklist behaves exactly as before — install/build/dev buttons gated only by whether `node_modules` and `build/` exist.

To see the bug this fixes, run the same steps on `trunk`: step 2 is clickable from the first frame, and clicking it during the clone breaks the setup.

Automated: `npm test` (9 new cases covering the full step-state truth table).


<details>
<summary><b>Changes</b></summary>

- **`src/renderer/setup-steps.cjs` (new)** — pure, dependency-free `computeSetupStepState({ isPending, statusLoading, hasNodeModules, hasBuilt, installing, building, starting })` returning `done` / `ready` / `disabled` for the four checklist steps. Extracted so the gating logic can be unit tested without a DOM (the repo has no React test setup); the renderer bundle imports it, `node --test` requires it directly.
- **`src/renderer/index.jsx`** — `SiteRow` accepts `isPending`; all four steps take their state from the helper.
- **Pending state made robust** — `pendingSite` becomes `pendingSites` (array), because on a directory-name collision the main process settles on a different dir than the renderer's optimistic one and the single-value compare missed the row. It is now also cleared in `handleCreateSiteSubmit`'s `finally` — `setupWordPress` resolving *is* the clone finishing — so the button cannot get stuck disabled if the `done` status event is missed.
- **`test/setup-steps.test.cjs` (new)** — 9 cases, including the regression itself and the unchanged truth table for the build/dev buttons.
- `src/renderer/index.js` regenerated with `npm run build:once` (committed esbuild artifact).

</details>
