### PR TITLE
[DO NOT MERGE] Windows fixes integration branch (#50 + #51 + #52 + #56 + #58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@wp-playground/cli": "^3.0.8",
         "@xterm/xterm": "^5.5.0",
         "diff": "^5.2.0",
+        "electron-log": "^5.4.4",
         "electron-store": "^10.0.1",
         "extract-zip": "^2.0.1",
         "fs-extra": "^11.2.0",
@@ -5138,6 +5139,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@wp-playground/cli": "^3.0.8",
     "@xterm/xterm": "^5.5.0",
     "diff": "^5.2.0",
+    "electron-log": "^5.4.4",
     "electron-store": "^10.0.1",
     "extract-zip": "^2.0.1",
     "fs-extra": "^11.2.0",

--- a/src/hide-child-windows.js
+++ b/src/hide-child-windows.js
@@ -1,0 +1,74 @@
+// Keeps Windows from flashing a console window for every grandchild process.
+//
+// electron.exe is a GUI-subsystem binary, so the runners we spawn from main.js
+// have no console of their own — `windowsHide: true` there only stops Windows
+// from showing one, it doesn't create one to inherit. When npm's run-script
+// then spawns `cmd.exe /d /s /c "grunt build"` (and cmd in turn runs the
+// grunt.cmd shim), each of those console applications finds nothing to inherit
+// and Windows allocates a brand new *visible* console for it.
+//
+// The runners load npm's CLI in-process, so patching child_process here — before
+// requiring that CLI — reaches those spawns. `windowsHide: true` maps to
+// CREATE_NO_WINDOW, which gives cmd.exe a console that is never displayed and
+// which its own descendants inherit, so one patch covers the whole subtree.
+
+const PATCHED = Symbol.for('wp-dev-env.windowsHidePatched');
+
+const METHODS = [
+	'spawn',
+	'spawnSync',
+	'exec',
+	'execSync',
+	'execFile',
+	'execFileSync',
+	'fork'
+];
+
+function isPlainObject(value) {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// These functions have incompatible signatures — spawn(cmd, args, opts),
+// exec(cmd, opts, cb), execFile(file, args, opts, cb) — so instead of special
+// casing each one we find the options object positionally: it is the last
+// argument that is a plain object, ignoring any trailing callback. spawn's
+// `args` is an array, so it is never mistaken for options.
+function withWindowsHide(args) {
+	const next = args.slice();
+	let index = next.length - 1;
+	while (index >= 0 && typeof next[index] === 'function') index -= 1;
+
+	if (index >= 0 && isPlainObject(next[index])) {
+		next[index] = { ...next[index], windowsHide: true };
+		return next;
+	}
+
+	next.splice(index + 1, 0, { windowsHide: true });
+	return next;
+}
+
+// Forces `windowsHide: true` on every child_process entry point of `cp`.
+// A no-op off Windows, and idempotent so requiring this twice can't double-wrap.
+function patchChildProcess(cp, platform = process.platform) {
+	if (platform !== 'win32') return cp;
+	if (cp[PATCHED]) return cp;
+
+	for (const name of METHODS) {
+		const original = cp[name];
+		if (typeof original !== 'function') continue;
+		cp[name] = function patched(...args) {
+			return original.apply(this, withWindowsHide(args));
+		};
+	}
+
+	Object.defineProperty(cp, PATCHED, { value: true, enumerable: false });
+	return cp;
+}
+
+// Patches the live child_process module for this process and everything it
+// requires afterwards.
+function hideChildWindows() {
+	return patchChildProcess(require('child_process'));
+}
+
+module.exports = { patchChildProcess, hideChildWindows, withWindowsHide };

--- a/src/install-runner.js
+++ b/src/install-runner.js
@@ -2,6 +2,10 @@
 // It programmatically executes npm install without using a shell.
 
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before npm's CLI is required — install scripts spawn cmd.exe too.
+hideChildWindows();
 
 async function main() {
 	const targetDir = process.argv[2];

--- a/src/log-lines.js
+++ b/src/log-lines.js
@@ -1,0 +1,34 @@
+// Reassembles child-process stream chunks into whole lines for the app log.
+// Deliberately free of Electron imports so it can be unit-tested.
+
+// Child stdout/stderr arrives in arbitrary chunks: a single npm message can be
+// split across two reads, and one read can carry a dozen messages. Logging the
+// chunks verbatim would stamp a timestamp mid-sentence and interleave the two
+// streams mid-word, which is exactly what makes a log unreadable at the moment
+// someone needs it. Buffering to line boundaries costs one partial line of
+// latency and is why `flush` exists — the last line before a process exits
+// usually has no trailing newline, and it is often the interesting one.
+function createLineBuffer() {
+	let pending = '';
+	return {
+		// Returns the complete lines contained in `chunk`, retaining any partial
+		// trailing line for the next call.
+		push(chunk) {
+			pending += String(chunk ?? '');
+			// A trailing \n yields a final '' element, which is dropped as the new
+			// pending — so a chunk ending exactly on a boundary leaves nothing behind.
+			const parts = pending.split('\n');
+			pending = parts.pop();
+			// \r\n from Windows child processes would otherwise show as a stray CR.
+			return parts.map((line) => line.replace(/\r$/, ''));
+		},
+		// The unterminated remainder, if any. Call once when the stream closes.
+		flush() {
+			const rest = pending.replace(/\r$/, '');
+			pending = '';
+			return rest ? [rest] : [];
+		}
+	};
+}
+
+module.exports = { createLineBuffer };

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,0 +1,127 @@
+// The app's on-disk log. This is the only module that touches electron-log, so
+// the rest of the codebase depends on these four functions rather than on the
+// library.
+//
+// Why a file at all: in a packaged GUI build the main process has no terminal,
+// so every console.* call and every byte of child-process stdout/stderr goes
+// nowhere. Child output is forwarded to the renderer over IPC, which means a
+// spawn that fails before producing output — or a renderer that never renders
+// what it received — leaves no trace whatsoever. "Nothing happened" and "the
+// spawn failed with EPERM" then look identical, and there is nothing to attach
+// to a bug report.
+
+const path = require('path');
+const { app } = require('electron');
+const log = require('electron-log/main');
+const { createLineBuffer } = require('./log-lines');
+
+// Rotated to main.old.log past this size, so an app left running through many
+// npm installs cannot grow the file without bound.
+const MAX_LOG_SIZE = 5 * 1024 * 1024;
+
+let initialized = false;
+
+function initLogging() {
+	if (initialized) return;
+	initialized = true;
+
+	// Must run before the first BrowserWindow is constructed: this preloads the
+	// IPC bridge that lets renderer output reach this file. Called later it
+	// silently does nothing for windows that already exist. spyRendererConsole
+	// is what captures the renderer's own console.* — the blind spot behind the
+	// class of bug where the main process is fine and the UI simply never shows
+	// what it was sent.
+	log.initialize({ spyRendererConsole: true });
+
+	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), 'main.log');
+	log.transports.file.maxSize = MAX_LOG_SIZE;
+
+	// Redirects the existing console.* calls throughout the main process into
+	// the log without editing their call sites. They keep printing to stdout in
+	// development via the console transport.
+	Object.assign(console, log.functions);
+
+	// There were no uncaughtException/unhandledRejection handlers at all, so a
+	// main-process crash previously produced an empty log — the exact moment the
+	// log is most wanted. showDialog is off deliberately: at a Contributor Day a
+	// modal error box derails the session, and the stack is in the file anyway.
+	log.errorHandler.startCatching({ showDialog: false });
+
+	writeHeader();
+}
+
+// A version/platform block at the top of each run. Nearly every bug report needs
+// it and nearly no reporter thinks to include it; asking for the log file should
+// be enough on its own.
+function writeHeader() {
+	const scoped = log.scope('app');
+	scoped.info('--- session start ---');
+	scoped.info(`app ${app.getVersion()} (${app.getName()})`);
+	scoped.info(`electron ${process.versions.electron} · node ${process.versions.node} · chrome ${process.versions.chrome}`);
+	scoped.info(`platform ${process.platform} ${process.arch} · ${process.env.NODE_ENV || 'production'}`);
+	scoped.info(`log file ${getLogFilePath()}`);
+}
+
+// Absolute path to the current log file, for the Help menu entries. Resolving it
+// through the transport rather than recomputing it keeps the menu honest if the
+// path logic ever changes.
+function getLogFilePath() {
+	return log.transports.file.getFile().path;
+}
+
+// One line buffer per (scope, stream). Chunks arrive mid-line, so writing them
+// raw would fragment single messages across timestamped entries.
+const buffers = new Map();
+
+function bufferFor(scope, type) {
+	const key = `${scope}:${type}`;
+	if (!buffers.has(key)) buffers.set(key, createLineBuffer());
+	return buffers.get(key);
+}
+
+// Mirrors a chunk of child-process output into the log. Callers keep sending the
+// same chunk to the renderer over IPC as before — this is an addition, never a
+// replacement, so the UI is unaffected.
+function logChildOutput(scope, type, chunk) {
+	const scoped = log.scope(scope);
+	const write = type === 'stderr' ? scoped.warn : scoped.info;
+	for (const line of bufferFor(scope, type).push(chunk)) {
+		write(line);
+	}
+}
+
+// Call when the child closes, to emit any line it left unterminated and drop the
+// buffers — scopes are keyed by site path or run id and would otherwise
+// accumulate for the lifetime of the app.
+function flushChildOutput(scope) {
+	const scoped = log.scope(scope);
+	for (const type of ['stdout', 'stderr']) {
+		const key = `${scope}:${type}`;
+		const buf = buffers.get(key);
+		if (!buf) continue;
+		for (const line of buf.flush()) {
+			(type === 'stderr' ? scoped.warn : scoped.info)(line);
+		}
+		buffers.delete(key);
+	}
+}
+
+// Structured events around a child process: the spawn itself and its exit code.
+// These matter more than the output — a spawn that dies immediately (EPERM on
+// Windows) produces no stdout at all, and that silence is the bug.
+function logEvent(scope, message) {
+	log.scope(scope).info(message);
+}
+
+function logError(scope, message) {
+	log.scope(scope).error(message);
+}
+
+module.exports = {
+	initLogging,
+	getLogFilePath,
+	logChildOutput,
+	flushChildOutput,
+	logEvent,
+	logError
+};

--- a/src/logging.js
+++ b/src/logging.js
@@ -15,7 +15,26 @@ const { app } = require('electron');
 const log = require('electron-log/main');
 const { createLineBuffer } = require('./log-lines');
 
-// Rotated to main.old.log past this size, so an app left running through many
+// Friendly platform names rather than process.platform's own values: 'win32'
+// reads as 32-bit to most people, and this string ends up in front of
+// contributors rather than only in code.
+const PLATFORM_NAMES = {
+	darwin: 'macos',
+	win32: 'windows',
+	linux: 'linux'
+};
+
+// Not electron-log's default of main.log. The point of this file is that people
+// attach it to bug reports, at which moment it is separated from the app-named
+// folder that would otherwise identify it — so the name has to stand alone in a
+// list of attachments. The platform is in there because a single issue thread
+// often collects logs from several contributors, and which OS a log came from is
+// the first thing anyone reading it needs to know.
+function logFileName(platform = process.platform) {
+	return `wordpress-contributor-toolkit-${PLATFORM_NAMES[platform] || platform}.log`;
+}
+
+// Rotated to <name>.old.log past this size, so an app left running through many
 // npm installs cannot grow the file without bound.
 const MAX_LOG_SIZE = 5 * 1024 * 1024;
 
@@ -33,7 +52,7 @@ function initLogging() {
 	// what it was sent.
 	log.initialize({ spyRendererConsole: true });
 
-	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), 'main.log');
+	log.transports.file.resolvePathFn = () => path.join(app.getPath('logs'), logFileName());
 	log.transports.file.maxSize = MAX_LOG_SIZE;
 
 	// Redirects the existing console.* calls throughout the main process into

--- a/src/main.js
+++ b/src/main.js
@@ -518,12 +518,21 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // relaxed. The first failure's output still reaches the log, so the real reason
 // stays visible instead of being silently papered over.
 //
-// The automatic retry is opt-in and only npm:install enables it. Scripts
-// (build, grunt, …) can fail partway through with side effects already on
-// disk, and npm prints EBADENGINE as a mere warning when engine-strict is off
-// — so a warning followed by an unrelated non-zero exit would wrongly restart
-// a half-finished script. An install, by contrast, is idempotent to re-run.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
+// Two independent knobs, and each command uses exactly one of them:
+//
+// `retryOnEngineMismatch` (npm:install) runs strict first and retries relaxed.
+// Scripts (build, grunt, …) must not do this: they can fail partway through
+// with side effects already on disk, and npm prints EBADENGINE as a mere
+// warning when engine-strict is off — so a warning followed by an unrelated
+// non-zero exit would wrongly restart a half-finished script. An install, by
+// contrast, is idempotent to re-run.
+//
+// `relaxEnginesFromStart` (npm:run-script) is the opposite trade and is safe
+// for exactly that reason: nothing is ever restarted, engine checks are simply
+// off from the first process onward. Scripts need it because they spawn nested
+// installs that inherit this environment — wordpress-develop's Gruntfile calls
+// install-changed at load time, which execSync's its own `npm install` (#54).
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false, relaxEnginesFromStart = false }) {
 	const start = (relaxEngines) => {
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
@@ -563,7 +572,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			onDone(code);
 		});
 	};
-	start(false);
+	start(relaxEnginesFromStart);
 }
 
 ipcMain.handle('npm:install', async (event, directoryPath) => {
@@ -601,6 +610,10 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 		runnerPath: path.join(__dirname, 'script-runner.js'),
 		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
+		// Baseline-relax rather than retry — see runNpmWithEngineRetry. Without
+		// this the nested `npm install` a build task spawns fails with EBADENGINE
+		// before grunt even starts (#54).
+		relaxEnginesFromStart: true,
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,12 @@ const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
 // Provide a PATH shim so npm's spawned scripts can find a 'node' binary that maps to Electron's Node
 let nodeShimDir = null;
+// Windows-only: absolute path of the child_process patch copied next to the
+// shims, preloaded into descendant Node processes via NODE_OPTIONS so that a
+// bare spawn('node') hitting node.cmd does not fail with EINVAL.
+let spawnPatchPath = null;
+let npmCliPath = null;
+let npxCliPath = null;
 function ensureNodeShimDir() {
     if (nodeShimDir) return nodeShimDir;
     nodeShimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
@@ -39,12 +45,23 @@ function ensureNodeShimDir() {
                 const npmRootDir = path.dirname(npmPkgJsonPath);
                 const npmCliAbsPath = path.join(npmRootDir, 'bin', 'npm-cli.js');
                 const npxCliAbsPath = path.join(npmRootDir, 'bin', 'npx-cli.js');
+                npmCliPath = npmCliAbsPath;
+                npxCliPath = npxCliAbsPath;
                 const npmCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npmCliAbsPath}" %*\r\n`;
                 const npxCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npxCliAbsPath}" %*\r\n`;
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.cmd'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.bat'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npx.cmd'), npxCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npx.bat'), npxCmd);
+            } catch {}
+            // Copy the child_process patch out of the app bundle: it is loaded with
+            // --require by child Node processes, and a path inside app.asar is not
+            // reliably resolvable under ELECTRON_RUN_AS_NODE. A failure here only
+            // means we are back to the pre-patch behaviour, so it stays non-fatal.
+            try {
+                const dest = path.join(nodeShimDir, 'win-spawn-patch.js');
+                fs.copyFileSync(path.join(__dirname, 'win-spawn-patch.js'), dest);
+                spawnPatchPath = dest;
             } catch {}
             // Intentionally do NOT create node.exe here, as Electron's exe depends on adjacent DLLs.
             // Using node.exe from a temp dir causes STATUS_DLL_NOT_FOUND (0xC0000135) when spawned by npm.
@@ -529,6 +546,9 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			cwd,
 			env: buildChildEnv({
 				shimDir: ensureNodeShimDir(),
+				spawnPatchPath,
+				npmCliPath,
+				npxCliPath,
 				extraEnv: relaxEngines ? RELAXED_ENGINES_ENV : {}
 			}),
 			shell: false,

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
+const { app, BrowserWindow, Menu, ipcMain, dialog, shell } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -18,6 +18,15 @@ const {
 	buildChildEnv,
 	RELAXED_ENGINES_ENV
 } = require('./npm-runner');
+const {
+	initLogging,
+	getLogFilePath,
+	logChildOutput,
+	flushChildOutput,
+	logEvent,
+	logError
+} = require('./logging');
+const { buildMenuTemplate } = require('./menu');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -346,6 +355,15 @@ ipcMain.handle('git:save-patch', async (_e, sitePath) => {
 });
 
 app.whenReady().then(() => {
+	// Before createWindow(): initLogging preloads the IPC bridge that carries
+	// renderer output into the log file, which only applies to windows created
+	// afterwards.
+	initLogging();
+	Menu.setApplicationMenu(Menu.buildFromTemplate(buildMenuTemplate({
+		onOpenLog: () => shell.openPath(getLogFilePath()),
+		onShowLogsFolder: () => shell.showItemInFolder(getLogFilePath())
+	})));
+
 	createWindow();
 
 	app.on('activate', function () {
@@ -523,8 +541,12 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // disk, and npm prints EBADENGINE as a mere warning when engine-strict is off
 // — so a warning followed by an unrelated non-zero exit would wrongly restart
 // a half-finished script. An install, by contrast, is idempotent to re-run.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, logScope, retryOnEngineMismatch = false }) {
 	const start = (relaxEngines) => {
+		// Logged before the spawn: a child that fails to start at all (EPERM on
+		// Windows) produces no output, so without this the log would show nothing
+		// where the failure was.
+		logEvent(logScope, `spawn ${path.basename(runnerPath)} ${args.join(' ')} in ${cwd}${relaxEngines ? ' (relaxed engines)' : ''}`);
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
 			env: buildChildEnv({
@@ -541,13 +563,20 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			stream.on('data', (data) => {
 				const text = data.toString();
 				if (retryOnEngineMismatch && !relaxEngines) detector.push(text);
+				logChildOutput(logScope, type, text);
 				onLog(type, text);
 			});
 		};
 		forward(child.stdout, 'stdout');
 		forward(child.stderr, 'stderr');
 
+		child.on('error', (err) => {
+			logError(logScope, `spawn failed: ${String(err)}`);
+		});
+
 		child.on('close', (code, signal) => {
+			flushChildOutput(logScope);
+			logEvent(logScope, `exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
 			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
@@ -575,6 +604,9 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		runnerPath: path.join(__dirname, 'install-runner.js'),
 		args: [directoryPath],
 		cwd: directoryPath,
+		// Suffixed with the correlation id so two installs running at once stay
+		// distinguishable in the log instead of interleaving.
+		logScope: `install#${installId.slice(-4)}`,
 		retryOnEngineMismatch: true,
 		register: (child) => {
 			runningInstalls[installId] = child;
@@ -601,6 +633,7 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 		runnerPath: path.join(__dirname, 'script-runner.js'),
 		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
+		logScope: `${scriptName}#${runId.slice(-4)}`,
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;
@@ -647,6 +680,8 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		return { ok: true, url: playgroundServers[sitePath].url };
 	}
 	const runnerPath = path.join(__dirname, 'server-runner.js');
+	const logScope = `playground:${path.basename(sitePath)}`;
+	logEvent(logScope, `starting server for ${buildDir} (smtp port ${(smtp && smtp.port) ? smtp.port : 25})`);
 	const child = spawn(process.execPath, [runnerPath, buildDir], {
 		cwd: buildDir,
 		env: {
@@ -671,13 +706,13 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 	child.stderr.setEncoding('utf8');
 	child.stdout.on('data', (data) => {
 		const text = String(data);
-		console.log("STDOUT", text);
+		logChildOutput(logScope, 'stdout', text);
 		event.sender.send('playground:log', { sitePath, type: 'stdout', data: text });
 		const match = text.match(/SERVER_URL:(.*)/);
 		if (match && !resolved) {
 			resolved = true;
 			playgroundServers[sitePath].url = match[1].trim();
-			console.log("URL", playgroundServers[sitePath].url);
+			logEvent(logScope, `server ready at ${playgroundServers[sitePath].url}`);
 			event.sender.send('playground:url', { sitePath, url: playgroundServers[sitePath].url });
 			if (typeof pendingResolve === 'function') {
 				clearTimeout(timeoutId);
@@ -687,14 +722,18 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		}
 	});
 	child.stderr.on('data', (data) => {
-		console.log("STDERR", data);
+		logChildOutput(logScope, 'stderr', String(data));
 		event.sender.send('playground:log', { sitePath, type: 'stderr', data: String(data) });
 	});
 	child.on('error', (err) => {
-		console.log("ERROR", err);
+		logError(logScope, `spawn failed: ${String(err)}`);
 		event.sender.send('playground:log', { sitePath, type: 'stderr', data: String(err) + '\n' });
 	});
-	child.on('close', (code) => {
+	// `signal` is logged as well as `code`: a killed process reports a null code,
+	// and "exited with code null" tells a reader nothing about why it stopped.
+	child.on('close', (code, signal) => {
+		flushChildOutput(logScope);
+		logEvent(logScope, `server exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
 		delete playgroundServers[sitePath];
 		event.sender.send('playground:stopped', { sitePath, code });
 		// Stop WP debug tail if running
@@ -727,6 +766,9 @@ ipcMain.handle('playground:stop', async (_event, sitePath) => {
 });
 
 // --- Global Playground web server (serves local-playground-web) ---
+// A single global server, so unlike the per-site ones its log scope is constant.
+const WEB_LOG_SCOPE = 'playground-web';
+
 ipcMain.handle('playground-web:available', async () => {
     const webDirCandidates = [
         path.join(app.getAppPath(), 'local-playground-web'),
@@ -767,6 +809,7 @@ ipcMain.handle('playground-web:start', async (event) => {
     }
 
     const runnerPath = path.join(__dirname, 'playground-web-runner.js');
+    logEvent(WEB_LOG_SCOPE, `starting web server for ${webDir} on port 39372`);
     const child = spawn(process.execPath, [runnerPath, webDir, '39372'], {
         cwd: webDir,
         env: {
@@ -786,11 +829,13 @@ ipcMain.handle('playground-web:start', async (event) => {
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (data) => {
         const text = String(data);
+        logChildOutput(WEB_LOG_SCOPE, 'stdout', text);
         try { broadcastToAll('playground-web:log', { type: 'stdout', data: text }); } catch {}
         const match = text.match(/WEB_SERVER_URL:(.*)/);
         if (match && !resolved) {
             resolved = true;
             playgroundWebServer.url = match[1].trim();
+            logEvent(WEB_LOG_SCOPE, `web server ready at ${playgroundWebServer.url}`);
             broadcastToAll('playground-web:url', { url: playgroundWebServer.url });
             if (typeof pendingResolve === 'function') {
                 clearTimeout(timeoutId);
@@ -801,12 +846,16 @@ ipcMain.handle('playground-web:start', async (event) => {
         }
     });
     child.stderr.on('data', (data) => {
+        logChildOutput(WEB_LOG_SCOPE, 'stderr', String(data));
         try { broadcastToAll('playground-web:log', { type: 'stderr', data: String(data) }); } catch {}
     });
     child.on('error', (err) => {
+        logError(WEB_LOG_SCOPE, `spawn failed: ${String(err)}`);
         try { broadcastToAll('playground-web:log', { type: 'stderr', data: String(err) + '\n' }); } catch {}
     });
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
+        flushChildOutput(WEB_LOG_SCOPE);
+        logEvent(WEB_LOG_SCOPE, `web server exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
         const stillPending = !resolved && typeof pendingResolve === 'function';
         playgroundWebServer = null;
         if (stillPending) {

--- a/src/main.js
+++ b/src/main.js
@@ -536,6 +536,21 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		});
 		register(child);
 
+		// A failed spawn (ENOENT/EPERM — most likely on Windows) emits 'error'
+		// and may never emit 'close'. Without this the renderer never receives a
+		// :done event and the UI stays stuck "installing"/"building" forever.
+		let finished = false;
+		const finish = (code) => {
+			if (finished) return;
+			finished = true;
+			onDone(code);
+		};
+
+		child.on('error', (err) => {
+			onLog('stderr', `\nFailed to start: ${err && err.message ? err.message : String(err)}\n`);
+			finish(-1);
+		});
+
 		const detector = createEngineMismatchDetector();
 		const forward = (stream, type) => {
 			stream.on('data', (data) => {
@@ -548,6 +563,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		forward(child.stderr, 'stderr');
 
 		child.on('close', (code, signal) => {
+			if (finished) return;
 			const retry = retryOnEngineMismatch && shouldRetryWithRelaxedEngines({
 				code,
 				signal,
@@ -556,11 +572,12 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 				cancelled: cancelledChildren.has(child)
 			});
 			if (retry) {
+				finished = true;
 				onLog('stdout', ENGINE_RETRY_NOTICE);
 				start(true);
 				return;
 			}
-			onDone(code);
+			finish(code);
 		});
 	};
 	start(false);

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,0 +1,47 @@
+// The application menu.
+//
+// The app previously set no menu at all and inherited Electron's default one.
+// Setting a menu replaces that default wholesale, so the template below rebuilds
+// it out of Electron's built-in roles — anything dropped here is a feature the
+// user silently loses. The only real addition is the Help submenu, which is how
+// a contributor gets at the log file without knowing where their OS keeps it.
+//
+// Kept free of Electron imports and of the log module: the caller supplies the
+// click handlers, so this file is a plain data structure.
+
+const isMac = (platform = process.platform) => platform === 'darwin';
+
+function buildMenuTemplate({ onOpenLog, onShowLogsFolder, platform = process.platform } = {}) {
+	return [
+		// On macOS the first submenu is the app menu (About/Quit/Services). On
+		// Windows and Linux those items live under File instead, which `fileMenu`
+		// already handles, so this entry is omitted entirely.
+		...(isMac(platform) ? [{ role: 'appMenu' }] : []),
+		{ role: 'fileMenu' },
+		{ role: 'editMenu' },
+		{ role: 'viewMenu' },
+		{ role: 'windowMenu' },
+		{
+			role: 'help',
+			submenu: [
+				{
+					// "App Log" rather than "Log": the app also tails each site's
+					// WordPress debug.log, and confusing the two would send people
+					// to the wrong file.
+					label: 'Open App Log',
+					click: () => onOpenLog?.()
+				},
+				{
+					label: 'Show Logs Folder',
+					click: () => onShowLogsFolder?.()
+				},
+				{ type: 'separator' },
+				// Duplicates the View entry on purpose. Someone who does not know
+				// the shortcut looks under Help, not View.
+				{ role: 'toggleDevTools' }
+			]
+		}
+	];
+}
+
+module.exports = { buildMenuTemplate };

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -60,12 +60,21 @@ function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alread
 
 // The env block for a spawned npm runner. On Windows both PATH and Path are set
 // and PATHEXT is extended so child npm processes can find the node shim.
+//
+// On Windows the node shim is a .cmd, which Node >= 20.12.2 refuses to spawn
+// without `shell: true` — so `spawnPatchPath` is preloaded into every descendant
+// Node process via NODE_OPTIONS to rewrite those spawns. See win-spawn-patch.js.
+// Electron only honours NODE_OPTIONS when ELECTRON_RUN_AS_NODE is set, which it
+// is just below.
 function buildChildEnv({
 	shimDir,
 	extraEnv = {},
 	baseEnv = process.env,
 	platform = process.platform,
-	execPath = process.execPath
+	execPath = process.execPath,
+	spawnPatchPath = null,
+	npmCliPath = null,
+	npxCliPath = null
 } = {}) {
 	const isWindows = platform === 'win32';
 	const separator = isWindows ? ';' : ':';
@@ -84,6 +93,17 @@ function buildChildEnv({
 	};
 	if (isWindows) {
 		env.Path = joinedPath;
+	}
+	if (isWindows && spawnPatchPath) {
+		// Appended, never replaced: an inherited NODE_OPTIONS may carry settings
+		// the build relies on (wordpress-develop bumps --max-old-space-size).
+		const requireFlag = `--require "${spawnPatchPath}"`;
+		env.NODE_OPTIONS = baseEnv.NODE_OPTIONS
+			? `${baseEnv.NODE_OPTIONS} ${requireFlag}`
+			: requireFlag;
+		env.WPTK_SPAWN_PATCH = '1';
+		if (npmCliPath) env.WPTK_NPM_CLI = npmCliPath;
+		if (npxCliPath) env.WPTK_NPX_CLI = npxCliPath;
 	}
 	return { ...env, ...extraEnv };
 }

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -95,9 +95,18 @@ function buildChildEnv({
 		env.Path = joinedPath;
 	}
 	if (isWindows && spawnPatchPath) {
+		// Forward slashes, always. Node does not read NODE_OPTIONS literally: it
+		// tokenises it with shell-like rules, and inside quotes a backslash is an
+		// escape character. A native path would arrive at the preloader as
+		// C:UsersJuanMaAppData… and die with MODULE_NOT_FOUND before the child
+		// runs a single line. Windows resolves forward slashes fine, and unlike
+		// doubling the backslashes this does not depend on how many layers of
+		// unescaping the value passes through. The quotes stay, for paths with
+		// spaces in them.
+		const requirePath = String(spawnPatchPath).replace(/\\/g, '/');
 		// Appended, never replaced: an inherited NODE_OPTIONS may carry settings
 		// the build relies on (wordpress-develop bumps --max-old-space-size).
-		const requireFlag = `--require "${spawnPatchPath}"`;
+		const requireFlag = `--require "${requirePath}"`;
 		env.NODE_OPTIONS = baseEnv.NODE_OPTIONS
 			? `${baseEnv.NODE_OPTIONS} ${requireFlag}`
 			: requireFlag;

--- a/src/playground-web-runner.js
+++ b/src/playground-web-runner.js
@@ -1,4 +1,9 @@
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before the Playground CLI is required, so anything it spawns is
+// covered too.
+hideChildWindows();
 
 async function main() {
     const hostMountDir = process.argv[2];

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -30964,6 +30964,44 @@ WARNING: This link could potentially be dangerous`)) {
     }
   });
 
+  // src/renderer/setup-steps.cjs
+  var require_setup_steps = __commonJS({
+    "src/renderer/setup-steps.cjs"(exports, module) {
+      "use strict";
+      function computeSetupStepState2(flags = {}) {
+        const isPending = Boolean(flags.isPending);
+        const statusLoading = Boolean(flags.statusLoading);
+        const hasNodeModules = Boolean(flags.hasNodeModules);
+        const hasBuilt = Boolean(flags.hasBuilt);
+        const installing = Boolean(flags.installing);
+        const building = Boolean(flags.building);
+        const starting = Boolean(flags.starting);
+        return {
+          download: {
+            done: !isPending,
+            ready: true
+          },
+          install: {
+            done: hasNodeModules,
+            ready: !isPending,
+            disabled: isPending || statusLoading || installing || hasNodeModules
+          },
+          build: {
+            done: hasBuilt,
+            ready: hasNodeModules,
+            disabled: statusLoading || building || !hasNodeModules || hasBuilt
+          },
+          dev: {
+            done: false,
+            ready: hasBuilt,
+            disabled: statusLoading || starting || !hasBuilt
+          }
+        };
+      }
+      module.exports = { computeSetupStepState: computeSetupStepState2 };
+    }
+  });
+
   // src/renderer/index.jsx
   var import_react69 = __toESM(require_react());
   var import_client2 = __toESM(require_client());
@@ -53327,6 +53365,7 @@ If there's a particular need for this, please submit a feature request at https:
 
   // src/renderer/index.jsx
   var import_xterm = __toESM(require_xterm());
+  var import_setup_steps = __toESM(require_setup_steps());
   var import_jsx_runtime61 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
@@ -53352,7 +53391,12 @@ If there's a particular need for this, please submit a feature request at https:
   function App() {
     const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
     const [downloadPhase, setDownloadPhase] = (0, import_react69.useState)("");
-    const [pendingSite, setPendingSite] = (0, import_react69.useState)(null);
+    const [pendingSites, setPendingSites] = (0, import_react69.useState)([]);
+    const addPendingSite = (0, import_react69.useCallback)((dir) => {
+      if (!dir) return;
+      setPendingSites((prev2) => prev2.includes(dir) ? prev2 : [...prev2, dir]);
+    }, []);
+    const clearPendingSites = (0, import_react69.useCallback)(() => setPendingSites([]), []);
     const [terminalMsgs, setTerminalMsgs] = (0, import_react69.useState)("");
     const termRef = (0, import_react69.useRef)(null);
     const createDirInputRef = (0, import_react69.useRef)(null);
@@ -53466,11 +53510,11 @@ If there's a particular need for this, please submit a feature request at https:
           appendSetupLog(p.target, `${p.message}
 `);
         }
-        if (p && p.target) setPendingSite({ targetDir: p.target });
+        if (p && p.target) addPendingSite(p.target);
       });
       const unsubStat = window.api.subscribeSetupStatus((s) => {
         if (!s) return;
-        if (s.target) setPendingSite({ targetDir: s.target });
+        if (s.target && s.phase !== "done") addPendingSite(s.target);
         const key = s.sitePath || s.target;
         if (key) {
           const phaseLabel = s.phase ? `Status: ${s.phase}` : "Status update";
@@ -53481,7 +53525,7 @@ If there's a particular need for this, please submit a feature request at https:
         if (s.phase === "cloning") setDownloadPhase("Cloning repository\u2026");
         else if (s.phase === "done") {
           setDownloadPhase("");
-          setPendingSite(null);
+          clearPendingSites();
           setTerminalMsgs("");
         }
       });
@@ -53489,7 +53533,7 @@ If there's a particular need for this, please submit a feature request at https:
         unsubProg && unsubProg();
         unsubStat && unsubStat();
       };
-    }, [appendSetupLog]);
+    }, [addPendingSite, appendSetupLog, clearPendingSites]);
     const chooseAndSetup = (0, import_react69.useCallback)(() => {
       setCreateSiteName("");
       setCreateSiteDir("");
@@ -53580,13 +53624,13 @@ If there's a particular need for this, please submit a feature request at https:
         setCreateSubmitting(true);
         setCreateSiteError("");
         setTerminalMsgs("");
-        setPendingSite({ targetDir });
+        addPendingSite(targetDir);
         appendSetupLog(targetDir, "Starting site setup\u2026\n");
         const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
         if (createdPath) {
           finalSitePath = createdPath;
           if (createdPath !== targetDir) {
-            setPendingSite({ targetDir: createdPath });
+            addPendingSite(createdPath);
             moveSetupLog(targetDir, createdPath);
             setSites((prev2) => {
               const filtered = prev2.filter((path) => path !== targetDir);
@@ -53610,7 +53654,6 @@ If there's a particular need for this, please submit a feature request at https:
         setActiveSite(finalSitePath);
         appendSetupLog(finalSitePath, "Site setup request completed.\n");
       } catch (e) {
-        setPendingSite(null);
         setCreateSiteError(String(e));
         appendSetupLog(targetDir, `Setup failed: ${String(e)}
 `);
@@ -53622,9 +53665,10 @@ If there's a particular need for this, please submit a feature request at https:
           return next2;
         });
       } finally {
+        clearPendingSites();
         setCreateSubmitting(false);
       }
-    }, [appendSetupLog, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+    }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
     const closeCreateModal = (0, import_react69.useCallback)(() => {
       if (createSubmitting) return;
       setCreateModalOpen(false);
@@ -53872,7 +53916,7 @@ If there's a particular need for this, please submit a feature request at https:
           /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { ref: webLogRef, style: { marginTop: 8, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: webLogs })
         ] }) }) : null,
         /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { id: "sites", children: [
-          pendingSite && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(component_default8, { children: [
+          pendingSites.length > 0 && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(component_default8, { children: [
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontWeight: 600 }, children: "Setting up new site\u2026" }),
             downloadPhase && /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontSize: 12, color: "#555", marginBottom: 6 }, children: downloadPhase }),
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { ref: termRef, style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: terminalMsgs })
@@ -53893,7 +53937,7 @@ If there's a particular need for this, please submit a feature request at https:
                   onForget,
                   onDelete,
                   onRename,
-                  isPending: Boolean(pendingSite && pendingSite.targetDir === s),
+                  isPending: pendingSites.includes(s),
                   setupLogs: setupLogsBySite[s] || ""
                 }
               )
@@ -53970,7 +54014,7 @@ If there's a particular need for this, please submit a feature request at https:
       ) : null
     ] });
   }
-  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = "" }) {
+  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = "" }) {
     const safeOnRename = onRename || (() => {
     });
     const [serverUrl, setServerUrl] = (0, import_react69.useState)("");
@@ -54673,27 +54717,34 @@ Try "help" for the list of supported commands.
         indicatorContent: "\u2013"
       }
     };
+    const stepState = (0, import_setup_steps.computeSetupStepState)({
+      isPending,
+      statusLoading,
+      hasNodeModules,
+      hasBuilt,
+      installing,
+      building,
+      starting
+    });
     const baseSteps = [
       {
         key: "download",
         label: "Download WordPress development version",
-        description: "Clone the WordPress develop repository.",
-        done: true,
-        ready: true
+        description: isPending ? "Cloning the WordPress develop repository\u2026 the next step unlocks when it finishes." : "Clone the WordPress develop repository.",
+        ...stepState.download
       },
       {
         key: "install",
         label: "Install npm dependencies",
         description: "Install npm packages so commands can run.",
-        done: hasNodeModules,
-        ready: true,
+        ...stepState.install,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
           {
             isBusy: installing,
             variant: hasNodeModules ? "secondary" : "primary",
             onClick: runInstallWithTerminal,
-            disabled: statusLoading || installing || hasNodeModules,
+            disabled: stepState.install.disabled,
             children: hasNodeModules ? "Dependencies installed" : "Install npm dependencies"
           }
         )
@@ -54702,15 +54753,14 @@ Try "help" for the list of supported commands.
         key: "build",
         label: "Run first full build",
         description: "Compile WordPress Core once to generate the initial dist files.",
-        done: hasBuilt,
-        ready: hasNodeModules,
+        ...stepState.build,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
           {
             isBusy: building,
             variant: hasBuilt ? "secondary" : "primary",
             onClick: () => runScript("build"),
-            disabled: statusLoading || building || !hasNodeModules || hasBuilt,
+            disabled: stepState.build.disabled,
             children: hasBuilt ? "First build complete" : "Run first full build"
           }
         )
@@ -54719,8 +54769,7 @@ Try "help" for the list of supported commands.
         key: "dev",
         label: "Start dev server & finish wizard",
         description: "Launch the development server once to complete the WordPress setup wizard.",
-        done: false,
-        ready: hasBuilt,
+        ...stepState.dev,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
             button_default,
@@ -54731,7 +54780,7 @@ Try "help" for the list of supported commands.
                 await markSkipWizard();
                 await toggleDevServer();
               },
-              disabled: statusLoading || starting || !hasBuilt,
+              disabled: stepState.dev.disabled,
               children: running ? "Stop dev server" : "Start dev server and finish the wizard"
             }
           ),

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -54219,6 +54219,16 @@ Failed to start npm run ${name}: ${error && error.message ? error.message : Stri
         }
       });
     }, [runInstall, writeToTerminal]);
+    const runBuildWithTerminal = (0, import_react69.useCallback)(() => {
+      writeToTerminal("Running npm run build\u2026\n");
+      runScript("build", {
+        onLog: (chunk) => writeToTerminal(chunk),
+        onDone: ({ code }) => {
+          writeToTerminal(`npm run build exited with code ${code}
+`);
+        }
+      });
+    }, [runScript, writeToTerminal]);
     const showPrompt = (0, import_react69.useCallback)((prependNewLine = true) => {
       const term = terminalRef.current;
       if (!term) return;
@@ -54709,7 +54719,7 @@ Try "help" for the list of supported commands.
           {
             isBusy: building,
             variant: hasBuilt ? "secondary" : "primary",
-            onClick: () => runScript("build"),
+            onClick: runBuildWithTerminal,
             disabled: statusLoading || building || !hasNodeModules || hasBuilt,
             children: hasBuilt ? "First build complete" : "Run first full build"
           }

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -16,6 +16,7 @@ import { plus, chevronLeft, chevronRight, copy as copyIcon, check as checkIcon, 
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
+import { computeSetupStepState } from './setup-steps.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
@@ -41,7 +42,15 @@ function useSites() {
 function App() {
   const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
   const [downloadPhase, setDownloadPhase] = useState('');
-  const [pendingSite, setPendingSite] = useState(null);
+  // Directories whose clone is still running. An array rather than a single
+  // path because the main process may settle on a different (deduplicated)
+  // directory than the one the renderer optimistically created a row for.
+  const [pendingSites, setPendingSites] = useState([]);
+  const addPendingSite = useCallback((dir) => {
+    if (!dir) return;
+    setPendingSites((prev) => (prev.includes(dir) ? prev : [...prev, dir]));
+  }, []);
+  const clearPendingSites = useCallback(() => setPendingSites([]), []);
   const [terminalMsgs, setTerminalMsgs] = useState('');
   const termRef = useRef(null);
   const createDirInputRef = useRef(null);
@@ -150,11 +159,11 @@ function App() {
         setTerminalMsgs((v) => v + p.message + '\n');
         appendSetupLog(p.target, `${p.message}\n`);
       }
-      if (p && p.target) setPendingSite({ targetDir: p.target });
+      if (p && p.target) addPendingSite(p.target);
     });
     const unsubStat = window.api.subscribeSetupStatus((s) => {
       if (!s) return;
-      if (s.target) setPendingSite({ targetDir: s.target });
+      if (s.target && s.phase !== 'done') addPendingSite(s.target);
       const key = s.sitePath || s.target;
       if (key) {
         const phaseLabel = s.phase ? `Status: ${s.phase}` : 'Status update';
@@ -162,10 +171,10 @@ function App() {
         if (s.phase === 'done') appendSetupLog(key, 'Setup finished.\n');
       }
       if (s.phase === 'cloning') setDownloadPhase('Cloning repository…');
-      else if (s.phase === 'done') { setDownloadPhase(''); setPendingSite(null); setTerminalMsgs(''); }
+      else if (s.phase === 'done') { setDownloadPhase(''); clearPendingSites(); setTerminalMsgs(''); }
     });
     return () => { unsubProg && unsubProg(); unsubStat && unsubStat(); };
-  }, [appendSetupLog]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites]);
 
   const chooseAndSetup = useCallback(() => {
     setCreateSiteName('');
@@ -274,13 +283,13 @@ function App() {
       setCreateSubmitting(true);
       setCreateSiteError('');
       setTerminalMsgs('');
-      setPendingSite({ targetDir });
+      addPendingSite(targetDir);
       appendSetupLog(targetDir, 'Starting site setup…\n');
       const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
       if (createdPath) {
         finalSitePath = createdPath;
         if (createdPath !== targetDir) {
-          setPendingSite({ targetDir: createdPath });
+          addPendingSite(createdPath);
           moveSetupLog(targetDir, createdPath);
           setSites((prev) => {
             const filtered = prev.filter((path) => path !== targetDir);
@@ -304,7 +313,6 @@ function App() {
       setActiveSite(finalSitePath);
       appendSetupLog(finalSitePath, 'Site setup request completed.\n');
     } catch (e) {
-      setPendingSite(null);
       setCreateSiteError(String(e));
       appendSetupLog(targetDir, `Setup failed: ${String(e)}\n`);
       setSites((prev) => prev.filter((path) => path !== targetDir));
@@ -315,9 +323,13 @@ function App() {
         return next;
       });
     } finally {
+      // `setupWordPress` resolving (or throwing) *is* the clone finishing, so
+      // clearing here guarantees the checklist can never stay locked even if
+      // the `done` status event is missed.
+      clearPendingSites();
       setCreateSubmitting(false);
     }
-  }, [appendSetupLog, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
 
   const closeCreateModal = useCallback(() => {
     if (createSubmitting) return;
@@ -579,7 +591,7 @@ function App() {
             ) : null}
 
             <div id="sites">
-              {pendingSite && (
+              {pendingSites.length > 0 && (
                 <Card style={{ marginBottom: 24 }}>
                   <CardBody>
                     <div style={{ fontWeight: 600 }}>Setting up new site…</div>
@@ -605,7 +617,7 @@ function App() {
                       onForget={onForget}
                       onDelete={onDelete}
                       onRename={onRename}
-                      isPending={Boolean(pendingSite && pendingSite.targetDir === s)}
+                      isPending={pendingSites.includes(s)}
                       setupLogs={setupLogsBySite[s] || ''}
                     />
                   </div>
@@ -683,7 +695,7 @@ function App() {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, setupLogs = '' }) {
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = '' }) {
   const safeOnRename = onRename || (() => {});
   // state
   const [serverUrl, setServerUrl] = useState('');
@@ -1366,26 +1378,36 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     }
   };
 
+  const stepState = computeSetupStepState({
+    isPending,
+    statusLoading,
+    hasNodeModules,
+    hasBuilt,
+    installing,
+    building,
+    starting
+  });
+
   const baseSteps = [
     {
       key: 'download',
       label: 'Download WordPress development version',
-      description: 'Clone the WordPress develop repository.',
-      done: true,
-      ready: true
+      description: isPending
+        ? 'Cloning the WordPress develop repository… the next step unlocks when it finishes.'
+        : 'Clone the WordPress develop repository.',
+      ...stepState.download
     },
     {
       key: 'install',
       label: 'Install npm dependencies',
       description: 'Install npm packages so commands can run.',
-      done: hasNodeModules,
-      ready: true,
+      ...stepState.install,
       action: (
         <Button
           isBusy={installing}
           variant={hasNodeModules ? 'secondary' : 'primary'}
           onClick={runInstallWithTerminal}
-          disabled={statusLoading || installing || hasNodeModules}
+          disabled={stepState.install.disabled}
         >{hasNodeModules ? 'Dependencies installed' : 'Install npm dependencies'}</Button>
       )
     },
@@ -1393,14 +1415,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       key: 'build',
       label: 'Run first full build',
       description: 'Compile WordPress Core once to generate the initial dist files.',
-      done: hasBuilt,
-      ready: hasNodeModules,
+      ...stepState.build,
       action: (
         <Button
           isBusy={building}
           variant={hasBuilt ? 'secondary' : 'primary'}
           onClick={()=>runScript('build')}
-          disabled={statusLoading || building || (!hasNodeModules) || hasBuilt}
+          disabled={stepState.build.disabled}
         >{hasBuilt ? 'First build complete' : 'Run first full build'}</Button>
       )
     },
@@ -1408,8 +1429,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       key: 'dev',
       label: 'Start dev server & finish wizard',
       description: 'Launch the development server once to complete the WordPress setup wizard.',
-      done: false,
-      ready: hasBuilt,
+      ...stepState.dev,
       action: (
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Button
@@ -1419,7 +1439,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               await markSkipWizard();
               await toggleDevServer();
             }}
-            disabled={statusLoading || starting || (!hasBuilt)}
+            disabled={stepState.dev.disabled}
           >{running ? 'Stop dev server' : 'Start dev server and finish the wizard'}</Button>
           {starting || serverUrl ? (
             <span style={{ fontSize: 12 }}>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -932,6 +932,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     });
   }, [runInstall, writeToTerminal]);
 
+  const runBuildWithTerminal = useCallback(() => {
+    writeToTerminal('Running npm run build…\n');
+    runScript('build', {
+      onLog: (chunk) => writeToTerminal(chunk),
+      onDone: ({ code }) => {
+        writeToTerminal(`npm run build exited with code ${code}\n`);
+      }
+    });
+  }, [runScript, writeToTerminal]);
+
   const showPrompt = useCallback((prependNewLine = true) => {
     const term = terminalRef.current;
     if (!term) return;
@@ -1399,7 +1409,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
         <Button
           isBusy={building}
           variant={hasBuilt ? 'secondary' : 'primary'}
-          onClick={()=>runScript('build')}
+          onClick={runBuildWithTerminal}
           disabled={statusLoading || building || (!hasNodeModules) || hasBuilt}
         >{hasBuilt ? 'First build complete' : 'Run first full build'}</Button>
       )

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Derives the done/ready/disabled state of every step in the site setup
+ * checklist.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly.
+ *
+ * `isPending` means the `wordpress-develop` clone for this site is still
+ * running, so nothing that touches the working tree may be offered yet.
+ */
+function computeSetupStepState(flags = {}) {
+	const isPending = Boolean(flags.isPending);
+	const statusLoading = Boolean(flags.statusLoading);
+	const hasNodeModules = Boolean(flags.hasNodeModules);
+	const hasBuilt = Boolean(flags.hasBuilt);
+	const installing = Boolean(flags.installing);
+	const building = Boolean(flags.building);
+	const starting = Boolean(flags.starting);
+
+	return {
+		download: {
+			done: !isPending,
+			ready: true
+		},
+		install: {
+			done: hasNodeModules,
+			ready: !isPending,
+			disabled: isPending || statusLoading || installing || hasNodeModules
+		},
+		build: {
+			done: hasBuilt,
+			ready: hasNodeModules,
+			disabled: statusLoading || building || !hasNodeModules || hasBuilt
+		},
+		dev: {
+			done: false,
+			ready: hasBuilt,
+			disabled: statusLoading || starting || !hasBuilt
+		}
+	};
+}
+
+module.exports = { computeSetupStepState };

--- a/src/script-runner.js
+++ b/src/script-runner.js
@@ -1,4 +1,9 @@
 const path = require('path');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before npm's CLI is required: it is what spawns cmd.exe for the
+// script body, and those spawns would otherwise pop up console windows.
+hideChildWindows();
 
 async function main() {
 	const targetDir = process.argv[2];

--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -1,5 +1,11 @@
 const path = require('path');
 const fs = require('fs');
+const { hideChildWindows } = require('./hide-child-windows');
+
+// Must run before the Playground CLI is required, so anything it spawns is
+// covered too.
+hideChildWindows();
+
 const { writeFiles: playgroundWriteFiles } = require('@php-wasm/universal');
 
 async function main() {

--- a/src/win-spawn-patch.js
+++ b/src/win-spawn-patch.js
@@ -1,0 +1,163 @@
+// Preloaded (via NODE_OPTIONS=--require) into every descendant Node process on
+// Windows so that a bare `spawn('node', …)` keeps working without a real node.exe.
+//
+// Why this is needed: the only `node` on PATH is the shim written by
+// ensureNodeShimDir() in main.js, and on Windows that shim is a .cmd/.bat.
+// Node >= 20.12.2 (CVE-2024-27980) refuses to spawn a .bat/.cmd unless
+// `shell: true`, so wordpress-develop's Gruntfile — which does
+// `grunt.util.spawn({ cmd: 'node', … })` with shell:false — dies with EINVAL.
+// Grunt runs two levels below us (script-runner -> cmd.exe -> grunt.cmd -> node),
+// so an inherited NODE_OPTIONS preload is the only way to reach it.
+//
+// Deliberately self-contained (Node built-ins only): this file is copied into the
+// temp shim dir and required from there, because --require into a path inside
+// app.asar is not reliable under ELECTRON_RUN_AS_NODE.
+
+const path = require('path');
+const fs = require('fs');
+
+const SCRIPT_EXTENSIONS = ['.cmd', '.bat'];
+// Args are handed to cmd.exe verbatim when shell:true, so anything cmd would
+// interpret has to be quoted by us — Node does no quoting in shell mode.
+const NEEDS_QUOTING = /[\s"&|<>^()%!]/;
+
+// Strips the extension Windows would have resolved, so `node`, `node.cmd` and
+// `C:\shims\node.bat` all collapse to the same name.
+function shimName(file) {
+	const base = path.win32.basename(String(file || '')).toLowerCase();
+	const ext = path.win32.extname(base);
+	if (ext === '.cmd' || ext === '.bat' || ext === '.exe') {
+		return base.slice(0, -ext.length);
+	}
+	return base;
+}
+
+// Mirrors libuv's PATH/PATHEXT search closely enough to tell whether a bare
+// command name would land on a script the OS cannot exec directly.
+function defaultLookup(file, env) {
+	const name = String(file || '');
+	if (!name) return null;
+	const hasDir = name.includes('/') || name.includes('\\');
+	const candidateDirs = hasDir
+		? [null]
+		: String(env.Path || env.PATH || '').split(';').filter(Boolean);
+	const pathExt = String(env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+	const extensions = path.win32.extname(name) ? [''] : pathExt;
+	for (const dir of candidateDirs) {
+		for (const ext of extensions) {
+			const candidate = (dir === null ? name : path.win32.join(dir, name)) + ext.toLowerCase();
+			try {
+				if (fs.existsSync(candidate)) return candidate;
+			} catch {}
+		}
+	}
+	return null;
+}
+
+function quoteForCmd(value) {
+	const text = String(value);
+	return NEEDS_QUOTING.test(text) ? `"${text}"` : text;
+}
+
+// Clones the caller's env (or inherits process.env) and forces Electron into
+// Node mode, since the command we redirect to is electron.exe.
+function withNodeMode(options) {
+	const baseEnv = options && options.env ? options.env : process.env;
+	return { ...options, env: { ...baseEnv, ELECTRON_RUN_AS_NODE: '1' } };
+}
+
+// Decides how a child_process call must be rewritten. Returns null when the call
+// is fine as-is. Pure and fully parameterised so it can be tested off-Windows.
+function resolveSpawnTarget({
+	file,
+	args = [],
+	options = {},
+	platform = process.platform,
+	execPath = process.execPath,
+	npmCliPath = null,
+	npxCliPath = null,
+	env = process.env,
+	lookup = defaultLookup
+} = {}) {
+	if (platform !== 'win32') return null;
+	if (options.shell) return null;
+
+	const name = shimName(file);
+
+	// Preferred path: call Electron's binary directly. No shell, so no quoting
+	// hazard, and it works even when the .cmd shim is missing entirely.
+	if (name === 'node') {
+		return { file: execPath, args: [...args], options: withNodeMode(options) };
+	}
+	if (name === 'npm' && npmCliPath) {
+		return { file: execPath, args: [npmCliPath, ...args], options: withNodeMode(options) };
+	}
+	if (name === 'npx' && npxCliPath) {
+		return { file: execPath, args: [npxCliPath, ...args], options: withNodeMode(options) };
+	}
+
+	// Fallback for every other .cmd/.bat shim (bin stubs of npm packages, etc.):
+	// cmd.exe can run them, CreateProcess cannot.
+	const resolved = path.win32.extname(String(file || ''))
+		? String(file)
+		: lookup(file, env);
+	if (!resolved) return null;
+	if (!SCRIPT_EXTENSIONS.includes(path.win32.extname(resolved).toLowerCase())) return null;
+
+	return {
+		// Always quoted: a resolved path cannot contain a quote character, and
+		// site paths under "C:\Users\…\My Sites" routinely contain spaces.
+		file: `"${resolved}"`,
+		args: args.map(quoteForCmd),
+		options: { ...options, shell: true }
+	};
+}
+
+// child_process signatures are (file, args?, options?, callback?) with every
+// tail argument optional, so the shape has to be re-derived before rewriting.
+function rewriteArguments(callArgs, config) {
+	const [file, ...rest] = callArgs;
+	let args = [];
+	let options = {};
+	let tail = [];
+	let index = 0;
+	if (Array.isArray(rest[0])) {
+		args = rest[0];
+		index = 1;
+	}
+	if (rest[index] && typeof rest[index] === 'object') {
+		options = rest[index];
+		index += 1;
+	}
+	tail = rest.slice(index);
+
+	const target = resolveSpawnTarget({ ...config, file, args, options });
+	if (!target) return callArgs;
+	return [target.file, target.args, target.options, ...tail];
+}
+
+const PATCH_MARKER = Symbol.for('wptk.winSpawnPatch');
+
+function applyPatch(childProcess = require('child_process'), config = {}) {
+	if (childProcess[PATCH_MARKER]) return childProcess;
+	for (const method of ['spawn', 'spawnSync', 'execFile', 'execFileSync']) {
+		const original = childProcess[method];
+		if (typeof original !== 'function') continue;
+		childProcess[method] = function patched(...callArgs) {
+			return original.apply(this, rewriteArguments(callArgs, config));
+		};
+	}
+	childProcess[PATCH_MARKER] = true;
+	return childProcess;
+}
+
+// Only self-applies when the app explicitly asked for it, so requiring this
+// module from a test never mutates the test process.
+if (process.env.WPTK_SPAWN_PATCH === '1') {
+	applyPatch(require('child_process'), {
+		npmCliPath: process.env.WPTK_NPM_CLI || null,
+		npxCliPath: process.env.WPTK_NPX_CLI || null
+	});
+}
+
+module.exports = { resolveSpawnTarget, applyPatch, PATCH_MARKER };

--- a/test/fixtures/nested-install/.npmrc
+++ b/test/fixtures/nested-install/.npmrc
@@ -1,0 +1,4 @@
+# Mirrors wordpress-develop's .npmrc, which is what turns an engines mismatch
+# from a warning into a fatal error — including for the nested install the
+# build script spawns.
+engine-strict = true

--- a/test/fixtures/nested-install/needs-future-node/package.json
+++ b/test/fixtures/nested-install/needs-future-node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "needs-future-node",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Declares a Node version that will never exist, so this fixture keeps reproducing EBADENGINE no matter how new the Node running the tests is. A real registry package would stop failing once CI's Node caught up, silently turning the test green.",
+  "engines": {
+    "node": ">=99.0.0"
+  }
+}

--- a/test/fixtures/nested-install/package.json
+++ b/test/fixtures/nested-install/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nested-install-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reproduces issue #54: a build script that shells out to a second `npm install`, the way wordpress-develop's Gruntfile does via install-changed.",
+  "scripts": {
+    "build": "node run-build.js"
+  },
+  "dependencies": {
+    "needs-future-node": "file:./needs-future-node"
+  }
+}

--- a/test/fixtures/nested-install/run-build.js.txt
+++ b/test/fixtures/nested-install/run-build.js.txt
@@ -1,0 +1,22 @@
+// Stands in for wordpress-develop's Gruntfile.js:130, which calls
+// installChanged.watchPackage() at load time. install-changed shells out with
+// execSync('npm install') (install-changed/lib/main.js:50), so the build spawns
+// a *second* npm install as a grandchild of the script runner.
+//
+// The swallow-and-continue below mirrors the real caller: an engines failure
+// here is not fatal to the build, it just dumps a stack trace into the log and
+// leaves the dependencies uninstalled. That is exactly the #54 symptom.
+
+// Ships as .js.txt and is renamed on copy — see copyFixture() in
+// nested-install.integration.test.cjs. `node --test` runs every .js under
+// test/, so a fixture script cannot ship with a .js extension.
+
+const { execSync } = require('child_process');
+
+try {
+	execSync('npm install', { stdio: 'inherit' });
+} catch (err) {
+	console.error(err && err.stack ? err.stack : String(err));
+}
+
+console.log('BUILD OK');

--- a/test/hide-child-windows.test.cjs
+++ b/test/hide-child-windows.test.cjs
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { patchChildProcess } = require('../src/hide-child-windows.js');
+
+// A stand-in for the child_process module that records what it was called with,
+// so the patch can be exercised without actually spawning anything.
+function fakeChildProcess() {
+	const calls = [];
+	const record = (name) => (...args) => {
+		calls.push({ name, args });
+		return name;
+	};
+	return {
+		calls,
+		spawn: record('spawn'),
+		spawnSync: record('spawnSync'),
+		exec: record('exec'),
+		execSync: record('execSync'),
+		execFile: record('execFile'),
+		execFileSync: record('execFileSync'),
+		fork: record('fork')
+	};
+}
+
+test('leaves child_process untouched off Windows', () => {
+	// Forcing windowsHide elsewhere is pointless and would be a silent behaviour
+	// change on the platforms where the flashes never happened.
+	const cp = fakeChildProcess();
+	const originalSpawn = cp.spawn;
+	patchChildProcess(cp, 'darwin');
+	assert.equal(cp.spawn, originalSpawn);
+	cp.spawn('cmd', ['/c', 'x']);
+	assert.deepEqual(cp.calls[0].args, ['cmd', ['/c', 'x']]);
+});
+
+test('appends an options object when the caller passed none', () => {
+	// npm spawns cmd.exe as spawn(cmd, args) with no options in some paths, so
+	// the options object has to be created rather than only amended.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	cp.spawn('cmd', ['/d', '/s', '/c', 'grunt build']);
+	assert.deepEqual(cp.calls[0].args, [
+		'cmd',
+		['/d', '/s', '/c', 'grunt build'],
+		{ windowsHide: true }
+	]);
+});
+
+test("preserves the caller's other options and overrides windowsHide: false", () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const options = { cwd: 'C:\\site', windowsHide: false, stdio: 'pipe' };
+	cp.spawn('cmd', ['/c', 'x'], options);
+	assert.deepEqual(cp.calls[0].args[2], {
+		cwd: 'C:\\site',
+		windowsHide: true,
+		stdio: 'pipe'
+	});
+	// The caller's object must not be mutated — npm reuses option objects.
+	assert.equal(options.windowsHide, false);
+});
+
+test('inserts options before a trailing callback', () => {
+	// exec(cmd, cb) and execFile(file, args, cb) put the callback last; appending
+	// options at the end would make Node treat the callback as options.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const cb = () => {};
+
+	cp.exec('grunt build', cb);
+	assert.deepEqual(cp.calls[0].args, ['grunt build', { windowsHide: true }, cb]);
+
+	cp.execFile('grunt.cmd', ['build'], cb);
+	assert.deepEqual(cp.calls[1].args, ['grunt.cmd', ['build'], { windowsHide: true }, cb]);
+
+	cp.exec('grunt build', { cwd: 'C:\\site' }, cb);
+	assert.deepEqual(cp.calls[2].args, ['grunt build', { cwd: 'C:\\site', windowsHide: true }, cb]);
+});
+
+test('patches every child_process entry point', () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	for (const name of ['spawn', 'spawnSync', 'exec', 'execSync', 'execFile', 'execFileSync', 'fork']) {
+		cp[name]('x');
+	}
+	for (const call of cp.calls) {
+		const last = call.args[call.args.length - 1];
+		assert.equal(last.windowsHide, true, `${call.name} was not patched`);
+	}
+});
+
+test('passes the underlying return value through', () => {
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	assert.equal(cp.spawn('cmd'), 'spawn');
+});
+
+test('patching twice does not wrap twice', () => {
+	// The runners require this module once each, but a double-require must not
+	// stack wrappers or the options object would be cloned repeatedly.
+	const cp = fakeChildProcess();
+	patchChildProcess(cp, 'win32');
+	const patchedSpawn = cp.spawn;
+	patchChildProcess(cp, 'win32');
+	assert.equal(cp.spawn, patchedSpawn);
+	cp.spawn('cmd', ['/c', 'x']);
+	assert.equal(cp.calls[0].args.length, 3);
+});

--- a/test/log-lines.test.cjs
+++ b/test/log-lines.test.cjs
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createLineBuffer } = require('../src/log-lines.js');
+
+test('emits complete lines and holds back a partial one', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('added 733 packages\nfound 0 vul'), ['added 733 packages']);
+	// The partial line only surfaces once its newline arrives.
+	assert.deepEqual(buf.push('nerabilities\n'), ['found 0 vulnerabilities']);
+});
+
+test('a chunk ending on a newline leaves nothing pending', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('one\ntwo\n'), ['one', 'two']);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('a line split across three chunks is reassembled', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('npm error code '), []);
+	assert.deepEqual(buf.push('EBAD'), []);
+	assert.deepEqual(buf.push('ENGINE\n'), ['npm error code EBADENGINE']);
+});
+
+test('strips the CR of Windows CRLF output', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('C:\\Users\\dev>npm install\r\ndone\r\n'), ['C:\\Users\\dev>npm install', 'done']);
+});
+
+test('flush returns the unterminated last line', () => {
+	// Servers commonly exit right after a prompt with no trailing newline, and
+	// that line is usually the one explaining why.
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('Error: listen EPERM'), []);
+	assert.deepEqual(buf.flush(), ['Error: listen EPERM']);
+	// Flushing twice must not repeat it.
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('blank lines are preserved but a trailing empty remainder is not', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push('a\n\nb\n'), ['a', '', 'b']);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('empty and nullish chunks are no-ops', () => {
+	const buf = createLineBuffer();
+	assert.deepEqual(buf.push(''), []);
+	assert.deepEqual(buf.push(undefined), []);
+	assert.deepEqual(buf.push(null), []);
+	assert.deepEqual(buf.flush(), []);
+});
+
+test('buffers are independent so stdout and stderr do not interleave', () => {
+	const out = createLineBuffer();
+	const err = createLineBuffer();
+	assert.deepEqual(out.push('half of stdout'), []);
+	assert.deepEqual(err.push('a whole stderr line\n'), ['a whole stderr line']);
+	assert.deepEqual(out.push(' completed\n'), ['half of stdout completed']);
+});

--- a/test/menu.test.cjs
+++ b/test/menu.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildMenuTemplate } = require('../src/menu.js');
+
+const roles = (template) => template.map((item) => item.role);
+const helpItems = (template) => template.find((item) => item.role === 'help').submenu;
+
+test('rebuilds the default menu roles that setting a menu would otherwise drop', () => {
+	// Setting an application menu replaces Electron's default wholesale, so a
+	// missing role here is a silent regression in existing menu behaviour.
+	for (const platform of ['darwin', 'win32', 'linux']) {
+		const template = buildMenuTemplate({ platform });
+		for (const role of ['fileMenu', 'editMenu', 'viewMenu', 'windowMenu', 'help']) {
+			assert.ok(roles(template).includes(role), `${role} missing on ${platform}`);
+		}
+	}
+});
+
+test('the app menu is macOS-only', () => {
+	// On Windows and Linux those items belong under File, which fileMenu covers;
+	// an appMenu there would render as a stray empty submenu.
+	assert.ok(roles(buildMenuTemplate({ platform: 'darwin' })).includes('appMenu'));
+	assert.ok(!roles(buildMenuTemplate({ platform: 'win32' })).includes('appMenu'));
+	assert.ok(!roles(buildMenuTemplate({ platform: 'linux' })).includes('appMenu'));
+});
+
+test('Help exposes both log entries plus DevTools', () => {
+	const items = helpItems(buildMenuTemplate({}));
+	assert.deepEqual(
+		items.filter((i) => i.label).map((i) => i.label),
+		['Open App Log', 'Show Logs Folder']
+	);
+	assert.ok(items.some((i) => i.role === 'toggleDevTools'));
+});
+
+test('Help entries invoke the handlers they were given', () => {
+	let opened = 0;
+	let revealed = 0;
+	const items = helpItems(buildMenuTemplate({
+		onOpenLog: () => { opened++; },
+		onShowLogsFolder: () => { revealed++; }
+	}));
+	items.find((i) => i.label === 'Open App Log').click();
+	items.find((i) => i.label === 'Show Logs Folder').click();
+	assert.equal(opened, 1);
+	assert.equal(revealed, 1);
+});
+
+test('clicking without handlers does not throw', () => {
+	// The template is built before the log path is known in some call orders;
+	// a click must not take the whole main process down with it.
+	const items = helpItems(buildMenuTemplate());
+	assert.doesNotThrow(() => items.find((i) => i.label === 'Open App Log').click());
+});

--- a/test/nested-install.integration.test.cjs
+++ b/test/nested-install.integration.test.cjs
@@ -1,0 +1,97 @@
+// Integration coverage for issue #54: a build script that shells out to a
+// second `npm install` (the way wordpress-develop's Gruntfile does through
+// install-changed) hits EBADENGINE, because the script runner's environment has
+// strict engine checks.
+//
+// This has to be an integration test. The thing under test is whether
+// npm_config_engine_strict survives *two* levels of npm — the outer `npm run`
+// re-exports its own resolved config into the script's environment before the
+// grandchild install reads it. No unit test over buildChildEnv's output strings
+// can show that; only real npm can.
+//
+// Companion to npm-install.integration.test.cjs, which covers the same env var
+// one level down, on the plain install path.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const {
+	isEngineMismatch,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+} = require('../src/npm-runner.js');
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'nested-install');
+const SCRIPT_RUNNER = path.join(__dirname, '..', 'src', 'script-runner.js');
+
+// Keep npm quiet and offline: the fixture's only dependency is a local folder,
+// so an audit or funding lookup would add network flakiness for nothing.
+const QUIET_NPM = {
+	npm_config_loglevel: 'warn',
+	npm_config_audit: 'false',
+	npm_config_fund: 'false',
+	npm_config_progress: 'false'
+};
+
+function copyFixture() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nested-install-'));
+	fs.cpSync(FIXTURE, dir, { recursive: true });
+	// The build script ships as .js.txt because `node --test` runs every .js
+	// under test/ and would otherwise execute the fixture as a test file.
+	fs.renameSync(path.join(dir, 'run-build.js.txt'), path.join(dir, 'run-build.js'));
+	return dir;
+}
+
+// Runs the production script runner the same way main.js spawns it.
+function runScript(dir, { relaxEngines }) {
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, [SCRIPT_RUNNER, dir, 'build'], {
+			cwd: dir,
+			env: buildChildEnv({
+				// The fixture's build script resolves `npm` off the real PATH, which
+				// buildChildEnv preserves; the shim dir it prepends is only needed
+				// inside Electron. See npm-install.integration.test.cjs's header.
+				shimDir: path.join(dir, 'unused-shim'),
+				extraEnv: { ...QUIET_NPM, ...(relaxEngines ? RELAXED_ENGINES_ENV : {}) }
+			}),
+			shell: false,
+			windowsHide: true
+		});
+		let output = '';
+		child.stdout.on('data', (d) => { output += d.toString(); });
+		child.stderr.on('data', (d) => { output += d.toString(); });
+		child.on('close', (code) => resolve({ code, output }));
+	});
+}
+
+const installedDep = (dir) => fs.existsSync(path.join(dir, 'node_modules', 'needs-future-node'));
+
+test('a nested install inside a script hits EBADENGINE when engines are strict', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { output } = await runScript(dir, { relaxEngines: false });
+
+	// #54's symptom is noise, not failure: the Gruntfile swallows the error, so
+	// the build still reaches its end. Assert on what the log shows instead.
+	assert.match(output, /BUILD OK/, `the build should still have finished. Output:\n${output}`);
+	assert.equal(isEngineMismatch(output), true, `expected a real EBADENGINE block:\n${output}`);
+	assert.equal(installedDep(dir), false, 'the nested install should have installed nothing');
+});
+
+test('the nested install succeeds once the script runs with engines relaxed', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { code, output } = await runScript(dir, { relaxEngines: true });
+
+	assert.equal(code, 0, `expected a clean exit, got ${code}. Output:\n${output}`);
+	assert.match(output, /BUILD OK/, `the build should have finished. Output:\n${output}`);
+	assert.equal(installedDep(dir), true, `the nested install should have succeeded. Output:\n${output}`);
+	// The whole point: no stack trace from the swallowed execSync failure.
+	assert.doesNotMatch(output, /Command failed: npm install/, `the nested install still failed:\n${output}`);
+});

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -146,6 +146,56 @@ test('buildChildEnv sets both PATH casings and PATHEXT on Windows only', () => {
 	assert.equal(posix.PATHEXT, undefined);
 });
 
+test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIONS', () => {
+	const env = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows', NODE_OPTIONS: '--max-old-space-size=4096' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js',
+		npmCliPath: 'C:\\App\\npm-cli.js',
+		npxCliPath: 'C:\\App\\npx-cli.js'
+	});
+
+	// An inherited NODE_OPTIONS must survive: the build relies on its own flags.
+	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(env.WPTK_SPAWN_PATCH, '1');
+	assert.equal(env.WPTK_NPM_CLI, 'C:\\App\\npm-cli.js');
+	assert.equal(env.WPTK_NPX_CLI, 'C:\\App\\npx-cli.js');
+
+	const noInherited = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js'
+	});
+	assert.equal(noInherited.NODE_OPTIONS, '--require "C:\\shims\\win-spawn-patch.js"');
+});
+
+test('buildChildEnv leaves NODE_OPTIONS alone off Windows or without a patch', () => {
+	// The .cmd shim problem is Windows-only; POSIX shims are executable scripts.
+	const posix = buildChildEnv({
+		shimDir: '/shims',
+		baseEnv: { PATH: '/usr/bin' },
+		platform: 'darwin',
+		execPath: '/opt/app',
+		spawnPatchPath: '/shims/win-spawn-patch.js'
+	});
+	assert.equal(posix.NODE_OPTIONS, undefined);
+	assert.equal(posix.WPTK_SPAWN_PATCH, undefined);
+
+	// Copying the patch is best-effort; without it we must stay as we were.
+	const noPatch = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows', NODE_OPTIONS: '--enable-source-maps' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe'
+	});
+	assert.equal(noPatch.NODE_OPTIONS, '--enable-source-maps');
+	assert.equal(noPatch.WPTK_SPAWN_PATCH, undefined);
+});
+
 test('buildChildEnv applies extraEnv last so the retry can relax engines', () => {
 	const env = buildChildEnv({
 		shimDir: '/shims',

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -158,7 +158,7 @@ test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIO
 	});
 
 	// An inherited NODE_OPTIONS must survive: the build relies on its own flags.
-	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:/shims/win-spawn-patch.js"');
 	assert.equal(env.WPTK_SPAWN_PATCH, '1');
 	assert.equal(env.WPTK_NPM_CLI, 'C:\\App\\npm-cli.js');
 	assert.equal(env.WPTK_NPX_CLI, 'C:\\App\\npx-cli.js');
@@ -170,7 +170,25 @@ test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIO
 		execPath: 'C:\\App\\App.exe',
 		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js'
 	});
-	assert.equal(noInherited.NODE_OPTIONS, '--require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(noInherited.NODE_OPTIONS, '--require "C:/shims/win-spawn-patch.js"');
+});
+
+// Regression for the MODULE_NOT_FOUND this shipped with: Node tokenises
+// NODE_OPTIONS with shell-like rules, so a backslash inside the quotes is eaten
+// as an escape and the preload path arrives mangled (C:UsersJuanMa…). Asserting
+// on the exact string above is not enough — that is precisely the assertion that
+// passed while the app was broken — so pin the property that actually matters.
+test('buildChildEnv never leaves a backslash in the NODE_OPTIONS preload path', () => {
+	const env = buildChildEnv({
+		shimDir: 'C:\\Users\\JuanMa\\AppData\\Local\\Temp\\electron-node-shims-9832',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\Users\\JuanMa\\AppData\\Local\\Temp\\electron-node-shims-9832\\win-spawn-patch.js'
+	});
+
+	assert.equal(env.NODE_OPTIONS.includes('\\'), false);
+	assert.match(env.NODE_OPTIONS, /--require "C:\/Users\/JuanMa\/.*\/win-spawn-patch\.js"$/);
 });
 
 test('buildChildEnv leaves NODE_OPTIONS alone off Windows or without a patch', () => {

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { computeSetupStepState } = require('../src/renderer/setup-steps.cjs');
+
+test('while the clone is still running, the install step is locked (issue #47)', () => {
+	const steps = computeSetupStepState({ isPending: true });
+
+	assert.strictEqual(steps.download.done, false, 'download must not read as complete mid-clone');
+	assert.strictEqual(steps.install.ready, false, 'install must stay locked mid-clone');
+	assert.strictEqual(steps.install.disabled, true, 'install button must be disabled mid-clone');
+});
+
+test('a pending clone never unlocks the later steps', () => {
+	const steps = computeSetupStepState({ isPending: true, hasNodeModules: true, hasBuilt: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+	assert.strictEqual(steps.download.done, false);
+});
+
+test('once the clone finishes the install step becomes actionable', () => {
+	const steps = computeSetupStepState({ isPending: false });
+
+	assert.strictEqual(steps.download.done, true);
+	assert.strictEqual(steps.install.ready, true);
+	assert.strictEqual(steps.install.disabled, false);
+});
+
+test('the status probe still gates the install button', () => {
+	const steps = computeSetupStepState({ statusLoading: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+});
+
+test('an install in flight disables its own button', () => {
+	const steps = computeSetupStepState({ installing: true });
+
+	assert.strictEqual(steps.install.disabled, true);
+	assert.strictEqual(steps.install.done, false);
+});
+
+test('installed dependencies complete the install step and unlock the build', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true });
+
+	assert.strictEqual(steps.install.done, true);
+	assert.strictEqual(steps.install.disabled, true, 'nothing left to install');
+	assert.strictEqual(steps.build.ready, true);
+	assert.strictEqual(steps.build.disabled, false);
+});
+
+test('the build stays locked without node_modules', () => {
+	const steps = computeSetupStepState({});
+
+	assert.strictEqual(steps.build.ready, false);
+	assert.strictEqual(steps.build.disabled, true);
+});
+
+test('a finished build completes its step and unlocks the dev server', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true });
+
+	assert.strictEqual(steps.build.done, true);
+	assert.strictEqual(steps.build.disabled, true, 'nothing left to build');
+	assert.strictEqual(steps.dev.ready, true);
+	assert.strictEqual(steps.dev.disabled, false);
+});
+
+test('the dev step is never marked done by the checklist', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true, starting: true });
+
+	assert.strictEqual(steps.dev.done, false);
+	assert.strictEqual(steps.dev.disabled, true, 'disabled while starting');
+});

--- a/test/win-spawn-patch.test.cjs
+++ b/test/win-spawn-patch.test.cjs
@@ -1,0 +1,147 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { resolveSpawnTarget, applyPatch, PATCH_MARKER } = require('../src/win-spawn-patch.js');
+
+// The Windows shim layout ensureNodeShimDir() writes, as the patch sees it.
+const WIN = {
+	platform: 'win32',
+	execPath: 'C:\\App\\App.exe',
+	npmCliPath: 'C:\\App\\resources\\app.asar\\node_modules\\npm\\bin\\npm-cli.js',
+	npxCliPath: 'C:\\App\\resources\\app.asar\\node_modules\\npm\\bin\\npx-cli.js',
+	env: { Path: 'C:\\shims;C:\\Windows', PATHEXT: '.COM;.EXE;.BAT;.CMD' },
+	lookup: (file) => {
+		const known = {
+			node: 'C:\\shims\\node.cmd',
+			grunt: 'C:\\site\\node_modules\\.bin\\grunt.cmd',
+			mysqld: 'C:\\tools\\mysqld.exe'
+		};
+		return known[String(file).toLowerCase()] || null;
+	}
+};
+
+// The exact call wordpress-develop's Gruntfile makes in gutenberg:verify.
+test('a bare `node` spawn is redirected to Electron in Node mode, without a shell', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		file: 'node',
+		args: ['tools/gutenberg/utils.js'],
+		options: { stdio: 'inherit' }
+	});
+
+	assert.equal(target.file, 'C:\\App\\App.exe');
+	assert.deepEqual(target.args, ['tools/gutenberg/utils.js']);
+	assert.equal(target.options.stdio, 'inherit');
+	assert.equal(target.options.env.ELECTRON_RUN_AS_NODE, '1');
+	// No shell means no quoting hazard — that is the point of this branch.
+	assert.ok(!target.options.shell);
+});
+
+test('node.cmd and NODE.EXE resolve to the same redirect as bare node', () => {
+	for (const file of ['node.cmd', 'C:\\shims\\node.bat', 'NODE.EXE']) {
+		const target = resolveSpawnTarget({ ...WIN, file, args: ['x.js'] });
+		assert.equal(target.file, 'C:\\App\\App.exe', file);
+		assert.deepEqual(target.args, ['x.js'], file);
+	}
+});
+
+test('npm and npx are redirected to their JS CLIs', () => {
+	const npm = resolveSpawnTarget({ ...WIN, file: 'npm', args: ['ci'] });
+	assert.deepEqual(npm.args, [WIN.npmCliPath, 'ci']);
+	assert.equal(npm.file, WIN.execPath);
+
+	const npx = resolveSpawnTarget({ ...WIN, file: 'npx.cmd', args: ['wp-scripts', 'build'] });
+	assert.deepEqual(npx.args, [WIN.npxCliPath, 'wp-scripts', 'build']);
+});
+
+test('npm falls through to the shell branch when no npm CLI path is known', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		npmCliPath: null,
+		file: 'npm',
+		args: ['ci'],
+		lookup: () => 'C:\\shims\\npm.cmd'
+	});
+	assert.equal(target.options.shell, true);
+	assert.equal(target.file, '"C:\\shims\\npm.cmd"');
+});
+
+test('the caller\'s env is cloned, never mutated', () => {
+	const callerEnv = { PATH: 'C:\\Windows' };
+	const target = resolveSpawnTarget({ ...WIN, file: 'node', args: [], options: { env: callerEnv } });
+
+	assert.equal(target.options.env.PATH, 'C:\\Windows');
+	assert.equal(target.options.env.ELECTRON_RUN_AS_NODE, '1');
+	assert.equal(callerEnv.ELECTRON_RUN_AS_NODE, undefined);
+});
+
+test('any other .cmd shim gets shell:true with cmd-safe quoting', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		file: 'grunt',
+		args: ['build', '--base=C:\\My Sites\\wp', 'plain']
+	});
+
+	assert.equal(target.options.shell, true);
+	assert.equal(target.file, '"C:\\site\\node_modules\\.bin\\grunt.cmd"');
+	// Only the argument cmd.exe would mis-split is quoted.
+	assert.deepEqual(target.args, ['build', '"--base=C:\\My Sites\\wp"', 'plain']);
+});
+
+test('commands that Windows can exec directly are left alone', () => {
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'mysqld', args: [] }), null);
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'C:\\tools\\thing.exe', args: [] }), null);
+	// Unresolvable name: leave it be so the caller sees the real ENOENT.
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'nonesuch', args: [] }), null);
+});
+
+test('a call that already asked for a shell is left alone', () => {
+	assert.equal(
+		resolveSpawnTarget({ ...WIN, file: 'node', args: ['x.js'], options: { shell: true } }),
+		null
+	);
+});
+
+test('nothing is rewritten off Windows', () => {
+	for (const platform of ['darwin', 'linux']) {
+		assert.equal(resolveSpawnTarget({ ...WIN, platform, file: 'node', args: ['x.js'] }), null, platform);
+	}
+});
+
+test('applyPatch rewrites spawn arguments in every optional-argument shape', () => {
+	const calls = [];
+	const fake = {
+		spawn: (...args) => { calls.push(args); return 'spawned'; },
+		spawnSync: (...args) => { calls.push(args); },
+		execFile: (...args) => { calls.push(args); },
+		execFileSync: (...args) => { calls.push(args); }
+	};
+	applyPatch(fake, { platform: 'win32', execPath: WIN.execPath, lookup: WIN.lookup, env: WIN.env });
+
+	assert.equal(fake.spawn('node', ['a.js']), 'spawned');
+	assert.deepEqual(calls[0][0], WIN.execPath);
+	assert.deepEqual(calls[0][1], ['a.js']);
+
+	// No args array, no options.
+	fake.spawn('node');
+	assert.deepEqual(calls[1][1], []);
+
+	// Trailing callback (execFile) must survive the rewrite.
+	const cb = () => {};
+	fake.execFile('node', ['a.js'], { cwd: 'C:\\site' }, cb);
+	assert.equal(calls[2][2].cwd, 'C:\\site');
+	assert.equal(calls[2][3], cb);
+});
+
+test('applyPatch is idempotent so a duplicated --require cannot double-wrap', () => {
+	let depth = 0;
+	const fake = { spawn: () => { depth += 1; } };
+	applyPatch(fake, { platform: 'darwin' });
+	const afterFirst = fake.spawn;
+	applyPatch(fake, { platform: 'darwin' });
+
+	assert.equal(fake.spawn, afterFirst);
+	assert.equal(fake[PATCH_MARKER], true);
+	fake.spawn('node');
+	assert.equal(depth, 1);
+});


### PR DESCRIPTION
## ⚠️ Do not merge — testing branch only

This PR exists so Buildkite produces a **single Windows artifact containing all the in-flight Windows fixes at once**, so they can be tested together on a Windows VM. Each fix keeps its own PR for review and merges separately; this branch is disposable and will be rebuilt as more PRs land.

## What's in it

`trunk` with these branches merged in:

| PR | Issue | Fix |
| --- | --- | --- |
| #50 | #49 | Write an app log to disk and add a Help menu to open it |
| #51 | #47 | Lock the "Install npm dependencies" step until the clone finishes |
| #52 | #48 | "Run first full build": stream output to the terminal, stop the Windows console flashes |
| #56 | #53 | Windows build aborting at `grunt gutenberg:verify` with `spawn EINVAL` |
| #58 | #54 | Relax npm engine checks for scripts so nested installs don't fail |

`npm test` passes on the merge result: **70/70** (including #58's two integration tests, which run real npm).

## Conflict resolution

Every conflict was additive — two branches adding different things to the same function or JSX element. Both sides were kept; no behaviour was dropped.

**`src/main.js` — `runNpmWithEngineRetry`**, touched by #50, #52, #56 and #58:

- Signature: `logScope` (#50) **and** `relaxEnginesFromStart` (#58) both kept. #58 branched off `trunk` without #50, so its version had dropped `logScope`.
- The two `child.on('error')` handlers (#50 and #52) folded into one that writes to the log file *and* reports the failure to the renderer via `finish(-1)`.
- In `child.on('close')`, the exit is logged (#50) before the `if (finished) return` guard (#52), so an exit is recorded even when the run already ended through the error path.
- Comment block: kept #58's rewrite, which documents both knobs (`retryOnEngineMismatch` vs `relaxEnginesFromStart`) and supersedes the older one.
- In the `npm:run-script` handler, both `logScope` (#50) and `relaxEnginesFromStart: true` (#58) are passed.

**`src/renderer/index.jsx`** — the build button uses `onClick={runBuildWithTerminal}` (#52) **and** `disabled={stepState.build.disabled}` (#51).

**`src/renderer/index.js`** — regenerated with `npm run build:once` rather than hand-merged.

#56 merged cleanly on top of the rest.

## What only exists on this branch

#52 and #56 both patch `child_process`, by different routes, and this is the first place they run together. #56's patch is preloaded into every descendant Node process via `NODE_OPTIONS=--require`, so it lands first; #52's `hide-child-windows` is applied inside the runners and wraps the already-rewritten `spawn`. The orders compose — target rewrite first, `windowsHide` on top — but if something behaves oddly on Windows, that interaction is the first place to look.

## How to refresh it as more PRs land

```
git checkout juanmaguitar/windows-fixes-integration
git merge origin/trunk
git merge origin/<new-pr-branch>
npm run build:once && npm test
git push
```
