### PR TITLE
Make the dev-server starting state always end, and show elapsed time

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -820,14 +820,24 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		stopSmtpServerForSite(sitePath);
 	});
 
+	// The server must report SERVER_URL within this window or the start has
+	// failed. Generous on purpose: booting WASM PHP on a slow Windows VM can
+	// legitimately take tens of seconds, and cutting off a slow-but-healthy
+	// boot would be worse than the wait. What this converts is "hangs forever"
+	// into "fails loudly" (issue #73): on expiry the child is killed — which
+	// fires the close handler and the playground:stopped event — and the
+	// renderer surfaces the returned error.
+	const START_TIMEOUT_MS = 120000;
 	return new Promise((resolve) => {
 		pendingResolve = resolve;
 		timeoutId = setTimeout(() => {
 			if (!resolved && typeof pendingResolve === 'function') {
-				pendingResolve({ ok: false, error: 'Timed out starting server' });
+				logError(logScope, `server did not report a URL within ${START_TIMEOUT_MS / 1000}s; killing it`);
+				try { child.kill(); } catch {}
+				pendingResolve({ ok: false, error: `Server did not start within ${START_TIMEOUT_MS / 1000} seconds` });
 				pendingResolve = null;
 			}
-		}, 20000);
+		}, START_TIMEOUT_MS);
 	});
 });
 

--- a/src/renderer/dev-server-command.cjs
+++ b/src/renderer/dev-server-command.cjs
@@ -43,4 +43,17 @@ function planDevServerStart(flags = {}) {
 	};
 }
 
-module.exports = { planDevServerStart };
+/**
+ * Formats a duration in whole seconds for the "Starting dev server…" counter:
+ * '42s' under a minute, '3m 05s' above. The counter exists so a contributor on
+ * a slow machine can tell a boot in progress from a hang (issue #73).
+ */
+function formatElapsed(seconds) {
+	const total = Math.max(0, Math.floor(Number(seconds) || 0));
+	if (total < 60) return `${total}s`;
+	const minutes = Math.floor(total / 60);
+	const rest = total % 60;
+	return `${minutes}m ${String(rest).padStart(2, '0')}s`;
+}
+
+module.exports = { planDevServerStart, formatElapsed };

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -31022,7 +31022,14 @@ WARNING: This link could potentially be dangerous`)) {
           }
         };
       }
-      module.exports = { planDevServerStart: planDevServerStart2 };
+      function formatElapsed2(seconds) {
+        const total = Math.max(0, Math.floor(Number(seconds) || 0));
+        if (total < 60) return `${total}s`;
+        const minutes = Math.floor(total / 60);
+        const rest = total % 60;
+        return `${minutes}m ${String(rest).padStart(2, "0")}s`;
+      }
+      module.exports = { planDevServerStart: planDevServerStart2, formatElapsed: formatElapsed2 };
     }
   });
 
@@ -54563,7 +54570,7 @@ Try "help" for the list of supported commands.
       if (!smtpStartedUnsubRef.current) smtpStartedUnsubRef.current = window.api.onSmtpStarted(sitePath, (port) => setSmtpPort(port || 0));
       if (!newEmailUnsubRef.current) newEmailUnsubRef.current = window.api.onNewEmail(sitePath, (msg) => setEmails((prev2) => sortEmails([msg, ...prev2])));
       try {
-        await window.api.startServer(
+        const res = await window.api.startServer(
           sitePath,
           (p) => appendRuntime(p.data || ""),
           (url) => {
@@ -54584,8 +54591,24 @@ Try "help" for the list of supported commands.
             runningRef.current = false;
             setServerUrl("");
             serverStartRequestedRef.current = false;
+            if (!stoppingRef.current) {
+              appendRuntime("Dev server stopped unexpectedly (see Help \u2192 Open App Log for details).\n");
+              killCurrent().catch(() => {
+              });
+              stopDevServer().catch(() => {
+              });
+            }
           }
         );
+        if (res && res.ok === false && !stoppingRef.current && !runningRef.current) {
+          appendRuntime(`Dev server failed to start: ${res.error || "unknown error"}
+`);
+          killCurrent().catch(() => {
+          });
+          stopDevServer().catch(() => {
+          });
+          return;
+        }
       } catch (error) {
         appendRuntime(`Failed to start PHP server: ${error && error.message ? error.message : String(error)}
 `);
@@ -54601,7 +54624,7 @@ Try "help" for the list of supported commands.
         setEmails(emails2 || []);
       } catch {
       }
-    }, [appendRuntime, ensureStick, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails]);
+    }, [appendRuntime, ensureStick, killCurrent, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails, stopDevServer]);
     const toggleDevServer = async () => {
       if (!running) {
         if (!skipInit && !hasBuilt) {
@@ -54689,6 +54712,15 @@ Running ${plan.watch.label}\u2026
     };
     const isServerStarting = waitingForWatch || starting && !serverUrl;
     const isDevProcessActive = running || isServerStarting;
+    const [startElapsed, setStartElapsed] = (0, import_react69.useState)(0);
+    (0, import_react69.useEffect)(() => {
+      if (!isServerStarting) {
+        setStartElapsed(0);
+        return void 0;
+      }
+      const id3 = setInterval(() => setStartElapsed((s) => s + 1), 1e3);
+      return () => clearInterval(id3);
+    }, [isServerStarting]);
     const markSkipWizard = (0, import_react69.useCallback)(async () => {
       await window.api.setSkipInitWizard(sitePath, true);
       setSkipInit(true);
@@ -54839,7 +54871,7 @@ Running ${plan.watch.label}\u2026
               children: running ? "Stop dev server" : "Start dev server and finish the wizard"
             }
           ),
-          starting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontSize: 12 }, children: starting ? "Starting..." : serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("a", { href: serverUrl, onClick: (e) => {
+          starting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontSize: 12 }, children: starting ? `Starting\u2026 (${(0, import_dev_server_command.formatElapsed)(startElapsed)})` : serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("a", { href: serverUrl, onClick: (e) => {
             e.preventDefault();
             window.api.openExternal(serverUrl);
           }, children: serverUrl }) : null }) : null
@@ -55030,7 +55062,7 @@ Running ${plan.watch.label}\u2026
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("code", { children: "admin" }),
             "."
           ] })
-        ] }) : "Dev server is starting\u2026" }) : null
+        ] }) : `Dev server is starting\u2026 (${(0, import_dev_server_command.formatElapsed)(startElapsed)})` }) : null
       ] }) : null,
       /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 16 }, children: [
         /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { children: [

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -17,7 +17,7 @@ import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
 import { computeSetupStepState } from './setup-steps.cjs';
-import { planDevServerStart } from './dev-server-command.cjs';
+import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
@@ -1215,7 +1215,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     if (!smtpStartedUnsubRef.current) smtpStartedUnsubRef.current = window.api.onSmtpStarted(sitePath, (port)=>setSmtpPort(port||0));
     if (!newEmailUnsubRef.current) newEmailUnsubRef.current = window.api.onNewEmail(sitePath, (msg)=>setEmails((prev)=>sortEmails([msg, ...prev])));
     try {
-      await window.api.startServer(
+      const res = await window.api.startServer(
         sitePath,
         (p)=>appendRuntime(p.data || ''),
         (url)=>{
@@ -1231,8 +1231,26 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           setStarting(false);
           serverStartRequestedRef.current = false;
         },
-        ()=>{ setRunning(false); runningRef.current = false; setServerUrl(''); serverStartRequestedRef.current = false; }
+        ()=>{
+          setRunning(false); runningRef.current = false; setServerUrl(''); serverStartRequestedRef.current = false;
+          // A stop the user did not ask for is a crash: say so, and tear the
+          // whole dev session down — watcher included — instead of leaving the
+          // button spinning "Starting dev server…" forever (issue #73).
+          if (!stoppingRef.current) {
+            appendRuntime('Dev server stopped unexpectedly (see Help → Open App Log for details).\n');
+            killCurrent().catch(() => {});
+            stopDevServer().catch(() => {});
+          }
+        }
       );
+      // A failed start reports through the return value, not an exception.
+      // This also covers spawn failures that never produce a "stopped" event.
+      if (res && res.ok === false && !stoppingRef.current && !runningRef.current) {
+        appendRuntime(`Dev server failed to start: ${res.error || 'unknown error'}\n`);
+        killCurrent().catch(() => {});
+        stopDevServer().catch(() => {});
+        return;
+      }
     } catch (error) {
       appendRuntime(`Failed to start PHP server: ${error && error.message ? error.message : String(error)}\n`);
       setStarting(false);
@@ -1242,7 +1260,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     }
     window.api.startWpDebug(sitePath,(d)=>appendRuntime(d || ''));
     try { const { port, emails } = await window.api.getEmails(sitePath); if (port) setSmtpPort(port); setEmails(emails||[]); } catch {}
-  }, [appendRuntime, ensureStick, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails]);
+  }, [appendRuntime, ensureStick, killCurrent, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails, stopDevServer]);
 
   const toggleDevServer = async ()=>{
     if (!running) {
@@ -1328,6 +1346,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   };
   const isServerStarting = waitingForWatch || (starting && !serverUrl);
   const isDevProcessActive = running || isServerStarting;
+  // Elapsed-seconds counter for the starting state, so a slow boot is
+  // distinguishable from a hang (issue #73).
+  const [startElapsed, setStartElapsed] = useState(0);
+  useEffect(() => {
+    if (!isServerStarting) {
+      setStartElapsed(0);
+      return undefined;
+    }
+    const id = setInterval(() => setStartElapsed((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isServerStarting]);
   const markSkipWizard = useCallback(async () => {
     await window.api.setSkipInitWizard(sitePath, true);
     setSkipInit(true);
@@ -1480,7 +1509,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           >{running ? 'Stop dev server' : 'Start dev server and finish the wizard'}</Button>
           {starting || serverUrl ? (
             <span style={{ fontSize: 12 }}>
-              {starting ? 'Starting...' : (serverUrl ? (
+              {starting ? `Starting… (${formatElapsed(startElapsed)})` : (serverUrl ? (
                 <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
               ) : null)}
             </span>
@@ -1664,7 +1693,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
                   <span style={{ fontSize: 12, color: '#3c434a' }}>Log in with <code>admin</code> / <code>admin</code>.</span>
                 </>
               ) : (
-                'Dev server is starting…'
+                `Dev server is starting… (${formatElapsed(startElapsed)})`
               )}
             </div>
           ) : null}

--- a/test/dev-server-command.test.cjs
+++ b/test/dev-server-command.test.cjs
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { planDevServerStart } = require('../src/renderer/dev-server-command.cjs');
+const { planDevServerStart, formatElapsed } = require('../src/renderer/dev-server-command.cjs');
 
 test('a built site skips the build and goes straight to the watcher (issue #72)', () => {
 	const plan = planDevServerStart({ hasBuilt: true });
@@ -42,4 +42,25 @@ test('the returned args are a fresh copy a caller cannot corrupt for the next st
 	first.watch.args.length = 0;
 
 	assert.deepStrictEqual(planDevServerStart({ hasBuilt: true }).watch.args, ['--', '_watch']);
+});
+
+test('formatElapsed shows plain seconds under a minute', () => {
+	assert.strictEqual(formatElapsed(0), '0s');
+	assert.strictEqual(formatElapsed(42), '42s');
+	assert.strictEqual(formatElapsed(59), '59s');
+});
+
+test('formatElapsed switches to zero-padded minutes form at a minute', () => {
+	assert.strictEqual(formatElapsed(60), '1m 00s');
+	assert.strictEqual(formatElapsed(185), '3m 05s');
+	assert.strictEqual(formatElapsed(671), '11m 11s');
+});
+
+// The counter is driven by an incrementing interval, but a clock hiccup or a
+// future refactor to timestamps must never render garbage next to the button.
+test('formatElapsed clamps negatives and non-numbers to 0s', () => {
+	assert.strictEqual(formatElapsed(-5), '0s');
+	assert.strictEqual(formatElapsed(NaN), '0s');
+	assert.strictEqual(formatElapsed(undefined), '0s');
+	assert.strictEqual(formatElapsed(12.9), '12s');
 });


### PR DESCRIPTION
> **Stacked on #74** (`juanmaguitar/issue-72-skip-rebuild-on-dev-server-start`), which is itself stacked on #77 — the diff below shows only this PR's own changes. Merge order: #77 → #74 → #75.

Fixes #73

## Problem

"Starting dev server…" was a one-way door: no timeout, no progress, no path back except quitting the app. #74 removed the biggest hang path (the output-scrape readiness marker) and the 30-minute silent build; this closes what remained:

1. **A dying server stranded the spinner.** The `onStopped` callback reset `running` and the URL but never `starting`, wrote nothing anywhere visible, and left the Grunt watcher running. Kill the Playground child mid-boot and the button spins forever.
2. **The 20-second timeout in `playground:start` was dead code.** It resolved `{ok:false}` into a return value the renderer ignored, and left the child and listeners alive — a server coming up at 25s still started normally. It changed nothing, in either direction.
3. **No sense of time.** Both starting texts were static; on a slow VM there was no way to tell a boot in progress from a hang — for the contributor or for whoever is helping them.

## Fix

- **Unexpected stop → full teardown.** If the server child stops and the user didn't ask for it, the renderer writes `Dev server stopped unexpectedly (see Help → Open App Log for details).` to the runtime log (the main process already logs the exit code/signal there), kills the watcher, and resets all state via the existing `stopDevServer`. This mirrors the direction that already worked (watcher dies → server stopped). The `stoppingRef` guard makes the two teardown paths race-safe.
- **The timeout is now real: 120 seconds.** Meaning: the server must report `SERVER_URL` in that window or the start has failed. On expiry the main process logs it, kills the child, and resolves `{ok:false, error}`; the renderer now checks that result, surfaces the error, and resets. The renderer-side check also covers spawn failures that never emit a `stopped` event (ENOENT-style). 120s rather than 20s because 20 was never enforced against a real slow machine, and WASM PHP on a Windows VM legitimately takes tens of seconds — the goal is converting "hangs forever" into "fails loudly", never cutting off a healthy boot.
- **Elapsed counter.** Both variants — the wizard's `Starting…` and the post-wizard `Dev server is starting…` — now show `(42s)` / `(1m 05s)`, ticking. Formatting is a pure function in `dev-server-command.cjs` with tests; the counter is one `useState` + one interval keyed on the existing `isServerStarting`.

## Notes for reviewers

- On a timeout, the runtime log shows two lines (the stop notice from the `close` event and the timeout error from the returned value). Both teardowns are no-ops after the first; collapsing them wasn't worth entangling the two failure paths.
- `src/renderer/index.js` is the regenerated esbuild bundle; review `index.jsx`.

## Testing

- `node --test test/dev-server-command.test.cjs` — 8 tests pass (3 new for `formatElapsed`: plain seconds, zero-padded minutes, clamping of negatives/NaN). Full suite: 80 pass, 1 pre-existing unrelated failure (`electron-node-version`, stale local `node_modules` from before #40).
- Manual (pending, needs a working wordpress-develop checkout):
  1. Start on a built site → counter ticks in both UI variants, disappears when the URL appears.
  2. `pkill -f server-runner.js` during boot and while running → "stopped unexpectedly" in the log, watcher killed, button back to idle. No eternal spinner.
  3. Timeout drill with the constant temporarily at ~3s → error surfaces, child killed, UI resets.
  4. Normal stop / Ctrl+C unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

