### PR TITLE
Start the dev server without re-downloading WordPress

### DIFF
--- a/src/error-chain.js
+++ b/src/error-chain.js
@@ -1,0 +1,52 @@
+// Renders an error together with everything it was caused by.
+//
+// Node's default `err.stack` shows only the outermost error. That is enough for
+// most failures, but not for the Playground CLI: when it boots WordPress with
+// `verbosity: 'debug'` and the boot fails, it re-throws as
+//
+//     new Error(<contents of its debug log>, { cause: originalError })
+//
+// and that debug log is frequently empty. Printing the stack alone then puts a
+// bare `Error` with no message in the app log while the actual failure sits
+// unread in `cause`, which is the difference between a report someone can act
+// on and one nobody can.
+
+// Bounded so a self-referential or absurdly deep chain can't hang the logger.
+const MAX_DEPTH = 10;
+
+function describe( error ) {
+	if ( error instanceof Error ) {
+		// An Error with an empty message still stacks as "Error\n    at ...",
+		// so the stack alone reads as if nothing went wrong. Say so explicitly.
+		if ( ! error.message ) {
+			return `${ error.name || 'Error' }: (no message)\n${ error.stack || '' }`.trimEnd();
+		}
+		return error.stack || `${ error.name }: ${ error.message }`;
+	}
+	return String( error );
+}
+
+function formatErrorChain( error ) {
+	const parts = [];
+	const seen = new Set();
+	let current = error;
+
+	while ( current !== undefined && current !== null && parts.length < MAX_DEPTH ) {
+		if ( typeof current === 'object' ) {
+			if ( seen.has( current ) ) {
+				parts.push( 'Caused by: <circular reference>' );
+				break;
+			}
+			seen.add( current );
+		}
+
+		const text = describe( current );
+		parts.push( parts.length === 0 ? text : `Caused by: ${ text }` );
+
+		current = typeof current === 'object' ? current.cause : undefined;
+	}
+
+	return parts.join( '\n' );
+}
+
+module.exports = { formatErrorChain };

--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const { hideChildWindows } = require('./hide-child-windows');
+const { formatErrorChain } = require('./error-chain');
 
 // Must run before the Playground CLI is required, so anything it spawns is
 // covered too.
@@ -23,7 +24,24 @@ async function main() {
 			command: 'server',
 			// Mount the build directory before install as /wordpress to use existing build
 			'mount-before-install': [ { hostPath: absBuild, vfsPath: '/wordpress' } ],
-			skipWordPressSetup: true,
+			// The mounted build/ already is WordPress, so Playground must not go
+			// looking for one. Left unset this defaults to `download-and-install`:
+			// it fetches a WordPress release and unpacks it over the mount, failing
+			// on every file that is already there. That wasted pass is what makes
+			// startup take minutes on Windows.
+			//
+			// Only `download-and-install` downloads, so any other value skips it —
+			// but not all of them are safe here. `do-not-attempt-installing` (the
+			// mode Playground also calls `mount-only`) additionally skips setting up
+			// the SQLite integration plugin, and a wordpress-develop build/ carries
+			// no database driver of its own, so WordPress would boot with nothing to
+			// connect to. `install-from-existing-files-if-needed` skips the download
+			// and still prepares SQLite.
+			//
+			// Passed as `wordpressInstallMode` rather than the equivalent `mode`
+			// option because `mode` is only read on the Blueprint v2 code path, and
+			// the blueprint below is v1. Passing both is an error.
+			wordpressInstallMode: 'install-from-existing-files-if-needed',
 			verbosity: 'debug',
 			blueprint: {
 				constants: {
@@ -123,7 +141,7 @@ async function main() {
 		// Keep process alive until parent kills it
 		process.stdin.resume();
 	} catch (err) {
-		console.error(err && err.stack ? err.stack : String(err));
+		console.error(formatErrorChain(err));
 		process.exit(1);
 	}
 }

--- a/test/error-chain.test.cjs
+++ b/test/error-chain.test.cjs
@@ -1,0 +1,69 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { formatErrorChain } = require('../src/error-chain.js');
+
+test('reproduces the Playground boot failure: the real error is in the cause', () => {
+	// What @wp-playground/cli throws when a boot fails under `verbosity: 'debug'`:
+	// the message is the contents of its debug log, which is usually empty, and
+	// the failure that matters is attached as `cause`. Logging `err.stack` alone
+	// reported a bare "Error" with no message and nothing to act on.
+	const real = new Error( 'Cannot connect to the database' );
+	const wrapped = new Error( '', { cause: real } );
+
+	const output = formatErrorChain( wrapped );
+
+	assert.match( output, /Cannot connect to the database/ );
+	assert.match( output, /Caused by:/ );
+} );
+
+test( 'flags an empty message instead of printing a stack that looks fine', () => {
+	const output = formatErrorChain( new Error( '' ) );
+
+	assert.match( output, /\(no message\)/ );
+} );
+
+test( 'a plain error is still rendered as its stack', () => {
+	const error = new Error( 'boom' );
+
+	const output = formatErrorChain( error );
+
+	assert.equal( output, error.stack );
+	assert.doesNotMatch( output, /Caused by:/ );
+} );
+
+test( 'walks a chain several levels deep, outermost first', () => {
+	const root = new Error( 'root' );
+	const middle = new Error( 'middle', { cause: root } );
+	const outer = new Error( 'outer', { cause: middle } );
+
+	const output = formatErrorChain( outer );
+
+	assert.ok( output.indexOf( 'outer' ) < output.indexOf( 'middle' ) );
+	assert.ok( output.indexOf( 'middle' ) < output.indexOf( 'root' ) );
+} );
+
+test( 'handles a cause that is not an Error', () => {
+	const output = formatErrorChain( new Error( 'outer', { cause: 'a string reason' } ) );
+
+	assert.match( output, /Caused by: a string reason/ );
+} );
+
+test( 'handles non-Error input', () => {
+	assert.equal( formatErrorChain( 'just a string' ), 'just a string' );
+} );
+
+test( 'stops on a circular cause chain instead of looping forever', () => {
+	const a = new Error( 'a' );
+	const b = new Error( 'b', { cause: a } );
+	a.cause = b;
+
+	const output = formatErrorChain( a );
+
+	assert.match( output, /circular reference/ );
+} );
+
+test( 'null and undefined do not throw', () => {
+	assert.equal( formatErrorChain( null ), '' );
+	assert.equal( formatErrorChain( undefined ), '' );
+} );


### PR DESCRIPTION
Fixes #76

## Problem

`server-runner.js` mounts the site's `build/` at `/wordpress` and then passes `skipWordPressSetup: true` to tell Playground not to install WordPress on top of it.

That option does not exist. It is not in `RunCLIArgs`, and the CLI ignores unknown properties silently, so the intent never reached Playground. Install mode resolves like this:

```js
switch (e.mode) {
  case "apply-to-existing-site": return "install-from-existing-files-if-needed";
  case "mount-only":             return "do-not-attempt-installing";
  case "create-new-site":        return "download-and-install";
}
return e.wordpressInstallMode || "download-and-install";
```

With neither `mode` nor `wordpressInstallMode` set, every dev-server start landed on `download-and-install`: fetch a WordPress release (~35 MB), unpack it over the mount, and fail on each of the ~7000 files already present. From an app log on Windows:

```
22:53:35  Resolved WordPress release URL: .../wordpress-7.0.2.zip
22:53:55  Cannot unzip WordPress files at /wordpress/index.php: already exists.
   …thousands more, one per file…
```

Every one of those is a stat through the WASM VFS onto a host filesystem. On macOS it finishes fast enough to pass for "the dev server is a bit slow"; on a Windows VM it is the startup time, and it can run past two minutes.

## Fix

Ask for `install-from-existing-files-if-needed`. Only `download-and-install` downloads, so any of the other modes skips the fetch and the unzip pass — but they are not interchangeable here:

```js
if (this.args.skipSqliteSetup || i === "do-not-attempt-installing")
    m.debug("Skipping SQLite integration plugin setup..."), a = void 0;
```

`do-not-attempt-installing` — the mode also spelled `mount-only` — additionally skips setting up the SQLite integration plugin. A `wordpress-develop` `build/` carries no database driver of its own; Playground is what supplies SQLite. Under that mode WordPress boots with nothing to connect to and the server exits about a second in, which is what a first pass at this PR did on Windows. `install-from-existing-files-if-needed` skips the download and still prepares SQLite.

It is passed as `wordpressInstallMode` rather than the equivalent `mode` option because `mode` is only translated into an install mode on the Blueprint v2 code path, while the blueprint here is v1 — the v1 path reads `args.wordpressInstallMode` directly. Passing both is an error.

### Also: log the whole `cause` chain

The failure above was reported as a bare `Error` with a stack and no message. Under `verbosity: 'debug'` the CLI re-throws boot failures as `new Error(<contents of its debug log>, { cause: realError })`, and that log is usually empty. `server-runner.js` printed `err.stack`, which shows only the outermost error, so the actual failure never reached the app log.

`src/error-chain.js` renders an error together with everything it was caused by, and flags an empty message rather than printing a stack that reads as if nothing went wrong. It is a pure module with tests, following the `setup-steps.cjs` convention.

## Notes for reviewers

- **This is a prerequisite for #75.** #75 adds a 120 s deadline that kills the child on expiry. Against today's startup cost that turns a slow-but-working boot into a hard failure on Windows — the boot legitimately exceeds 120 s there. With the download gone the deadline is comfortable and does what #73 asked for. #74 and #75 are stacked on this one; merge order is #77 → #74 → #75.
- No test covers the argument itself: it is one property passed to a third-party CLI, and asserting the object we pass would only restate the source. The behaviour it fixes shows up in startup time and in the app log.

## Testing

- `node --test`: 88 pass, 1 fail on the tip of the stack. The failure is `electron-node-version`, the pre-existing Electron/Node engine-range mismatch tracked in #37 and #46, unrelated to this diff.
- Manual, on a Windows VM (app version 0.1.0, built from the top of the stack):
  1. Dev server starts and reports a URL 29 s after the CLI launches. The app log shows no WordPress release URL and no unzip failures — the download and the ~7000-file unpack pass are gone.
  2. The database works **on a fresh site whose `build/` had never been served** — the case that matters, since that is when WordPress actually has to be installed. The SQLite drop-in under `wp-content/database/` is set up during boot, and Adminer opens against it afterwards. This was the behaviour I would not have merged without seeing, since `do-not-attempt-installing` would have skipped it.
  3. `grunt _watch` runs in parallel with the server, without the production build in front of it (#74).

  Still visible, and unrelated to this change: `lockWholeFile: unlock failed` warnings on files under `wp-content/database/` and on Adminer's session files. They no longer sit buried under thousands of unzip errors, but nothing failed because of them — boot completed and Adminer worked. They look like Windows file-locking noise inside Playground rather than something this app causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


