### PR TITLE
Pin the checkout action and drop the stats job to weekly

### DIFF
--- a/.github/workflows/download-stats.yml
+++ b/.github/workflows/download-stats.yml
@@ -1,12 +1,17 @@
-# Records release-asset download counts once a day, onto an orphan `metrics` branch.
+# Records release-asset download counts once a week, onto an orphan `metrics` branch.
 #
 # GitHub exposes only a running total per asset (`download_count`) and no history endpoint, so a
 # trend can only exist if we write it down ourselves. The counter is also destroyed when an asset
 # is deleted and re-uploaded — renaming a published file restarts it at zero — which makes these
 # snapshots the only durable record.
 #
-# The data lives on `metrics`, an orphan branch sharing no history with trunk: a daily commit
-# stays out of trunk's log, and the branch can be deleted without touching anything else.
+# The data lives on `metrics`, an orphan branch sharing no history with trunk: the commit stays
+# out of trunk's log, and the branch can be deleted without touching anything else.
+#
+# Weekly rather than daily. Download counts do not move fast enough for a daily point to say
+# anything a Monday one does not, and this job holds a write-capable token — running it 52 times
+# a year instead of 365 is the cheapest reduction in how often that token is handed to a
+# third-party action.
 #
 # Note that GitHub disables cron workflows after 60 days without repository activity. The job can
 # always be started by hand from the Actions tab.
@@ -15,8 +20,9 @@ name: Download stats
 
 on:
   schedule:
-    # 03:17 UTC. Scheduled runs queue behind everyone else's on-the-hour jobs.
-    - cron: '17 3 * * *'
+    # Mondays at 03:17 UTC. Off the hour: scheduled runs queue behind everyone else's on-the-hour
+    # jobs, and GitHub drops a scheduled run entirely if the queue is long enough.
+    - cron: '17 3 * * 1'
   workflow_dispatch:
 
 # Writes to the `metrics` branch.
@@ -33,7 +39,10 @@ jobs:
     name: snapshot download counts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to a commit, not a tag. This job is the only one in the repo holding
+      # `contents: write`, so a moved tag here would mean third-party code running weekly with a
+      # token that can push to any branch, trunk included. A SHA cannot be repointed.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Record today's counts
         env:


### PR DESCRIPTION
Follow-up to #103, from a fair question about a scheduled job committing to an unreviewed branch.

Most of what looks risky there isn't. The branch is orphaned, so nothing enters `trunk`'s history; the volume is ~50 bytes a row on a branch nothing clones; `unit-tests.yml` only fires on PRs and pushes to `trunk`, so the commit triggers no other CI.

**The part that is worth tightening is the token.** This is the only workflow in the repo with `contents: write`, and it was calling `actions/checkout@v4` — a mutable tag. If that tag were ever repointed, the job would run third-party code on a schedule holding a token that can push to any branch, `trunk` included. The data in `metrics` is not the blast radius; the token is.

## Changes

- **`actions/checkout` pinned to `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0).** Same code the tag resolves to today, but a SHA cannot be repointed.
- **Schedule moves from daily to Mondays** (`17 3 * * 1`). Download counts don't move fast enough for a daily point to say anything a weekly one doesn't, and it means handing that token to the action 52 times a year rather than 365.

The trade is a coarser series: attributing a spike to a specific day — the day an announcement post goes out, say — is no longer possible. Worth revisiting if the numbers get big enough for that to matter.

`unit-tests.yml` still uses `actions/checkout@v4` unpinned. Left alone deliberately: it's `contents: read`, so the same compromise gets far less, and pinning it is a separate call about repo-wide policy.

## Testing

YAML parses; cron is `17 3 * * 1`, `uses` resolves to the pinned SHA, permissions unchanged. No change to the data path — rows are still one per asset per snapshot, date-stamped, and replaced rather than duplicated on a same-day re-run.

The first run still creates the `metrics` branch via the `--orphan` path, and is still worth triggering by hand rather than waiting until Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)