### PR TITLE
Run the unit suite on macOS and Windows, on both Node runtimes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,51 @@
+# Runs the unit suite on the two platforms the app ships to, once per Node runtime.
+#
+# The second pass is not redundant: the suite spawns `process.execPath`, so the first pass
+# exercises the Node from .nvmrc while the second exercises the Node Electron bundles — two
+# versions that are set independently and have drifted before (#37/#46).
+#
+# Nothing here packages or signs an artifact, so this workflow needs no secrets. Buildkite still
+# owns the signed builds (.buildkite/pipeline.yml).
+
+name: Unit tests
+
+on:
+  pull_request:
+  push:
+    branches: [trunk]
+
+permissions:
+  contents: read
+
+# A new push supersedes the previous run on the same ref.
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: unit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Report both platforms: a Windows failure must not hide the macOS result.
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # `npm ci` and not `--ignore-scripts`: the postinstall downloads the Electron binary the
+      # second pass runs on, and test/npm-install.integration.test.cjs needs node_modules/npm.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit suite on the system Node
+        run: npm test
+
+      - name: Unit suite on Electron's bundled Node
+        run: npm run test:electron

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dist:win": "electron-builder --win --publish never",
     "dist:win:arm64": "electron-builder --win --arm64 --publish never",
     "dist": "electron-builder --publish never",
-    "test": "node --test"
+    "test": "node --test",
+    "test:electron": "node scripts/run-tests-electron.cjs"
   },
   "build": {
     "appId": "org.wordpress.contributor.toolkit",

--- a/scripts/run-tests-electron.cjs
+++ b/scripts/run-tests-electron.cjs
@@ -1,0 +1,51 @@
+// Runs the unit suite on Electron's bundled Node instead of the system Node.
+//
+// This is not a duplicate of `npm test`. The suite spawns `process.execPath` (see
+// test/npm-install.integration.test.cjs), so on the system Node it exercises whatever version
+// is in .nvmrc — not the version the app actually ships. The two are set independently and
+// have drifted before (#37/#46), so CI runs the suite once per runtime.
+//
+// ELECTRON_RUN_AS_NODE makes the Electron binary behave as a plain Node process: no window and
+// no display required. buildChildEnv (src/npm-runner.js) sets the same variable, so any npm
+// the tests spawn stays on the Electron runtime too.
+
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+// The `electron` package's entry point resolves to the absolute path of its binary —
+// Electron.app/Contents/MacOS/Electron on macOS, electron.exe on Windows.
+function electronBinaryPath() {
+  return require('electron');
+}
+
+function runSuite() {
+  const child = spawn(electronBinaryPath(), ['--test', 'test/'], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    stdio: 'inherit',
+    shell: false,
+    windowsHide: true,
+  });
+
+  child.on('error', (err) => {
+    console.error(`[test:electron] could not start Electron: ${err.message}`);
+    process.exit(1);
+  });
+
+  // A run that was killed, or that exited without a code, must never read as a pass.
+  child.on('close', (code, signal) => {
+    if (signal) {
+      console.error(`[test:electron] test run terminated by signal ${signal}`);
+      process.exit(1);
+    }
+    process.exit(code === null ? 1 : code);
+  });
+}
+
+if (require.main === module) {
+  runSuite();
+}
+
+module.exports = { electronBinaryPath };

--- a/test/electron-node-version.test.cjs
+++ b/test/electron-node-version.test.cjs
@@ -1,0 +1,101 @@
+// Guards the gap between the Node the app ships (Electron's bundled Node) and the Node that
+// wordpress-develop's dependencies demand.
+//
+// The expectation below is deliberately inverted, because the current state is a mismatch:
+// Electron 32 bundles Node 20.18.1, which is under wordpress-develop's range. The app copes by
+// retrying installs with engine checks relaxed (src/npm-runner.js) — a workaround, not a fix.
+//
+// So when a future Electron bump makes the bundled runtime satisfy the range on its own, this
+// test fails. That failure is the point: it says the relaxed-engines retry is no longer needed
+// and the expectation here should be flipped to `true`. See #37, #46 and #40.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+
+const { electronBinaryPath } = require('../scripts/run-tests-electron.cjs');
+
+// wordpress-develop's `engines.node`. The same range appears verbatim in the sample npm output
+// in npm-runner.test.cjs — keep the two in step.
+const WORDPRESS_DEVELOP_NODE_RANGE = '^20.19.0 || ^22.13.0 || >=24';
+
+// Whether Electron's bundled Node currently satisfies that range. Read the header before
+// changing this.
+const BUNDLED_NODE_SATISFIES_RANGE = false;
+
+function parseVersion(version) {
+	const match = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version);
+	assert.ok(match, `unparseable version: ${version}`);
+	return [match[1], match[2], match[3]].map((part) => Number(part ?? 0));
+}
+
+function compareVersions(a, b) {
+	for (let i = 0; i < 3; i += 1) {
+		if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+	}
+	return 0;
+}
+
+// Just enough semver to evaluate the range above — `^x.y.z` and `>=x` clauses. Hand-rolled
+// because the app must not grow a dependency for a version comparison.
+function satisfiesClause(version, clause) {
+	if (clause.startsWith('^')) {
+		const bound = parseVersion(clause.slice(1));
+		// A caret clause is >= the bound and < the next major.
+		return version[0] === bound[0] && compareVersions(version, bound) >= 0;
+	}
+	if (clause.startsWith('>=')) {
+		return compareVersions(version, parseVersion(clause.slice(2))) >= 0;
+	}
+	throw new Error(`unsupported range clause: ${clause}`);
+}
+
+function satisfies(version, range) {
+	const parsed = parseVersion(version);
+	return range.split('||').map((clause) => clause.trim()).some((clause) => satisfiesClause(parsed, clause));
+}
+
+// Asks the Electron binary itself rather than mapping Electron versions to Node versions by
+// hand, so this reads the runtime that will actually ship.
+function bundledNodeVersion() {
+	const result = spawnSync(electronBinaryPath(), ['-p', 'process.versions.node'], {
+		env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+		encoding: 'utf8',
+		shell: false,
+		windowsHide: true,
+	});
+	assert.equal(
+		result.status,
+		0,
+		`could not read Electron's bundled Node version (status ${result.status}): ${result.stderr}`
+	);
+	return result.stdout.trim();
+}
+
+// The pinned expectation is only meaningful if the comparison behind it is right: a broken
+// parser would also report a mismatch, for the wrong reason.
+test('the range check matches semver on the boundaries that matter', () => {
+	const check = (version) => satisfies(version, WORDPRESS_DEVELOP_NODE_RANGE);
+
+	assert.equal(check('20.18.1'), false, "Electron 32's Node is below the range");
+	assert.equal(check('20.19.0'), true, 'the lower bound of the first clause is included');
+	assert.equal(check('20.19.5'), true, "the .nvmrc version satisfies the range");
+	assert.equal(check('21.0.0'), false, 'a caret clause must not cross a major');
+	assert.equal(check('22.12.0'), false, 'below the second clause');
+	assert.equal(check('22.13.0'), true, 'the lower bound of the second clause is included');
+	assert.equal(check('24.0.0'), true, '>=24 is open ended');
+	assert.equal(check('25.1.2'), true, '>=24 is open ended');
+});
+
+test("Electron's bundled Node still mismatches wordpress-develop's engine range", () => {
+	const bundled = bundledNodeVersion();
+
+	assert.equal(
+		satisfies(bundled, WORDPRESS_DEVELOP_NODE_RANGE),
+		BUNDLED_NODE_SATISFIES_RANGE,
+		`Electron now bundles Node ${bundled}, which changes its relationship to `
+			+ `wordpress-develop's range (${WORDPRESS_DEVELOP_NODE_RANGE}). If it now satisfies the `
+			+ 'range, the relaxed-engines retry in src/npm-runner.js is no longer needed: remove it '
+			+ 'and set BUNDLED_NODE_SATISFIES_RANGE to true. See #46.'
+	);
+});


### PR DESCRIPTION
Fixes #66. Part of #65 (Phase 1).

## Why

The unit suite ran only on contributors' laptops. There was no `.github/workflows/` at all, and Buildkite only builds and signs artifacts — nothing executed `npm test` on any platform.

## Changes

A GitHub Actions `unit` job on `macos-latest` and `windows-latest`, on pull requests and pushes to `trunk`, running the suite twice per platform:

1. on the system Node (the version in `.nvmrc`)
2. on Electron's bundled Node, via `ELECTRON_RUN_AS_NODE`

The second pass is the point of the issue, not an extra. The tests spawn `process.execPath`, so on a plain runner they exercise the Node in `.nvmrc` — not the Node the app ships. Those two versions are set independently and have already drifted: `.nvmrc` is 20.19.5 while Electron 32.3.3 bundles Node 20.18.1. A suite that only runs the first pass is green on a Node no user has.

Also adds `test/electron-node-version.test.cjs`, which reads the bundled Node from the Electron binary and pins its current relationship to the engine range `wordpress-develop` requires (`^20.19.0 || ^22.13.0 || >=24`). That relationship is a mismatch today, which is exactly why installs are retried with engine checks relaxed. The expectation is inverted on purpose: a future Electron bump makes the test fail, and that failure is the signal that the workaround can go. The range comparison itself is covered by its own boundary test, so the pinned verdict can't pass for the wrong reason.

No application changes and no new dependencies. This job never packages or signs anything, so it needs no secrets, and `ELECTRON_RUN_AS_NODE` opens no window, so it needs no display.

## Validation

Locally on macOS arm64, both passes green at 28 tests each. Verified that a failing test exits non-zero through both passes, and that flipping the pinned expectation fails with the message telling you what to do about it.

## Notes

- Based on `trunk` rather than the open #50 → #58 stack, so it can land on its own. The stack picks the workflow up when it rebases.
- Deliberately before #40 (Electron 43 / Node 24): that upgrade's validation is Linux-only and needs macOS and Windows evidence, which this workflow supplies. #40 then flips the pinned expectation, which is the test doing its job.
- "A failing test blocks the PR" still needs `unit (macos-latest)` and `unit (windows-latest)` marked as required status checks in branch protection — that part needs repo admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)