### PR TITLE
Fix Windows build aborting at `grunt gutenberg:verify` with `spawn EINVAL`

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,12 @@ const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
 // Provide a PATH shim so npm's spawned scripts can find a 'node' binary that maps to Electron's Node
 let nodeShimDir = null;
+// Windows-only: absolute path of the child_process patch copied next to the
+// shims, preloaded into descendant Node processes via NODE_OPTIONS so that a
+// bare spawn('node') hitting node.cmd does not fail with EINVAL.
+let spawnPatchPath = null;
+let npmCliPath = null;
+let npxCliPath = null;
 function ensureNodeShimDir() {
     if (nodeShimDir) return nodeShimDir;
     nodeShimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
@@ -39,12 +45,23 @@ function ensureNodeShimDir() {
                 const npmRootDir = path.dirname(npmPkgJsonPath);
                 const npmCliAbsPath = path.join(npmRootDir, 'bin', 'npm-cli.js');
                 const npxCliAbsPath = path.join(npmRootDir, 'bin', 'npx-cli.js');
+                npmCliPath = npmCliAbsPath;
+                npxCliPath = npxCliAbsPath;
                 const npmCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npmCliAbsPath}" %*\r\n`;
                 const npxCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npxCliAbsPath}" %*\r\n`;
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.cmd'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.bat'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npx.cmd'), npxCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npx.bat'), npxCmd);
+            } catch {}
+            // Copy the child_process patch out of the app bundle: it is loaded with
+            // --require by child Node processes, and a path inside app.asar is not
+            // reliably resolvable under ELECTRON_RUN_AS_NODE. A failure here only
+            // means we are back to the pre-patch behaviour, so it stays non-fatal.
+            try {
+                const dest = path.join(nodeShimDir, 'win-spawn-patch.js');
+                fs.copyFileSync(path.join(__dirname, 'win-spawn-patch.js'), dest);
+                spawnPatchPath = dest;
             } catch {}
             // Intentionally do NOT create node.exe here, as Electron's exe depends on adjacent DLLs.
             // Using node.exe from a temp dir causes STATUS_DLL_NOT_FOUND (0xC0000135) when spawned by npm.
@@ -529,6 +546,9 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			cwd,
 			env: buildChildEnv({
 				shimDir: ensureNodeShimDir(),
+				spawnPatchPath,
+				npmCliPath,
+				npxCliPath,
 				extraEnv: relaxEngines ? RELAXED_ENGINES_ENV : {}
 			}),
 			shell: false,

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -60,12 +60,21 @@ function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alread
 
 // The env block for a spawned npm runner. On Windows both PATH and Path are set
 // and PATHEXT is extended so child npm processes can find the node shim.
+//
+// On Windows the node shim is a .cmd, which Node >= 20.12.2 refuses to spawn
+// without `shell: true` — so `spawnPatchPath` is preloaded into every descendant
+// Node process via NODE_OPTIONS to rewrite those spawns. See win-spawn-patch.js.
+// Electron only honours NODE_OPTIONS when ELECTRON_RUN_AS_NODE is set, which it
+// is just below.
 function buildChildEnv({
 	shimDir,
 	extraEnv = {},
 	baseEnv = process.env,
 	platform = process.platform,
-	execPath = process.execPath
+	execPath = process.execPath,
+	spawnPatchPath = null,
+	npmCliPath = null,
+	npxCliPath = null
 } = {}) {
 	const isWindows = platform === 'win32';
 	const separator = isWindows ? ';' : ':';
@@ -84,6 +93,17 @@ function buildChildEnv({
 	};
 	if (isWindows) {
 		env.Path = joinedPath;
+	}
+	if (isWindows && spawnPatchPath) {
+		// Appended, never replaced: an inherited NODE_OPTIONS may carry settings
+		// the build relies on (wordpress-develop bumps --max-old-space-size).
+		const requireFlag = `--require "${spawnPatchPath}"`;
+		env.NODE_OPTIONS = baseEnv.NODE_OPTIONS
+			? `${baseEnv.NODE_OPTIONS} ${requireFlag}`
+			: requireFlag;
+		env.WPTK_SPAWN_PATCH = '1';
+		if (npmCliPath) env.WPTK_NPM_CLI = npmCliPath;
+		if (npxCliPath) env.WPTK_NPX_CLI = npxCliPath;
 	}
 	return { ...env, ...extraEnv };
 }

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -95,9 +95,18 @@ function buildChildEnv({
 		env.Path = joinedPath;
 	}
 	if (isWindows && spawnPatchPath) {
+		// Forward slashes, always. Node does not read NODE_OPTIONS literally: it
+		// tokenises it with shell-like rules, and inside quotes a backslash is an
+		// escape character. A native path would arrive at the preloader as
+		// C:UsersJuanMaAppData… and die with MODULE_NOT_FOUND before the child
+		// runs a single line. Windows resolves forward slashes fine, and unlike
+		// doubling the backslashes this does not depend on how many layers of
+		// unescaping the value passes through. The quotes stay, for paths with
+		// spaces in them.
+		const requirePath = String(spawnPatchPath).replace(/\\/g, '/');
 		// Appended, never replaced: an inherited NODE_OPTIONS may carry settings
 		// the build relies on (wordpress-develop bumps --max-old-space-size).
-		const requireFlag = `--require "${spawnPatchPath}"`;
+		const requireFlag = `--require "${requirePath}"`;
 		env.NODE_OPTIONS = baseEnv.NODE_OPTIONS
 			? `${baseEnv.NODE_OPTIONS} ${requireFlag}`
 			: requireFlag;

--- a/src/win-spawn-patch.js
+++ b/src/win-spawn-patch.js
@@ -1,0 +1,163 @@
+// Preloaded (via NODE_OPTIONS=--require) into every descendant Node process on
+// Windows so that a bare `spawn('node', …)` keeps working without a real node.exe.
+//
+// Why this is needed: the only `node` on PATH is the shim written by
+// ensureNodeShimDir() in main.js, and on Windows that shim is a .cmd/.bat.
+// Node >= 20.12.2 (CVE-2024-27980) refuses to spawn a .bat/.cmd unless
+// `shell: true`, so wordpress-develop's Gruntfile — which does
+// `grunt.util.spawn({ cmd: 'node', … })` with shell:false — dies with EINVAL.
+// Grunt runs two levels below us (script-runner -> cmd.exe -> grunt.cmd -> node),
+// so an inherited NODE_OPTIONS preload is the only way to reach it.
+//
+// Deliberately self-contained (Node built-ins only): this file is copied into the
+// temp shim dir and required from there, because --require into a path inside
+// app.asar is not reliable under ELECTRON_RUN_AS_NODE.
+
+const path = require('path');
+const fs = require('fs');
+
+const SCRIPT_EXTENSIONS = ['.cmd', '.bat'];
+// Args are handed to cmd.exe verbatim when shell:true, so anything cmd would
+// interpret has to be quoted by us — Node does no quoting in shell mode.
+const NEEDS_QUOTING = /[\s"&|<>^()%!]/;
+
+// Strips the extension Windows would have resolved, so `node`, `node.cmd` and
+// `C:\shims\node.bat` all collapse to the same name.
+function shimName(file) {
+	const base = path.win32.basename(String(file || '')).toLowerCase();
+	const ext = path.win32.extname(base);
+	if (ext === '.cmd' || ext === '.bat' || ext === '.exe') {
+		return base.slice(0, -ext.length);
+	}
+	return base;
+}
+
+// Mirrors libuv's PATH/PATHEXT search closely enough to tell whether a bare
+// command name would land on a script the OS cannot exec directly.
+function defaultLookup(file, env) {
+	const name = String(file || '');
+	if (!name) return null;
+	const hasDir = name.includes('/') || name.includes('\\');
+	const candidateDirs = hasDir
+		? [null]
+		: String(env.Path || env.PATH || '').split(';').filter(Boolean);
+	const pathExt = String(env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+	const extensions = path.win32.extname(name) ? [''] : pathExt;
+	for (const dir of candidateDirs) {
+		for (const ext of extensions) {
+			const candidate = (dir === null ? name : path.win32.join(dir, name)) + ext.toLowerCase();
+			try {
+				if (fs.existsSync(candidate)) return candidate;
+			} catch {}
+		}
+	}
+	return null;
+}
+
+function quoteForCmd(value) {
+	const text = String(value);
+	return NEEDS_QUOTING.test(text) ? `"${text}"` : text;
+}
+
+// Clones the caller's env (or inherits process.env) and forces Electron into
+// Node mode, since the command we redirect to is electron.exe.
+function withNodeMode(options) {
+	const baseEnv = options && options.env ? options.env : process.env;
+	return { ...options, env: { ...baseEnv, ELECTRON_RUN_AS_NODE: '1' } };
+}
+
+// Decides how a child_process call must be rewritten. Returns null when the call
+// is fine as-is. Pure and fully parameterised so it can be tested off-Windows.
+function resolveSpawnTarget({
+	file,
+	args = [],
+	options = {},
+	platform = process.platform,
+	execPath = process.execPath,
+	npmCliPath = null,
+	npxCliPath = null,
+	env = process.env,
+	lookup = defaultLookup
+} = {}) {
+	if (platform !== 'win32') return null;
+	if (options.shell) return null;
+
+	const name = shimName(file);
+
+	// Preferred path: call Electron's binary directly. No shell, so no quoting
+	// hazard, and it works even when the .cmd shim is missing entirely.
+	if (name === 'node') {
+		return { file: execPath, args: [...args], options: withNodeMode(options) };
+	}
+	if (name === 'npm' && npmCliPath) {
+		return { file: execPath, args: [npmCliPath, ...args], options: withNodeMode(options) };
+	}
+	if (name === 'npx' && npxCliPath) {
+		return { file: execPath, args: [npxCliPath, ...args], options: withNodeMode(options) };
+	}
+
+	// Fallback for every other .cmd/.bat shim (bin stubs of npm packages, etc.):
+	// cmd.exe can run them, CreateProcess cannot.
+	const resolved = path.win32.extname(String(file || ''))
+		? String(file)
+		: lookup(file, env);
+	if (!resolved) return null;
+	if (!SCRIPT_EXTENSIONS.includes(path.win32.extname(resolved).toLowerCase())) return null;
+
+	return {
+		// Always quoted: a resolved path cannot contain a quote character, and
+		// site paths under "C:\Users\…\My Sites" routinely contain spaces.
+		file: `"${resolved}"`,
+		args: args.map(quoteForCmd),
+		options: { ...options, shell: true }
+	};
+}
+
+// child_process signatures are (file, args?, options?, callback?) with every
+// tail argument optional, so the shape has to be re-derived before rewriting.
+function rewriteArguments(callArgs, config) {
+	const [file, ...rest] = callArgs;
+	let args = [];
+	let options = {};
+	let tail = [];
+	let index = 0;
+	if (Array.isArray(rest[0])) {
+		args = rest[0];
+		index = 1;
+	}
+	if (rest[index] && typeof rest[index] === 'object') {
+		options = rest[index];
+		index += 1;
+	}
+	tail = rest.slice(index);
+
+	const target = resolveSpawnTarget({ ...config, file, args, options });
+	if (!target) return callArgs;
+	return [target.file, target.args, target.options, ...tail];
+}
+
+const PATCH_MARKER = Symbol.for('wptk.winSpawnPatch');
+
+function applyPatch(childProcess = require('child_process'), config = {}) {
+	if (childProcess[PATCH_MARKER]) return childProcess;
+	for (const method of ['spawn', 'spawnSync', 'execFile', 'execFileSync']) {
+		const original = childProcess[method];
+		if (typeof original !== 'function') continue;
+		childProcess[method] = function patched(...callArgs) {
+			return original.apply(this, rewriteArguments(callArgs, config));
+		};
+	}
+	childProcess[PATCH_MARKER] = true;
+	return childProcess;
+}
+
+// Only self-applies when the app explicitly asked for it, so requiring this
+// module from a test never mutates the test process.
+if (process.env.WPTK_SPAWN_PATCH === '1') {
+	applyPatch(require('child_process'), {
+		npmCliPath: process.env.WPTK_NPM_CLI || null,
+		npxCliPath: process.env.WPTK_NPX_CLI || null
+	});
+}
+
+module.exports = { resolveSpawnTarget, applyPatch, PATCH_MARKER };

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -146,6 +146,56 @@ test('buildChildEnv sets both PATH casings and PATHEXT on Windows only', () => {
 	assert.equal(posix.PATHEXT, undefined);
 });
 
+test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIONS', () => {
+	const env = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows', NODE_OPTIONS: '--max-old-space-size=4096' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js',
+		npmCliPath: 'C:\\App\\npm-cli.js',
+		npxCliPath: 'C:\\App\\npx-cli.js'
+	});
+
+	// An inherited NODE_OPTIONS must survive: the build relies on its own flags.
+	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(env.WPTK_SPAWN_PATCH, '1');
+	assert.equal(env.WPTK_NPM_CLI, 'C:\\App\\npm-cli.js');
+	assert.equal(env.WPTK_NPX_CLI, 'C:\\App\\npx-cli.js');
+
+	const noInherited = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js'
+	});
+	assert.equal(noInherited.NODE_OPTIONS, '--require "C:\\shims\\win-spawn-patch.js"');
+});
+
+test('buildChildEnv leaves NODE_OPTIONS alone off Windows or without a patch', () => {
+	// The .cmd shim problem is Windows-only; POSIX shims are executable scripts.
+	const posix = buildChildEnv({
+		shimDir: '/shims',
+		baseEnv: { PATH: '/usr/bin' },
+		platform: 'darwin',
+		execPath: '/opt/app',
+		spawnPatchPath: '/shims/win-spawn-patch.js'
+	});
+	assert.equal(posix.NODE_OPTIONS, undefined);
+	assert.equal(posix.WPTK_SPAWN_PATCH, undefined);
+
+	// Copying the patch is best-effort; without it we must stay as we were.
+	const noPatch = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows', NODE_OPTIONS: '--enable-source-maps' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe'
+	});
+	assert.equal(noPatch.NODE_OPTIONS, '--enable-source-maps');
+	assert.equal(noPatch.WPTK_SPAWN_PATCH, undefined);
+});
+
 test('buildChildEnv applies extraEnv last so the retry can relax engines', () => {
 	const env = buildChildEnv({
 		shimDir: '/shims',

--- a/test/npm-runner.test.cjs
+++ b/test/npm-runner.test.cjs
@@ -158,7 +158,7 @@ test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIO
 	});
 
 	// An inherited NODE_OPTIONS must survive: the build relies on its own flags.
-	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(env.NODE_OPTIONS, '--max-old-space-size=4096 --require "C:/shims/win-spawn-patch.js"');
 	assert.equal(env.WPTK_SPAWN_PATCH, '1');
 	assert.equal(env.WPTK_NPM_CLI, 'C:\\App\\npm-cli.js');
 	assert.equal(env.WPTK_NPX_CLI, 'C:\\App\\npx-cli.js');
@@ -170,7 +170,25 @@ test('buildChildEnv preloads the spawn patch on Windows, appending to NODE_OPTIO
 		execPath: 'C:\\App\\App.exe',
 		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js'
 	});
-	assert.equal(noInherited.NODE_OPTIONS, '--require "C:\\shims\\win-spawn-patch.js"');
+	assert.equal(noInherited.NODE_OPTIONS, '--require "C:/shims/win-spawn-patch.js"');
+});
+
+// Regression for the MODULE_NOT_FOUND this shipped with: Node tokenises
+// NODE_OPTIONS with shell-like rules, so a backslash inside the quotes is eaten
+// as an escape and the preload path arrives mangled (C:UsersJuanMa…). Asserting
+// on the exact string above is not enough — that is precisely the assertion that
+// passed while the app was broken — so pin the property that actually matters.
+test('buildChildEnv never leaves a backslash in the NODE_OPTIONS preload path', () => {
+	const env = buildChildEnv({
+		shimDir: 'C:\\Users\\JuanMa\\AppData\\Local\\Temp\\electron-node-shims-9832',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\Users\\JuanMa\\AppData\\Local\\Temp\\electron-node-shims-9832\\win-spawn-patch.js'
+	});
+
+	assert.equal(env.NODE_OPTIONS.includes('\\'), false);
+	assert.match(env.NODE_OPTIONS, /--require "C:\/Users\/JuanMa\/.*\/win-spawn-patch\.js"$/);
 });
 
 test('buildChildEnv leaves NODE_OPTIONS alone off Windows or without a patch', () => {

--- a/test/win-spawn-patch.test.cjs
+++ b/test/win-spawn-patch.test.cjs
@@ -1,0 +1,147 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { resolveSpawnTarget, applyPatch, PATCH_MARKER } = require('../src/win-spawn-patch.js');
+
+// The Windows shim layout ensureNodeShimDir() writes, as the patch sees it.
+const WIN = {
+	platform: 'win32',
+	execPath: 'C:\\App\\App.exe',
+	npmCliPath: 'C:\\App\\resources\\app.asar\\node_modules\\npm\\bin\\npm-cli.js',
+	npxCliPath: 'C:\\App\\resources\\app.asar\\node_modules\\npm\\bin\\npx-cli.js',
+	env: { Path: 'C:\\shims;C:\\Windows', PATHEXT: '.COM;.EXE;.BAT;.CMD' },
+	lookup: (file) => {
+		const known = {
+			node: 'C:\\shims\\node.cmd',
+			grunt: 'C:\\site\\node_modules\\.bin\\grunt.cmd',
+			mysqld: 'C:\\tools\\mysqld.exe'
+		};
+		return known[String(file).toLowerCase()] || null;
+	}
+};
+
+// The exact call wordpress-develop's Gruntfile makes in gutenberg:verify.
+test('a bare `node` spawn is redirected to Electron in Node mode, without a shell', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		file: 'node',
+		args: ['tools/gutenberg/utils.js'],
+		options: { stdio: 'inherit' }
+	});
+
+	assert.equal(target.file, 'C:\\App\\App.exe');
+	assert.deepEqual(target.args, ['tools/gutenberg/utils.js']);
+	assert.equal(target.options.stdio, 'inherit');
+	assert.equal(target.options.env.ELECTRON_RUN_AS_NODE, '1');
+	// No shell means no quoting hazard — that is the point of this branch.
+	assert.ok(!target.options.shell);
+});
+
+test('node.cmd and NODE.EXE resolve to the same redirect as bare node', () => {
+	for (const file of ['node.cmd', 'C:\\shims\\node.bat', 'NODE.EXE']) {
+		const target = resolveSpawnTarget({ ...WIN, file, args: ['x.js'] });
+		assert.equal(target.file, 'C:\\App\\App.exe', file);
+		assert.deepEqual(target.args, ['x.js'], file);
+	}
+});
+
+test('npm and npx are redirected to their JS CLIs', () => {
+	const npm = resolveSpawnTarget({ ...WIN, file: 'npm', args: ['ci'] });
+	assert.deepEqual(npm.args, [WIN.npmCliPath, 'ci']);
+	assert.equal(npm.file, WIN.execPath);
+
+	const npx = resolveSpawnTarget({ ...WIN, file: 'npx.cmd', args: ['wp-scripts', 'build'] });
+	assert.deepEqual(npx.args, [WIN.npxCliPath, 'wp-scripts', 'build']);
+});
+
+test('npm falls through to the shell branch when no npm CLI path is known', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		npmCliPath: null,
+		file: 'npm',
+		args: ['ci'],
+		lookup: () => 'C:\\shims\\npm.cmd'
+	});
+	assert.equal(target.options.shell, true);
+	assert.equal(target.file, '"C:\\shims\\npm.cmd"');
+});
+
+test('the caller\'s env is cloned, never mutated', () => {
+	const callerEnv = { PATH: 'C:\\Windows' };
+	const target = resolveSpawnTarget({ ...WIN, file: 'node', args: [], options: { env: callerEnv } });
+
+	assert.equal(target.options.env.PATH, 'C:\\Windows');
+	assert.equal(target.options.env.ELECTRON_RUN_AS_NODE, '1');
+	assert.equal(callerEnv.ELECTRON_RUN_AS_NODE, undefined);
+});
+
+test('any other .cmd shim gets shell:true with cmd-safe quoting', () => {
+	const target = resolveSpawnTarget({
+		...WIN,
+		file: 'grunt',
+		args: ['build', '--base=C:\\My Sites\\wp', 'plain']
+	});
+
+	assert.equal(target.options.shell, true);
+	assert.equal(target.file, '"C:\\site\\node_modules\\.bin\\grunt.cmd"');
+	// Only the argument cmd.exe would mis-split is quoted.
+	assert.deepEqual(target.args, ['build', '"--base=C:\\My Sites\\wp"', 'plain']);
+});
+
+test('commands that Windows can exec directly are left alone', () => {
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'mysqld', args: [] }), null);
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'C:\\tools\\thing.exe', args: [] }), null);
+	// Unresolvable name: leave it be so the caller sees the real ENOENT.
+	assert.equal(resolveSpawnTarget({ ...WIN, file: 'nonesuch', args: [] }), null);
+});
+
+test('a call that already asked for a shell is left alone', () => {
+	assert.equal(
+		resolveSpawnTarget({ ...WIN, file: 'node', args: ['x.js'], options: { shell: true } }),
+		null
+	);
+});
+
+test('nothing is rewritten off Windows', () => {
+	for (const platform of ['darwin', 'linux']) {
+		assert.equal(resolveSpawnTarget({ ...WIN, platform, file: 'node', args: ['x.js'] }), null, platform);
+	}
+});
+
+test('applyPatch rewrites spawn arguments in every optional-argument shape', () => {
+	const calls = [];
+	const fake = {
+		spawn: (...args) => { calls.push(args); return 'spawned'; },
+		spawnSync: (...args) => { calls.push(args); },
+		execFile: (...args) => { calls.push(args); },
+		execFileSync: (...args) => { calls.push(args); }
+	};
+	applyPatch(fake, { platform: 'win32', execPath: WIN.execPath, lookup: WIN.lookup, env: WIN.env });
+
+	assert.equal(fake.spawn('node', ['a.js']), 'spawned');
+	assert.deepEqual(calls[0][0], WIN.execPath);
+	assert.deepEqual(calls[0][1], ['a.js']);
+
+	// No args array, no options.
+	fake.spawn('node');
+	assert.deepEqual(calls[1][1], []);
+
+	// Trailing callback (execFile) must survive the rewrite.
+	const cb = () => {};
+	fake.execFile('node', ['a.js'], { cwd: 'C:\\site' }, cb);
+	assert.equal(calls[2][2].cwd, 'C:\\site');
+	assert.equal(calls[2][3], cb);
+});
+
+test('applyPatch is idempotent so a duplicated --require cannot double-wrap', () => {
+	let depth = 0;
+	const fake = { spawn: () => { depth += 1; } };
+	applyPatch(fake, { platform: 'darwin' });
+	const afterFirst = fake.spawn;
+	applyPatch(fake, { platform: 'darwin' });
+
+	assert.equal(fake.spawn, afterFirst);
+	assert.equal(fake[PATCH_MARKER], true);
+	fake.spawn('node');
+	assert.equal(depth, 1);
+});


### PR DESCRIPTION
> **Stack — 4 of 5** · `trunk` → #50 → #51 → #52 → **#56** → #58
> The diff below is only this PR's own changes. All five were verified together end to end on a Windows VM: clone → install → build → dev server → WordPress wizard → wp-admin.

Fixes #53.

## Problem

On Windows `npm run build` died on its very first grunt subtask (`gutenberg:verify`) with `spawn EINVAL`, exit code 3, and no `build/` output — so the wizard could never reach a working site.

`wordpress-develop`'s Gruntfile spawns a bare `node`. There is no real `node` on the host — that's the whole point of this app — so it hits our `node.cmd` shim, and Node ≥ 20.12.2 refuses to spawn a `.cmd` without `shell: true`.

## Fix

Grunt runs two levels below us (`script-runner` → `cmd.exe` → `grunt.cmd` → node), so patching `child_process` in our own process can't reach it. The patch is preloaded into **every** descendant Node process via `NODE_OPTIONS=--require`, and rewrites `node` to Electron's own executable — no shell involved.

## How to test

**Windows only** — the failure does not reproduce on macOS or Linux. Use a packaged build from this branch (Buildkite on this branch produces one).

1. Create a site, let the clone finish, click **Install npm dependencies** and wait for it to complete.
2. Click **Run first full build**.
3. It should get past `gutenberg:verify` and `gutenberg:download` and run to completion, producing a `build/` directory. On `trunk` it dies on the first of those with `spawn EINVAL` and exit code 3.
4. Open **Help → Open App Log** and search it for:
   - `EINVAL` — should not appear
   - `MODULE_NOT_FOUND` / `win-spawn-patch.js` — should not appear either; that was the bug fixed in 9fb73e4, where the preload path arrived with its backslashes stripped and killed every child process
5. `exited with code 0` for the `build#…` scope.

Automated: `npm test` (11 cases in `test/win-spawn-patch.test.cjs`, plus three `buildChildEnv` cases).


<details>
<summary><b>The full failure chain</b></summary>

1. `wordpress-develop`'s Gruntfile does `grunt.util.spawn({ cmd: 'node', args: [...], opts: { stdio: 'inherit' } })`, which reaches `child_process.spawn` with `shell: false`.
2. The only `node` on `PATH` is the shim from `ensureNodeShimDir()`, and on Windows it's a `.cmd`/`.bat` — there is deliberately no `node.exe`, because Electron's exe needs its adjacent DLLs.
3. Node >= 20.12.2 (CVE-2024-27980) refuses to spawn a `.bat`/`.cmd` without `shell: true`. Electron 32 bundles Node 20.18.1 → `EINVAL`.

`gutenberg:download` does the same thing and would have failed next.

</details>

<details>
<summary><b>What the patch rewrites, and the changes</b></summary>

- `node` → Electron's own `process.execPath` with `ELECTRON_RUN_AS_NODE=1`. **No shell**, so there is no quoting hazard at all — this is the branch that fixes the reported failure.
- `npm` / `npx` → `execPath` + their JS CLIs, same way.
- any other `.cmd`/`.bat` shim (package bin stubs) → `shell: true` with cmd-safe quoting, as a last resort.

Electron only honours `NODE_OPTIONS` in packaged builds when `ELECTRON_RUN_AS_NODE` is set, which `buildChildEnv` already does and all our children inherit.

Changes:

- **`src/win-spawn-patch.js`** (new) — the preloaded patch. Self-contained (Node built-ins only) because it's copied into the temp shim dir: `--require` into a path inside `app.asar` is not reliable under `ELECTRON_RUN_AS_NODE`. Its core is a pure, platform-parameterised `resolveSpawnTarget()`, and it only self-applies when `WPTK_SPAWN_PATCH=1`, so requiring it from a test never mutates the test process.
- **`src/main.js`** — `ensureNodeShimDir()` copies the patch next to the existing `node.cmd`/`npm.cmd` shims and records the npm/npx CLI paths; both are handed to `buildChildEnv`. Copy failure stays non-fatal — worst case we're exactly where we are today.
- **`src/npm-runner.js`** — `buildChildEnv` **appends** `--require "<patch>"` to any inherited `NODE_OPTIONS` (never replaces it) and sets `WPTK_SPAWN_PATCH` / `WPTK_NPM_CLI` / `WPTK_NPX_CLI`. Inert on POSIX and when no patch path is supplied.

</details>

<details>
<summary><b>The bug this shipped with, and how it was caught (commit 9fb73e4)</b></summary>

The first Windows test of this branch failed immediately, and took every child process with it:

```
Error: Cannot find module 'C:UsersJuanMaAppDataLocalTempelectron-node-shims-9832win-spawn-patch.js'
Require stack: - internal/preload
```

Every backslash is gone. Node doesn't read `NODE_OPTIONS` literally — it tokenises it with shell-like rules, and inside quotes a backslash is an escape character. The preload path arrived mangled, `MODULE_NOT_FOUND`, and the process died before running a line. Not just the build: everything goes through `buildChildEnv`.

Fixed by passing the path with forward slashes, which Windows resolves fine in a `require` and which — unlike doubling the backslashes — doesn't depend on how many layers of unescaping the value passes through.

Worth knowing for review: the original test asserted the exact string `--require "C:\shims\win-spawn-patch.js"`, so it passed *because* it encoded the broken value. A string test can't know what Node's tokeniser does with that string afterwards. The assertion now pins the property that matters — no backslash survives in the flag.

</details>
