### PR TITLE
Fail the dev-server start as soon as the server dies

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -825,6 +825,16 @@ ipcMain.handle('playground:start', async (event, sitePath) => {
 		flushChildOutput(logScope);
 		logEvent(logScope, `server exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
 		delete playgroundServers[sitePath];
+		// A server that dies before reporting its URL must fail the start request
+		// now, not at the 120s timeout: the stale resolution would arrive while a
+		// restarted session is still starting and the renderer's failure handling
+		// would tear down the wrong session (#82). The web-server variant below
+		// settles on close the same way.
+		if (typeof pendingResolve === 'function') {
+			clearTimeout(timeoutId);
+			pendingResolve({ ok: false, error: `Server exited with code ${code}${signal ? ` (signal ${signal})` : ''} before reporting a URL` });
+			pendingResolve = null;
+		}
 		event.sender.send('playground:stopped', { sitePath, code });
 		// Stop WP debug tail if running
 		stopWpDebugTail(sitePath);


### PR DESCRIPTION
## Why

When the dev-server child exits before printing `SERVER_URL:`, its close handler cleaned the registry and emitted `playground:stopped` — but never settled the promise the renderer was awaiting from `playground:start`. Two consequences (#82):

- The UI stayed on "Dev server is starting… (Xs)" for the full 2-minute timeout after the crash had already happened — the failure mode #73/#75 aimed to eliminate.
- When the stale promise finally resolved as failed, the renderer's failure branch (guarded only by "not stopping / not running") could run against a *newer* session: restart the server within the window and the new session gets stopped while still starting.

The global web-server variant of the same state machine already settles its pending start on close; the two copies had drifted.

## What

Settle the pending start request as failed from the per-site close handler, mirroring the web-server variant. The success path and the timeout path already null out the pending resolver, so this only fires for a genuine early death.

## Testing

`npm test` — 100 pass. Manual check: make the server exit at boot (e.g. corrupt the build dir) — the start button must fail within seconds, not after 2 minutes, and an immediate restart must not be torn down.

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)