### PR TITLE
Fix the Electron test pass silently breaking on Node 22 and newer

### DIFF
--- a/scripts/run-tests-electron.cjs
+++ b/scripts/run-tests-electron.cjs
@@ -20,8 +20,13 @@ function electronBinaryPath() {
   return require('electron');
 }
 
+// `--test` takes no path on purpose. Since Node 22 a positional argument is a glob matching test
+// *files*, so `test/` matches nothing and Node then tries to load it as the entry module —
+// Electron 43 (Node 24) fails with MODULE_NOT_FOUND where Electron 32 (Node 20) was fine. Bare
+// `--test` discovers from the cwd on every version, and is exactly what `npm test` runs, so both
+// passes always cover the same files.
 function runSuite() {
-  const child = spawn(electronBinaryPath(), ['--test', 'test/'], {
+  const child = spawn(electronBinaryPath(), ['--test'], {
     cwd: REPO_ROOT,
     env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
     stdio: 'inherit',


### PR DESCRIPTION
Follow-up to #68, found by #40.

## What was wrong

`scripts/run-tests-electron.cjs` spawned `--test test/`. Since Node 22 a positional argument to `--test` is a glob matching test *files*, not a directory to search — so `test/` matches nothing and Node falls back to loading it as the entry module.

On Electron 32 (Node 20.18.1) the old behaviour made it work, which is why #68 went green. On Electron 43 (Node 24.18.0) it fails before a single test runs:

```
Error: Cannot find module '/home/runner/work/experimental-wp-dev-env/test'
Node.js v24.18.0
ℹ tests 1
ℹ fail 1
```

The failure mode is the dangerous part: `tests 1, fail 1` reads like one broken test, not like a suite that never executed.

## The fix

Drop the argument. Bare `--test` discovers from the cwd on every version, and is exactly what `npm test` already runs — so both passes cover the same files by construction, and a divergence in counts between them becomes visible rather than possible.

## Validation

Locally on macOS arm64, both runtimes, with the fix:

- Electron 32.3.3 / Node 20.18.1 — 28/28, exit 0
- Electron 43.2.0 / Node 24.18.0 — 28/28, exit 0

Reproduced the failure first on Electron 43 without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)