### PR TITLE
Show the correct dev-server login password

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -55059,7 +55059,7 @@ Running ${plan.watch.label}\u2026
             "Log in with ",
             /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("code", { children: "admin" }),
             " / ",
-            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("code", { children: "admin" }),
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("code", { children: "password" }),
             "."
           ] })
         ] }) : `Dev server is starting\u2026 (${(0, import_dev_server_command.formatElapsed)(startElapsed)})` }) : null

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1690,7 +1690,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               {serverUrl ? (
                 <>
                   <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
-                  <span style={{ fontSize: 12, color: '#3c434a' }}>Log in with <code>admin</code> / <code>admin</code>.</span>
+                  <span style={{ fontSize: 12, color: '#3c434a' }}>Log in with <code>admin</code> / <code>password</code>.</span>
                 </>
               ) : (
                 `Dev server is starting… (${formatElapsed(startElapsed)})`


### PR DESCRIPTION
## What

The dev-server panel says **Log in with `admin` / `admin`**, but sites are created with the Playground default password. The real credentials are `admin` / `password`, so anyone following the label hits an "incorrect password" error on their first trip to `wp-login.php`.

This changes the label to say `admin` / `password`.

## Why not change the password instead?

The site is right; the label is wrong. `admin` / `password` is the Playground default and is what every other tool in that ecosystem shows, so matching it is less surprising than inventing our own.

## Testing

Start a dev server on a site and check the line under the URL now reads `Log in with admin / password`, then confirm those credentials actually log you in at `/wp-login.php`.

## Note on the diff

`src/renderer/index.js` is the committed esbuild bundle of `src/renderer/index.jsx`. The bundle change here was applied by hand (a single string literal) because deps weren't installed locally — re-running `npm run build:once` should reproduce it byte-for-byte.

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)