### PR TITLE
Show the folder name, not the full path, for Windows sites

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -31035,6 +31035,18 @@ WARNING: This link could potentially be dangerous`)) {
     }
   });
 
+  // src/renderer/path-basename.cjs
+  var require_path_basename = __commonJS({
+    "src/renderer/path-basename.cjs"(exports, module) {
+      "use strict";
+      function pathBasename2(p) {
+        const s = String(p ?? "");
+        return s.split(/[\\/]/).filter(Boolean).pop() || s;
+      }
+      module.exports = { pathBasename: pathBasename2 };
+    }
+  });
+
   // src/renderer/index.jsx
   var import_react69 = __toESM(require_react());
   var import_client2 = __toESM(require_client());
@@ -53400,6 +53412,7 @@ If there's a particular need for this, please submit a feature request at https:
   var import_xterm = __toESM(require_xterm());
   var import_setup_steps = __toESM(require_setup_steps());
   var import_dev_server_command = __toESM(require_dev_server_command());
+  var import_path_basename = __toESM(require_path_basename());
   var import_jsx_runtime61 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
@@ -53876,7 +53889,7 @@ If there's a particular need for this, please submit a feature request at https:
         ] }),
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { flex: 1, overflowY: "auto", padding: sidebarCollapsed ? "12px 8px" : "12px 16px", display: "flex", flexDirection: "column", gap: 8 }, children: sortedSites.length > 0 ? sortedSites.map((sitePath) => {
           const meta = siteMeta?.[sitePath] || {};
-          const siteName = meta.label && meta.label.trim() || sitePath.split("/").pop() || sitePath;
+          const siteName = meta.label && meta.label.trim() || (0, import_path_basename.pathBasename)(sitePath);
           const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : "";
           const isActive = activeSite === sitePath;
           const statusLabel = meta.initialized ? "Initialized" : "Not initialized";
@@ -54097,7 +54110,7 @@ If there's a particular need for this, please submit a feature request at https:
       const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
       updateStick(key, atBottom);
     }, [threshold, updateStick]);
-    const siteName = sitePath.split("/").pop();
+    const siteName = (0, import_path_basename.pathBasename)(sitePath);
     const displayName = label && label.trim() || siteName;
     const [renameModalOpen, setRenameModalOpen] = (0, import_react69.useState)(false);
     const [renameValue, setRenameValue] = (0, import_react69.useState)(displayName);

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -18,6 +18,7 @@ import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
 import { computeSetupStepState } from './setup-steps.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
+import { pathBasename } from './path-basename.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
@@ -502,7 +503,7 @@ function App() {
         <div style={{ flex: 1, overflowY: 'auto', padding: sidebarCollapsed ? '12px 8px' : '12px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
           {sortedSites.length > 0 ? sortedSites.map((sitePath) => {
             const meta = siteMeta?.[sitePath] || {};
-            const siteName = (meta.label && meta.label.trim()) || sitePath.split('/').pop() || sitePath;
+            const siteName = (meta.label && meta.label.trim()) || pathBasename(sitePath);
             const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : '';
             const isActive = activeSite === sitePath;
             const statusLabel = meta.initialized ? 'Initialized' : 'Not initialized';
@@ -744,7 +745,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     updateStick(key, atBottom);
   }, [threshold, updateStick]);
 
-  const siteName = sitePath.split('/').pop();
+  const siteName = pathBasename(sitePath);
   const displayName = (label && label.trim()) || siteName;
   const [renameModalOpen, setRenameModalOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(displayName);

--- a/src/renderer/path-basename.cjs
+++ b/src/renderer/path-basename.cjs
@@ -1,0 +1,13 @@
+// The renderer has no Node `path` module, and the site paths it displays come
+// from the main process in the platform's native form — forward slashes on
+// macOS/Linux, backslashes on Windows. Splitting on '/' alone showed the full
+// `C:\...` path in the sidebar for any site without a stored label (#87).
+'use strict';
+
+/** Last path segment on any platform; the input itself when there is none. */
+function pathBasename(p) {
+	const s = String(p ?? '');
+	return s.split(/[\\/]/).filter(Boolean).pop() || s;
+}
+
+module.exports = { pathBasename };

--- a/test/path-basename.test.cjs
+++ b/test/path-basename.test.cjs
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { pathBasename } = require('../src/renderer/path-basename.cjs');
+
+test('pathBasename handles POSIX paths', () => {
+	assert.equal(pathBasename('/Users/me/wp-sites/my-site'), 'my-site');
+	assert.equal(pathBasename('/Users/me/wp-sites/my-site/'), 'my-site');
+});
+
+test('pathBasename handles Windows paths', () => {
+	// The bug: split('/') returned the whole path for these.
+	assert.equal(pathBasename('C:\\Users\\me\\wp-sites\\my-site'), 'my-site');
+	assert.equal(pathBasename('C:\\Users\\me\\wp-sites\\my-site\\'), 'my-site');
+});
+
+test('pathBasename handles mixed separators', () => {
+	assert.equal(pathBasename('C:/Users/me\\wp-sites\\my-site'), 'my-site');
+});
+
+test('pathBasename falls back to the input when there is no segment', () => {
+	assert.equal(pathBasename(''), '');
+	assert.equal(pathBasename('/'), '/');
+	assert.equal(pathBasename(null), '');
+	assert.equal(pathBasename('my-site'), 'my-site');
+});


### PR DESCRIPTION
## Why

The renderer derived a site's display name by splitting the site path on forward slashes, in two independent places (sidebar entry and site heading). Windows paths use backslashes, so any site without a stored label — i.e. one registered by pointing at an existing directory rather than created through the wizard — showed its entire `C:\Users\...` path (#87). The main process already handles this correctly via `path.basename`; the renderer had duplicated the logic with a hardcoded separator.

## What

A new `src/renderer/path-basename.cjs` (the renderer has no Node `path` module) that takes the last segment across `/`, `\`, and mixed separators, used from both display sites. Follows the repo's extracted-tested-module pattern with `test/path-basename.test.cjs`; the Windows cases in that test fail against the old `split('/')` behavior.

`src/renderer/index.js` is the committed esbuild output for the same change.

## Testing

`npm test` — 104 pass (4 new). Manual check on Windows: add an existing folder as a site without renaming it — the sidebar and heading must show the folder name only.

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)