### PR TITLE
Do not mark a site initialized when npm install fails

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -415,9 +415,9 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		const meta = s.get('siteMeta') || {};
 		const m = meta[sitePath] || {};
 
-		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized) };
+		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed) };
 	} catch (e) {
-		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false };
+		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false };
 	}
 });
 
@@ -678,7 +678,19 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		onLog: (type, data) => {
 			event.sender.send('npm:install:log', { installId, type, data });
 		},
-		onDone: (code) => {
+		onDone: async (code) => {
+			// Recorded before the done event so the renderer's status reload
+			// sees the outcome. node_modules existing is not evidence the
+			// install succeeded (#42); this flag is what site:status reports
+			// so a failed install's partial node_modules doesn't read as a
+			// completed setup step. Sites that predate the flag read as not
+			// failed, which matches the old behaviour.
+			try {
+				const s = await getStore();
+				const meta = s.get('siteMeta') || {};
+				meta[directoryPath] = { ...(meta[directoryPath] || {}), installFailed: code !== 0 };
+				s.set('siteMeta', meta);
+			} catch {}
 			event.sender.send('npm:install:done', { installId, code });
 			delete runningInstalls[installId];
 		}

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -54206,7 +54206,7 @@ If there's a particular need for this, please submit a feature request at https:
 install exited with code ${code}
 `);
         setInstalling(false);
-        if (1) {
+        if (code === 0) {
           try {
             await window.api.markSiteInitialized(sitePath);
           } catch {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -30976,20 +30976,22 @@ WARNING: This link could potentially be dangerous`)) {
         const installing = Boolean(flags.installing);
         const building = Boolean(flags.building);
         const starting = Boolean(flags.starting);
+        const installFailed = Boolean(flags.installFailed);
+        const installOk = hasNodeModules && !installFailed;
         return {
           download: {
             done: !isPending,
             ready: true
           },
           install: {
-            done: hasNodeModules,
+            done: installOk,
             ready: !isPending,
-            disabled: isPending || statusLoading || installing || hasNodeModules
+            disabled: isPending || statusLoading || installing || installOk
           },
           build: {
             done: hasBuilt,
-            ready: hasNodeModules,
-            disabled: statusLoading || building || !hasNodeModules || hasBuilt
+            ready: installOk,
+            disabled: statusLoading || building || !installOk || hasBuilt
           },
           dev: {
             done: false,
@@ -54067,6 +54069,7 @@ If there's a particular need for this, please submit a feature request at https:
     const [emailViewTab, setEmailViewTab] = (0, import_react69.useState)("rendered");
     const [building, setBuilding] = (0, import_react69.useState)(false);
     const [hasNodeModules, setHasNodeModules] = (0, import_react69.useState)(false);
+    const [installFailed, setInstallFailed] = (0, import_react69.useState)(false);
     const [hasBuilt, setHasBuilt] = (0, import_react69.useState)(false);
     const [skipInit, setSkipInit] = (0, import_react69.useState)(false);
     const [statusLoading, setStatusLoading] = (0, import_react69.useState)(true);
@@ -54184,6 +54187,7 @@ If there's a particular need for this, please submit a feature request at https:
         setStatusLoading(true);
         const s = await window.api.getSiteStatus(sitePath);
         setHasNodeModules(Boolean(s?.hasNodeModules));
+        setInstallFailed(Boolean(s?.installFailed));
         setHasBuilt(Boolean(s?.hasBuilt));
         setSkipInit(Boolean(s?.skipInitWizard));
       } catch {
@@ -54811,7 +54815,8 @@ Running ${plan.watch.label}\u2026
       hasBuilt,
       installing,
       building,
-      starting
+      starting,
+      installFailed
     });
     const baseSteps = [
       {
@@ -54829,10 +54834,10 @@ Running ${plan.watch.label}\u2026
           button_default,
           {
             isBusy: installing,
-            variant: hasNodeModules ? "secondary" : "primary",
+            variant: stepState.install.done ? "secondary" : "primary",
             onClick: runInstallWithTerminal,
             disabled: stepState.install.disabled,
-            children: hasNodeModules ? "Dependencies installed" : "Install npm dependencies"
+            children: stepState.install.done ? "Dependencies installed" : installFailed ? "Retry npm install" : "Install npm dependencies"
           }
         )
       },

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -849,27 +849,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     }, async ({ code }) => {
       appendNpm(`\ninstall exited with code ${code}\n`);
       setInstalling(false);
-      /**
-       * Still let us through when this happens on Windows:
-       * 
-       * npm verbose stack Error: command failed
-       * npm verbose stack     at promiseSpawn (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\promise-spawn\\lib\\index.js:22:22)
-       * npm verbose stack     at spawnWithShell (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\promise-spawn\\lib\\index.js:124:10)
-       * npm verbose stack     at promiseSpawn (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\promise-spawn\\lib\\index.js:12:12)
-       * npm verbose stack     at runScriptPkg (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\run-script\\lib\\run-script-pkg.js:79:13)
-       * npm verbose stack     at runScript (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\run-script\\lib\\run-script.js:9:12)
-       * npm verbose stack     at C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\@npmcli\\arborist\\lib\\arborist\\rebuild.js:329:17
-       * npm verbose stack     at run (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\promise-call-limit\\dist\\commonjs\\index.js:67:22)
-       * npm verbose stack     at C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\promise-call-limit\\dist\\commonjs\\index.js:84:9
-       * npm verbose stack     at new Promise (<anonymous>)
-       * npm verbose stack     at callLimit (C:\\Users\\Adam\\AppData\\Local\\Programs\\electron-setup-wordpress-core\\resources\\app.asar\\node_modules\\npm\\node_modules\\promise-call-limit\\dist\\commonjs\\index.js:35:69)
-       * npm verbose pkgid core-js-pure@3.35.1
-       * npm error code 1
-       * npm error path C:\\wp\\wordpress-develop-trunk\\node_modules\\core-js-pure
-       * 
-       * @TODO: Do not mark as initialized if the installation fails.
-       */
-      if (1 || code === 0) { try { await window.api.markSiteInitialized(sitePath); } catch {} onInitialized(sitePath); }
+      // A failed install must not mark the site initialized (#42): the wizard
+      // would advance to a build that cannot work. Leaving the step incomplete
+      // keeps the install button available for a retry.
+      if (code === 0) { try { await window.api.markSiteInitialized(sitePath); } catch {} onInitialized(sitePath); }
       try { await loadStatus(); } catch {}
       if (onDone) onDone({ code });
     });

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -717,6 +717,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   const [emailViewTab, setEmailViewTab] = useState('rendered');
   const [building, setBuilding] = useState(false);
   const [hasNodeModules, setHasNodeModules] = useState(false);
+  const [installFailed, setInstallFailed] = useState(false);
   const [hasBuilt, setHasBuilt] = useState(false);
   const [skipInit, setSkipInit] = useState(false);
   const [statusLoading, setStatusLoading] = useState(true);
@@ -832,6 +833,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       setStatusLoading(true);
       const s = await window.api.getSiteStatus(sitePath);
       setHasNodeModules(Boolean(s?.hasNodeModules));
+      setInstallFailed(Boolean(s?.installFailed));
       setHasBuilt(Boolean(s?.hasBuilt));
       setSkipInit(Boolean(s?.skipInitWizard));
     } catch {}
@@ -1434,7 +1436,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     hasBuilt,
     installing,
     building,
-    starting
+    starting,
+    installFailed
   });
 
   const baseSteps = [
@@ -1454,10 +1457,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       action: (
         <Button
           isBusy={installing}
-          variant={hasNodeModules ? 'secondary' : 'primary'}
+          variant={stepState.install.done ? 'secondary' : 'primary'}
           onClick={runInstallWithTerminal}
           disabled={stepState.install.disabled}
-        >{hasNodeModules ? 'Dependencies installed' : 'Install npm dependencies'}</Button>
+        >{stepState.install.done ? 'Dependencies installed' : installFailed ? 'Retry npm install' : 'Install npm dependencies'}</Button>
       )
     },
     {

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -18,6 +18,13 @@ function computeSetupStepState(flags = {}) {
 	const installing = Boolean(flags.installing);
 	const building = Boolean(flags.building);
 	const starting = Boolean(flags.starting);
+	const installFailed = Boolean(flags.installFailed);
+
+	// node_modules existing is not evidence the install succeeded: a failed
+	// install leaves a partial one behind, and treating that as a completed
+	// step disabled the retry and unlocked a build that could not work (#42).
+	// The recorded outcome of the last install run overrides existence.
+	const installOk = hasNodeModules && !installFailed;
 
 	return {
 		download: {
@@ -25,14 +32,14 @@ function computeSetupStepState(flags = {}) {
 			ready: true
 		},
 		install: {
-			done: hasNodeModules,
+			done: installOk,
 			ready: !isPending,
-			disabled: isPending || statusLoading || installing || hasNodeModules
+			disabled: isPending || statusLoading || installing || installOk
 		},
 		build: {
 			done: hasBuilt,
-			ready: hasNodeModules,
-			disabled: statusLoading || building || !hasNodeModules || hasBuilt
+			ready: installOk,
+			disabled: statusLoading || building || !installOk || hasBuilt
 		},
 		dev: {
 			done: false,

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -50,6 +50,22 @@ test('installed dependencies complete the install step and unlock the build', ()
 	assert.strictEqual(steps.build.disabled, false);
 });
 
+test('a failed install does not complete the step, even though node_modules exists (issue #42)', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, installFailed: true });
+
+	assert.strictEqual(steps.install.done, false, 'a failed install is not a completed step');
+	assert.strictEqual(steps.install.disabled, false, 'the retry must stay available');
+	assert.strictEqual(steps.build.ready, false, 'the build stays locked after a failed install');
+	assert.strictEqual(steps.build.disabled, true);
+});
+
+test('a successful install after a failure completes the step again', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, installFailed: false });
+
+	assert.strictEqual(steps.install.done, true);
+	assert.strictEqual(steps.build.ready, true);
+});
+
 test('the build stays locked without node_modules', () => {
 	const steps = computeSetupStepState({});
 


### PR DESCRIPTION
## Why

The wizard's install-done callback still contained a debug short-circuit — `if (1 || code === 0)` with its own `@TODO` — left over from diagnosing a Windows install failure. Any failed "Install npm dependencies" run marked the site initialized anyway, so a newcomer with a broken install advanced to a build step that could not succeed, with no route back (#42).

The Windows failure the short-circuit papered over (EBADENGINE on the bundled Node) has since been fixed properly (#37/#46/#54), so the workaround now only hides real failures.

## What

Gate `markSiteInitialized` on a zero exit code and replace the pasted stack-trace comment with the rationale. On failure the step stays incomplete and the install button remains available for a retry; the exit code is already printed to the terminal.

`src/renderer/index.js` is the committed esbuild output for the same change.

## Testing

`npm test` — 100 pass. Manual check is behavioral: kill the network mid-install and the site must remain "Not initialized" with the install step still actionable.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)