### PR TITLE
Add unit tests, latest release and downloads badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## WordPress Contributor Toolkit (Electron)
 
+[![Unit tests](https://github.com/WordPress/experimental-wp-dev-env/actions/workflows/unit-tests.yml/badge.svg?branch=trunk)](https://github.com/WordPress/experimental-wp-dev-env/actions/workflows/unit-tests.yml)
+[![Latest release](https://img.shields.io/github/v/release/WordPress/experimental-wp-dev-env)](https://github.com/WordPress/experimental-wp-dev-env/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/WordPress/experimental-wp-dev-env/total)](https://github.com/WordPress/experimental-wp-dev-env/releases)
+
 The [WordPress Core Dev Environment Toolkit](https://github.com/WordPress/experimental-wp-dev-env) is a desktop electron application (available for macOS on Apple Silicon, Windows, and Linux) that sets up a full WordPress core development environment with zero prerequisites.
 
 You install it, choose a directory for `wordpress-develop`, click a button, and you have:


### PR DESCRIPTION
## What

Three badges under the README heading:

- **Unit tests** — the status of `.github/workflows/unit-tests.yml` on `trunk`. Served by GitHub, no third party involved.
- **Latest release** — the current version, linking to `/releases/latest`.
- **Downloads** — total release-asset downloads.

## Notes

- The last two come from **shields.io**; GitHub has no native badge for either. If taking that dependency on a WordPress-org README isn't wanted, dropping those two lines leaves the workflow badge working on its own.
- **The release badge will read `v0.1.0` until v0.1.2 is published.** `github/v/release` skips pre-releases and v0.1.1 is flagged as one. It corrects itself on publish, so this is best merged around the release rather than long before it.
- **No test-count badge.** A hand-maintained "113 tests" would be wrong within a week; doing it properly needs a shields endpoint fed by CI. The workflow badge already answers the question that matters — does the suite pass on macOS and Windows.

## Testing

Badge URLs are static; render them in the PR's Files-changed preview to confirm all three resolve and link correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)