### PR TITLE
Fix Adminer on Windows by giving PHP sessions a directory that exists

### DIFF
--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -55,6 +55,16 @@ async function main() {
 			await playgroundWriteFiles(result.playground, '/wordpress', {
 				'adminer.php': `<?php
 
+				// PHP defaults session.save_path to /home/web_user, which doesn't exist in
+				// the Playground VFS (we mount the build dir and skip WordPress setup), so
+				// Adminer's session_start() emits warnings and its later header() calls die.
+				// Point sessions at a directory we create ourselves instead.
+				$sessionDir = '/tmp/adminer-sessions';
+				if (!is_dir($sessionDir)) {
+					mkdir($sessionDir, 0777, true);
+				}
+				ini_set('session.save_path', $sessionDir);
+
 				if ($_SERVER['QUERY_STRING'] === '' || empty($_COOKIE['adminer_permanent'])) {
 					$_POST['auth'] = [
 						'driver'    => 'sqlite',


### PR DESCRIPTION
Fixes #63

## Problem

On Windows 11, clicking **Open Adminer** renders a page of PHP warnings instead of the database browser:

```
Warning: session_start(): open(/home/web_user/sess_82346babc9120e7184790b30db6b1857, O_RDWR) failed: No such file or directory (44) in /wordpress/adminer-core.php on line 197
Warning: session_start(): Failed to read session data: files (path: /home/web_user) in /wordpress/adminer-core.php on line 197
Warning: session_regenerate_id(): Session ID cannot be regenerated when there is no active session in /wordpress/adminer-core.php on line 1405
Warning: Cannot modify header information - headers already sent by (output started at /wordpress/adminer-core.php:197) in /wordpress/adminer-core.php on line 56
Warning: Cannot modify header information - headers already sent by (output started at /wordpress/adminer-core.php:197) in /wordpress/adminer-core.php on line 65
```

## Root cause

Adminer calls `session_start()` during bootstrap. PHP's `session.save_path` is left at the php-wasm default of `/home/web_user`, which doesn't exist in this VFS — we mount the build dir via `mount-before-install` and pass `skipWordPressSetup: true`, so the home directory is never provisioned.

Everything after the first warning cascades from it:

- `session_regenerate_id()` fails because no session was ever started.
- Both "headers already sent" warnings fire because the earlier warnings were emitted as body output, so Adminer's `header()` calls for its permanent-login cookie and redirect never take effect.

That last part is why the auto-login wrapper in `server-runner.js` can't work: it sets `$_POST['auth']` with `'permanent' => 1`, but the cookie that would persist it is never sent.

## Fix

Point `session.save_path` at `/tmp/adminer-sessions`, created on demand, in the wrapper that runs before `adminer-core.php` is required — so the `ini_set()` lands before `session_start()`.

Creating a dedicated directory is more robust than `mkdir`-ing `/home/web_user`: it doesn't depend on what Playground provisions as the home directory on a given platform, so the fix holds if that default ever changes.

## Testing

- `node --check src/server-runner.js` passes.
- Extracted the generated PHP wrapper and ran `php -l` on it — no syntax errors.
- `npm test`: 24 pass, 2 fail. Both failures are in `test/npm-install.integration.test.cjs`, which shells out to a real `npm install`; they fail identically on a clean tree without this change, so they're pre-existing and unrelated.

**Still needs a manual check on Windows 11** — I don't have a Windows box here, so the actual "Adminer loads and auto-logs into the SQLite database" path is unverified. Worth confirming on macOS too, to see whether the bug reproduces there or is genuinely Windows-only.

## What could break

- If `/tmp` isn't writable in some Playground configuration, `mkdir` would fail and we'd land back on today's behaviour — no worse, but no better either.
- Sessions now live under `/tmp`, so they don't survive a server restart. Adminer's auto-login re-runs on each fresh load anyway, so this shouldn't be user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
