### PR TITLE
Name build artifacts consistently, with the architecture in every filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "build": {
     "appId": "org.wordpress.contributor.toolkit",
     "productName": "WordPress Contributor Toolkit",
+    "artifactName": "wordpress-contributor-toolkit-${version}-${os}-${arch}.${ext}",
     "directories": {
       "buildResources": "build"
     },


### PR DESCRIPTION
## Why

electron-builder's defaults gave us four naming schemes for one app:

```
WordPress Contributor Toolkit-0.1.2-arm64.dmg
WordPress Contributor Toolkit Setup 0.1.2.exe
WordPress Contributor Toolkit-0.1.2.AppImage
electron-setup-wordpress-core_0.1.2_amd64.deb
```

- **The deb and snap use the npm package name** — `electron-setup-wordpress-core`, the internal name from before the app was branded. A contributor who downloads one gets a file that doesn't look like the thing they read about.
- **The AppImage has no architecture**, because electron-builder omits it for x64. It's the Linux file we promote first, and the only one whose name can't answer "will this run on my machine?".
- **Spaces become dots** when GitHub serves a release asset, so the name on the release page never matches the name in the build log.

For **v0.1.2 these were renamed by hand** after the build. Worth removing as a step: it happens under time pressure at release, and it already went wrong once — the AppImage was labelled `linux-arm64` for an x64 build, which is precisely the ambiguity above resolved the wrong way. Since a download counter belongs to the asset, correcting a name after upload also resets that asset's count to zero.

## What

One line in `build`:

```json
"artifactName": "wordpress-contributor-toolkit-${version}-${os}-${arch}.${ext}"
```

`${arch}` follows each format's own convention rather than a single string — `x86_64` for AppImage, `amd64` for deb and snap, `x64` for NSIS.

## Testing

Expanded through electron-builder's own macro expander (`app-builder-lib/out/util/macroExpander.js` with `getArtifactArchName`) for every configured target:

| Target | Filename |
|---|---|
| macOS dmg (arm64) | `wordpress-contributor-toolkit-0.1.2-mac-arm64.dmg` |
| macOS zip (arm64) | `wordpress-contributor-toolkit-0.1.2-mac-arm64.zip` |
| Windows nsis (x64) | `wordpress-contributor-toolkit-0.1.2-win-x64.exe` |
| Windows nsis (arm64) | `wordpress-contributor-toolkit-0.1.2-win-arm64.exe` |
| Linux AppImage (x64) | `wordpress-contributor-toolkit-0.1.2-linux-x86_64.AppImage` |
| Linux deb (x64) | `wordpress-contributor-toolkit-0.1.2-linux-amd64.deb` |
| Linux snap (x64) | `wordpress-contributor-toolkit-0.1.2-linux-amd64.snap` |

**No CI step depends on the old names.** Buildkite globs `dist/*.dmg`, `dist/*.zip`, `dist\*.exe`, `dist/*.AppImage`; fastlane's `verify_code_signing` reads `dist/mac*/**.app` from the unpacked staging directory, which `artifactName` doesn't rename.

Still worth confirming on the first real build that all three artifacts appear under the new names and the Windows signature verification still finds its `.exe`.

## Note

`-linux-x86_64` rather than the `-linux-x64` used for v0.1.2's hand-renamed file. `x86_64` is the AppImage convention and what electron-builder emits for that format; forcing `x64` would mean hardcoding the arch and breaking a future arm64 Linux build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)