### PR TITLE
Bump the version to 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.13.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "description": "Electron app to setup WordPress develop structure and run npm install",
   "homepage": "https://github.com/WordPress/experimental-wp-dev-env",


### PR DESCRIPTION
## Why

`package.json` has read `0.1.0` since the v0.1.0 release, so the v0.1.1 tag and the artifacts built for it also identified themselves as `0.1.0`. Shipping v0.1.2 off the same value would repeat that.

The version reaches two places a contributor sees:

- **Artifact filenames.** electron-builder embeds it, so the release assets would be `WordPress.Contributor.Toolkit-0.1.0-arm64.dmg` under a v0.1.2 tag.
- **The app log.** `src/logging.js:78` writes `app <version>` as its first line. That log is what #50 added so a problem report can carry real detail — a log from the v0.1.2 build that says `0.1.0` leaves triage guessing which build it came from.

## What

`npm version 0.1.2 --no-git-tag-version`. Only the two root `version` fields change, in `package.json` and `package-lock.json`; the lockfile's dependency versions are untouched.

## Testing

`npm test` — 99 pass. `test/electron-node-version.test.cjs` fails on a working copy whose `node_modules/electron` predates #40 (it reads Electron 32's Node 20.18.1 against the range `^20.19.0 || ^22.13.0 || >=24`); `npm ci` clears it, and CI installs fresh.

This needs to merge before the build that gets attached to the v0.1.2 release, since the version is baked in at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)