### PR TITLE
Fix "Run first full build": no output in the terminal and flashing Windows consoles

### DIFF
--- a/src/hide-child-windows.js
+++ b/src/hide-child-windows.js
@@ -1,0 +1,74 @@
+// Keeps Windows from flashing a console window for every grandchild process.
+//
+// electron.exe is a GUI-subsystem binary, so the runners we spawn from main.js
+// have no console of their own — `windowsHide: true` there only stops Windows
+// from showing one, it doesn't create one to inherit. When npm's run-script
+// then spawns `cmd.exe /d /s /c "grunt build"` (and cmd in turn runs the
+// grunt.cmd shim), each of those console applications finds nothing to inherit
+// and Windows allocates a brand new *visible* console for it.
+//
+// The runners load npm's CLI in-process, so patching child_process here — before
+// requiring that CLI — reaches those spawns. `windowsHide: true` maps to
+// CREATE_NO_WINDOW, which gives cmd.exe a console that is never displayed and
+// which its own descendants inherit, so one patch covers the whole subtree.
+
+const PATCHED = Symbol.for('wp-dev-env.windowsHidePatched');
+
+const METHODS = [
+	'spawn',
+	'spawnSync',
+	'exec',
+	'execSync',
+	'execFile',
+	'execFileSync',
+	'fork'
+];
+
+function isPlainObject(value) {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// These functions have incompatible signatures — spawn(cmd, args, opts),
+// exec(cmd, opts, cb), execFile(file, args, opts, cb) — so instead of special
+// casing each one we find the options object positionally: it is the last
+// argument that is a plain object, ignoring any trailing callback. spawn's
+// `args` is an array, so it is never mistaken for options.
+function withWindowsHide(args) {
+	const next = args.slice();
+	let index = next.length - 1;
+	while (index >= 0 && typeof next[index] === 'function') index -= 1;
+
+	if (index >= 0 && isPlainObject(next[index])) {
+		next[index] = { ...next[index], windowsHide: true };
+		return next;
+	}
+
+	next.splice(index + 1, 0, { windowsHide: true });
+	return next;
+}
+
+// Forces `windowsHide: true` on every child_process entry point of `cp`.
+// A no-op off Windows, and idempotent so requiring this twice can't double-wrap.
+function patchChildProcess(cp, platform = process.platform) {
+	if (platform !== 'win32') return cp;
+	if (cp[PATCHED]) return cp;
+
+	for (const name of METHODS) {
+		const original = cp[name];
+		if (typeof original !== 'function') continue;
+		cp[name] = function patched(...args) {
+			return original.apply(this, withWindowsHide(args));
+		};
+	}
+
+	Object.defineProperty(cp, PATCHED, { value: true, enumerable: false });
+	return cp;
+}
+
+// Patches the live child_process module for this process and everything it
+// requires afterwards.
+function hideChildWindows() {
+	return patchChildProcess(require('child_process'));
+}
+
+module.exports = { patchChildProcess, hideChildWindows, withWindowsHide };

--- a/src/install-runner.js
+++ b/src/install-runner.js
@@ -2,6 +2,10 @@
 // It programmatically executes npm install without using a shell.
 
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before npm's CLI is required — install scripts spawn cmd.exe too.
+hideChildWindows();
 
 async function main() {
 	const targetDir = process.argv[2];

--- a/src/main.js
+++ b/src/main.js
@@ -536,6 +536,21 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		});
 		register(child);
 
+		// A failed spawn (ENOENT/EPERM — most likely on Windows) emits 'error'
+		// and may never emit 'close'. Without this the renderer never receives a
+		// :done event and the UI stays stuck "installing"/"building" forever.
+		let finished = false;
+		const finish = (code) => {
+			if (finished) return;
+			finished = true;
+			onDone(code);
+		};
+
+		child.on('error', (err) => {
+			onLog('stderr', `\nFailed to start: ${err && err.message ? err.message : String(err)}\n`);
+			finish(-1);
+		});
+
 		const detector = createEngineMismatchDetector();
 		const forward = (stream, type) => {
 			stream.on('data', (data) => {
@@ -548,6 +563,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		forward(child.stderr, 'stderr');
 
 		child.on('close', (code, signal) => {
+			if (finished) return;
 			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
@@ -556,11 +572,12 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 				cancelled: cancelledChildren.has(child)
 			});
 			if (retry) {
+				finished = true;
 				onLog('stdout', ENGINE_RETRY_NOTICE);
 				start(true);
 				return;
 			}
-			onDone(code);
+			finish(code);
 		});
 	};
 	start(false);

--- a/src/playground-web-runner.js
+++ b/src/playground-web-runner.js
@@ -1,4 +1,9 @@
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before the Playground CLI is required, so anything it spawns is
+// covered too.
+hideChildWindows();
 
 async function main() {
     const hostMountDir = process.argv[2];

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -54219,6 +54219,16 @@ Failed to start npm run ${name}: ${error && error.message ? error.message : Stri
         }
       });
     }, [runInstall, writeToTerminal]);
+    const runBuildWithTerminal = (0, import_react69.useCallback)(() => {
+      writeToTerminal("Running npm run build\u2026\n");
+      runScript("build", {
+        onLog: (chunk) => writeToTerminal(chunk),
+        onDone: ({ code }) => {
+          writeToTerminal(`npm run build exited with code ${code}
+`);
+        }
+      });
+    }, [runScript, writeToTerminal]);
     const showPrompt = (0, import_react69.useCallback)((prependNewLine = true) => {
       const term = terminalRef.current;
       if (!term) return;
@@ -54709,7 +54719,7 @@ Try "help" for the list of supported commands.
           {
             isBusy: building,
             variant: hasBuilt ? "secondary" : "primary",
-            onClick: () => runScript("build"),
+            onClick: runBuildWithTerminal,
             disabled: statusLoading || building || !hasNodeModules || hasBuilt,
             children: hasBuilt ? "First build complete" : "Run first full build"
           }

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -932,6 +932,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     });
   }, [runInstall, writeToTerminal]);
 
+  const runBuildWithTerminal = useCallback(() => {
+    writeToTerminal('Running npm run build…\n');
+    runScript('build', {
+      onLog: (chunk) => writeToTerminal(chunk),
+      onDone: ({ code }) => {
+        writeToTerminal(`npm run build exited with code ${code}\n`);
+      }
+    });
+  }, [runScript, writeToTerminal]);
+
   const showPrompt = useCallback((prependNewLine = true) => {
     const term = terminalRef.current;
     if (!term) return;
@@ -1399,7 +1409,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
         <Button
           isBusy={building}
           variant={hasBuilt ? 'secondary' : 'primary'}
-          onClick={()=>runScript('build')}
+          onClick={runBuildWithTerminal}
           disabled={statusLoading || building || (!hasNodeModules) || hasBuilt}
         >{hasBuilt ? 'First build complete' : 'Run first full build'}</Button>
       )

--- a/src/script-runner.js
+++ b/src/script-runner.js
@@ -1,4 +1,9 @@
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before npm's CLI is required: it is what spawns cmd.exe for the
+// script body, and those spawns would otherwise pop up console windows.
+hideChildWindows();
 
 async function main() {
 	const targetDir = process.argv[2];

--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -1,5 +1,11 @@
 const path = require('path');
 const fs = require('fs');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before the Playground CLI is required, so anything it spawns is
+// covered too.
+hideChildWindows();
+
 const { writeFiles: playgroundWriteFiles } = require('@php-wasm/universal');
 
 async function main() {

--- a/test/hide-child-windows.test.cjs
+++ b/test/hide-child-windows.test.cjs
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { patchChildProcess } = require('../src/hide-child-windows.js');
+
+// A stand-in for the child_process module that records what it was called with,
+// so the patch can be exercised without actually spawning anything.
+function fakeChildProcess() {
+	const calls = [];
+	const record = (name) => (...args) => {
+		calls.push({ name, args });
+		return name;
+	};
+	return {
+		calls,
+		spawn: record('spawn'),
+		spawnSync: record('spawnSync'),
+		exec: record('exec'),
+		execSync: record('execSync'),
+		execFile: record('execFile'),
+		execFileSync: record('execFileSync'),
+		fork: record('fork')
+	};
+}
+
+test('leaves child_process untouched off Windows', () => {
+	// Forcing windowsHide elsewhere is pointless and would be a silent behaviour
+	// change on the platforms where the flashes never happened.
+	const cp = fakeChildProcess();
+	const originalSpawn = cp.spawn;
+	patchChildProcess(cp, 'darwin');
+	assert.equal(cp.spawn, originalSpawn);
+	cp.spawn('cmd', ['/c', 'x']);
+	assert.deepEqual(cp.calls[0].args, ['cmd', ['/c', 'x']]);
+});
+
+test('appends an options object when the caller passed none', () => {
+	// npm spawns cmd.exe as spawn(cmd, args) with no options in some paths, so
+	// the options object has to be created rather than only amended.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	cp.spawn('cmd', ['/d', '/s', '/c', 'grunt build']);
+	assert.deepEqual(cp.calls[0].args, [
+		'cmd',
+		['/d', '/s', '/c', 'grunt build'],
+		{ windowsHide: true }
+	]);
+});
+
+test("preserves the caller's other options and overrides windowsHide: false", () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const options = { cwd: 'C:\\site', windowsHide: false, stdio: 'pipe' };
+	cp.spawn('cmd', ['/c', 'x'], options);
+	assert.deepEqual(cp.calls[0].args[2], {
+		cwd: 'C:\\site',
+		windowsHide: true,
+		stdio: 'pipe'
+	});
+	// The caller's object must not be mutated — npm reuses option objects.
+	assert.equal(options.windowsHide, false);
+});
+
+test('inserts options before a trailing callback', () => {
+	// exec(cmd, cb) and execFile(file, args, cb) put the callback last; appending
+	// options at the end would make Node treat the callback as options.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const cb = () => {};
+
+	cp.exec('grunt build', cb);
+	assert.deepEqual(cp.calls[0].args, ['grunt build', { windowsHide: true }, cb]);
+
+	cp.execFile('grunt.cmd', ['build'], cb);
+	assert.deepEqual(cp.calls[1].args, ['grunt.cmd', ['build'], { windowsHide: true }, cb]);
+
+	cp.exec('grunt build', { cwd: 'C:\\site' }, cb);
+	assert.deepEqual(cp.calls[2].args, ['grunt build', { cwd: 'C:\\site', windowsHide: true }, cb]);
+});
+
+test('patches every child_process entry point', () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	for (const name of ['spawn', 'spawnSync', 'exec', 'execSync', 'execFile', 'execFileSync', 'fork']) {
+		cp[name]('x');
+	}
+	for (const call of cp.calls) {
+		const last = call.args[call.args.length - 1];
+		assert.equal(last.windowsHide, true, `${call.name} was not patched`);
+	}
+});
+
+test('passes the underlying return value through', () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	assert.equal(cp.spawn('cmd'), 'spawn');
+});
+
+test('patching twice does not wrap twice', () => {
+	// The runners require this module once each, but a double-require must not
+	// stack wrappers or the options object would be cloned repeatedly.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const patchedSpawn = cp.spawn;
+	patchChildProcess(cp, 'win32');
+	assert.equal(cp.spawn, patchedSpawn);
+	cp.spawn('cmd', ['/c', 'x']);
+	assert.equal(cp.calls[0].args.length, 3);
+});


### PR DESCRIPTION
> **Stack — 3 of 5** · `trunk` → #50 → #51 → **#52** → #56 → #58
> The diff below is only this PR's own changes. All five were verified together end to end on a Windows VM: clone → install → build → dev server → WordPress wizard → wp-admin.

Fixes #48.

## Problem

Clicking **Run first full build** produced no output at all in the app's terminal. On Windows it also flashed black console windows on and off the screen.

## Fix

Two independent defects:

1. **No output (all platforms).** The checklist button never sent the build's output anywhere that gets rendered. It now streams into the terminal, exactly like `npm install` already did.
2. **Flashing console windows (Windows only).** Every child process in the chain was allocating its own visible console. New `src/hide-child-windows.js` gives them a hidden one that the whole subtree inherits.

## How to test

Needs a site with dependencies already installed. The console-window half is Windows-only — for that, use a packaged build from this branch.

1. Click **Run first full build**.
2. **Output:** grunt's output appears in the Terminal panel *live*, task by task (`Running "clean:files" (clean) task`, `>> 5645 paths cleaned.`, …), not at the end and not nowhere.
3. **Ctrl+C** in the terminal stops the build and returns the prompt.
4. **Windows only:** watch the screen for the whole build. No black console window should appear at any point — not even a flash. On `trunk` they flash repeatedly.
5. Let it finish: the terminal prints the exit code and step 3 flips to *completed*.

To see the bug, run step 1 on `trunk`: the terminal stays empty for the entire build.

Automated: `npm test` (7 new cases in `test/hide-child-windows.test.cjs`).


<details>
<summary><b>1 — Why no output appeared</b></summary>

The checklist button called `runScript('build')` with no `onLog`/`onDone`, so output only reached `appendNpm` → `npmLogs` — a state value that is never rendered, since `npmRef` is never attached to a DOM node. Now it goes through `writeToTerminal`, exactly like `runInstallWithTerminal`, the `npm run <script>` terminal command, and the dev-server `watch` already do.

</details>

<details>
<summary><b>2 — Why Windows opened a console for every child</b></summary>

`electron.exe` is a GUI-subsystem binary, so the runners spawned from `main.js` have no console of their own — `windowsHide: true` there has nothing to inherit. When npm's run-script then spawns `cmd.exe /d /s /c "grunt build"` (and cmd runs the `grunt.cmd` shim), Windows allocates a new **visible** console for each.

The runners load npm's CLI in-process, so `src/hide-child-windows.js` patches `child_process` before that require. `windowsHide: true` maps to `CREATE_NO_WINDOW`, which gives `cmd.exe` a console that is never displayed and that its descendants inherit, so one patch covers the whole subtree. Applied to the script, install, server and playground-web runners; a no-op off Windows.

</details>

<details>
<summary><b>Scope change from stacking: the spawn-error guard now comes from #50</b></summary>

This PR originally carried a third fix — neither `npm:install` nor `npm:run-script` listened for `'error'` on the child, so a spawn that failed outright (ENOENT/EPERM) could leave the button busy forever.

Stacking on #50 revealed that it had grown its own guard for the same failure: this PR had `finished` / `finish()`, #50 has `settled` / `settle()`. #50's is the better one and it won — it defers by a turn so `close` (the path that knows about the engines retry) wins whenever it does arrive, and it guards the retry with `!settled` so a run the caller already considers over cannot be restarted behind its back. The duplicate here was removed.

What was kept from this PR is the part #50 didn't have: the `onLog('stderr', 'Failed to start: …')` line. #50 only wrote the failure to the log file; the person who just clicked the button needs to see it in the terminal too.

</details>
