### PR TITLE
Bind the dev server to loopback only

### DIFF
--- a/src/bind-loopback.js
+++ b/src/bind-loopback.js
@@ -1,0 +1,87 @@
+// Keeps the Playground servers on the loopback interface.
+//
+// `@wp-playground/cli` starts its server with `server.listen(port, callback)` —
+// no address — and Node then listens on `::`/`0.0.0.0`, i.e. every interface.
+// That makes the contributor's WordPress, admin/admin credentials and all,
+// reachable from the local network, and on Windows it is what raises the
+// firewall prompt asking to allow public and private networks.
+//
+// `runCLI()` has no `host` option to pass instead (`RunCLIArgs` only knows
+// `db-host`), so the only place to fix it from the outside is `listen` itself.
+// Patching `net.Server.prototype.listen` before the CLI is required covers every
+// server it creates — `http.Server` extends `net.Server` and doesn't override
+// `listen`. Same "patch the built-in first" shape as `hide-child-windows.js`.
+//
+// Delete this once `runCLI` accepts a host.
+
+const PATCHED = Symbol.for('wp-dev-env.loopbackPatched');
+
+const LOOPBACK = '127.0.0.1';
+
+function isPlainObject(value) {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Node treats a numeric string port the same as a number.
+function isPort(value) {
+	if (typeof value === 'number') return Number.isInteger(value) && value >= 0;
+	return typeof value === 'string' && /^\d+$/.test(value);
+}
+
+// Given the arguments of `net.Server.prototype.listen`, returns them with a
+// loopback host filled in — but only when the caller asked for a TCP port and
+// left the address out. Every other overload is passed through untouched:
+// `listen(path, ...)` is an IPC socket, `listen(handle, ...)` carries its own
+// binding, and an explicit host (even a deliberate '0.0.0.0') wins.
+function withLoopbackHost(args, host = LOOPBACK) {
+	if (args.length === 0) return args;
+
+	const [first] = args;
+
+	if (isPlainObject(first)) {
+		// Options form. `path` means IPC; anything already bound to a host or
+		// carrying its own handle is left alone.
+		if (!isPort(first.port)) return args;
+		if (first.host !== undefined || first.path !== undefined) return args;
+		const next = args.slice();
+		next[0] = { ...first, host };
+		return next;
+	}
+
+	if (!isPort(first)) return args;
+
+	// listen(port[, host][, backlog][, callback]) — a string in second position
+	// is the host, so there is nothing to add. A number there is the backlog,
+	// and the host belongs in front of it.
+	if (typeof args[1] === 'string') return args;
+
+	const next = args.slice();
+	next.splice(1, 0, host);
+	return next;
+}
+
+// Wraps `listen` on the given `net` module's Server prototype. Idempotent, so
+// requiring this from two places can't double-wrap.
+function patchNetListen(net, host = LOOPBACK) {
+	if (net[PATCHED]) return net;
+
+	const proto = net.Server && net.Server.prototype;
+	const original = proto && proto.listen;
+	if (typeof original !== 'function') return net;
+
+	proto.listen = function listen(...args) {
+		return original.apply(this, withLoopbackHost(args, host));
+	};
+
+	Object.defineProperty(net, PATCHED, { value: true, enumerable: false });
+	return net;
+}
+
+// Patches the live net module for this process and everything it requires
+// afterwards. Applied on every platform: only the firewall prompt is
+// Windows-only, the exposure isn't.
+function bindLoopbackOnly() {
+	return patchNetListen(require('net'));
+}
+
+module.exports = { patchNetListen, bindLoopbackOnly, withLoopbackHost, LOOPBACK };

--- a/src/playground-web-runner.js
+++ b/src/playground-web-runner.js
@@ -1,9 +1,14 @@
 const path = require('path');
 const { hideChildWindows } = require('./hide-child-windows');
+const { bindLoopbackOnly } = require('./bind-loopback');
 
 // Must run before the Playground CLI is required, so anything it spawns is
 // covered too.
 hideChildWindows();
+
+// Same reason: the CLI calls `listen` with no address, so the patch has to be in
+// place before it is loaded. Without it the dev site is served to the whole LAN.
+bindLoopbackOnly();
 
 async function main() {
     const hostMountDir = process.argv[2];
@@ -19,7 +24,9 @@ async function main() {
 		console.log("Running Playground Web Server from", absHost);
         const result = await runCLI({
             command: 'mount-only',
-            host: '127.0.0.1',
+            // No `host` here on purpose: RunCLIArgs has no such option, so
+            // passing one only looked safe. bindLoopbackOnly() above is what
+            // actually keeps this server off the network.
             port: desiredPort,
             'mount': [ { hostPath: absHost, vfsPath: '/wordpress' } ],
             verbosity: 'debug'

--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -1,11 +1,16 @@
 const path = require('path');
 const fs = require('fs');
 const { hideChildWindows } = require('./hide-child-windows');
+const { bindLoopbackOnly } = require('./bind-loopback');
 const { formatErrorChain } = require('./error-chain');
 
 // Must run before the Playground CLI is required, so anything it spawns is
 // covered too.
 hideChildWindows();
+
+// Same reason: the CLI calls `listen` with no address, so the patch has to be in
+// place before it is loaded. Without it the dev site is served to the whole LAN.
+bindLoopbackOnly();
 
 const { writeFiles: playgroundWriteFiles } = require('@php-wasm/universal');
 

--- a/test/bind-loopback.test.cjs
+++ b/test/bind-loopback.test.cjs
@@ -1,0 +1,99 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { patchNetListen, withLoopbackHost } = require('../src/bind-loopback.js');
+
+// A stand-in for the net module that records how `listen` was called, so the
+// patch can be exercised without binding a real socket.
+function fakeNet() {
+	const calls = [];
+	class Server {
+		listen(...args) {
+			calls.push(args);
+			return this;
+		}
+	}
+	return { calls, Server };
+}
+
+// The exact call @wp-playground/cli makes: a port and a callback, no address.
+test('a port with no address gets 127.0.0.1', () => {
+	const noop = () => {};
+	assert.deepEqual(withLoopbackHost([8080, noop]), [8080, '127.0.0.1', noop]);
+	assert.deepEqual(withLoopbackHost([8080]), [8080, '127.0.0.1']);
+});
+
+test('an ephemeral port still gets a host', () => {
+	// listen(0) is the "pick a free port" form the runners rely on; 0 is a
+	// perfectly valid port and must not be mistaken for "no port given".
+	assert.deepEqual(withLoopbackHost([0]), [0, '127.0.0.1']);
+});
+
+test('a numeric string port is treated as a port', () => {
+	// Node accepts '8080' as readily as 8080, and so does the CLI when the port
+	// comes from argv.
+	assert.deepEqual(withLoopbackHost(['8080']), ['8080', '127.0.0.1']);
+});
+
+test('the host goes in front of a backlog', () => {
+	// listen(port, backlog, cb) — a number in second position is the backlog, so
+	// the host cannot simply be appended.
+	const noop = () => {};
+	assert.deepEqual(withLoopbackHost([8080, 511, noop]), [8080, '127.0.0.1', 511, noop]);
+});
+
+test('an explicit address is left alone', () => {
+	// Including a deliberate 0.0.0.0: the caller asked for it, and this patch is
+	// a default, not a lock.
+	assert.deepEqual(withLoopbackHost([8080, '0.0.0.0']), [8080, '0.0.0.0']);
+	assert.deepEqual(withLoopbackHost([8080, '::1']), [8080, '::1']);
+});
+
+test('an options object gains a host without being mutated', () => {
+	// The caller may reuse the object, so the copy matters.
+	const options = { port: 8080, backlog: 511 };
+	const patched = withLoopbackHost([options]);
+	assert.deepEqual(patched[0], { port: 8080, backlog: 511, host: '127.0.0.1' });
+	assert.deepEqual(options, { port: 8080, backlog: 511 });
+	assert.notEqual(patched[0], options);
+});
+
+test('an options object that already has a host is left alone', () => {
+	const args = [{ port: 8080, host: '0.0.0.0' }];
+	assert.equal(withLoopbackHost(args), args);
+});
+
+test('IPC and handle forms are left alone', () => {
+	// listen(path) and listen({ path }) are unix sockets / named pipes, and
+	// listen(handle) carries its own binding — a host would break all three.
+	const noop = () => {};
+	assert.deepEqual(withLoopbackHost(['/tmp/app.sock', noop]), ['/tmp/app.sock', noop]);
+	assert.deepEqual(withLoopbackHost([{ path: '/tmp/app.sock' }]), [{ path: '/tmp/app.sock' }]);
+	const handle = { fd: 3 };
+	assert.equal(withLoopbackHost([handle])[0], handle);
+	assert.deepEqual(withLoopbackHost([]), []);
+});
+
+test('patching the prototype redirects a real listen call', () => {
+	const net = fakeNet();
+	patchNetListen(net);
+	const noop = () => {};
+	new net.Server().listen(8080, noop);
+	assert.deepEqual(net.calls[0], [8080, '127.0.0.1', noop]);
+});
+
+test('patching twice wraps only once', () => {
+	// Both runners require this module, and so may anything they load.
+	const net = fakeNet();
+	patchNetListen(net);
+	const wrapped = net.Server.prototype.listen;
+	patchNetListen(net);
+	assert.equal(net.Server.prototype.listen, wrapped);
+});
+
+test('the host is configurable', () => {
+	const net = fakeNet();
+	patchNetListen(net, '::1');
+	new net.Server().listen(8080);
+	assert.deepEqual(net.calls[0], [8080, '::1']);
+});


### PR DESCRIPTION
Fixes #59.

## The problem

`@wp-playground/cli` starts its server with `server.listen(port, callback)` — no address — so Node binds to `::`/`0.0.0.0`, every interface. The contributor's WordPress, `admin`/`admin` credentials and all, is served to the local network. On Windows that is what raises the firewall prompt at every dev-server start; on macOS and Linux it happens silently.

`runCLI()` has no `host` option to pass instead — `RunCLIArgs` only knows `db-host` — which also means the `host: '127.0.0.1'` that `playground-web-runner.js` was passing had never done anything. It just read as safe.

## The fix

`src/bind-loopback.js` patches `net.Server.prototype.listen` to fill in `127.0.0.1` when the caller gives a port and no address, and both runners apply it before requiring the Playground CLI. Same shape as `hide-child-windows.js` (#52), and for the same reason: the CLI can't be told, so the built-in is patched before it loads. `http.Server` extends `net.Server` without overriding `listen`, so one patch covers the HTTP server.

It's a default, not a lock — an explicit address (including a deliberate `0.0.0.0`), an IPC path and a handle all pass through untouched. The patch lives only in the two runner subprocesses; the main process is unchanged, and its SMTP bridge was already loopback-only.

The dead `host` argument in `playground-web-runner.js` is removed, with a comment pointing at where the protection actually comes from now.

## Verification

`node --test test/bind-loopback.test.cjs` — 11 tests over every `listen` overload. The rest of the suite is unaffected.

Against a real server, before and after the patch:

```
unpatched: {"address":"::","family":"IPv6","port":49697}
patched:   {"address":"127.0.0.1","family":"IPv4","port":49698}
```

**Still needs a check on a real machine.** On Windows, start the dev server on a box that hasn't previously allowed the app through the firewall — no prompt should appear, and `netstat -ano | findstr :<port>` should show `127.0.0.1:<port>`. On macOS/Linux, `lsof -nP -iTCP -sTCP:LISTEN | grep <port>` should show `127.0.0.1:<port>` rather than `*:<port>`, and `curl http://<lan-ip>:<port>/` should refuse while `127.0.0.1` answers. Worth exercising both the dev server and the Playground web runner.

## Upstream

Filed as WordPress/wordpress-playground#4224 — a loopback default and a real `host` option on `runCLI`. When that lands, `src/bind-loopback.js` and the workaround both go away. Not a blocker: the patch is what stops shipping a LAN-exposed dev site today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
