### PR TITLE
Record release download counts daily on a metrics branch

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -1,0 +1,86 @@
+# Records release-asset download counts once a day, onto an orphan `metrics` branch.
+#
+# GitHub exposes only a running total per asset (`download_count`) and no history endpoint, so a
+# trend can only exist if we write it down ourselves. The counter is also destroyed when an asset
+# is deleted and re-uploaded — renaming a published file restarts it at zero — which makes these
+# snapshots the only durable record.
+#
+# The data lives on `metrics`, an orphan branch sharing no history with trunk: a daily commit
+# stays out of trunk's log, and the branch can be deleted without touching anything else.
+#
+# Note that GitHub disables cron workflows after 60 days without repository activity. The job can
+# always be started by hand from the Actions tab.
+
+name: Download stats
+
+on:
+  schedule:
+    # 03:17 UTC. Scheduled runs queue behind everyone else's on-the-hour jobs.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+# Writes to the `metrics` branch.
+permissions:
+  contents: write
+
+# Two runs appending to the same branch would race on the push.
+concurrency:
+  group: download-stats
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: snapshot download counts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record today's counts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          # `metrics` does not exist on the first run. Orphaning keeps trunk's files out of the
+          # commit: `--cached` unstages everything, leaving them untracked on disk, and only the
+          # two files below are ever added back.
+          if git ls-remote --exit-code --heads origin metrics >/dev/null 2>&1; then
+            git fetch --depth=1 origin metrics:metrics
+            git checkout metrics
+          else
+            git checkout --orphan metrics
+            git rm -rf --cached . >/dev/null
+          fi
+
+          DATE=$(date -u +%F)
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases" > releases.json
+
+          [ -f downloads.csv ] || echo 'date,tag,asset,downloads' > downloads.csv
+
+          # A manual re-run replaces the day's rows instead of duplicating them.
+          grep -v "^$DATE," downloads.csv > downloads.next
+          mv -f downloads.next downloads.csv
+
+          # One row per asset per day: which platform people take is the interesting part, and a
+          # single total cannot be broken back down later.
+          jq -r '.[] | .tag_name as $tag | .assets[] | [$tag, .name, .download_count] | @csv' \
+            releases.json | sed "s/^/$DATE,/" >> downloads.csv
+
+          # A shields.io endpoint badge can read this, so the README's number comes from data we
+          # control rather than a live third-party query.
+          TOTAL=$(jq '[.[].assets[].download_count] | add // 0' releases.json)
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","color":"blue"}\n' \
+            "$TOTAL" > badge.json
+
+          rm releases.json
+
+          git add downloads.csv badge.json
+          if git diff --cached --quiet; then
+            echo "No change to record."
+            exit 0
+          fi
+          git commit -m "Download counts for $DATE ($TOTAL total)"
+          git push origin metrics


### PR DESCRIPTION
## Why

GitHub keeps a running total per release asset and offers **no history endpoint**. The trend doesn't exist anywhere unless we record it. Today's 126 is all that can ever be known about the first nine months — v0.1.0's and v0.1.1's curves aren't recoverable.

The counter also belongs to the *asset*, not the release, so deleting and re-uploading a file restarts it at zero. That already happened here: the three artifacts replaced on the v0.1.2 draft took their counts with them. A daily snapshot is the only record that survives an asset swap.

## What

A scheduled workflow (03:17 UTC, plus `workflow_dispatch`) that appends to `downloads.csv` on **`metrics`** — an orphan branch sharing no history with `trunk`, so the daily commit stays out of `trunk`'s log and the branch can be deleted with no other consequence.

One row per asset per day:

```csv
date,tag,asset,downloads
2026-07-31,"v0.1.2","wordpress-contributor-toolkit-0.1.2-mac-arm64.dmg",1
2026-07-31,"v0.1.1","WordPress.Contributor.Toolkit-0.1.0.AppImage",20
2026-07-31,"v0.1.0","mac-release-arm64.dmg",47
```

Per-asset and not a single total, because which platform people take is the interesting question and a total can't be broken back down later.

It also writes `badge.json` in shields.io's [endpoint format](https://shields.io/badges/endpoint-badge), so the README's downloads badge can eventually read a number we control rather than a live third-party query. Not wired up in this PR.

## Testing

The data pipeline was run against the live API from a checkout — 9 rows across 3 releases, `badge.json` reporting 126, matching what the current shields badge shows. YAML parses; `permissions: contents: write` (the branch push) and nothing else.

The git half only runs in CI. First run takes the `--orphan` path and creates the branch; `git rm -rf --cached .` unstages `trunk`'s files so they stay untracked on disk and never enter the commit — only `downloads.csv` and `badge.json` are added. Worth watching the first manual run from the Actions tab to confirm the branch lands with two files and nothing else.

## Notes

- **GitHub disables cron workflows after 60 days without repository activity.** Not a concern while the repo is active, and the job can always be started by hand.
- Counts are requests, not people: re-downloads, `curl` in scripts and bots all increment. It's an interest signal, not an install count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)