### PR TITLE
Relax npm engine checks for scripts so nested installs don't fail

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -518,12 +518,21 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // relaxed. The first failure's output still reaches the log, so the real reason
 // stays visible instead of being silently papered over.
 //
-// The automatic retry is opt-in and only npm:install enables it. Scripts
-// (build, grunt, …) can fail partway through with side effects already on
-// disk, and npm prints EBADENGINE as a mere warning when engine-strict is off
-// — so a warning followed by an unrelated non-zero exit would wrongly restart
-// a half-finished script. An install, by contrast, is idempotent to re-run.
-function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false }) {
+// Two independent knobs, and each command uses exactly one of them:
+//
+// `retryOnEngineMismatch` (npm:install) runs strict first and retries relaxed.
+// Scripts (build, grunt, …) must not do this: they can fail partway through
+// with side effects already on disk, and npm prints EBADENGINE as a mere
+// warning when engine-strict is off — so a warning followed by an unrelated
+// non-zero exit would wrongly restart a half-finished script. An install, by
+// contrast, is idempotent to re-run.
+//
+// `relaxEnginesFromStart` (npm:run-script) is the opposite trade and is safe
+// for exactly that reason: nothing is ever restarted, engine checks are simply
+// off from the first process onward. Scripts need it because they spawn nested
+// installs that inherit this environment — wordpress-develop's Gruntfile calls
+// install-changed at load time, which execSync's its own `npm install` (#54).
+function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, retryOnEngineMismatch = false, relaxEnginesFromStart = false }) {
 	const start = (relaxEngines) => {
 		const child = spawn(process.execPath, [runnerPath, ...args], {
 			cwd,
@@ -563,7 +572,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			onDone(code);
 		});
 	};
-	start(false);
+	start(relaxEnginesFromStart);
 }
 
 ipcMain.handle('npm:install', async (event, directoryPath) => {
@@ -601,6 +610,10 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 		runnerPath: path.join(__dirname, 'script-runner.js'),
 		args: [directoryPath, scriptName, ...scriptArgs],
 		cwd: directoryPath,
+		// Baseline-relax rather than retry — see runNpmWithEngineRetry. Without
+		// this the nested `npm install` a build task spawns fails with EBADENGINE
+		// before grunt even starts (#54).
+		relaxEnginesFromStart: true,
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;

--- a/test/fixtures/nested-install/.npmrc
+++ b/test/fixtures/nested-install/.npmrc
@@ -1,0 +1,4 @@
+# Mirrors wordpress-develop's .npmrc, which is what turns an engines mismatch
+# from a warning into a fatal error — including for the nested install the
+# build script spawns.
+engine-strict = true

--- a/test/fixtures/nested-install/needs-future-node/package.json
+++ b/test/fixtures/nested-install/needs-future-node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "needs-future-node",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Declares a Node version that will never exist, so this fixture keeps reproducing EBADENGINE no matter how new the Node running the tests is. A real registry package would stop failing once CI's Node caught up, silently turning the test green.",
+  "engines": {
+    "node": ">=99.0.0"
+  }
+}

--- a/test/fixtures/nested-install/package.json
+++ b/test/fixtures/nested-install/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "nested-install-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reproduces issue #54: a build script that shells out to a second `npm install`, the way wordpress-develop's Gruntfile does via install-changed.",
+  "scripts": {
+    "build": "node run-build.js"
+  },
+  "dependencies": {
+    "needs-future-node": "file:./needs-future-node"
+  }
+}

--- a/test/fixtures/nested-install/run-build.js.txt
+++ b/test/fixtures/nested-install/run-build.js.txt
@@ -1,0 +1,22 @@
+// Stands in for wordpress-develop's Gruntfile.js:130, which calls
+// installChanged.watchPackage() at load time. install-changed shells out with
+// execSync('npm install') (install-changed/lib/main.js:50), so the build spawns
+// a *second* npm install as a grandchild of the script runner.
+//
+// The swallow-and-continue below mirrors the real caller: an engines failure
+// here is not fatal to the build, it just dumps a stack trace into the log and
+// leaves the dependencies uninstalled. That is exactly the #54 symptom.
+
+// Ships as .js.txt and is renamed on copy — see copyFixture() in
+// nested-install.integration.test.cjs. `node --test` runs every .js under
+// test/, so a fixture script cannot ship with a .js extension.
+
+const { execSync } = require('child_process');
+
+try {
+	execSync('npm install', { stdio: 'inherit' });
+} catch (err) {
+	console.error(err && err.stack ? err.stack : String(err));
+}
+
+console.log('BUILD OK');

--- a/test/nested-install.integration.test.cjs
+++ b/test/nested-install.integration.test.cjs
@@ -1,0 +1,97 @@
+// Integration coverage for issue #54: a build script that shells out to a
+// second `npm install` (the way wordpress-develop's Gruntfile does through
+// install-changed) hits EBADENGINE, because the script runner's environment has
+// strict engine checks.
+//
+// This has to be an integration test. The thing under test is whether
+// npm_config_engine_strict survives *two* levels of npm — the outer `npm run`
+// re-exports its own resolved config into the script's environment before the
+// grandchild install reads it. No unit test over buildChildEnv's output strings
+// can show that; only real npm can.
+//
+// Companion to npm-install.integration.test.cjs, which covers the same env var
+// one level down, on the plain install path.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const {
+	isEngineMismatch,
+	buildChildEnv,
+	RELAXED_ENGINES_ENV
+} = require('../src/npm-runner.js');
+
+const FIXTURE = path.join(__dirname, 'fixtures', 'nested-install');
+const SCRIPT_RUNNER = path.join(__dirname, '..', 'src', 'script-runner.js');
+
+// Keep npm quiet and offline: the fixture's only dependency is a local folder,
+// so an audit or funding lookup would add network flakiness for nothing.
+const QUIET_NPM = {
+	npm_config_loglevel: 'warn',
+	npm_config_audit: 'false',
+	npm_config_fund: 'false',
+	npm_config_progress: 'false'
+};
+
+function copyFixture() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nested-install-'));
+	fs.cpSync(FIXTURE, dir, { recursive: true });
+	// The build script ships as .js.txt because `node --test` runs every .js
+	// under test/ and would otherwise execute the fixture as a test file.
+	fs.renameSync(path.join(dir, 'run-build.js.txt'), path.join(dir, 'run-build.js'));
+	return dir;
+}
+
+// Runs the production script runner the same way main.js spawns it.
+function runScript(dir, { relaxEngines }) {
+	return new Promise((resolve) => {
+		const child = spawn(process.execPath, [SCRIPT_RUNNER, dir, 'build'], {
+			cwd: dir,
+			env: buildChildEnv({
+				// The fixture's build script resolves `npm` off the real PATH, which
+				// buildChildEnv preserves; the shim dir it prepends is only needed
+				// inside Electron. See npm-install.integration.test.cjs's header.
+				shimDir: path.join(dir, 'unused-shim'),
+				extraEnv: { ...QUIET_NPM, ...(relaxEngines ? RELAXED_ENGINES_ENV : {}) }
+			}),
+			shell: false,
+			windowsHide: true
+		});
+		let output = '';
+		child.stdout.on('data', (d) => { output += d.toString(); });
+		child.stderr.on('data', (d) => { output += d.toString(); });
+		child.on('close', (code) => resolve({ code, output }));
+	});
+}
+
+const installedDep = (dir) => fs.existsSync(path.join(dir, 'node_modules', 'needs-future-node'));
+
+test('a nested install inside a script hits EBADENGINE when engines are strict', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { output } = await runScript(dir, { relaxEngines: false });
+
+	// #54's symptom is noise, not failure: the Gruntfile swallows the error, so
+	// the build still reaches its end. Assert on what the log shows instead.
+	assert.match(output, /BUILD OK/, `the build should still have finished. Output:\n${output}`);
+	assert.equal(isEngineMismatch(output), true, `expected a real EBADENGINE block:\n${output}`);
+	assert.equal(installedDep(dir), false, 'the nested install should have installed nothing');
+});
+
+test('the nested install succeeds once the script runs with engines relaxed', { timeout: 120000 }, async (t) => {
+	const dir = copyFixture();
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+	const { code, output } = await runScript(dir, { relaxEngines: true });
+
+	assert.equal(code, 0, `expected a clean exit, got ${code}. Output:\n${output}`);
+	assert.match(output, /BUILD OK/, `the build should have finished. Output:\n${output}`);
+	assert.equal(installedDep(dir), true, `the nested install should have succeeded. Output:\n${output}`);
+	// The whole point: no stack trace from the swallowed execSync failure.
+	assert.doesNotMatch(output, /Command failed: npm install/, `the nested install still failed:\n${output}`);
+});


### PR DESCRIPTION
> **Stack — 5 of 5** · `trunk` → #50 → #51 → #52 → #56 → **#58**
> The diff below is only this PR's own changes. All five were verified together end to end on a Windows VM: clone → install → build → dev server → WordPress wizard → wp-admin.

Fixes #54.

## Problem

The first thing `npm run build` does is a nested `npm install` — `wordpress-develop`'s Gruntfile calls `install-changed` at load time, which shells out with `execSync('npm install')`.

That grandchild inherited strict engine checks, so it hit the same `EBADENGINE` wall the app already knows how to get past, dumping an `Unsupported engine` block and a `Command failed: npm install` stack trace into the log before grunt even started. Not fatal — the caller swallows it — but it's the first thing a Contributor Day newcomer sees now that #48 makes build output visible.

## Fix

Relax engine checks **from the start** for `npm:run-script`, rather than retrying. `npm:install` is untouched: `relaxEnginesFromStart` defaults to `false`, so the #38 retry path and its "show the real reason first" output are unchanged.

## How to test

Best seen on Windows, where Electron's bundled Node (20.18.1) is older than what several dependencies ask for. Needs a site with dependencies already installed.

1. Click **Run first full build**.
2. Open **Help → Open App Log** and follow the `build#…` lines. The log should go from `package.json has been modified. Installing...` straight into the grunt tasks.
3. Neither of these should appear anywhere in that section — on `trunk` both do:
   - `npm error code EBADENGINE` / `Unsupported engine`
   - `Command failed: npm install`
4. Run **Run first full build** a second time. It should now print `package.json has not been modified.` and skip the nested install entirely — that repeat was a side effect of the failure, not a separate bug.
5. Regression check on the install path: click **Install npm dependencies** on a fresh site. It must still try strict first and only then retry — you should see the `EBADENGINE` block followed by `⚠ This site requires a newer Node.js than this app bundles. Retrying with engine checks relaxed…`. That behaviour from #38 is deliberately untouched here.

Automated: `npm test` (two new integration tests that run real npm).


<details>
<summary><b>Why baseline-relax here and retry there</b></summary>

The two are opposite trades, and this one is safe for precisely the reason the retry isn't: nothing is ever restarted.

Scripts must not be retried — they can fail partway through with side effects already on disk, and npm downgrades EBADENGINE to a warning when engine-strict is off, so a warning plus an unrelated non-zero exit would wrongly restart a half-finished script. Baseline-relax sidesteps all of that: engine checks are simply off from the first process onward, and nested installs inherit it.

**Rejected:** relaxing engines inside `buildChildEnv` for all children. It's only called from `runNpmWithEngineRetry`, so that would also relax `npm:install`'s first attempt and destroy that deliberate behaviour.

</details>

<details>
<summary><b>Why the tests have to be integration tests</b></summary>

`test/nested-install.integration.test.cjs` + `test/fixtures/nested-install/`, modelled on the existing `npm-install.integration.test.cjs`. One test pins the bug (strict env → real EBADENGINE in the log, dependency not installed, build still "succeeds" — the noise-not-failure symptom), the other pins the fix.

What's being proven is that `npm_config_engine_strict` survives *two* levels of npm: the outer `npm run` re-exports its own resolved config into the script's environment before the grandchild install reads it. No unit test over `buildChildEnv`'s output strings can show that; only real npm can.

Two fixture details worth knowing:

- The dependency is pinned to `engines.node: ">=99.0.0"` rather than a registry package, so the test can't quietly go green once CI's Node catches up.
- The build script ships as `run-build.js.txt` and is renamed on copy, because `node --test` runs every `.js` under `test/` and was otherwise executing the fixture as a test file (a stray 10s "passing test" that ran a real npm install).

**The tests don't cover the wiring in `main.js`.** They exercise `buildChildEnv` with the flag set explicitly; `main.js` can't be imported under `node --test` because it requires `electron`. So they prove the mechanism, not that the handler passes the flag — that line was confirmed manually on Windows instead.

</details>

<details>
<summary><b>This also fixes the per-build repeat (#54's notes had the cause wrong)</b></summary>

`install-changed` writes its `packagehash.txt` *inside the try, after* the install succeeds (`lib/main.js:50-51`), so while the nested install was failing the hash was never written and every build re-ran it. Once the install succeeds the hash gets written and subsequent builds print `package.json has not been modified.` and skip it.

Details, empirical verification, and the narrower residual issue (the first build after a fresh install still pays one redundant install) are in #57 and in a correction comment on #54.

</details>
