### PR TITLE
Add an update path so sites can move to the latest trunk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ See `package.json` scripts. To run a single test file (not exposed as a script):
 ## Architecture notes (non-obvious)
 
 - **Child processes run on Electron's own Node, not the system Node.** `npm install`, `npm run <script>`, and the Playground server are spawned via `process.execPath` + `ELECTRON_RUN_AS_NODE=1` — this is the mechanism behind "zero prerequisites." On Windows this requires shimming `node`/`npm`/`npx` into `PATH` so child `npm` processes can find a `node` binary at all.
-- **Git has no system dependency** — all Git ops go through `isomorphic-git`, not a shelled-out `git` binary. Patch/diff generation is done by hand in `main.js` (stage untracked files, diff working tree vs `origin/trunk`), not `git diff`.
+- **Git has no system dependency** — all Git ops go through `isomorphic-git`, not a shelled-out `git` binary. Patch/diff generation is done by hand in `main.js` (stage untracked files, diff working tree vs `HEAD` — the cloned trunk snapshot, kept deliberately as the diff base; see #94), not `git diff`.
 - **`electron-store` is the only persistence layer** — no separate DB. It holds the site registry and per-site metadata; treat it as the single source of truth for "known sites."
 - Long-running child-process output (installs, scripts, server) is streamed to the renderer via correlated IDs (`installId`/`runId`), not returned synchronously — expect async event handlers, not return values, when tracing that flow.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "electron-setup-wordpress-core",
       "version": "0.1.2",
       "hasInstallScript": true,
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -15,6 +15,8 @@
  * stage column is deliberately ignored: a file staged but byte-identical to
  * HEAD produces no patch hunks, so warning about it would show a scary
  * modal for a no-op. This matches exactly what the patch generator emits.
+ *
+ * @param {Array} matrix
  */
 function isDirtyFromStatusMatrix(matrix) {
 	const rows = (matrix || []).filter(([, head, workdir]) => head !== workdir);
@@ -27,6 +29,8 @@ function isDirtyFromStatusMatrix(matrix) {
  * deletes workdir files that are in the index but not in the target tree, so
  * these must be removed from the index (index-only) before a reset or the
  * user's untracked files get destroyed.
+ *
+ * @param {Array} matrix
  */
 function staleStagedPaths(matrix) {
 	return (matrix || [])
@@ -37,6 +41,9 @@ function staleStagedPaths(matrix) {
 /**
  * Whether package-lock.json changed between two trunk snapshots, from the
  * blob oids on each side (null when the file is absent in that tree).
+ *
+ * @param {string|null} oldBlobOid
+ * @param {string|null} newBlobOid
  */
 function lockfileChangedFromBlobOids(oldBlobOid, newBlobOid) {
 	if (!oldBlobOid && !newBlobOid) return false;
@@ -49,6 +56,8 @@ function lockfileChangedFromBlobOids(oldBlobOid, newBlobOid) {
  * checked out by native git on Windows (default core.autocrlf=true) has CRLF
  * on disk — without normalization every text file diffs on every line.
  * Matches git's autocrlf read-side behavior: lone \r is left alone.
+ *
+ * @param {string} text
  */
 function normalizeEol(text) {
 	return String(text).replace(/\r\n/g, '\n');
@@ -60,6 +69,8 @@ function normalizeEol(text) {
  * text fixtures (e.g. wordpress-develop's Big5/Latin-1 encoding tests)
  * smudged to CRLF by a native-git checkout still hash as modified. This
  * works on raw bytes, so encoding doesn't matter.
+ *
+ * @param {Buffer|Uint8Array} buf
  */
 function normalizeEolBuffer(buf) {
 	const src = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -44,4 +44,14 @@ function lockfileChangedFromBlobOids(oldBlobOid, newBlobOid) {
 	return oldBlobOid !== newBlobOid;
 }
 
-module.exports = { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids };
+/**
+ * Normalizes CRLF to LF. wordpress-develop's blobs are LF-only, but a site
+ * checked out by native git on Windows (default core.autocrlf=true) has CRLF
+ * on disk — without normalization every text file diffs on every line.
+ * Matches git's autocrlf read-side behavior: lone \r is left alone.
+ */
+function normalizeEol(text) {
+	return String(text).replace(/\r\n/g, '\n');
+}
+
+module.exports = { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol };

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -17,8 +17,8 @@
  * modal for a no-op. This matches exactly what the patch generator emits.
  */
 function isDirtyFromStatusMatrix(matrix) {
-	const changed = (matrix || []).filter(([, head, workdir]) => head !== workdir);
-	return { dirty: changed.length > 0, changedCount: changed.length, files: changed.map(([filepath]) => filepath) };
+	const rows = (matrix || []).filter(([, head, workdir]) => head !== workdir);
+	return { dirty: rows.length > 0, changedCount: rows.length, files: rows.map(([filepath]) => filepath), rows };
 }
 
 /**

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -54,4 +54,22 @@ function normalizeEol(text) {
 	return String(text).replace(/\r\n/g, '\n');
 }
 
-module.exports = { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol };
+/**
+ * Byte-level CRLF→LF normalization for Buffers. isomorphic-git's autocrlf
+ * handling only normalizes files that decode as valid UTF-8, so non-UTF8
+ * text fixtures (e.g. wordpress-develop's Big5/Latin-1 encoding tests)
+ * smudged to CRLF by a native-git checkout still hash as modified. This
+ * works on raw bytes, so encoding doesn't matter.
+ */
+function normalizeEolBuffer(buf) {
+	const src = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+	const out = Buffer.alloc(src.length);
+	let j = 0;
+	for (let i = 0; i < src.length; i++) {
+		if (src[i] === 13 && src[i + 1] === 10) continue;
+		out[j++] = src[i];
+	}
+	return out.subarray(0, j);
+}
+
+module.exports = { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol, normalizeEolBuffer };

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -18,7 +18,7 @@
  */
 function isDirtyFromStatusMatrix(matrix) {
 	const changed = (matrix || []).filter(([, head, workdir]) => head !== workdir);
-	return { dirty: changed.length > 0, changedCount: changed.length };
+	return { dirty: changed.length > 0, changedCount: changed.length, files: changed.map(([filepath]) => filepath) };
 }
 
 /**

--- a/src/git-update.cjs
+++ b/src/git-update.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * Pure helpers for the trunk update path (issue #94), operating on
+ * isomorphic-git statusMatrix rows and blob oids. Kept dependency-free so
+ * `node --test` can require them directly while the git I/O stays in main.js.
+ *
+ * statusMatrix row shape: [filepath, head, workdir, stage] where
+ * head: 0 absent, 1 present; workdir: 0 absent, 1 identical, 2 different;
+ * stage: 0 absent, 1 identical, 2 modified-staged, 3 modified-unstaged.
+ */
+
+/**
+ * A worktree is dirty when any file's working copy differs from HEAD. The
+ * stage column is deliberately ignored: a file staged but byte-identical to
+ * HEAD produces no patch hunks, so warning about it would show a scary
+ * modal for a no-op. This matches exactly what the patch generator emits.
+ */
+function isDirtyFromStatusMatrix(matrix) {
+	const changed = (matrix || []).filter(([, head, workdir]) => head !== workdir);
+	return { dirty: changed.length > 0, changedCount: changed.length };
+}
+
+/**
+ * Files staged but absent from HEAD — the residue patch generation leaves
+ * behind (it stages untracked files and never unstages). checkout({force})
+ * deletes workdir files that are in the index but not in the target tree, so
+ * these must be removed from the index (index-only) before a reset or the
+ * user's untracked files get destroyed.
+ */
+function staleStagedPaths(matrix) {
+	return (matrix || [])
+		.filter(([, head, , stage]) => head === 0 && stage !== 0)
+		.map(([filepath]) => filepath);
+}
+
+/**
+ * Whether package-lock.json changed between two trunk snapshots, from the
+ * blob oids on each side (null when the file is absent in that tree).
+ */
+function lockfileChangedFromBlobOids(oldBlobOid, newBlobOid) {
+	if (!oldBlobOid && !newBlobOid) return false;
+	if (!oldBlobOid || !newBlobOid) return true;
+	return oldBlobOid !== newBlobOid;
+}
+
+module.exports = { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids };

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const {
 } = require('./logging');
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
-const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol } = require('./git-update.cjs');
+const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol, normalizeEolBuffer } = require('./git-update.cjs');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -430,10 +430,30 @@ async function readLockfileBlobOid(dir, oid) {
 
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
-        await ensureAutocrlf(sitePath);
-        const matrix = await git.statusMatrix({ fs, dir: sitePath });
-        const { dirty, changedCount, files } = isDirtyFromStatusMatrix(matrix);
-        return { ok: true, dirty, changedCount, files };
+        const dir = sitePath;
+        await ensureAutocrlf(dir);
+        const matrix = await git.statusMatrix({ fs, dir });
+        const candidates = isDirtyFromStatusMatrix(matrix).files;
+        // statusMatrix's autocrlf normalization only covers valid-UTF8 files;
+        // non-UTF8 text fixtures smudged to CRLF by a native-git checkout
+        // still hash as modified. Confirm each candidate with a byte-level
+        // CRLF-insensitive comparison before calling the tree dirty.
+        let headOid = null;
+        try { headOid = await git.resolveRef({ fs, dir, ref: 'HEAD' }); } catch {}
+        const rowByPath = new Map(matrix.map((row) => [row[0], row]));
+        const files = [];
+        for (const filepath of candidates) {
+            const [, head, workdir] = rowByPath.get(filepath) || [];
+            if (head === 1 && workdir === 2 && headOid) {
+                try {
+                    const { blob } = await git.readBlob({ fs, dir, oid: headOid, filepath });
+                    const work = await fs.promises.readFile(path.join(dir, filepath));
+                    if (normalizeEolBuffer(Buffer.from(blob)).equals(normalizeEolBuffer(work))) continue;
+                } catch {}
+            }
+            files.push(filepath);
+        }
+        return { ok: true, dirty: files.length > 0, changedCount: files.length, files };
     } catch (e) {
         return { ok: false, error: String(e) };
     }

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const {
 } = require('./logging');
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
-const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids } = require('./git-update.cjs');
+const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol } = require('./git-update.cjs');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -286,7 +286,25 @@ function buildPatchHtml(content) {
     </body></html>`;
 }
 
+// A site checked out by native git on Windows (default core.autocrlf=true,
+// set globally — which isomorphic-git never reads) has CRLF on disk while
+// wordpress-develop's blobs are LF-only. Without this, statusMatrix hashes
+// the raw CRLF bytes and reports every text file as modified (~5k phantom
+// changes; isomorphic-git#1275). Writing core.autocrlf into the site's LOCAL
+// config makes isomorphic-git strip CRLF before hashing workdir files. LF
+// checkouts are unaffected. Called before every status/patch/update git op
+// so pre-existing sites are covered, not just new clones.
+async function ensureAutocrlf(dir) {
+    try {
+        const current = await git.getConfig({ fs, dir, path: 'core.autocrlf' });
+        if (current !== 'true') {
+            await git.setConfig({ fs, dir, path: 'core.autocrlf', value: 'true' });
+        }
+    } catch {}
+}
+
 async function createMinimalPatchForDir(dir) {
+    await ensureAutocrlf(dir);
     // The diff base is deliberately the local HEAD (the cloned trunk
     // snapshot), NOT the remote trunk ref: diffing local edits against a
     // trunk that has moved would embed reversed upstream changes and foreign
@@ -324,8 +342,11 @@ async function createMinimalPatchForDir(dir) {
         const abs = require('path').join(dir, filepath);
         const workBuf = workdir ? await fs.promises.readFile(abs).catch(() => null) : null;
         const base = head && headOid ? await git.readBlob({ fs, dir, oid: headOid, filepath }).catch(() => null) : null;
-        const a = base ? Buffer.from(base.blob).toString('utf8') : '';
-        const b = workBuf ? workBuf.toString('utf8') : a;
+        // CRLF→LF on both sides: the workdir may be a CRLF checkout (native
+        // git on Windows), and a patch full of line-ending churn applies
+        // nowhere on Trac.
+        const a = base ? normalizeEol(Buffer.from(base.blob).toString('utf8')) : '';
+        const b = workBuf ? normalizeEol(workBuf.toString('utf8')) : a;
         if (a === b) continue;
         // Skip likely-binary
         if ((a.indexOf('\0') !== -1) || (b.indexOf('\0') !== -1)) continue;
@@ -409,6 +430,7 @@ async function readLockfileBlobOid(dir, oid) {
 
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
+        await ensureAutocrlf(sitePath);
         const matrix = await git.statusMatrix({ fs, dir: sitePath });
         const { dirty, changedCount, files } = isDirtyFromStatusMatrix(matrix);
         return { ok: true, dirty, changedCount, files };
@@ -420,6 +442,7 @@ ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
 ipcMain.handle('git:discard-changes', async (_e, sitePath) => {
     try {
         const dir = sitePath;
+        await ensureAutocrlf(dir);
         const matrix = await git.statusMatrix({ fs, dir });
         // Files absent from HEAD must be removed from the index AND the
         // workdir — a "discard" that leaves new files behind would put them
@@ -458,6 +481,7 @@ ipcMain.handle('git:update-trunk', async (event, sitePath) => {
         let stage = 'fetch';
         let oldOid = null;
         try {
+            await ensureAutocrlf(dir);
             oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
             sendLog(`Fetching latest trunk…\n`);
             const fetchResult = await git.fetch({
@@ -622,6 +646,9 @@ ipcMain.handle('sites:set-skip-init', async (_e, sitePath, skip) => {
 });
 
 ipcMain.handle('sites:add', async (_e, sitePath) => {
+	// A pre-existing dir was likely cloned by native git — exactly the case
+	// where CRLF checkouts break status/patch generation (see ensureAutocrlf).
+	await ensureAutocrlf(sitePath);
 	const s = await getStore();
 	const sites = s.get('sites');
 	if (!sites.includes(sitePath)) {
@@ -678,6 +705,7 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 		// Fallback/error
 		throw e;
 	}
+	await ensureAutocrlf(siteDir);
 
 	const s = await getStore();
 	const sites = s.get('sites');

--- a/src/main.js
+++ b/src/main.js
@@ -410,8 +410,8 @@ async function readLockfileBlobOid(dir, oid) {
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
         const matrix = await git.statusMatrix({ fs, dir: sitePath });
-        const { dirty, changedCount } = isDirtyFromStatusMatrix(matrix);
-        return { ok: true, dirty, changedCount };
+        const { dirty, changedCount, files } = isDirtyFromStatusMatrix(matrix);
+        return { ok: true, dirty, changedCount, files };
     } catch (e) {
         return { ok: false, error: String(e) };
     }

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,8 @@ const {
 } = require('./logging');
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
-const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids, normalizeEol, normalizeEolBuffer } = require('./git-update.cjs');
+const { normalizeEol } = require('./git-update.cjs');
+const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, updateToLatestTrunk } = require('./trunk-update');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -286,23 +287,6 @@ function buildPatchHtml(content) {
     </body></html>`;
 }
 
-// A site checked out by native git on Windows (default core.autocrlf=true,
-// set globally — which isomorphic-git never reads) has CRLF on disk while
-// wordpress-develop's blobs are LF-only. Without this, statusMatrix hashes
-// the raw CRLF bytes and reports every text file as modified (~5k phantom
-// changes; isomorphic-git#1275). Writing core.autocrlf into the site's LOCAL
-// config makes isomorphic-git strip CRLF before hashing workdir files. LF
-// checkouts are unaffected. Called before every status/patch/update git op
-// so pre-existing sites are covered, not just new clones.
-async function ensureAutocrlf(dir) {
-    try {
-        const current = await git.getConfig({ fs, dir, path: 'core.autocrlf' });
-        if (current !== 'true') {
-            await git.setConfig({ fs, dir, path: 'core.autocrlf', value: 'true' });
-        }
-    } catch {}
-}
-
 async function createMinimalPatchForDir(dir) {
     await ensureAutocrlf(dir);
     // The diff base is deliberately the local HEAD (the cloned trunk
@@ -401,16 +385,8 @@ ipcMain.handle('git:save-patch', async (_e, sitePath) => {
     }
 });
 
-// --- Trunk update path (#94) ---
-
-// Reads the commit the site's HEAD points at; its committer date is the age
-// of the trunk snapshot. One object read, no network.
-async function readTrunkInfo(dir) {
-    const trunkOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
-    const { commit } = await git.readCommit({ fs, dir, oid: trunkOid });
-    const trunkDate = new Date(commit.committer.timestamp * 1000).toISOString();
-    return { trunkOid, trunkDate };
-}
+// --- Trunk update path (#94) --- git mechanics live in src/trunk-update.js;
+// these handlers only add IPC plumbing and electron-store writes.
 
 async function mergeSiteMeta(sitePath, patch) {
     const s = await getStore();
@@ -419,40 +395,9 @@ async function mergeSiteMeta(sitePath, patch) {
     s.set('siteMeta', meta);
 }
 
-async function readLockfileBlobOid(dir, oid) {
-    try {
-        const { oid: blobOid } = await git.readBlob({ fs, dir, oid, filepath: 'package-lock.json' });
-        return blobOid;
-    } catch {
-        return null;
-    }
-}
-
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
-        const dir = sitePath;
-        await ensureAutocrlf(dir);
-        const matrix = await git.statusMatrix({ fs, dir });
-        const candidates = isDirtyFromStatusMatrix(matrix).files;
-        // statusMatrix's autocrlf normalization only covers valid-UTF8 files;
-        // non-UTF8 text fixtures smudged to CRLF by a native-git checkout
-        // still hash as modified. Confirm each candidate with a byte-level
-        // CRLF-insensitive comparison before calling the tree dirty.
-        let headOid = null;
-        try { headOid = await git.resolveRef({ fs, dir, ref: 'HEAD' }); } catch {}
-        const rowByPath = new Map(matrix.map((row) => [row[0], row]));
-        const files = [];
-        for (const filepath of candidates) {
-            const [, head, workdir] = rowByPath.get(filepath) || [];
-            if (head === 1 && workdir === 2 && headOid) {
-                try {
-                    const { blob } = await git.readBlob({ fs, dir, oid: headOid, filepath });
-                    const work = await fs.promises.readFile(path.join(dir, filepath));
-                    if (normalizeEolBuffer(Buffer.from(blob)).equals(normalizeEolBuffer(work))) continue;
-                } catch {}
-            }
-            files.push(filepath);
-        }
+        const files = await collectDirtyFiles(sitePath);
         return { ok: true, dirty: files.length > 0, changedCount: files.length, files };
     } catch (e) {
         return { ok: false, error: String(e) };
@@ -461,103 +406,39 @@ ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
 
 ipcMain.handle('git:discard-changes', async (_e, sitePath) => {
     try {
-        const dir = sitePath;
-        await ensureAutocrlf(dir);
-        const matrix = await git.statusMatrix({ fs, dir });
-        // Files absent from HEAD must be removed from the index AND the
-        // workdir — a "discard" that leaves new files behind would put them
-        // straight back into the next patch.
-        for (const [filepath, head, workdir] of matrix) {
-            if (head === 0) {
-                try { await git.remove({ fs, dir, filepath }); } catch {}
-                if (workdir !== 0) {
-                    try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
-                }
-            }
-        }
-        await git.checkout({ fs, dir, ref: 'trunk', force: true });
+        await discardChanges(sitePath);
         return { ok: true };
     } catch (e) {
         return { ok: false, error: String(e) };
     }
 });
 
-const runningTrunkUpdates = {};
-
 ipcMain.handle('git:update-trunk', async (event, sitePath) => {
     const updateId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const sender = event.sender;
-    const dir = sitePath;
     const sendLog = (data) => {
         try { sender.send('git:update-trunk:log', { updateId, data }); } catch {}
     };
     const sendDone = (payload) => {
-        delete runningTrunkUpdates[updateId];
         try { sender.send('git:update-trunk:done', { updateId, ...payload }); } catch {}
     };
-    runningTrunkUpdates[updateId] = { sitePath };
 
     (async () => {
-        let stage = 'fetch';
-        let oldOid = null;
         try {
-            await ensureAutocrlf(dir);
-            oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
-            sendLog(`Fetching latest trunk…\n`);
-            const fetchResult = await git.fetch({
-                fs, http, dir,
-                url: WORDPRESS_GIT_URL,
-                ref: 'trunk',
-                singleBranch: true,
-                depth: 1,
-                tags: false,
-                onProgress: (evt) => {
-                    sendLog(`${evt.phase || 'fetch'} ${evt.loaded || 0}/${evt.total || 0}\r`);
-                }
-            });
-            let newOid = fetchResult && fetchResult.fetchHead;
-            if (!newOid) newOid = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/trunk' });
-
-            if (newOid === oldOid) {
-                const { trunkDate } = await readTrunkInfo(dir);
-                await mergeSiteMeta(sitePath, { trunkOid: oldOid, trunkDate });
-                sendLog('\nAlready up to date.\n');
-                sendDone({ ok: true, upToDate: true, oldOid, newOid, lockfileChanged: false, trunkDate });
-                return;
+            const result = await updateToLatestTrunk({ dir: sitePath, url: WORDPRESS_GIT_URL, onLog: sendLog });
+            if (result.upToDate) {
+                await mergeSiteMeta(sitePath, { trunkOid: result.oldOid, trunkDate: result.trunkDate });
+            } else {
+                // HEAD has moved but install/build have not run yet: persist
+                // the incomplete flag now so the state survives a crash or
+                // quit mid-chain; the renderer clears it after a successful
+                // build.
+                await mergeSiteMeta(sitePath, { trunkOid: result.newOid, trunkDate: result.trunkDate, updateIncomplete: true });
             }
-
-            // Decide the install step before touching the worktree.
-            const oldLock = await readLockfileBlobOid(dir, oldOid);
-            const newLock = await readLockfileBlobOid(dir, newOid);
-            const lockfileChanged = lockfileChangedFromBlobOids(oldLock, newLock);
-
-            stage = 'checkout';
-            // Patch generation stages untracked files and never unstages
-            // them; checkout({force}) deletes workdir files that are in the
-            // index but absent from the target tree, so drop those index
-            // entries first (index-only — the workdir files survive).
-            const matrix = await git.statusMatrix({ fs, dir });
-            for (const filepath of staleStagedPaths(matrix)) {
-                try { await git.remove({ fs, dir, filepath }); } catch {}
-            }
-            sendLog(`\nResetting to latest trunk (${newOid.slice(0, 7)})…\n`);
-            await git.writeRef({ fs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
-            await git.checkout({
-                fs, dir, ref: 'trunk', force: true,
-                onProgress: (evt) => {
-                    sendLog(`${evt.phase || 'checkout'} ${evt.loaded || 0}/${evt.total || 0}\r`);
-                }
-            });
-
-            const { trunkDate } = await readTrunkInfo(dir);
-            // HEAD has moved but install/build have not run yet: persist the
-            // incomplete flag now so the state survives a crash or quit
-            // mid-chain; the renderer clears it after a successful build.
-            await mergeSiteMeta(sitePath, { trunkOid: newOid, trunkDate, updateIncomplete: true });
-            sendLog(`\nNow on trunk as of ${trunkDate}.\n`);
-            sendDone({ ok: true, upToDate: false, oldOid, newOid, lockfileChanged, trunkDate });
+            sendDone({ ok: true, ...result });
         } catch (e) {
             logError('git:update-trunk', String(e && e.stack ? e.stack : e));
+            const stage = (e && e.stage) || 'fetch';
             // A failure during checkout leaves the ref moved over a partial
             // worktree — that is the "code is new, assets are old" state, so
             // persist it; a fetch failure moved nothing and stays plain.
@@ -565,7 +446,7 @@ ipcMain.handle('git:update-trunk', async (event, sitePath) => {
                 try { await mergeSiteMeta(sitePath, { updateIncomplete: true }); } catch {}
             }
             sendLog(`\nUpdate failed during ${stage}: ${String(e && e.message ? e.message : e)}\n`);
-            sendDone({ ok: false, upToDate: false, oldOid, newOid: null, lockfileChanged: false, error: String(e), stage });
+            sendDone({ ok: false, upToDate: false, error: String(e), stage });
         }
     })();
 

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ const {
 } = require('./logging');
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
+const { isDirtyFromStatusMatrix, staleStagedPaths, lockfileChangedFromBlobOids } = require('./git-update.cjs');
 
 const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
@@ -286,6 +287,12 @@ function buildPatchHtml(content) {
 }
 
 async function createMinimalPatchForDir(dir) {
+    // The diff base is deliberately the local HEAD (the cloned trunk
+    // snapshot), NOT the remote trunk ref: diffing local edits against a
+    // trunk that has moved would embed reversed upstream changes and foreign
+    // context lines into the patch, and it would apply nowhere. The route to
+    // Trac-applicable patches is the "Update to latest trunk" action (#94),
+    // after which HEAD == origin/trunk and the two bases coincide.
     // Ensure we have origin/trunk and HEAD reference
     try { await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/trunk' }); }
     catch { await git.fetch({ fs, http, dir, url: WORDPRESS_GIT_URL, depth: 1, singleBranch: true, ref: 'trunk' }); }
@@ -373,6 +380,159 @@ ipcMain.handle('git:save-patch', async (_e, sitePath) => {
     }
 });
 
+// --- Trunk update path (#94) ---
+
+// Reads the commit the site's HEAD points at; its committer date is the age
+// of the trunk snapshot. One object read, no network.
+async function readTrunkInfo(dir) {
+    const trunkOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+    const { commit } = await git.readCommit({ fs, dir, oid: trunkOid });
+    const trunkDate = new Date(commit.committer.timestamp * 1000).toISOString();
+    return { trunkOid, trunkDate };
+}
+
+async function mergeSiteMeta(sitePath, patch) {
+    const s = await getStore();
+    const meta = s.get('siteMeta') || {};
+    meta[sitePath] = { ...(meta[sitePath] || {}), ...patch };
+    s.set('siteMeta', meta);
+}
+
+async function readLockfileBlobOid(dir, oid) {
+    try {
+        const { oid: blobOid } = await git.readBlob({ fs, dir, oid, filepath: 'package-lock.json' });
+        return blobOid;
+    } catch {
+        return null;
+    }
+}
+
+ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
+    try {
+        const matrix = await git.statusMatrix({ fs, dir: sitePath });
+        const { dirty, changedCount } = isDirtyFromStatusMatrix(matrix);
+        return { ok: true, dirty, changedCount };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+});
+
+ipcMain.handle('git:discard-changes', async (_e, sitePath) => {
+    try {
+        const dir = sitePath;
+        const matrix = await git.statusMatrix({ fs, dir });
+        // Files absent from HEAD must be removed from the index AND the
+        // workdir — a "discard" that leaves new files behind would put them
+        // straight back into the next patch.
+        for (const [filepath, head, workdir] of matrix) {
+            if (head === 0) {
+                try { await git.remove({ fs, dir, filepath }); } catch {}
+                if (workdir !== 0) {
+                    try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
+                }
+            }
+        }
+        await git.checkout({ fs, dir, ref: 'trunk', force: true });
+        return { ok: true };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+});
+
+const runningTrunkUpdates = {};
+
+ipcMain.handle('git:update-trunk', async (event, sitePath) => {
+    const updateId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sender = event.sender;
+    const dir = sitePath;
+    const sendLog = (data) => {
+        try { sender.send('git:update-trunk:log', { updateId, data }); } catch {}
+    };
+    const sendDone = (payload) => {
+        delete runningTrunkUpdates[updateId];
+        try { sender.send('git:update-trunk:done', { updateId, ...payload }); } catch {}
+    };
+    runningTrunkUpdates[updateId] = { sitePath };
+
+    (async () => {
+        let stage = 'fetch';
+        let oldOid = null;
+        try {
+            oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+            sendLog(`Fetching latest trunk…\n`);
+            const fetchResult = await git.fetch({
+                fs, http, dir,
+                url: WORDPRESS_GIT_URL,
+                ref: 'trunk',
+                singleBranch: true,
+                depth: 1,
+                tags: false,
+                onProgress: (evt) => {
+                    sendLog(`${evt.phase || 'fetch'} ${evt.loaded || 0}/${evt.total || 0}\r`);
+                }
+            });
+            let newOid = fetchResult && fetchResult.fetchHead;
+            if (!newOid) newOid = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/trunk' });
+
+            if (newOid === oldOid) {
+                const { trunkDate } = await readTrunkInfo(dir);
+                await mergeSiteMeta(sitePath, { trunkOid: oldOid, trunkDate });
+                sendLog('\nAlready up to date.\n');
+                sendDone({ ok: true, upToDate: true, oldOid, newOid, lockfileChanged: false, trunkDate });
+                return;
+            }
+
+            // Decide the install step before touching the worktree.
+            const oldLock = await readLockfileBlobOid(dir, oldOid);
+            const newLock = await readLockfileBlobOid(dir, newOid);
+            const lockfileChanged = lockfileChangedFromBlobOids(oldLock, newLock);
+
+            stage = 'checkout';
+            // Patch generation stages untracked files and never unstages
+            // them; checkout({force}) deletes workdir files that are in the
+            // index but absent from the target tree, so drop those index
+            // entries first (index-only — the workdir files survive).
+            const matrix = await git.statusMatrix({ fs, dir });
+            for (const filepath of staleStagedPaths(matrix)) {
+                try { await git.remove({ fs, dir, filepath }); } catch {}
+            }
+            sendLog(`\nResetting to latest trunk (${newOid.slice(0, 7)})…\n`);
+            await git.writeRef({ fs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
+            await git.checkout({
+                fs, dir, ref: 'trunk', force: true,
+                onProgress: (evt) => {
+                    sendLog(`${evt.phase || 'checkout'} ${evt.loaded || 0}/${evt.total || 0}\r`);
+                }
+            });
+
+            const { trunkDate } = await readTrunkInfo(dir);
+            // HEAD has moved but install/build have not run yet: persist the
+            // incomplete flag now so the state survives a crash or quit
+            // mid-chain; the renderer clears it after a successful build.
+            await mergeSiteMeta(sitePath, { trunkOid: newOid, trunkDate, updateIncomplete: true });
+            sendLog(`\nNow on trunk as of ${trunkDate}.\n`);
+            sendDone({ ok: true, upToDate: false, oldOid, newOid, lockfileChanged, trunkDate });
+        } catch (e) {
+            logError('git:update-trunk', String(e && e.stack ? e.stack : e));
+            // A failure during checkout leaves the ref moved over a partial
+            // worktree — that is the "code is new, assets are old" state, so
+            // persist it; a fetch failure moved nothing and stays plain.
+            if (stage === 'checkout') {
+                try { await mergeSiteMeta(sitePath, { updateIncomplete: true }); } catch {}
+            }
+            sendLog(`\nUpdate failed during ${stage}: ${String(e && e.message ? e.message : e)}\n`);
+            sendDone({ ok: false, upToDate: false, oldOid, newOid: null, lockfileChanged: false, error: String(e), stage });
+        }
+    })();
+
+    return { updateId };
+});
+
+ipcMain.handle('sites:mark-update-complete', async (_e, sitePath) => {
+    await mergeSiteMeta(sitePath, { updateIncomplete: false });
+    return true;
+});
+
 app.whenReady().then(() => {
 	// Before createWindow(): initLogging preloads the IPC bridge that carries
 	// renderer output into the log file, which only applies to windows created
@@ -433,9 +593,23 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		const meta = s.get('siteMeta') || {};
 		const m = meta[sitePath] || {};
 
-		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed) };
+		// Trunk snapshot age (#94). Read from HEAD each time (one object
+		// read) and written through to siteMeta, so the sidebar can render
+		// staleness dots from siteMeta alone, without per-site git I/O.
+		let trunkOid = m.trunkOid || null;
+		let trunkDate = m.trunkDate || null;
+		try {
+			const info = await readTrunkInfo(sitePath);
+			trunkOid = info.trunkOid;
+			trunkDate = info.trunkDate;
+			if (m.trunkOid !== trunkOid || m.trunkDate !== trunkDate) {
+				await mergeSiteMeta(sitePath, { trunkOid, trunkDate });
+			}
+		} catch {}
+
+		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(m.updateIncomplete) };
 	} catch (e) {
-		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false };
+		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false };
 	}
 });
 
@@ -515,6 +689,11 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 			? options.siteLabel.trim()
 			: uniqueName;
 		meta[siteDir] = { initialized: false, createdAt: new Date().toISOString(), label: siteLabel };
+		try {
+			const { trunkOid, trunkDate } = await readTrunkInfo(siteDir);
+			meta[siteDir].trunkOid = trunkOid;
+			meta[siteDir].trunkDate = trunkDate;
+		} catch {}
 		s.set('siteMeta', meta);
 	}
 	event.sender.send('download:status', { phase: 'done', target: siteDir, sitePath: siteDir });

--- a/src/preload.js
+++ b/src/preload.js
@@ -70,6 +70,29 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	savePatch: (sitePath) => ipcRenderer.invoke('git:save-patch', sitePath)
 ,
+	isWorktreeDirty: (sitePath) => ipcRenderer.invoke('git:worktree-dirty', sitePath)
+,
+	discardChanges: (sitePath) => ipcRenderer.invoke('git:discard-changes', sitePath)
+,
+	markUpdateComplete: (sitePath) => ipcRenderer.invoke('sites:mark-update-complete', sitePath)
+,
+	updateTrunk: async (sitePath, onLog, onDone) => {
+		const { updateId } = await ipcRenderer.invoke('git:update-trunk', sitePath);
+		const logHandler = (_e, payload) => {
+			if (payload.updateId === updateId && onLog) onLog(payload);
+		};
+		const doneHandler = (_e, payload) => {
+			if (payload.updateId === updateId) {
+				ipcRenderer.removeListener('git:update-trunk:log', logHandler);
+				ipcRenderer.removeListener('git:update-trunk:done', doneHandler);
+				if (onDone) onDone(payload);
+			}
+		};
+		ipcRenderer.on('git:update-trunk:log', logHandler);
+		ipcRenderer.on('git:update-trunk:done', doneHandler);
+		return { updateId };
+	}
+,
 	startWpDebug: async (sitePath, onData) => {
 		const handler = (_e, payload) => {
 			if (payload.sitePath === sitePath) onData && onData(payload.data);

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -53479,6 +53479,11 @@ If there's a particular need for this, please submit a feature request at https:
   var import_update_plan = __toESM(require_update_plan());
   var import_jsx_runtime61 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
+  var UPDATE_STEP_LABELS = {
+    fetch: { pending: "Fetch and reset to trunk", current: "Fetching and resetting to trunk\u2026", complete: "Fetched and reset to trunk" },
+    install: { pending: "Install dependencies", current: "Dependencies changed \u2014 installing the difference\u2026", complete: "Dependencies installed", skipped: import_update_plan.SKIP_INSTALL_MESSAGE },
+    build: { pending: "Rebuild", current: "Rebuilding \u2014 output in the Terminal below", complete: "Rebuilt" }
+  };
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
   var RENAME_INPUT_ID = "rename-site-name-input";
   var CREATE_SITE_NAME_INPUT_ID = "create-site-name-input";
@@ -54180,7 +54185,12 @@ If there's a particular need for this, please submit a feature request at https:
     const [updateState, setUpdateState] = (0, import_react69.useState)("idle");
     const [dirtyModalOpen, setDirtyModalOpen] = (0, import_react69.useState)(false);
     const [dirtySaving, setDirtySaving] = (0, import_react69.useState)(false);
+    const [dirtyFiles, setDirtyFiles] = (0, import_react69.useState)([]);
+    const [dirtyChoice, setDirtyChoice] = (0, import_react69.useState)("save");
     const [updateLockfileChanged, setUpdateLockfileChanged] = (0, import_react69.useState)(false);
+    const [lastUpdateSummary, setLastUpdateSummary] = (0, import_react69.useState)(null);
+    const updateStartRef = (0, import_react69.useRef)(null);
+    const savedPatchPathRef = (0, import_react69.useRef)(null);
     const setupLogsRef = (0, import_react69.useRef)("");
     const npmRef = (0, import_react69.useRef)(null);
     const runtimeRef = (0, import_react69.useRef)(null);
@@ -54870,6 +54880,8 @@ Running ${plan.watch.label}\u2026
                 await window.api.markUpdateComplete(sitePath);
               } catch {
               }
+              const elapsedSeconds = updateStartRef.current ? Math.round((Date.now() - updateStartRef.current) / 1e3) : null;
+              setLastUpdateSummary({ lockfileChanged, elapsedSeconds, savedPatchPath: savedPatchPathRef.current });
               finishUpdate("\nUpdate complete \u2014 this site is now on the latest trunk.\n");
             } else {
               finishUpdate("\nUpdate incomplete \u2014 the build failed. The code is new but the built assets are old; retry install & build from the banner above.\n");
@@ -54909,6 +54921,8 @@ ${import_update_plan.SKIP_INSTALL_MESSAGE}
         });
       };
       setUpdateLockfileChanged(false);
+      setLastUpdateSummary(null);
+      updateStartRef.current = Date.now();
       setUpdateState("fetching");
       window.api.updateTrunk(sitePath, ({ data }) => writeToTerminal(data), (res) => {
         if (!res || !res.ok || res.upToDate) {
@@ -54921,9 +54935,12 @@ ${import_update_plan.SKIP_INSTALL_MESSAGE}
     };
     const startTrunkUpdate = async () => {
       if (isUpdating || installing || building || isDevProcessActive) return;
+      savedPatchPathRef.current = null;
       try {
         const res = await window.api.isWorktreeDirty(sitePath);
         if (res && res.ok && res.dirty) {
+          setDirtyFiles(Array.isArray(res.files) ? res.files : []);
+          setDirtyChoice("save");
           setDirtyModalOpen(true);
           return;
         }
@@ -54945,6 +54962,7 @@ ${import_update_plan.SKIP_INSTALL_MESSAGE}
           alert(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : "Unknown error"}`);
           return;
         }
+        savedPatchPathRef.current = res.filePath;
         setDirtyModalOpen(false);
         writeToTerminal(`
 Saved your changes to ${res.filePath} and reset the working tree.
@@ -54976,6 +54994,8 @@ Saved your changes to ${res.filePath} and reset the working tree.
         });
       };
       setUpdateLockfileChanged(true);
+      setLastUpdateSummary(null);
+      updateStartRef.current = Date.now();
       runUpdateInstallAndBuild(true);
     };
     const openPatchModal = async () => {
@@ -55202,6 +55222,10 @@ Saved your changes to ${res.filePath} and reset the working tree.
             text: "",
             controls: [
               { title: "Copy path", onClick: copyPath },
+              // Also reachable when the site is not yet stale (the staleness
+              // notice is the primary entry point) — a fresh site just gets
+              // "Already up to date." in the terminal.
+              { title: "Update to latest trunk", onClick: startTrunkUpdate },
               { title: "Forget this site", onClick: () => confirmAnd("Remove this site from the list?", () => onForget(sitePath)) },
               { title: "Delete this site", onClick: () => confirmAnd("Delete this site from disk? This cannot be undone.", () => onDelete(sitePath)) }
             ]
@@ -55224,14 +55248,18 @@ Saved your changes to ${res.filePath} and reset the working tree.
           }
         )
       ] }) : null,
-      age.stale && !updateIncomplete && !isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", padding: "12px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 8, fontSize: 13, color: "#6e5406" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { flex: "1 1 320px" }, children: [
-          "This site's trunk snapshot is ",
-          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("strong", { children: [
+      age.stale && !updateIncomplete && !isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "flex-start", gap: 12, flexWrap: "wrap", padding: "14px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 8, fontSize: 13, color: "#6e5406" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { flex: "1 1 320px", display: "flex", flexDirection: "column", gap: 4 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("strong", { style: { color: "#5c4400" }, children: [
+            "This site's trunk snapshot is ",
             age.ageDays,
             " days old"
           ] }),
-          " \u2014 patches you create now may not apply on Trac."
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { children: [
+            "Patches you create now are diffed against ",
+            age.label.replace("trunk as of ", ""),
+            " and may not apply on Trac."
+          ] })
         ] }),
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
@@ -55244,16 +55272,49 @@ Saved your changes to ${res.filePath} and reset the working tree.
           }
         )
       ] }) : null,
-      isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap", padding: "12px 16px", background: "#e8f3ff", border: "1px solid #66afe9", borderRadius: 8, fontSize: 13, color: "#0b5d95" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600 }, children: "Updating to latest trunk\u2026" }),
-        updateStepStates.map((s, i) => {
-          const step = updateSteps[i];
-          const symbol2 = s.status === "complete" ? "\u2713" : s.status === "skipped" ? "\u21B7" : s.status === "current" ? "\u25CF" : "\u25CB";
-          return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { display: "inline-flex", alignItems: "center", gap: 6, opacity: s.status === "pending" ? 0.55 : 1 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { "aria-hidden": "true", children: symbol2 }),
-            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: s.status === "current" ? 600 : 400 }, children: s.status === "skipped" ? step.skipMessage : step.label })
+      isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: "14px 16px", background: "#fff", border: "1px solid #dcdcde", borderRadius: 8 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600, fontSize: 14, color: "#1d2327" }, children: "Updating to latest trunk" }),
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { fontSize: 12, color: "#6c6f72" }, children: [
+            "step ",
+            Math.max(1, updateStepStates.filter((s) => s.status === "complete" || s.status === "skipped").length + 1),
+            " of ",
+            updateSteps.length
+          ] })
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { marginTop: 10, display: "flex", flexDirection: "column", gap: 6, fontSize: 13 }, children: updateStepStates.map((s) => {
+          const labels = UPDATE_STEP_LABELS[s.key] || {};
+          const text = labels[s.status] || labels.pending || s.key;
+          const symbol2 = s.status === "complete" ? "\u2713" : s.status === "current" ? "\u203A" : "";
+          const color2 = s.status === "complete" ? "#0f5132" : s.status === "current" ? "#0b5d95" : "#6c6f72";
+          return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "baseline", gap: 8, color: color2, opacity: s.status === "pending" || s.status === "skipped" ? 0.75 : 1 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { "aria-hidden": "true", style: { width: 12, display: "inline-block", textAlign: "center" }, children: symbol2 }),
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: s.status === "current" ? 600 : 400 }, children: text })
           ] }, s.key);
-        })
+        }) }),
+        updateState === "installing" ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { marginTop: 10, paddingTop: 10, borderTop: "1px solid #f0f0f1", fontSize: 12, color: "#6c6f72" }, children: "Most packages are already cached, so this is a download of the difference \u2014 not the whole tree." }) : null
+      ] }) : null,
+      lastUpdateSummary && !isUpdating && !updateIncomplete ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "flex-start", gap: 12, padding: "14px 16px", background: "#f4fbf4", border: "1px solid #94d3ae", borderRadius: 8, fontSize: 13, color: "#0f5132" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { "aria-hidden": "true", style: { fontWeight: 700 }, children: "\u2713" }),
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { flex: "1 1 auto", display: "flex", flexDirection: "column", gap: 4 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("strong", { children: "Up to date with trunk as of today." }),
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { children: [
+            lastUpdateSummary.lockfileChanged ? "Dependencies updated" : "Dependencies unchanged",
+            lastUpdateSummary.elapsedSeconds != null ? `, rebuilt in ${(0, import_dev_server_command.formatElapsed)(lastUpdateSummary.elapsedSeconds)}.` : ", rebuilt.",
+            lastUpdateSummary.savedPatchPath ? ` Your changes were saved to ${lastUpdateSummary.savedPatchPath} before the reset.` : ""
+          ] })
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+          button_default,
+          {
+            variant: "tertiary",
+            isSmall: true,
+            "aria-label": "Dismiss",
+            onClick: () => setLastUpdateSummary(null),
+            style: { color: "#0f5132" },
+            children: "\u2715"
+          }
+        )
       ] }) : null,
       !skipInit ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: 20, border: "1px solid #dcdcde", borderRadius: 12, background: "#fff" }, children: [
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontWeight: 600, fontSize: 16, color: "#1d2327" }, children: "Initial setup checklist" }),
@@ -55349,18 +55410,6 @@ Saved your changes to ${res.filePath} and reset the working tree.
               children: "Submit patch"
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
-            button_default,
-            {
-              variant: "secondary",
-              isBusy: isUpdating,
-              onClick: startTrunkUpdate,
-              disabled: isDevProcessActive || isUpdating || installing || building,
-              title: isDevProcessActive ? "Stop the dev server before updating" : void 0,
-              style: { padding: "10px 16px", borderRadius: 10 },
-              children: isUpdating ? "Updating\u2026" : "Update to latest trunk"
-            }
-          ),
           running && serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
             button_default,
             {
@@ -55444,17 +55493,65 @@ Saved your changes to ${res.filePath} and reset the working tree.
       dirtyModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
         modal_default,
         {
-          title: "You have local changes",
+          title: "Update to latest trunk?",
           onRequestClose: () => {
             if (!dirtySaving) setDirtyModalOpen(false);
           },
           shouldCloseOnClickOutside: !dirtySaving,
-          children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 12, maxWidth: 460 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("p", { style: { margin: 0, fontSize: 13, lineHeight: 1.5 }, children: "Updating resets this site to the latest trunk, which would overwrite your local changes. Save them as a patch file first (nothing is sent to Trac), or discard them." }),
+          children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 12, maxWidth: 520 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("p", { style: { margin: 0, fontSize: 13, lineHeight: 1.5 }, children: [
+              "You've changed ",
+              dirtyFiles.length === 1 ? "1 file" : `${dirtyFiles.length} files`,
+              " in this site. Resetting to trunk would throw them away."
+            ] }),
+            dirtyFiles.length ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { border: "1px solid #dcdcde", borderRadius: 6, padding: "10px 12px", maxHeight: 140, overflowY: "auto" }, children: dirtyFiles.map((f) => /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontFamily: "monospace", fontSize: 12, color: "#3c434a", lineHeight: 1.7, overflowWrap: "anywhere" }, children: f }, f)) }) : null,
+            [
+              { key: "save", label: "Save them as a patch first (as a local file)", detail: "a .diff on your machine \u2014 nothing is sent to Trac" },
+              { key: "discard", label: "Discard them", detail: "your changes are lost; this cannot be undone", destructive: true }
+            ].map((opt) => {
+              const selected = dirtyChoice === opt.key;
+              return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)(
+                "button",
+                {
+                  type: "button",
+                  onClick: () => setDirtyChoice(opt.key),
+                  disabled: dirtySaving,
+                  "aria-pressed": selected,
+                  style: {
+                    textAlign: "left",
+                    cursor: "pointer",
+                    font: "inherit",
+                    fontSize: 13,
+                    padding: "10px 12px",
+                    borderRadius: 6,
+                    border: selected ? "2px solid #3858e9" : "1px solid #dcdcde",
+                    background: selected ? "#f0f3ff" : "#fff",
+                    color: opt.destructive ? "#b32d2e" : "#1d2327"
+                  },
+                  children: [
+                    /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600 }, children: opt.label }),
+                    /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { color: opt.destructive ? "#b32d2e" : "#6c6f72" }, children: [
+                      " \u2014 ",
+                      opt.detail
+                    ] })
+                  ]
+                },
+                opt.key
+              );
+            }),
             /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "tertiary", onClick: () => setDirtyModalOpen(false), disabled: dirtySaving, children: "Cancel" }),
-              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "secondary", isDestructive: true, onClick: dirtyDiscardAndUpdate, disabled: dirtySaving, children: "Discard changes" }),
-              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "primary", isBusy: dirtySaving, onClick: dirtySaveAndUpdate, disabled: dirtySaving, children: "Save changes as a patch" })
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "secondary", onClick: () => setDirtyModalOpen(false), disabled: dirtySaving, children: "Cancel" }),
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+                button_default,
+                {
+                  variant: "primary",
+                  isDestructive: dirtyChoice === "discard",
+                  isBusy: dirtySaving,
+                  disabled: dirtySaving,
+                  onClick: () => dirtyChoice === "discard" ? dirtyDiscardAndUpdate() : dirtySaveAndUpdate(),
+                  children: dirtyChoice === "discard" ? "Discard & update" : "Save patch & update"
+                }
+              )
             ] })
           ] })
         }

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -31047,6 +31047,69 @@ WARNING: This link could potentially be dangerous`)) {
     }
   });
 
+  // src/renderer/update-plan.cjs
+  var require_update_plan = __commonJS({
+    "src/renderer/update-plan.cjs"(exports, module) {
+      "use strict";
+      var STALE_THRESHOLD_DAYS = 14;
+      var DAY_MS = 24 * 60 * 60 * 1e3;
+      function trunkAgeInfo2({ trunkDate, now: now2 = Date.now() } = {}) {
+        const ts = trunkDate ? Date.parse(trunkDate) : NaN;
+        if (!Number.isFinite(ts)) {
+          return { known: false, ageDays: null, stale: false, label: "" };
+        }
+        const ageDays = Math.max(0, Math.floor((now2 - ts) / DAY_MS));
+        const label = `trunk as of ${new Date(ts).toLocaleDateString(void 0, {
+          year: "numeric",
+          month: "short",
+          day: "numeric"
+        })}`;
+        return { known: true, ageDays, stale: ageDays > STALE_THRESHOLD_DAYS, label };
+      }
+      var SKIP_INSTALL_MESSAGE2 = "Dependencies unchanged \u2014 skipping npm install";
+      function planUpdateSteps2({ lockfileChanged } = {}) {
+        return [
+          { key: "fetch", label: "Fetch latest trunk", skipped: false },
+          {
+            key: "install",
+            label: "Install dependencies",
+            skipped: !lockfileChanged,
+            skipMessage: SKIP_INSTALL_MESSAGE2
+          },
+          { key: "build", label: "Rebuild", skipped: false }
+        ];
+      }
+      var STATE_TO_STEP = { fetching: "fetch", installing: "install", building: "build" };
+      function updateStepStatuses2(steps, updateState) {
+        const activeKey = STATE_TO_STEP[updateState] || null;
+        const order = steps.map((s) => s.key);
+        const activeIndex = activeKey ? order.indexOf(activeKey) : updateState === "done" ? steps.length : -1;
+        return steps.map((step, i) => {
+          if (step.skipped && i < activeIndex) return { key: step.key, status: "skipped" };
+          if (i < activeIndex) return { key: step.key, status: "complete" };
+          if (i === activeIndex) return { key: step.key, status: "current" };
+          return { key: step.key, status: "pending" };
+        });
+      }
+      function updateOutcome({ fetchOk, upToDate, moved, installNeeded, installCode, buildCode } = {}) {
+        if (!fetchOk) return "failed-fetch";
+        if (upToDate) return "up-to-date";
+        if (!moved) return "failed-fetch";
+        if (installNeeded && installCode !== 0) return "incomplete";
+        if (buildCode !== 0) return "incomplete";
+        return "done";
+      }
+      module.exports = {
+        STALE_THRESHOLD_DAYS,
+        SKIP_INSTALL_MESSAGE: SKIP_INSTALL_MESSAGE2,
+        trunkAgeInfo: trunkAgeInfo2,
+        planUpdateSteps: planUpdateSteps2,
+        updateStepStatuses: updateStepStatuses2,
+        updateOutcome
+      };
+    }
+  });
+
   // src/renderer/index.jsx
   var import_react69 = __toESM(require_react());
   var import_client2 = __toESM(require_client());
@@ -53413,6 +53476,7 @@ If there's a particular need for this, please submit a feature request at https:
   var import_setup_steps = __toESM(require_setup_steps());
   var import_dev_server_command = __toESM(require_dev_server_command());
   var import_path_basename = __toESM(require_path_basename());
+  var import_update_plan = __toESM(require_update_plan());
   var import_jsx_runtime61 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
@@ -53778,6 +53842,9 @@ If there's a particular need for this, please submit a feature request at https:
     const onInitialized = (0, import_react69.useCallback)((sitePath) => {
       setSiteMeta((m) => ({ ...m || {}, [sitePath]: { ...m?.[sitePath] || {}, initialized: true } }));
     }, [setSiteMeta]);
+    const onSiteMetaPatch = (0, import_react69.useCallback)((sitePath, patch) => {
+      setSiteMeta((m) => ({ ...m || {}, [sitePath]: { ...m?.[sitePath] || {}, ...patch } }));
+    }, [setSiteMeta]);
     const onForget = (0, import_react69.useCallback)(async (sitePath) => {
       await window.api.forgetSite(sitePath);
       await refresh();
@@ -53893,6 +53960,16 @@ If there's a particular need for this, please submit a feature request at https:
           const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : "";
           const isActive = activeSite === sitePath;
           const statusLabel = meta.initialized ? "Initialized" : "Not initialized";
+          const trunkAge = (0, import_update_plan.trunkAgeInfo)({ trunkDate: meta.trunkDate });
+          const staleDotColor = meta.updateIncomplete ? "#d63638" : trunkAge.stale ? "#dba617" : null;
+          const staleDotTitle = meta.updateIncomplete ? "Update incomplete \u2014 code is new, built assets are old" : `Trunk snapshot is ${trunkAge.ageDays} days old \u2014 update to latest trunk`;
+          const staleDot = staleDotColor ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+            "span",
+            {
+              title: staleDotTitle,
+              style: { display: "inline-block", width: 8, height: 8, borderRadius: "50%", background: staleDotColor, flexShrink: 0 }
+            }
+          ) : null;
           return /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
             button_default,
             {
@@ -53909,7 +53986,13 @@ If there's a particular need for this, please submit a feature request at https:
                 padding: sidebarCollapsed ? "8px 0" : "10px 12px",
                 borderRadius: 6
               },
-              children: sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600 }, children: siteName.slice(0, 1).toUpperCase() }) : /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600 }, children: siteName }) })
+              children: sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 4 }, children: [
+                siteName.slice(0, 1).toUpperCase(),
+                staleDot
+              ] }) : /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }, children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { fontWeight: 600, display: "inline-flex", alignItems: "center", gap: 6 }, children: [
+                siteName,
+                staleDot
+              ] }) })
             },
             sitePath
           );
@@ -53981,6 +54064,7 @@ If there's a particular need for this, please submit a feature request at https:
                   createdAt: siteMeta?.[s]?.createdAt,
                   label: siteMeta?.[s]?.label,
                   onInitialized,
+                  onSiteMetaPatch,
                   onForget,
                   onDelete,
                   onRename,
@@ -54061,9 +54145,13 @@ If there's a particular need for this, please submit a feature request at https:
       ) : null
     ] });
   }
-  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = "" }) {
+  function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onForget, onDelete, onRename, isPending = false, setupLogs = "" }) {
     const safeOnRename = onRename || (() => {
     });
+    const metaPatchRef = (0, import_react69.useRef)(onSiteMetaPatch);
+    (0, import_react69.useEffect)(() => {
+      metaPatchRef.current = onSiteMetaPatch;
+    }, [onSiteMetaPatch]);
     const [serverUrl, setServerUrl] = (0, import_react69.useState)("");
     const [starting, setStarting] = (0, import_react69.useState)(false);
     const [running, setRunning] = (0, import_react69.useState)(false);
@@ -54087,6 +54175,12 @@ If there's a particular need for this, please submit a feature request at https:
     const [skipInit, setSkipInit] = (0, import_react69.useState)(false);
     const [statusLoading, setStatusLoading] = (0, import_react69.useState)(true);
     const [waitingForWatch, setWaitingForWatch] = (0, import_react69.useState)(false);
+    const [trunkDate, setTrunkDate] = (0, import_react69.useState)(null);
+    const [updateIncomplete, setUpdateIncomplete] = (0, import_react69.useState)(false);
+    const [updateState, setUpdateState] = (0, import_react69.useState)("idle");
+    const [dirtyModalOpen, setDirtyModalOpen] = (0, import_react69.useState)(false);
+    const [dirtySaving, setDirtySaving] = (0, import_react69.useState)(false);
+    const [updateLockfileChanged, setUpdateLockfileChanged] = (0, import_react69.useState)(false);
     const setupLogsRef = (0, import_react69.useRef)("");
     const npmRef = (0, import_react69.useRef)(null);
     const runtimeRef = (0, import_react69.useRef)(null);
@@ -54203,6 +54297,13 @@ If there's a particular need for this, please submit a feature request at https:
         setInstallFailed(Boolean(s?.installFailed));
         setHasBuilt(Boolean(s?.hasBuilt));
         setSkipInit(Boolean(s?.skipInitWizard));
+        setTrunkDate(s?.trunkDate || null);
+        setUpdateIncomplete(Boolean(s?.updateIncomplete));
+        if (metaPatchRef.current) {
+          const patch = { updateIncomplete: Boolean(s?.updateIncomplete) };
+          if (s?.trunkDate) patch.trunkDate = s.trunkDate;
+          metaPatchRef.current(sitePath, patch);
+        }
       } catch {
       } finally {
         setStatusLoading(false);
@@ -54745,6 +54846,138 @@ Running ${plan.watch.label}\u2026
     const confirmAnd = async (m, a) => {
       if (window.confirm(m)) await a();
     };
+    const age = (0, import_update_plan.trunkAgeInfo)({ trunkDate });
+    const isUpdating = updateState !== "idle";
+    const updateSteps = (0, import_update_plan.planUpdateSteps)({ lockfileChanged: updateLockfileChanged });
+    const updateStepStates = (0, import_update_plan.updateStepStatuses)(updateSteps, updateState);
+    const finishUpdate = (message) => {
+      terminalStateRef.current.running = false;
+      terminalKillRef.current = null;
+      setUpdateState("idle");
+      if (message) writeToTerminal(message);
+      loadStatus().catch(() => {
+      });
+    };
+    const runUpdateInstallAndBuild = (lockfileChanged) => {
+      const runBuildStep = () => {
+        setUpdateState("building");
+        writeToTerminal("\nRunning npm run build\u2026\n");
+        runScript("build", {
+          onLog: (chunk) => writeToTerminal(chunk),
+          onDone: async ({ code }) => {
+            if (code === 0) {
+              try {
+                await window.api.markUpdateComplete(sitePath);
+              } catch {
+              }
+              finishUpdate("\nUpdate complete \u2014 this site is now on the latest trunk.\n");
+            } else {
+              finishUpdate("\nUpdate incomplete \u2014 the build failed. The code is new but the built assets are old; retry install & build from the banner above.\n");
+            }
+          }
+        });
+      };
+      if (lockfileChanged) {
+        setUpdateState("installing");
+        writeToTerminal("\npackage-lock.json changed \u2014 running npm install (only the changed packages are downloaded)\u2026\n");
+        runInstall({
+          onLog: (chunk) => writeToTerminal(chunk),
+          onDone: ({ code }) => {
+            if (code !== 0) {
+              finishUpdate("\nUpdate incomplete \u2014 npm install failed. The code is new but dependencies and built assets are old; retry install & build from the banner above.\n");
+              return;
+            }
+            runBuildStep();
+          }
+        });
+      } else {
+        writeToTerminal(`
+${import_update_plan.SKIP_INSTALL_MESSAGE}
+`);
+        runBuildStep();
+      }
+    };
+    const beginTrunkUpdate = () => {
+      const state = terminalStateRef.current;
+      if (state.running) {
+        writeToTerminal("A command is already running. Press Ctrl+C to stop it.\n");
+        return;
+      }
+      state.running = true;
+      terminalKillRef.current = () => {
+        killCurrent().catch(() => {
+        });
+      };
+      setUpdateLockfileChanged(false);
+      setUpdateState("fetching");
+      window.api.updateTrunk(sitePath, ({ data }) => writeToTerminal(data), (res) => {
+        if (!res || !res.ok || res.upToDate) {
+          finishUpdate();
+          return;
+        }
+        setUpdateLockfileChanged(Boolean(res.lockfileChanged));
+        runUpdateInstallAndBuild(Boolean(res.lockfileChanged));
+      });
+    };
+    const startTrunkUpdate = async () => {
+      if (isUpdating || installing || building || isDevProcessActive) return;
+      try {
+        const res = await window.api.isWorktreeDirty(sitePath);
+        if (res && res.ok && res.dirty) {
+          setDirtyModalOpen(true);
+          return;
+        }
+      } catch {
+      }
+      beginTrunkUpdate();
+    };
+    const dirtySaveAndUpdate = async () => {
+      setDirtySaving(true);
+      try {
+        const res = await window.api.savePatch(sitePath);
+        if (res && res.canceled) return;
+        if (!res || !res.ok || !res.filePath) {
+          alert(`Error saving diff: ${res && res.error ? res.error : "Unknown error"}`);
+          return;
+        }
+        const d = await window.api.discardChanges(sitePath);
+        if (!d || !d.ok) {
+          alert(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : "Unknown error"}`);
+          return;
+        }
+        setDirtyModalOpen(false);
+        writeToTerminal(`
+Saved your changes to ${res.filePath} and reset the working tree.
+`);
+        beginTrunkUpdate();
+      } finally {
+        setDirtySaving(false);
+      }
+    };
+    const dirtyDiscardAndUpdate = () => confirmAnd("Discard all local changes? This cannot be undone.", async () => {
+      const d = await window.api.discardChanges(sitePath);
+      if (!d || !d.ok) {
+        alert(`Failed to discard changes: ${d && d.error ? d.error : "Unknown error"}`);
+        return;
+      }
+      setDirtyModalOpen(false);
+      writeToTerminal("\nDiscarded local changes.\n");
+      beginTrunkUpdate();
+    });
+    const retryInstallAndBuild = () => {
+      const state = terminalStateRef.current;
+      if (state.running) {
+        writeToTerminal("A command is already running. Press Ctrl+C to stop it.\n");
+        return;
+      }
+      state.running = true;
+      terminalKillRef.current = () => {
+        killCurrent().catch(() => {
+        });
+      };
+      setUpdateLockfileChanged(true);
+      runUpdateInstallAndBuild(true);
+    };
     const openPatchModal = async () => {
       setIsPatchOpen(true);
       setPatchLoading(true);
@@ -54933,6 +55166,18 @@ Running ${plan.watch.label}\u2026
             createdLabel ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { children: [
               "Created ",
               createdLabel
+            ] }) : null,
+            age.known ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { display: "inline-flex", alignItems: "center", gap: 6 }, children: [
+              createdLabel ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { "aria-hidden": "true", children: "\xB7" }) : null,
+              age.stale ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+                "span",
+                {
+                  "aria-hidden": "true",
+                  title: `Trunk snapshot is ${age.ageDays} days old`,
+                  style: { display: "inline-block", width: 8, height: 8, borderRadius: "50%", background: "#dba617" }
+                }
+              ) : null,
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { children: age.label })
             ] }) : null
           ] }),
           /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, marginTop: 6 }, children: [
@@ -54963,6 +55208,53 @@ Running ${plan.watch.label}\u2026
           }
         ) })
       ] }),
+      updateIncomplete && !isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", padding: "12px 16px", background: "#fcf0f1", border: "1px solid #d63638", borderRadius: 8, fontSize: 13, color: "#8a1f21" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { flex: "1 1 320px" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("strong", { children: "Update incomplete" }),
+          " \u2014 the code is new but the built assets are old. The site may not run correctly until install and build succeed."
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+          button_default,
+          {
+            variant: "secondary",
+            isDestructive: true,
+            onClick: retryInstallAndBuild,
+            disabled: installing || building || isDevProcessActive,
+            children: "Retry install & build"
+          }
+        )
+      ] }) : null,
+      age.stale && !updateIncomplete && !isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", padding: "12px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 8, fontSize: 13, color: "#6e5406" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { flex: "1 1 320px" }, children: [
+          "This site's trunk snapshot is ",
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("strong", { children: [
+            age.ageDays,
+            " days old"
+          ] }),
+          " \u2014 patches you create now may not apply on Trac."
+        ] }),
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+          button_default,
+          {
+            variant: "secondary",
+            onClick: startTrunkUpdate,
+            disabled: installing || building || isDevProcessActive,
+            title: isDevProcessActive ? "Stop the dev server before updating" : void 0,
+            children: "Update to latest trunk"
+          }
+        )
+      ] }) : null,
+      isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap", padding: "12px 16px", background: "#e8f3ff", border: "1px solid #66afe9", borderRadius: 8, fontSize: 13, color: "#0b5d95" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: 600 }, children: "Updating to latest trunk\u2026" }),
+        updateStepStates.map((s, i) => {
+          const step = updateSteps[i];
+          const symbol2 = s.status === "complete" ? "\u2713" : s.status === "skipped" ? "\u21B7" : s.status === "current" ? "\u25CF" : "\u25CB";
+          return /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { style: { display: "inline-flex", alignItems: "center", gap: 6, opacity: s.status === "pending" ? 0.55 : 1 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { "aria-hidden": "true", children: symbol2 }),
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { style: { fontWeight: s.status === "current" ? 600 : 400 }, children: s.status === "skipped" ? step.skipMessage : step.label })
+          ] }, s.key);
+        })
+      ] }) : null,
       !skipInit ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: 20, border: "1px solid #dcdcde", borderRadius: 12, background: "#fff" }, children: [
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { fontWeight: 600, fontSize: 16, color: "#1d2327" }, children: "Initial setup checklist" }),
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { marginTop: 4, fontSize: 13, color: "#3c434a" }, children: "Complete each step to prepare this site for development." }),
@@ -55025,6 +55317,7 @@ Running ${plan.watch.label}\u2026
               isBusy: isServerStarting,
               variant: isDevProcessActive ? "secondary" : "primary",
               onClick: toggleDevServer,
+              disabled: isUpdating,
               style: { display: "inline-flex", alignItems: "center", gap: 10, minWidth: 220, justifyContent: "center", padding: "12px 20px", fontSize: 15, borderRadius: 12 },
               children: [
                 isDevProcessActive ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
@@ -55051,8 +55344,21 @@ Running ${plan.watch.label}\u2026
             {
               variant: "secondary",
               onClick: openPatchModal,
+              disabled: isUpdating,
               style: { padding: "10px 16px", borderRadius: 10 },
               children: "Submit patch"
+            }
+          ),
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+            button_default,
+            {
+              variant: "secondary",
+              isBusy: isUpdating,
+              onClick: startTrunkUpdate,
+              disabled: isDevProcessActive || isUpdating || installing || building,
+              title: isDevProcessActive ? "Stop the dev server before updating" : void 0,
+              style: { padding: "10px 16px", borderRadius: 10 },
+              children: isUpdating ? "Updating\u2026" : "Update to latest trunk"
             }
           ),
           running && serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
@@ -55135,6 +55441,24 @@ Running ${plan.watch.label}\u2026
           }) : /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("div", { style: { padding: 12, color: "#666" }, children: "No emails yet." }) })
         ] })
       ] }),
+      dirtyModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
+        modal_default,
+        {
+          title: "You have local changes",
+          onRequestClose: () => {
+            if (!dirtySaving) setDirtyModalOpen(false);
+          },
+          shouldCloseOnClickOutside: !dirtySaving,
+          children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 12, maxWidth: 460 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("p", { style: { margin: 0, fontSize: 13, lineHeight: 1.5 }, children: "Updating resets this site to the latest trunk, which would overwrite your local changes. Save them as a patch file first (nothing is sent to Trac), or discard them." }),
+            /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "tertiary", onClick: () => setDirtyModalOpen(false), disabled: dirtySaving, children: "Cancel" }),
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "secondary", isDestructive: true, onClick: dirtyDiscardAndUpdate, disabled: dirtySaving, children: "Discard changes" }),
+              /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(button_default, { variant: "primary", isBusy: dirtySaving, onClick: dirtySaveAndUpdate, disabled: dirtySaving, children: "Save changes as a patch" })
+            ] })
+          ] })
+        }
+      ) : null,
       renameModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
         modal_default,
         {
@@ -55178,6 +55502,11 @@ Running ${plan.watch.label}\u2026
           isFullScreen: true,
           headerClassName: "patch-modal-header",
           children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", height: "80vh", gap: 12 }, children: [
+            !patchLoading && age.stale && /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: "12px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 6, fontSize: 13, lineHeight: 1.5, color: "#6e5406" }, children: [
+              "This site's trunk snapshot is ",
+              age.ageDays,
+              " days old \u2014 this patch may not apply on Trac. Consider updating to the latest trunk first."
+            ] }),
             !patchLoading && /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: "12px 16px", background: "#f0f6fc", border: "1px solid #d0d7de", borderRadius: 6, fontSize: 14, lineHeight: 1.5, color: "#24292f" }, children: [
               /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("strong", { children: "Next steps:" }),
               " Save this patch and submit it to the relevant WordPress Trac ticket at ",

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -53967,7 +53967,7 @@ If there's a particular need for this, please submit a feature request at https:
           const statusLabel = meta.initialized ? "Initialized" : "Not initialized";
           const trunkAge = (0, import_update_plan.trunkAgeInfo)({ trunkDate: meta.trunkDate });
           const staleDotColor = meta.updateIncomplete ? "#d63638" : trunkAge.stale ? "#dba617" : null;
-          const staleDotTitle = meta.updateIncomplete ? "Update incomplete \u2014 code is new, built assets are old" : `Trunk snapshot is ${trunkAge.ageDays} days old \u2014 update to latest trunk`;
+          const staleDotTitle = meta.updateIncomplete ? "Update incomplete \u2014 code is new, built assets are old" : `WordPress code is ${trunkAge.ageDays} days old \u2014 update to latest trunk`;
           const staleDot = staleDotColor ? /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
             "span",
             {
@@ -55251,15 +55251,11 @@ Saved your changes to ${res.filePath} and reset the working tree.
       age.stale && !updateIncomplete && !isUpdating ? /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", alignItems: "flex-start", gap: 12, flexWrap: "wrap", padding: "14px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 8, fontSize: 13, color: "#6e5406" }, children: [
         /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { flex: "1 1 320px", display: "flex", flexDirection: "column", gap: 4 }, children: [
           /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("strong", { style: { color: "#5c4400" }, children: [
-            "This site's trunk snapshot is ",
+            "This site's WordPress code is ",
             age.ageDays,
             " days old"
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("span", { children: [
-            "Patches you create now are diffed against ",
-            age.label.replace("trunk as of ", ""),
-            " and may not apply on Trac."
-          ] })
+          /* @__PURE__ */ (0, import_jsx_runtime61.jsx)("span", { children: "Patches you create now may not apply on Trac. Updating takes a few minutes." })
         ] }),
         /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
@@ -55600,7 +55596,7 @@ Saved your changes to ${res.filePath} and reset the working tree.
           headerClassName: "patch-modal-header",
           children: /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { display: "flex", flexDirection: "column", height: "80vh", gap: 12 }, children: [
             !patchLoading && age.stale && /* @__PURE__ */ (0, import_jsx_runtime61.jsxs)("div", { style: { padding: "12px 16px", background: "#fcf9e8", border: "1px solid #dba617", borderRadius: 6, fontSize: 13, lineHeight: 1.5, color: "#6e5406" }, children: [
-              "This site's trunk snapshot is ",
+              "This site's WordPress code is ",
               age.ageDays,
               " days old \u2014 this patch may not apply on Trac. Consider updating to the latest trunk first."
             ] }),

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -529,7 +529,7 @@ function App() {
             const staleDotColor = meta.updateIncomplete ? '#d63638' : (trunkAge.stale ? '#dba617' : null);
             const staleDotTitle = meta.updateIncomplete
               ? 'Update incomplete — code is new, built assets are old'
-              : `Trunk snapshot is ${trunkAge.ageDays} days old — update to latest trunk`;
+              : `WordPress code is ${trunkAge.ageDays} days old — update to latest trunk`;
             const staleDot = staleDotColor ? (
               <span
                 title={staleDotTitle}
@@ -1806,8 +1806,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {age.stale && !updateIncomplete && !isUpdating ? (
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '14px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
           <div style={{ flex: '1 1 320px', display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <strong style={{ color: '#5c4400' }}>This site's trunk snapshot is {age.ageDays} days old</strong>
-            <span>Patches you create now are diffed against {age.label.replace('trunk as of ', '')} and may not apply on Trac.</span>
+            <strong style={{ color: '#5c4400' }}>This site's WordPress code is {age.ageDays} days old</strong>
+            <span>Patches you create now may not apply on Trac. Updating takes a few minutes.</span>
           </div>
           <Button
             variant="secondary"
@@ -2128,7 +2128,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           <div style={{ display:'flex', flexDirection:'column', height:'80vh', gap:12 }}>
             {!patchLoading && age.stale && (
               <div style={{ padding:'12px 16px', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, fontSize:13, lineHeight:1.5, color:'#6e5406' }}>
-                This site's trunk snapshot is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
+                This site's WordPress code is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
               </div>
             )}
             {!patchLoading && (

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -22,6 +22,14 @@ import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE } from './update-plan.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
+// Per-status wording for the update chain card (#94), following the issue's
+// mockups: the skipped install step is named, never hidden, and the build
+// step points at the Terminal instead of opening a second log surface.
+const UPDATE_STEP_LABELS = {
+  fetch: { pending: 'Fetch and reset to trunk', current: 'Fetching and resetting to trunk…', complete: 'Fetched and reset to trunk' },
+  install: { pending: 'Install dependencies', current: 'Dependencies changed — installing the difference…', complete: 'Dependencies installed', skipped: SKIP_INSTALL_MESSAGE },
+  build: { pending: 'Rebuild', current: 'Rebuilding — output in the Terminal below', complete: 'Rebuilt' }
+};
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
 const RENAME_INPUT_ID = 'rename-site-name-input';
 const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
@@ -755,7 +763,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [updateState, setUpdateState] = useState('idle'); // idle | fetching | installing | building
   const [dirtyModalOpen, setDirtyModalOpen] = useState(false);
   const [dirtySaving, setDirtySaving] = useState(false);
+  const [dirtyFiles, setDirtyFiles] = useState([]);
+  const [dirtyChoice, setDirtyChoice] = useState('save'); // save | discard
   const [updateLockfileChanged, setUpdateLockfileChanged] = useState(false);
+  const [lastUpdateSummary, setLastUpdateSummary] = useState(null);
+  const updateStartRef = useRef(null);
+  const savedPatchPathRef = useRef(null);
   const setupLogsRef = useRef('');
 
   // sticky refs per log
@@ -1418,6 +1431,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         onDone: async ({ code }) => {
           if (code === 0) {
             try { await window.api.markUpdateComplete(sitePath); } catch {}
+            const elapsedSeconds = updateStartRef.current ? Math.round((Date.now() - updateStartRef.current) / 1000) : null;
+            setLastUpdateSummary({ lockfileChanged, elapsedSeconds, savedPatchPath: savedPatchPathRef.current });
             finishUpdate('\nUpdate complete — this site is now on the latest trunk.\n');
           } else {
             finishUpdate('\nUpdate incomplete — the build failed. The code is new but the built assets are old; retry install & build from the banner above.\n');
@@ -1455,6 +1470,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     state.running = true;
     terminalKillRef.current = () => { killCurrent().catch(() => {}); };
     setUpdateLockfileChanged(false);
+    setLastUpdateSummary(null);
+    updateStartRef.current = Date.now();
     setUpdateState('fetching');
     window.api.updateTrunk(sitePath, ({ data }) => writeToTerminal(data), (res) => {
       if (!res || !res.ok || res.upToDate) {
@@ -1470,9 +1487,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   const startTrunkUpdate = async () => {
     if (isUpdating || installing || building || isDevProcessActive) return;
+    savedPatchPathRef.current = null;
     try {
       const res = await window.api.isWorktreeDirty(sitePath);
       if (res && res.ok && res.dirty) {
+        setDirtyFiles(Array.isArray(res.files) ? res.files : []);
+        setDirtyChoice('save');
         setDirtyModalOpen(true);
         return;
       }
@@ -1496,6 +1516,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         alert(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : 'Unknown error'}`);
         return;
       }
+      savedPatchPathRef.current = res.filePath;
       setDirtyModalOpen(false);
       writeToTerminal(`\nSaved your changes to ${res.filePath} and reset the working tree.\n`);
       beginTrunkUpdate();
@@ -1527,6 +1548,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     state.running = true;
     terminalKillRef.current = () => { killCurrent().catch(() => {}); };
     setUpdateLockfileChanged(true);
+    setLastUpdateSummary(null);
+    updateStartRef.current = Date.now();
     runUpdateInstallAndBuild(true);
   };
 
@@ -1757,6 +1780,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             text=""
             controls={[
               { title: 'Copy path', onClick: copyPath },
+              // Also reachable when the site is not yet stale (the staleness
+              // notice is the primary entry point) — a fresh site just gets
+              // "Already up to date." in the terminal.
+              { title: 'Update to latest trunk', onClick: startTrunkUpdate },
               { title:'Forget this site', onClick:()=>confirmAnd('Remove this site from the list?', ()=>onForget(sitePath)) },
               { title:'Delete this site', onClick:()=>confirmAnd('Delete this site from disk? This cannot be undone.', ()=>onDelete(sitePath)) }
             ]}
@@ -1777,10 +1804,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       ) : null}
       {age.stale && !updateIncomplete && !isUpdating ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
-          <span style={{ flex: '1 1 320px' }}>
-            This site's trunk snapshot is <strong>{age.ageDays} days old</strong> — patches you create now may not apply on Trac.
-          </span>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '14px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
+          <div style={{ flex: '1 1 320px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <strong style={{ color: '#5c4400' }}>This site's trunk snapshot is {age.ageDays} days old</strong>
+            <span>Patches you create now are diffed against {age.label.replace('trunk as of ', '')} and may not apply on Trac.</span>
+          </div>
           <Button
             variant="secondary"
             onClick={startTrunkUpdate}
@@ -1790,20 +1818,52 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       ) : null}
       {isUpdating ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', padding: '12px 16px', background: '#e8f3ff', border: '1px solid #66afe9', borderRadius: 8, fontSize: 13, color: '#0b5d95' }}>
-          <span style={{ fontWeight: 600 }}>Updating to latest trunk…</span>
-          {updateStepStates.map((s, i) => {
-            const step = updateSteps[i];
-            const symbol = s.status === 'complete' ? '✓' : s.status === 'skipped' ? '↷' : s.status === 'current' ? '●' : '○';
-            return (
-              <span key={s.key} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, opacity: s.status === 'pending' ? 0.55 : 1 }}>
-                <span aria-hidden="true">{symbol}</span>
-                <span style={{ fontWeight: s.status === 'current' ? 600 : 400 }}>
-                  {s.status === 'skipped' ? step.skipMessage : step.label}
-                </span>
-              </span>
-            );
-          })}
+        <div style={{ padding: '14px 16px', background: '#fff', border: '1px solid #dcdcde', borderRadius: 8 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
+            <span style={{ fontWeight: 600, fontSize: 14, color: '#1d2327' }}>Updating to latest trunk</span>
+            <span style={{ fontSize: 12, color: '#6c6f72' }}>
+              step {Math.max(1, updateStepStates.filter((s) => s.status === 'complete' || s.status === 'skipped').length + 1)} of {updateSteps.length}
+            </span>
+          </div>
+          <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 6, fontSize: 13 }}>
+            {updateStepStates.map((s) => {
+              const labels = UPDATE_STEP_LABELS[s.key] || {};
+              const text = labels[s.status] || labels.pending || s.key;
+              const symbol = s.status === 'complete' ? '✓' : s.status === 'current' ? '›' : '';
+              const color = s.status === 'complete' ? '#0f5132' : s.status === 'current' ? '#0b5d95' : '#6c6f72';
+              return (
+                <div key={s.key} style={{ display: 'flex', alignItems: 'baseline', gap: 8, color, opacity: s.status === 'pending' || s.status === 'skipped' ? 0.75 : 1 }}>
+                  <span aria-hidden="true" style={{ width: 12, display: 'inline-block', textAlign: 'center' }}>{symbol}</span>
+                  <span style={{ fontWeight: s.status === 'current' ? 600 : 400 }}>{text}</span>
+                </div>
+              );
+            })}
+          </div>
+          {updateState === 'installing' ? (
+            <div style={{ marginTop: 10, paddingTop: 10, borderTop: '1px solid #f0f0f1', fontSize: 12, color: '#6c6f72' }}>
+              Most packages are already cached, so this is a download of the difference — not the whole tree.
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {lastUpdateSummary && !isUpdating && !updateIncomplete ? (
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: '14px 16px', background: '#f4fbf4', border: '1px solid #94d3ae', borderRadius: 8, fontSize: 13, color: '#0f5132' }}>
+          <span aria-hidden="true" style={{ fontWeight: 700 }}>✓</span>
+          <div style={{ flex: '1 1 auto', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <strong>Up to date with trunk as of today.</strong>
+            <span>
+              {lastUpdateSummary.lockfileChanged ? 'Dependencies updated' : 'Dependencies unchanged'}
+              {lastUpdateSummary.elapsedSeconds != null ? `, rebuilt in ${formatElapsed(lastUpdateSummary.elapsedSeconds)}.` : ', rebuilt.'}
+              {lastUpdateSummary.savedPatchPath ? ` Your changes were saved to ${lastUpdateSummary.savedPatchPath} before the reset.` : ''}
+            </span>
+          </div>
+          <Button
+            variant="tertiary"
+            isSmall
+            aria-label="Dismiss"
+            onClick={() => setLastUpdateSummary(null)}
+            style={{ color: '#0f5132' }}
+          >✕</Button>
         </div>
       ) : null}
       {!skipInit ? (
@@ -1900,14 +1960,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               disabled={isUpdating}
               style={{ padding: '10px 16px', borderRadius: 10 }}
             >Submit patch</Button>
-            <Button
-              variant="secondary"
-              isBusy={isUpdating}
-              onClick={startTrunkUpdate}
-              disabled={isDevProcessActive || isUpdating || installing || building}
-              title={isDevProcessActive ? 'Stop the dev server before updating' : undefined}
-              style={{ padding: '10px 16px', borderRadius: 10 }}
-            >{isUpdating ? 'Updating…' : 'Update to latest trunk'}</Button>
             {running && serverUrl ? (
               <Button
                 variant="secondary"
@@ -1981,19 +2033,59 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       </div>
       {dirtyModalOpen ? (
         <Modal
-          title="You have local changes"
+          title="Update to latest trunk?"
           onRequestClose={() => { if (!dirtySaving) setDirtyModalOpen(false); }}
           shouldCloseOnClickOutside={!dirtySaving}
         >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 460 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 520 }}>
             <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5 }}>
-              Updating resets this site to the latest trunk, which would overwrite your local changes.
-              Save them as a patch file first (nothing is sent to Trac), or discard them.
+              You've changed {dirtyFiles.length === 1 ? '1 file' : `${dirtyFiles.length} files`} in this site. Resetting to trunk would throw them away.
             </p>
+            {dirtyFiles.length ? (
+              <div style={{ border: '1px solid #dcdcde', borderRadius: 6, padding: '10px 12px', maxHeight: 140, overflowY: 'auto' }}>
+                {dirtyFiles.map((f) => (
+                  <div key={f} style={{ fontFamily: 'monospace', fontSize: 12, color: '#3c434a', lineHeight: 1.7, overflowWrap: 'anywhere' }}>{f}</div>
+                ))}
+              </div>
+            ) : null}
+            {[
+              { key: 'save', label: 'Save them as a patch first (as a local file)', detail: 'a .diff on your machine — nothing is sent to Trac' },
+              { key: 'discard', label: 'Discard them', detail: 'your changes are lost; this cannot be undone', destructive: true }
+            ].map((opt) => {
+              const selected = dirtyChoice === opt.key;
+              return (
+                <button
+                  key={opt.key}
+                  type="button"
+                  onClick={() => setDirtyChoice(opt.key)}
+                  disabled={dirtySaving}
+                  aria-pressed={selected}
+                  style={{
+                    textAlign: 'left',
+                    cursor: 'pointer',
+                    font: 'inherit',
+                    fontSize: 13,
+                    padding: '10px 12px',
+                    borderRadius: 6,
+                    border: selected ? '2px solid #3858e9' : '1px solid #dcdcde',
+                    background: selected ? '#f0f3ff' : '#fff',
+                    color: opt.destructive ? '#b32d2e' : '#1d2327'
+                  }}
+                >
+                  <span style={{ fontWeight: 600 }}>{opt.label}</span>
+                  <span style={{ color: opt.destructive ? '#b32d2e' : '#6c6f72' }}> — {opt.detail}</span>
+                </button>
+              );
+            })}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' }}>
-              <Button variant="tertiary" onClick={() => setDirtyModalOpen(false)} disabled={dirtySaving}>Cancel</Button>
-              <Button variant="secondary" isDestructive onClick={dirtyDiscardAndUpdate} disabled={dirtySaving}>Discard changes</Button>
-              <Button variant="primary" isBusy={dirtySaving} onClick={dirtySaveAndUpdate} disabled={dirtySaving}>Save changes as a patch</Button>
+              <Button variant="secondary" onClick={() => setDirtyModalOpen(false)} disabled={dirtySaving}>Cancel</Button>
+              <Button
+                variant="primary"
+                isDestructive={dirtyChoice === 'discard'}
+                isBusy={dirtySaving}
+                disabled={dirtySaving}
+                onClick={() => (dirtyChoice === 'discard' ? dirtyDiscardAndUpdate() : dirtySaveAndUpdate())}
+              >{dirtyChoice === 'discard' ? 'Discard & update' : 'Save patch & update'}</Button>
             </div>
           </div>
         </Modal>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,6 +30,12 @@ const UPDATE_STEP_LABELS = {
   install: { pending: 'Install dependencies', current: 'Dependencies changed — installing the difference…', complete: 'Dependencies installed', skipped: SKIP_INSTALL_MESSAGE },
   build: { pending: 'Rebuild', current: 'Rebuilding — output in the Terminal below', complete: 'Rebuilt' }
 };
+// Checkmark/pointer and color per step status; pending/skipped fall back to
+// no symbol in muted gray.
+const UPDATE_STEP_MARKS = {
+  complete: { symbol: '✓', color: '#0f5132' },
+  current: { symbol: '›', color: '#0b5d95' }
+};
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
 const RENAME_INPUT_ID = 'rename-site-name-input';
 const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
@@ -526,7 +532,9 @@ function App() {
             // opened (#94): amber = old trunk snapshot, red = an update that
             // moved trunk but never finished install/build.
             const trunkAge = trunkAgeInfo({ trunkDate: meta.trunkDate });
-            const staleDotColor = meta.updateIncomplete ? '#d63638' : (trunkAge.stale ? '#dba617' : null);
+            let staleDotColor = null;
+            if (meta.updateIncomplete) staleDotColor = '#d63638';
+            else if (trunkAge.stale) staleDotColor = '#dba617';
             const staleDotTitle = meta.updateIncomplete
               ? 'Update incomplete — code is new, built assets are old'
               : `WordPress code is ${trunkAge.ageDays} days old — update to latest trunk`;
@@ -765,6 +773,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [dirtySaving, setDirtySaving] = useState(false);
   const [dirtyFiles, setDirtyFiles] = useState([]);
   const [dirtyChoice, setDirtyChoice] = useState('save'); // save | discard
+  const [dirtyError, setDirtyError] = useState(null); // failure text shown inside the dirty-tree modal
   const [updateLockfileChanged, setUpdateLockfileChanged] = useState(false);
   const [lastUpdateSummary, setLastUpdateSummary] = useState(null);
   const updateStartRef = useRef(null);
@@ -1493,6 +1502,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       if (res && res.ok && res.dirty) {
         setDirtyFiles(Array.isArray(res.files) ? res.files : []);
         setDirtyChoice('save');
+        setDirtyError(null);
         setDirtyModalOpen(true);
         return;
       }
@@ -1504,16 +1514,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // for, and it is the only option that cannot lose work.
   const dirtySaveAndUpdate = async () => {
     setDirtySaving(true);
+    setDirtyError(null);
     try {
       const res = await window.api.savePatch(sitePath);
       if (res && res.canceled) return; // stay in the modal
       if (!res || !res.ok || !res.filePath) {
-        alert(`Error saving diff: ${res && res.error ? res.error : 'Unknown error'}`);
+        setDirtyError(`Error saving diff: ${res && res.error ? res.error : 'Unknown error'}`);
         return;
       }
       const d = await window.api.discardChanges(sitePath);
       if (!d || !d.ok) {
-        alert(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : 'Unknown error'}`);
+        setDirtyError(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : 'Unknown error'}`);
         return;
       }
       savedPatchPathRef.current = res.filePath;
@@ -1526,9 +1537,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   };
 
   const dirtyDiscardAndUpdate = () => confirmAnd('Discard all local changes? This cannot be undone.', async () => {
+    setDirtyError(null);
     const d = await window.api.discardChanges(sitePath);
     if (!d || !d.ok) {
-      alert(`Failed to discard changes: ${d && d.error ? d.error : 'Unknown error'}`);
+      setDirtyError(`Failed to discard changes: ${d && d.error ? d.error : 'Unknown error'}`);
       return;
     }
     setDirtyModalOpen(false);
@@ -1642,7 +1654,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     installing,
     building,
     starting,
-    installFailed
+    installFailed,
+    isUpdating
   });
 
   const baseSteps = [
@@ -1806,7 +1819,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {age.stale && !updateIncomplete && !isUpdating ? (
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '14px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
           <div style={{ flex: '1 1 320px', display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <strong style={{ color: '#5c4400' }}>This site's WordPress code is {age.ageDays} days old</strong>
+            <strong style={{ color: '#5c4400' }}>This site&apos;s WordPress code is {age.ageDays} days old</strong>
             <span>Patches you create now may not apply on Trac. Updating takes a few minutes.</span>
           </div>
           <Button
@@ -1829,8 +1842,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             {updateStepStates.map((s) => {
               const labels = UPDATE_STEP_LABELS[s.key] || {};
               const text = labels[s.status] || labels.pending || s.key;
-              const symbol = s.status === 'complete' ? '✓' : s.status === 'current' ? '›' : '';
-              const color = s.status === 'complete' ? '#0f5132' : s.status === 'current' ? '#0b5d95' : '#6c6f72';
+              const { symbol = '', color = '#6c6f72' } = UPDATE_STEP_MARKS[s.status] || {};
               return (
                 <div key={s.key} style={{ display: 'flex', alignItems: 'baseline', gap: 8, color, opacity: s.status === 'pending' || s.status === 'skipped' ? 0.75 : 1 }}>
                   <span aria-hidden="true" style={{ width: 12, display: 'inline-block', textAlign: 'center' }}>{symbol}</span>
@@ -1853,7 +1865,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             <strong>Up to date with trunk as of today.</strong>
             <span>
               {lastUpdateSummary.lockfileChanged ? 'Dependencies updated' : 'Dependencies unchanged'}
-              {lastUpdateSummary.elapsedSeconds != null ? `, rebuilt in ${formatElapsed(lastUpdateSummary.elapsedSeconds)}.` : ', rebuilt.'}
+              {typeof lastUpdateSummary.elapsedSeconds === 'number' ? `, rebuilt in ${formatElapsed(lastUpdateSummary.elapsedSeconds)}.` : ', rebuilt.'}
               {lastUpdateSummary.savedPatchPath ? ` Your changes were saved to ${lastUpdateSummary.savedPatchPath} before the reset.` : ''}
             </span>
           </div>
@@ -2039,7 +2051,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         >
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 520 }}>
             <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5 }}>
-              You've changed {dirtyFiles.length === 1 ? '1 file' : `${dirtyFiles.length} files`} in this site. Resetting to trunk would throw them away.
+              You&apos;ve changed {dirtyFiles.length === 1 ? '1 file' : `${dirtyFiles.length} files`} in this site. Resetting to trunk would throw them away.
             </p>
             {dirtyFiles.length ? (
               <div style={{ border: '1px solid #dcdcde', borderRadius: 6, padding: '10px 12px', maxHeight: 140, overflowY: 'auto' }}>
@@ -2077,6 +2089,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 </button>
               );
             })}
+            {dirtyError ? (
+              <div role="alert" style={{ padding: '10px 12px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 13, lineHeight: 1.5, color: '#8a2424', overflowWrap: 'anywhere' }}>
+                {dirtyError}
+              </div>
+            ) : null}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' }}>
               <Button variant="secondary" onClick={() => setDirtyModalOpen(false)} disabled={dirtySaving}>Cancel</Button>
               <Button
@@ -2128,7 +2145,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           <div style={{ display:'flex', flexDirection:'column', height:'80vh', gap:12 }}>
             {!patchLoading && age.stale && (
               <div style={{ padding:'12px 16px', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, fontSize:13, lineHeight:1.5, color:'#6e5406' }}>
-                This site's WordPress code is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
+                This site&apos;s WordPress code is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
               </div>
             )}
             {!patchLoading && (

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -19,6 +19,7 @@ import 'xterm/css/xterm.css';
 import { computeSetupStepState } from './setup-steps.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
 import { pathBasename } from './path-basename.cjs';
+import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE } from './update-plan.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
@@ -389,6 +390,12 @@ function App() {
     setSiteMeta((m) => ({ ...(m || {}), [sitePath]: { ...(m?.[sitePath] || {}), initialized: true } }));
   }, [setSiteMeta]);
 
+  // Lets a SiteRow push meta changes (trunk date, update-incomplete flag)
+  // into App's copy so the sidebar staleness dots update without a restart.
+  const onSiteMetaPatch = useCallback((sitePath, patch) => {
+    setSiteMeta((m) => ({ ...(m || {}), [sitePath]: { ...(m?.[sitePath] || {}), ...patch } }));
+  }, [setSiteMeta]);
+
   const onForget = useCallback(async (sitePath) => {
     await window.api.forgetSite(sitePath);
     await refresh();
@@ -507,6 +514,20 @@ function App() {
             const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : '';
             const isActive = activeSite === sitePath;
             const statusLabel = meta.initialized ? 'Initialized' : 'Not initialized';
+            // Staleness surfaces in the sidebar before the site is even
+            // opened (#94): amber = old trunk snapshot, red = an update that
+            // moved trunk but never finished install/build.
+            const trunkAge = trunkAgeInfo({ trunkDate: meta.trunkDate });
+            const staleDotColor = meta.updateIncomplete ? '#d63638' : (trunkAge.stale ? '#dba617' : null);
+            const staleDotTitle = meta.updateIncomplete
+              ? 'Update incomplete — code is new, built assets are old'
+              : `Trunk snapshot is ${trunkAge.ageDays} days old — update to latest trunk`;
+            const staleDot = staleDotColor ? (
+              <span
+                title={staleDotTitle}
+                style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: staleDotColor, flexShrink: 0 }}
+              />
+            ) : null;
             return (
               <Button
                 key={sitePath}
@@ -525,10 +546,10 @@ function App() {
                 }}
               >
                 {sidebarCollapsed ? (
-                  <span style={{ fontWeight: 600 }}>{siteName.slice(0, 1).toUpperCase()}</span>
+                  <span style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>{siteName.slice(0, 1).toUpperCase()}{staleDot}</span>
                 ) : (
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
-                    <span style={{ fontWeight: 600 }}>{siteName}</span>
+                    <span style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 6 }}>{siteName}{staleDot}</span>
                   </div>
                 )}
               </Button>
@@ -616,6 +637,7 @@ function App() {
                       createdAt={siteMeta?.[s]?.createdAt}
                       label={siteMeta?.[s]?.label}
                       onInitialized={onInitialized}
+                      onSiteMetaPatch={onSiteMetaPatch}
                       onForget={onForget}
                       onDelete={onDelete}
                       onRename={onRename}
@@ -697,8 +719,12 @@ function App() {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = '' }) {
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onForget, onDelete, onRename, isPending = false, setupLogs = '' }) {
   const safeOnRename = onRename || (() => {});
+  // Kept in a ref so loadStatus's dependency list stays [sitePath] — a
+  // recreated callback prop must not retrigger the status-loading effect.
+  const metaPatchRef = useRef(onSiteMetaPatch);
+  useEffect(() => { metaPatchRef.current = onSiteMetaPatch; }, [onSiteMetaPatch]);
   // state
   const [serverUrl, setServerUrl] = useState('');
   const [starting, setStarting] = useState(false);
@@ -723,6 +749,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   const [skipInit, setSkipInit] = useState(false);
   const [statusLoading, setStatusLoading] = useState(true);
   const [waitingForWatch, setWaitingForWatch] = useState(false);
+  // Trunk update path (#94)
+  const [trunkDate, setTrunkDate] = useState(null);
+  const [updateIncomplete, setUpdateIncomplete] = useState(false);
+  const [updateState, setUpdateState] = useState('idle'); // idle | fetching | installing | building
+  const [dirtyModalOpen, setDirtyModalOpen] = useState(false);
+  const [dirtySaving, setDirtySaving] = useState(false);
+  const [updateLockfileChanged, setUpdateLockfileChanged] = useState(false);
   const setupLogsRef = useRef('');
 
   // sticky refs per log
@@ -837,6 +870,15 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       setInstallFailed(Boolean(s?.installFailed));
       setHasBuilt(Boolean(s?.hasBuilt));
       setSkipInit(Boolean(s?.skipInitWizard));
+      setTrunkDate(s?.trunkDate || null);
+      setUpdateIncomplete(Boolean(s?.updateIncomplete));
+      if (metaPatchRef.current) {
+        // A null trunkDate here means the git read failed (e.g. clone still
+        // running) — keep whatever the sidebar already shows in that case.
+        const patch = { updateIncomplete: Boolean(s?.updateIncomplete) };
+        if (s?.trunkDate) patch.trunkDate = s.trunkDate;
+        metaPatchRef.current(sitePath, patch);
+      }
     } catch {}
     finally { setStatusLoading(false); }
   }, [sitePath]);
@@ -1349,6 +1391,145 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   }, [sitePath]);
   const confirmAnd = async (m,a)=>{ if(window.confirm(m)) await a(); };
 
+  // --- Update to latest trunk (#94) ---
+  const age = trunkAgeInfo({ trunkDate });
+  const isUpdating = updateState !== 'idle';
+  const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
+  const updateStepStates = updateStepStatuses(updateSteps, updateState);
+
+  const finishUpdate = (message) => {
+    terminalStateRef.current.running = false;
+    terminalKillRef.current = null;
+    setUpdateState('idle');
+    if (message) writeToTerminal(message);
+    loadStatus().catch(() => {});
+  };
+
+  // Steps 2 and 3 of the chain: npm install (only when the lockfile moved,
+  // and named when skipped) then a rebuild. Reuses the wizard's runInstall /
+  // runScript so exit codes, retries and terminal streaming all behave
+  // exactly as they do everywhere else (same pattern as toggleDevServer).
+  const runUpdateInstallAndBuild = (lockfileChanged) => {
+    const runBuildStep = () => {
+      setUpdateState('building');
+      writeToTerminal('\nRunning npm run build…\n');
+      runScript('build', {
+        onLog: (chunk) => writeToTerminal(chunk),
+        onDone: async ({ code }) => {
+          if (code === 0) {
+            try { await window.api.markUpdateComplete(sitePath); } catch {}
+            finishUpdate('\nUpdate complete — this site is now on the latest trunk.\n');
+          } else {
+            finishUpdate('\nUpdate incomplete — the build failed. The code is new but the built assets are old; retry install & build from the banner above.\n');
+          }
+        }
+      });
+    };
+    if (lockfileChanged) {
+      setUpdateState('installing');
+      writeToTerminal('\npackage-lock.json changed — running npm install (only the changed packages are downloaded)…\n');
+      runInstall({
+        onLog: (chunk) => writeToTerminal(chunk),
+        onDone: ({ code }) => {
+          if (code !== 0) {
+            finishUpdate('\nUpdate incomplete — npm install failed. The code is new but dependencies and built assets are old; retry install & build from the banner above.\n');
+            return;
+          }
+          runBuildStep();
+        }
+      });
+    } else {
+      writeToTerminal(`\n${SKIP_INSTALL_MESSAGE}\n`);
+      runBuildStep();
+    }
+  };
+
+  // Step 1: fetch + reset in the main process, then hand over to the npm
+  // steps. Assumes the tree is clean (startTrunkUpdate handles dirty trees).
+  const beginTrunkUpdate = () => {
+    const state = terminalStateRef.current;
+    if (state.running) {
+      writeToTerminal('A command is already running. Press Ctrl+C to stop it.\n');
+      return;
+    }
+    state.running = true;
+    terminalKillRef.current = () => { killCurrent().catch(() => {}); };
+    setUpdateLockfileChanged(false);
+    setUpdateState('fetching');
+    window.api.updateTrunk(sitePath, ({ data }) => writeToTerminal(data), (res) => {
+      if (!res || !res.ok || res.upToDate) {
+        // The main process already wrote the failure or "Already up to
+        // date." message to the stream.
+        finishUpdate();
+        return;
+      }
+      setUpdateLockfileChanged(Boolean(res.lockfileChanged));
+      runUpdateInstallAndBuild(Boolean(res.lockfileChanged));
+    });
+  };
+
+  const startTrunkUpdate = async () => {
+    if (isUpdating || installing || building || isDevProcessActive) return;
+    try {
+      const res = await window.api.isWorktreeDirty(sitePath);
+      if (res && res.ok && res.dirty) {
+        setDirtyModalOpen(true);
+        return;
+      }
+    } catch {}
+    beginTrunkUpdate();
+  };
+
+  // Dirty-tree resolutions. Saving is the default: it is what the tool is
+  // for, and it is the only option that cannot lose work.
+  const dirtySaveAndUpdate = async () => {
+    setDirtySaving(true);
+    try {
+      const res = await window.api.savePatch(sitePath);
+      if (res && res.canceled) return; // stay in the modal
+      if (!res || !res.ok || !res.filePath) {
+        alert(`Error saving diff: ${res && res.error ? res.error : 'Unknown error'}`);
+        return;
+      }
+      const d = await window.api.discardChanges(sitePath);
+      if (!d || !d.ok) {
+        alert(`Saved your changes to ${res.filePath}, but resetting the working tree failed: ${d && d.error ? d.error : 'Unknown error'}`);
+        return;
+      }
+      setDirtyModalOpen(false);
+      writeToTerminal(`\nSaved your changes to ${res.filePath} and reset the working tree.\n`);
+      beginTrunkUpdate();
+    } finally {
+      setDirtySaving(false);
+    }
+  };
+
+  const dirtyDiscardAndUpdate = () => confirmAnd('Discard all local changes? This cannot be undone.', async () => {
+    const d = await window.api.discardChanges(sitePath);
+    if (!d || !d.ok) {
+      alert(`Failed to discard changes: ${d && d.error ? d.error : 'Unknown error'}`);
+      return;
+    }
+    setDirtyModalOpen(false);
+    writeToTerminal('\nDiscarded local changes.\n');
+    beginTrunkUpdate();
+  });
+
+  // Re-entry point for a previously interrupted update: trunk already moved,
+  // so only install+build remain. Install runs unconditionally — the
+  // lockfile delta from the failed run is no longer known.
+  const retryInstallAndBuild = () => {
+    const state = terminalStateRef.current;
+    if (state.running) {
+      writeToTerminal('A command is already running. Press Ctrl+C to stop it.\n');
+      return;
+    }
+    state.running = true;
+    terminalKillRef.current = () => { killCurrent().catch(() => {}); };
+    setUpdateLockfileChanged(true);
+    runUpdateInstallAndBuild(true);
+  };
+
   const openPatchModal = async ()=>{
     setIsPatchOpen(true);
     setPatchLoading(true);
@@ -1542,6 +1723,19 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               {initialized ? 'Initialized' : 'Uninitialized'}
             </span>
             {createdLabel ? <span>Created {createdLabel}</span> : null}
+            {age.known ? (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                {createdLabel ? <span aria-hidden="true">·</span> : null}
+                {age.stale ? (
+                  <span
+                    aria-hidden="true"
+                    title={`Trunk snapshot is ${age.ageDays} days old`}
+                    style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: '#dba617' }}
+                  />
+                ) : null}
+                <span>{age.label}</span>
+              </span>
+            ) : null}
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 6 }}>
             <code style={{ fontSize: 12, color: '#3c434a', background: '#f0f0f1', padding: '2px 6px', borderRadius: 4, overflowWrap: 'anywhere' }}>
@@ -1569,6 +1763,49 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           />
         </div>
       </Flex>
+      {updateIncomplete && !isUpdating ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 8, fontSize: 13, color: '#8a1f21' }}>
+          <span style={{ flex: '1 1 320px' }}>
+            <strong>Update incomplete</strong> — the code is new but the built assets are old. The site may not run correctly until install and build succeed.
+          </span>
+          <Button
+            variant="secondary"
+            isDestructive
+            onClick={retryInstallAndBuild}
+            disabled={installing || building || isDevProcessActive}
+          >Retry install &amp; build</Button>
+        </div>
+      ) : null}
+      {age.stale && !updateIncomplete && !isUpdating ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
+          <span style={{ flex: '1 1 320px' }}>
+            This site's trunk snapshot is <strong>{age.ageDays} days old</strong> — patches you create now may not apply on Trac.
+          </span>
+          <Button
+            variant="secondary"
+            onClick={startTrunkUpdate}
+            disabled={installing || building || isDevProcessActive}
+            title={isDevProcessActive ? 'Stop the dev server before updating' : undefined}
+          >Update to latest trunk</Button>
+        </div>
+      ) : null}
+      {isUpdating ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap', padding: '12px 16px', background: '#e8f3ff', border: '1px solid #66afe9', borderRadius: 8, fontSize: 13, color: '#0b5d95' }}>
+          <span style={{ fontWeight: 600 }}>Updating to latest trunk…</span>
+          {updateStepStates.map((s, i) => {
+            const step = updateSteps[i];
+            const symbol = s.status === 'complete' ? '✓' : s.status === 'skipped' ? '↷' : s.status === 'current' ? '●' : '○';
+            return (
+              <span key={s.key} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, opacity: s.status === 'pending' ? 0.55 : 1 }}>
+                <span aria-hidden="true">{symbol}</span>
+                <span style={{ fontWeight: s.status === 'current' ? 600 : 400 }}>
+                  {s.status === 'skipped' ? step.skipMessage : step.label}
+                </span>
+              </span>
+            );
+          })}
+        </div>
+      ) : null}
       {!skipInit ? (
         <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
           <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Initial setup checklist</div>
@@ -1638,6 +1875,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               isBusy={isServerStarting}
               variant={isDevProcessActive ? 'secondary' : 'primary'}
               onClick={toggleDevServer}
+              disabled={isUpdating}
               style={{ display: 'inline-flex', alignItems: 'center', gap: 10, minWidth: 220, justifyContent: 'center', padding: '12px 20px', fontSize: 15, borderRadius: 12 }}
             >
               {isDevProcessActive ? (
@@ -1659,8 +1897,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
             <Button
               variant="secondary"
               onClick={openPatchModal}
+              disabled={isUpdating}
               style={{ padding: '10px 16px', borderRadius: 10 }}
             >Submit patch</Button>
+            <Button
+              variant="secondary"
+              isBusy={isUpdating}
+              onClick={startTrunkUpdate}
+              disabled={isDevProcessActive || isUpdating || installing || building}
+              title={isDevProcessActive ? 'Stop the dev server before updating' : undefined}
+              style={{ padding: '10px 16px', borderRadius: 10 }}
+            >{isUpdating ? 'Updating…' : 'Update to latest trunk'}</Button>
             {running && serverUrl ? (
               <Button
                 variant="secondary"
@@ -1732,6 +1979,25 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           </div>
         </div>
       </div>
+      {dirtyModalOpen ? (
+        <Modal
+          title="You have local changes"
+          onRequestClose={() => { if (!dirtySaving) setDirtyModalOpen(false); }}
+          shouldCloseOnClickOutside={!dirtySaving}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 460 }}>
+            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5 }}>
+              Updating resets this site to the latest trunk, which would overwrite your local changes.
+              Save them as a patch file first (nothing is sent to Trac), or discard them.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, flexWrap: 'wrap' }}>
+              <Button variant="tertiary" onClick={() => setDirtyModalOpen(false)} disabled={dirtySaving}>Cancel</Button>
+              <Button variant="secondary" isDestructive onClick={dirtyDiscardAndUpdate} disabled={dirtySaving}>Discard changes</Button>
+              <Button variant="primary" isBusy={dirtySaving} onClick={dirtySaveAndUpdate} disabled={dirtySaving}>Save changes as a patch</Button>
+            </div>
+          </div>
+        </Modal>
+      ) : null}
       {renameModalOpen ? (
         <Modal
           title="Rename site"
@@ -1768,6 +2034,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           headerClassName="patch-modal-header"
         >
           <div style={{ display:'flex', flexDirection:'column', height:'80vh', gap:12 }}>
+            {!patchLoading && age.stale && (
+              <div style={{ padding:'12px 16px', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, fontSize:13, lineHeight:1.5, color:'#6e5406' }}>
+                This site's trunk snapshot is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
+              </div>
+            )}
             {!patchLoading && (
               <div style={{ padding:'12px 16px', background:'#f0f6fc', border:'1px solid #d0d7de', borderRadius:6, fontSize:14, lineHeight:1.5, color:'#24292f' }}>
                 <strong>Next steps:</strong> Save this patch and submit it to the relevant WordPress Trac ticket at <a href="#" onClick={(e) => { e.preventDefault(); window.api.openExternal('https://core.trac.wordpress.org'); }} style={{color:'#0969da', cursor:'pointer'}}>core.trac.wordpress.org</a>

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -9,6 +9,12 @@
  *
  * `isPending` means the `wordpress-develop` clone for this site is still
  * running, so nothing that touches the working tree may be offered yet.
+ * `isUpdating` means the trunk-update chain (#94) owns the working tree —
+ * its own fetch/checkout step runs before `installing`/`building` are set,
+ * so without this flag the checklist's install/build buttons stay clickable
+ * during that window and a click races `git.checkout({force: true})`.
+ *
+ * @param {Object} flags
  */
 function computeSetupStepState(flags = {}) {
 	const isPending = Boolean(flags.isPending);
@@ -19,6 +25,7 @@ function computeSetupStepState(flags = {}) {
 	const building = Boolean(flags.building);
 	const starting = Boolean(flags.starting);
 	const installFailed = Boolean(flags.installFailed);
+	const isUpdating = Boolean(flags.isUpdating);
 
 	// node_modules existing is not evidence the install succeeded: a failed
 	// install leaves a partial one behind, and treating that as a completed
@@ -34,17 +41,17 @@ function computeSetupStepState(flags = {}) {
 		install: {
 			done: installOk,
 			ready: !isPending,
-			disabled: isPending || statusLoading || installing || installOk
+			disabled: isPending || statusLoading || installing || installOk || isUpdating
 		},
 		build: {
 			done: hasBuilt,
 			ready: installOk,
-			disabled: statusLoading || building || !installOk || hasBuilt
+			disabled: statusLoading || building || !installOk || hasBuilt || isUpdating
 		},
 		dev: {
 			done: false,
 			ready: hasBuilt,
-			disabled: statusLoading || starting || !hasBuilt
+			disabled: statusLoading || starting || !hasBuilt || isUpdating
 		}
 	};
 }

--- a/src/renderer/update-plan.cjs
+++ b/src/renderer/update-plan.cjs
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * Decision logic for the "Update to latest trunk" feature (issue #94): how old
+ * a site's trunk snapshot is, which steps an update runs, and how the chain
+ * ends.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly
+ * (same convention as setup-steps.cjs and dev-server-command.cjs).
+ */
+
+// A site older than this shows the staleness dot and notice. Local-only:
+// staleness is judged from the snapshot's own age, never from a network probe,
+// so it works offline and never talks to GitHub on app launch. A spuriously
+// stale site just gets "Already up to date." when the user clicks Update.
+const STALE_THRESHOLD_DAYS = 14;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Describes the age of a site's trunk snapshot from its stored commit date.
+ * Unknown or invalid dates are never reported stale — a missing date means an
+ * older site record, not an old checkout.
+ */
+function trunkAgeInfo({ trunkDate, now = Date.now() } = {}) {
+	const ts = trunkDate ? Date.parse(trunkDate) : NaN;
+	if (!Number.isFinite(ts)) {
+		return { known: false, ageDays: null, stale: false, label: '' };
+	}
+	const ageDays = Math.max(0, Math.floor((now - ts) / DAY_MS));
+	const label = `trunk as of ${new Date(ts).toLocaleDateString(undefined, {
+		year: 'numeric', month: 'short', day: 'numeric'
+	})}`;
+	return { known: true, ageDays, stale: ageDays > STALE_THRESHOLD_DAYS, label };
+}
+
+const SKIP_INSTALL_MESSAGE = 'Dependencies unchanged — skipping npm install';
+
+/**
+ * The update chain always has the same three steps; the middle one is skipped
+ * (but still shown, with an explicit message) when package-lock.json did not
+ * change between the old and new trunk. Naming the skipped step is deliberate:
+ * "update" should always mean the same thing to the contributor.
+ */
+function planUpdateSteps({ lockfileChanged } = {}) {
+	return [
+		{ key: 'fetch', label: 'Fetch latest trunk', skipped: false },
+		{
+			key: 'install',
+			label: 'Install dependencies',
+			skipped: !lockfileChanged,
+			skipMessage: SKIP_INSTALL_MESSAGE
+		},
+		{ key: 'build', label: 'Rebuild', skipped: false }
+	];
+}
+
+// Which chain step each renderer updateState is executing.
+const STATE_TO_STEP = { fetching: 'fetch', installing: 'install', building: 'build' };
+
+/**
+ * Maps the chain steps to checklist visual states for a given renderer
+ * updateState. Steps before the current one are complete, the current one is
+ * current, later ones pending; skipped steps stay 'skipped' once passed.
+ */
+function updateStepStatuses(steps, updateState) {
+	const activeKey = STATE_TO_STEP[updateState] || null;
+	const order = steps.map((s) => s.key);
+	const activeIndex = activeKey ? order.indexOf(activeKey) : (updateState === 'done' ? steps.length : -1);
+	return steps.map((step, i) => {
+		if (step.skipped && i < activeIndex) return { key: step.key, status: 'skipped' };
+		if (i < activeIndex) return { key: step.key, status: 'complete' };
+		if (i === activeIndex) return { key: step.key, status: 'current' };
+		return { key: step.key, status: 'pending' };
+	});
+}
+
+/**
+ * How the chain ended. 'incomplete' is the state worth its own name: trunk
+ * moved but install/build failed, so the code is new while the built assets
+ * are old — the site may not run until install+build succeed.
+ */
+function updateOutcome({ fetchOk, upToDate, moved, installNeeded, installCode, buildCode } = {}) {
+	if (!fetchOk) return 'failed-fetch';
+	if (upToDate) return 'up-to-date';
+	if (!moved) return 'failed-fetch';
+	if (installNeeded && installCode !== 0) return 'incomplete';
+	if (buildCode !== 0) return 'incomplete';
+	return 'done';
+}
+
+module.exports = {
+	STALE_THRESHOLD_DAYS,
+	SKIP_INSTALL_MESSAGE,
+	trunkAgeInfo,
+	planUpdateSteps,
+	updateStepStatuses,
+	updateOutcome
+};

--- a/src/renderer/update-plan.cjs
+++ b/src/renderer/update-plan.cjs
@@ -22,6 +22,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
  * Describes the age of a site's trunk snapshot from its stored commit date.
  * Unknown or invalid dates are never reported stale — a missing date means an
  * older site record, not an old checkout.
+ *
+ * @param {Object} root0
+ * @param {string} [root0.trunkDate]
+ * @param {number} [root0.now]
  */
 function trunkAgeInfo({ trunkDate, now = Date.now() } = {}) {
 	const ts = trunkDate ? Date.parse(trunkDate) : NaN;
@@ -42,6 +46,9 @@ const SKIP_INSTALL_MESSAGE = 'Dependencies unchanged — skipping npm install';
  * (but still shown, with an explicit message) when package-lock.json did not
  * change between the old and new trunk. Naming the skipped step is deliberate:
  * "update" should always mean the same thing to the contributor.
+ *
+ * @param {Object}  root0
+ * @param {boolean} [root0.lockfileChanged]
  */
 function planUpdateSteps({ lockfileChanged } = {}) {
 	return [
@@ -63,11 +70,19 @@ const STATE_TO_STEP = { fetching: 'fetch', installing: 'install', building: 'bui
  * Maps the chain steps to checklist visual states for a given renderer
  * updateState. Steps before the current one are complete, the current one is
  * current, later ones pending; skipped steps stay 'skipped' once passed.
+ *
+ * @param {Array}  steps
+ * @param {string} updateState
  */
 function updateStepStatuses(steps, updateState) {
 	const activeKey = STATE_TO_STEP[updateState] || null;
 	const order = steps.map((s) => s.key);
-	const activeIndex = activeKey ? order.indexOf(activeKey) : (updateState === 'done' ? steps.length : -1);
+	let activeIndex = -1;
+	if (activeKey) {
+		activeIndex = order.indexOf(activeKey);
+	} else if (updateState === 'done') {
+		activeIndex = steps.length;
+	}
 	return steps.map((step, i) => {
 		if (step.skipped && i < activeIndex) return { key: step.key, status: 'skipped' };
 		if (i < activeIndex) return { key: step.key, status: 'complete' };
@@ -80,6 +95,14 @@ function updateStepStatuses(steps, updateState) {
  * How the chain ended. 'incomplete' is the state worth its own name: trunk
  * moved but install/build failed, so the code is new while the built assets
  * are old — the site may not run until install+build succeed.
+ *
+ * @param {Object}  root0
+ * @param {boolean} [root0.fetchOk]
+ * @param {boolean} [root0.upToDate]
+ * @param {boolean} [root0.moved]
+ * @param {boolean} [root0.installNeeded]
+ * @param {number}  [root0.installCode]
+ * @param {number}  [root0.buildCode]
  */
 function updateOutcome({ fetchOk, upToDate, moved, installNeeded, installCode, buildCode } = {}) {
 	if (!fetchOk) return 'failed-fetch';

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -30,6 +30,8 @@ const {
  * config makes isomorphic-git strip CRLF before hashing workdir files. LF
  * checkouts are unaffected. Called before every status/patch/update git op
  * so pre-existing sites are covered, not just new clones.
+ *
+ * @param {string} dir
  */
 async function ensureAutocrlf(dir) {
 	try {
@@ -43,6 +45,8 @@ async function ensureAutocrlf(dir) {
 /**
  * The commit the site's HEAD points at; its committer date is the age of the
  * trunk snapshot. One object read, no network.
+ *
+ * @param {string} dir
  */
 async function readTrunkInfo(dir) {
 	const trunkOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
@@ -78,6 +82,8 @@ async function isCrlfOnlyChange(dir, headOid, filepath) {
  * The files that genuinely differ from HEAD — statusMatrix candidates minus
  * CRLF-only false positives. What this returns is what the dirty-tree dialog
  * lists, and it matches what patch generation would emit.
+ *
+ * @param {string} dir
  */
 async function collectDirtyFiles(dir) {
 	await ensureAutocrlf(dir);
@@ -96,6 +102,8 @@ async function collectDirtyFiles(dir) {
  * Resets the worktree to HEAD. Files absent from HEAD are removed from the
  * index AND the workdir — a "discard" that leaves new files behind would put
  * them straight back into the next patch.
+ *
+ * @param {string} dir
  */
 async function discardChanges(dir) {
 	await ensureAutocrlf(dir);
@@ -120,6 +128,11 @@ async function discardChanges(dir) {
  *
  * Shallow-clone safe: a depth-1 re-fetch negotiates a new shallow tip, and
  * the forced checkout resets tracked files while untracked ones survive.
+ *
+ * @param {Object}   root0
+ * @param {string}   root0.dir
+ * @param {string}   root0.url
+ * @param {Function} [root0.onLog]
  */
 async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 	await ensureAutocrlf(dir);

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -1,0 +1,184 @@
+'use strict';
+
+/**
+ * Git operations for the trunk update path (#94). No Electron dependency, so
+ * `node --test` can exercise it against real repositories (same rationale as
+ * npm-runner.js). All git I/O goes through isomorphic-git — the app never
+ * shells out to a git binary.
+ *
+ * main.js owns the IPC plumbing and electron-store writes; the pure
+ * statusMatrix/oid decision rules live in git-update.cjs.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const git = require('isomorphic-git');
+const http = require('isomorphic-git/http/node');
+const {
+	isDirtyFromStatusMatrix,
+	staleStagedPaths,
+	lockfileChangedFromBlobOids,
+	normalizeEolBuffer
+} = require('./git-update.cjs');
+
+/**
+ * A site checked out by native git on Windows (default core.autocrlf=true,
+ * set globally — which isomorphic-git never reads) has CRLF on disk while
+ * wordpress-develop's blobs are LF-only. Without this, statusMatrix hashes
+ * the raw CRLF bytes and reports every text file as modified (~5k phantom
+ * changes; isomorphic-git#1275). Writing core.autocrlf into the site's LOCAL
+ * config makes isomorphic-git strip CRLF before hashing workdir files. LF
+ * checkouts are unaffected. Called before every status/patch/update git op
+ * so pre-existing sites are covered, not just new clones.
+ */
+async function ensureAutocrlf(dir) {
+	try {
+		const current = await git.getConfig({ fs, dir, path: 'core.autocrlf' });
+		if (current !== 'true') {
+			await git.setConfig({ fs, dir, path: 'core.autocrlf', value: 'true' });
+		}
+	} catch {}
+}
+
+/**
+ * The commit the site's HEAD points at; its committer date is the age of the
+ * trunk snapshot. One object read, no network.
+ */
+async function readTrunkInfo(dir) {
+	const trunkOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+	const { commit } = await git.readCommit({ fs, dir, oid: trunkOid });
+	const trunkDate = new Date(commit.committer.timestamp * 1000).toISOString();
+	return { trunkOid, trunkDate };
+}
+
+async function readLockfileBlobOid(dir, oid) {
+	try {
+		const { oid: blobOid } = await git.readBlob({ fs, dir, oid, filepath: 'package-lock.json' });
+		return blobOid;
+	} catch {
+		return null;
+	}
+}
+
+// statusMatrix's autocrlf normalization only covers valid-UTF8 files, so
+// non-UTF8 text fixtures (wordpress-develop's Big5/Latin-1 encoding tests)
+// smudged to CRLF by a native-git checkout still hash as modified. Confirm
+// with a byte-level, encoding-agnostic comparison.
+async function isCrlfOnlyChange(dir, headOid, filepath) {
+	try {
+		const { blob } = await git.readBlob({ fs, dir, oid: headOid, filepath });
+		const work = await fs.promises.readFile(path.join(dir, filepath));
+		return normalizeEolBuffer(Buffer.from(blob)).equals(normalizeEolBuffer(work));
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The files that genuinely differ from HEAD — statusMatrix candidates minus
+ * CRLF-only false positives. What this returns is what the dirty-tree dialog
+ * lists, and it matches what patch generation would emit.
+ */
+async function collectDirtyFiles(dir) {
+	await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs, dir });
+	let headOid = null;
+	try { headOid = await git.resolveRef({ fs, dir, ref: 'HEAD' }); } catch {}
+	const files = [];
+	for (const [filepath, head, workdir] of isDirtyFromStatusMatrix(matrix).rows) {
+		if (head === 1 && workdir === 2 && headOid && await isCrlfOnlyChange(dir, headOid, filepath)) continue;
+		files.push(filepath);
+	}
+	return files;
+}
+
+/**
+ * Resets the worktree to HEAD. Files absent from HEAD are removed from the
+ * index AND the workdir — a "discard" that leaves new files behind would put
+ * them straight back into the next patch.
+ */
+async function discardChanges(dir) {
+	await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs, dir });
+	for (const [filepath, head, workdir] of matrix) {
+		if (head === 0) {
+			try { await git.remove({ fs, dir, filepath }); } catch {}
+			if (workdir !== 0) {
+				try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
+			}
+		}
+	}
+	await git.checkout({ fs, dir, ref: 'trunk', force: true });
+}
+
+/**
+ * Step 1 of the update chain: fetch the latest remote trunk and hard-reset
+ * the site to it. Returns { upToDate, oldOid, newOid, lockfileChanged,
+ * trunkDate }; throws with `error.stage` set to 'fetch' (nothing moved —
+ * plain failure) or 'checkout' (HEAD moved over a partial tree — the caller
+ * must persist the incomplete state).
+ *
+ * Shallow-clone safe: a depth-1 re-fetch negotiates a new shallow tip, and
+ * the forced checkout resets tracked files while untracked ones survive.
+ */
+async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
+	await ensureAutocrlf(dir);
+	let stage = 'fetch';
+	try {
+		const oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+		onLog('Fetching latest trunk…\n');
+		const fetchResult = await git.fetch({
+			fs, http, dir, url,
+			ref: 'trunk',
+			singleBranch: true,
+			depth: 1,
+			tags: false,
+			onProgress: (evt) => onLog(`${evt.phase || 'fetch'} ${evt.loaded || 0}/${evt.total || 0}\r`)
+		});
+		let newOid = fetchResult && fetchResult.fetchHead;
+		if (!newOid) newOid = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/trunk' });
+
+		if (newOid === oldOid) {
+			const { trunkDate } = await readTrunkInfo(dir);
+			onLog('\nAlready up to date.\n');
+			return { upToDate: true, oldOid, newOid, lockfileChanged: false, trunkDate };
+		}
+
+		// Decide the install step before touching the worktree.
+		const lockfileChanged = lockfileChangedFromBlobOids(
+			await readLockfileBlobOid(dir, oldOid),
+			await readLockfileBlobOid(dir, newOid)
+		);
+
+		stage = 'checkout';
+		// Patch generation stages untracked files and never unstages them;
+		// checkout({force}) deletes workdir files that are in the index but
+		// absent from the target tree, so drop those index entries first
+		// (index-only — the workdir files survive).
+		const matrix = await git.statusMatrix({ fs, dir });
+		for (const filepath of staleStagedPaths(matrix)) {
+			try { await git.remove({ fs, dir, filepath }); } catch {}
+		}
+		onLog(`\nResetting to latest trunk (${newOid.slice(0, 7)})…\n`);
+		await git.writeRef({ fs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
+		await git.checkout({
+			fs, dir, ref: 'trunk', force: true,
+			onProgress: (evt) => onLog(`${evt.phase || 'checkout'} ${evt.loaded || 0}/${evt.total || 0}\r`)
+		});
+
+		const { trunkDate } = await readTrunkInfo(dir);
+		onLog(`\nNow on trunk as of ${trunkDate}.\n`);
+		return { upToDate: false, oldOid, newOid, lockfileChanged, trunkDate };
+	} catch (e) {
+		if (e && typeof e === 'object') e.stage = stage;
+		throw e;
+	}
+}
+
+module.exports = {
+	ensureAutocrlf,
+	readTrunkInfo,
+	collectDirtyFiles,
+	discardChanges,
+	updateToLatestTrunk
+};

--- a/test/git-update.test.cjs
+++ b/test/git-update.test.cjs
@@ -15,7 +15,7 @@ test('isDirtyFromStatusMatrix: clean tree (issue #94)', () => {
 		['a.php', 1, 1, 1],
 		['b.php', 1, 1, 1]
 	];
-	assert.deepStrictEqual(isDirtyFromStatusMatrix(matrix), { dirty: false, changedCount: 0, files: [] });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(matrix), { dirty: false, changedCount: 0, files: [], rows: [] });
 });
 
 test('isDirtyFromStatusMatrix: modified, deleted and untracked files are dirty, and named (issue #94)', () => {
@@ -29,7 +29,7 @@ test('isDirtyFromStatusMatrix: modified, deleted and untracked files are dirty, 
 });
 
 test('isDirtyFromStatusMatrix: staged-but-identical to HEAD is clean — no patch hunks would result (issue #94)', () => {
-	assert.deepStrictEqual(isDirtyFromStatusMatrix([['s.php', 1, 1, 3]]), { dirty: false, changedCount: 0, files: [] });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([['s.php', 1, 1, 3]]), { dirty: false, changedCount: 0, files: [], rows: [] });
 });
 
 test('isDirtyFromStatusMatrix: untracked file staged by a prior patch generation is dirty (issue #94)', () => {
@@ -37,8 +37,8 @@ test('isDirtyFromStatusMatrix: untracked file staged by a prior patch generation
 });
 
 test('isDirtyFromStatusMatrix: empty or missing matrix is clean (issue #94)', () => {
-	assert.deepStrictEqual(isDirtyFromStatusMatrix([]), { dirty: false, changedCount: 0, files: [] });
-	assert.deepStrictEqual(isDirtyFromStatusMatrix(undefined), { dirty: false, changedCount: 0, files: [] });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([]), { dirty: false, changedCount: 0, files: [], rows: [] });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(undefined), { dirty: false, changedCount: 0, files: [], rows: [] });
 });
 
 test('staleStagedPaths: picks only staged files absent from HEAD (issue #94)', () => {

--- a/test/git-update.test.cjs
+++ b/test/git-update.test.cjs
@@ -13,17 +13,21 @@ test('isDirtyFromStatusMatrix: clean tree (issue #94)', () => {
 		['a.php', 1, 1, 1],
 		['b.php', 1, 1, 1]
 	];
-	assert.deepStrictEqual(isDirtyFromStatusMatrix(matrix), { dirty: false, changedCount: 0 });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(matrix), { dirty: false, changedCount: 0, files: [] });
 });
 
-test('isDirtyFromStatusMatrix: modified, deleted and untracked files are dirty (issue #94)', () => {
+test('isDirtyFromStatusMatrix: modified, deleted and untracked files are dirty, and named (issue #94)', () => {
 	assert.strictEqual(isDirtyFromStatusMatrix([['m.php', 1, 2, 1]]).dirty, true); // modified
 	assert.strictEqual(isDirtyFromStatusMatrix([['d.php', 1, 0, 1]]).dirty, true); // deleted
 	assert.strictEqual(isDirtyFromStatusMatrix([['u.php', 0, 2, 0]]).dirty, true); // untracked
+	assert.deepStrictEqual(
+		isDirtyFromStatusMatrix([['m.php', 1, 2, 1], ['ok.php', 1, 1, 1], ['u.php', 0, 2, 0]]).files,
+		['m.php', 'u.php']
+	);
 });
 
 test('isDirtyFromStatusMatrix: staged-but-identical to HEAD is clean — no patch hunks would result (issue #94)', () => {
-	assert.deepStrictEqual(isDirtyFromStatusMatrix([['s.php', 1, 1, 3]]), { dirty: false, changedCount: 0 });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([['s.php', 1, 1, 3]]), { dirty: false, changedCount: 0, files: [] });
 });
 
 test('isDirtyFromStatusMatrix: untracked file staged by a prior patch generation is dirty (issue #94)', () => {
@@ -31,8 +35,8 @@ test('isDirtyFromStatusMatrix: untracked file staged by a prior patch generation
 });
 
 test('isDirtyFromStatusMatrix: empty or missing matrix is clean (issue #94)', () => {
-	assert.deepStrictEqual(isDirtyFromStatusMatrix([]), { dirty: false, changedCount: 0 });
-	assert.deepStrictEqual(isDirtyFromStatusMatrix(undefined), { dirty: false, changedCount: 0 });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([]), { dirty: false, changedCount: 0, files: [] });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(undefined), { dirty: false, changedCount: 0, files: [] });
 });
 
 test('staleStagedPaths: picks only staged files absent from HEAD (issue #94)', () => {

--- a/test/git-update.test.cjs
+++ b/test/git-update.test.cjs
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	isDirtyFromStatusMatrix,
+	staleStagedPaths,
+	lockfileChangedFromBlobOids
+} = require('../src/git-update.cjs');
+
+test('isDirtyFromStatusMatrix: clean tree (issue #94)', () => {
+	const matrix = [
+		['a.php', 1, 1, 1],
+		['b.php', 1, 1, 1]
+	];
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(matrix), { dirty: false, changedCount: 0 });
+});
+
+test('isDirtyFromStatusMatrix: modified, deleted and untracked files are dirty (issue #94)', () => {
+	assert.strictEqual(isDirtyFromStatusMatrix([['m.php', 1, 2, 1]]).dirty, true); // modified
+	assert.strictEqual(isDirtyFromStatusMatrix([['d.php', 1, 0, 1]]).dirty, true); // deleted
+	assert.strictEqual(isDirtyFromStatusMatrix([['u.php', 0, 2, 0]]).dirty, true); // untracked
+});
+
+test('isDirtyFromStatusMatrix: staged-but-identical to HEAD is clean — no patch hunks would result (issue #94)', () => {
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([['s.php', 1, 1, 3]]), { dirty: false, changedCount: 0 });
+});
+
+test('isDirtyFromStatusMatrix: untracked file staged by a prior patch generation is dirty (issue #94)', () => {
+	assert.strictEqual(isDirtyFromStatusMatrix([['new.php', 0, 2, 2]]).dirty, true);
+});
+
+test('isDirtyFromStatusMatrix: empty or missing matrix is clean (issue #94)', () => {
+	assert.deepStrictEqual(isDirtyFromStatusMatrix([]), { dirty: false, changedCount: 0 });
+	assert.deepStrictEqual(isDirtyFromStatusMatrix(undefined), { dirty: false, changedCount: 0 });
+});
+
+test('staleStagedPaths: picks only staged files absent from HEAD (issue #94)', () => {
+	const matrix = [
+		['tracked.php', 1, 2, 3],
+		['staged-untracked.php', 0, 2, 2],
+		['plain-untracked.php', 0, 2, 0],
+		['staged-then-deleted.php', 0, 0, 3]
+	];
+	assert.deepStrictEqual(staleStagedPaths(matrix), ['staged-untracked.php', 'staged-then-deleted.php']);
+});
+
+test('lockfileChangedFromBlobOids: both absent -> unchanged (issue #94)', () => {
+	assert.strictEqual(lockfileChangedFromBlobOids(null, null), false);
+});
+
+test('lockfileChangedFromBlobOids: presence differing -> changed (issue #94)', () => {
+	assert.strictEqual(lockfileChangedFromBlobOids('abc', null), true);
+	assert.strictEqual(lockfileChangedFromBlobOids(null, 'abc'), true);
+});
+
+test('lockfileChangedFromBlobOids: same oid -> unchanged, different oid -> changed (issue #94)', () => {
+	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'abc'), false);
+	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'def'), true);
+});

--- a/test/git-update.test.cjs
+++ b/test/git-update.test.cjs
@@ -6,7 +6,8 @@ const {
 	isDirtyFromStatusMatrix,
 	staleStagedPaths,
 	lockfileChangedFromBlobOids,
-	normalizeEol
+	normalizeEol,
+	normalizeEolBuffer
 } = require('../src/git-update.cjs');
 
 test('isDirtyFromStatusMatrix: clean tree (issue #94)', () => {
@@ -62,6 +63,19 @@ test('lockfileChangedFromBlobOids: presence differing -> changed (issue #94)', (
 test('lockfileChangedFromBlobOids: same oid -> unchanged, different oid -> changed (issue #94)', () => {
 	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'abc'), false);
 	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'def'), true);
+});
+
+test('normalizeEolBuffer: byte-level CRLF stripping works on non-UTF8 content (issue #94)', () => {
+	// Big5-style bytes that are not valid UTF-8, with CRLF line endings —
+	// the case isomorphic-git's utf8-based autocrlf normalization skips.
+	const crlf = Buffer.from([0xa4, 0xa4, 0x0d, 0x0a, 0xa4, 0xe5, 0x0d, 0x0a]);
+	const lf = Buffer.from([0xa4, 0xa4, 0x0a, 0xa4, 0xe5, 0x0a]);
+	assert.ok(normalizeEolBuffer(crlf).equals(lf));
+	assert.ok(normalizeEolBuffer(lf).equals(lf));
+	// Lone CR (not followed by LF) is preserved.
+	const loneCr = Buffer.from([0x61, 0x0d, 0x62]);
+	assert.ok(normalizeEolBuffer(loneCr).equals(loneCr));
+	assert.ok(normalizeEolBuffer(Buffer.alloc(0)).equals(Buffer.alloc(0)));
 });
 
 test('normalizeEol: CRLF becomes LF, lone CR and LF are untouched (issue #94)', () => {

--- a/test/git-update.test.cjs
+++ b/test/git-update.test.cjs
@@ -5,7 +5,8 @@ const assert = require('node:assert');
 const {
 	isDirtyFromStatusMatrix,
 	staleStagedPaths,
-	lockfileChangedFromBlobOids
+	lockfileChangedFromBlobOids,
+	normalizeEol
 } = require('../src/git-update.cjs');
 
 test('isDirtyFromStatusMatrix: clean tree (issue #94)', () => {
@@ -61,4 +62,11 @@ test('lockfileChangedFromBlobOids: presence differing -> changed (issue #94)', (
 test('lockfileChangedFromBlobOids: same oid -> unchanged, different oid -> changed (issue #94)', () => {
 	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'abc'), false);
 	assert.strictEqual(lockfileChangedFromBlobOids('abc', 'def'), true);
+});
+
+test('normalizeEol: CRLF becomes LF, lone CR and LF are untouched (issue #94)', () => {
+	assert.strictEqual(normalizeEol('a\r\nb\r\n'), 'a\nb\n');
+	assert.strictEqual(normalizeEol('a\nb\n'), 'a\nb\n');
+	assert.strictEqual(normalizeEol('a\rb'), 'a\rb');
+	assert.strictEqual(normalizeEol(''), '');
 });

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -88,3 +88,23 @@ test('the dev step is never marked done by the checklist', () => {
 	assert.strictEqual(steps.dev.done, false);
 	assert.strictEqual(steps.dev.disabled, true, 'disabled while starting');
 });
+
+test('a trunk update in flight locks the checklist even before its own install/build flags are set (#111 review)', () => {
+	// The update chain's fetch step runs before `installing`/`building` are
+	// ever set, so this reproduces the exact window a race would occur in:
+	// node_modules and a build already exist, nothing is "installing" yet,
+	// but the working tree is being reset underneath the checklist.
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true, isUpdating: true });
+
+	assert.strictEqual(steps.install.disabled, true, 'install must not race the update chain\'s checkout');
+	assert.strictEqual(steps.build.disabled, true, 'build must not race the update chain\'s checkout');
+	assert.strictEqual(steps.dev.disabled, true, 'the dev server must not start against a tree the update owns');
+});
+
+test('a finished update releases the checklist again', () => {
+	const steps = computeSetupStepState({ hasNodeModules: true, hasBuilt: true, isUpdating: false });
+
+	assert.strictEqual(steps.install.disabled, true, 'nothing left to install');
+	assert.strictEqual(steps.build.disabled, true, 'nothing left to build');
+	assert.strictEqual(steps.dev.disabled, false);
+});

--- a/test/trunk-update.integration.test.cjs
+++ b/test/trunk-update.integration.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+
+// Integration tests for src/trunk-update.js against real on-disk repositories
+// (no network — updateToLatestTrunk's fetch path is covered by manual testing
+// against GitHub; see PR #111). Windows line-ending scenarios are simulated
+// by writing CRLF bytes directly, which is exactly what a native-git
+// autocrlf checkout leaves on disk.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const git = require('isomorphic-git');
+const { collectDirtyFiles, discardChanges, readTrunkInfo } = require('../src/trunk-update.js');
+
+const AUTHOR = { name: 'test', email: 'test@example.com' };
+
+async function makeRepo(t) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trunk-update-test-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\nline2\n');
+	// Big5-style bytes: not valid UTF-8, the encoding-fixture case.
+	fs.writeFileSync(path.join(dir, 'big5.txt'), Buffer.from([0xa4, 0xa4, 0x0a, 0xa4, 0xe5, 0x0a]));
+	await git.add({ fs, dir, filepath: ['text.txt', 'big5.txt'] });
+	await git.commit({ fs, dir, message: 'init', author: AUTHOR });
+	return dir;
+}
+
+test('collectDirtyFiles: a pristine repo is clean (issue #94)', async (t) => {
+	const dir = await makeRepo(t);
+	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+test('collectDirtyFiles: CRLF-smudged files, UTF-8 or not, are not dirty (issue #94)', async (t) => {
+	const dir = await makeRepo(t);
+	// What a native-git checkout with core.autocrlf=true leaves on disk.
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\r\nline2\r\n');
+	fs.writeFileSync(path.join(dir, 'big5.txt'), Buffer.from([0xa4, 0xa4, 0x0d, 0x0a, 0xa4, 0xe5, 0x0d, 0x0a]));
+	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+test('collectDirtyFiles: real edits and untracked files are detected (issue #94)', async (t) => {
+	const dir = await makeRepo(t);
+	fs.appendFileSync(path.join(dir, 'text.txt'), 'line3\n');
+	fs.appendFileSync(path.join(dir, 'big5.txt'), Buffer.from([0xff, 0xfe]));
+	fs.writeFileSync(path.join(dir, 'untracked.txt'), 'new\n');
+	assert.deepStrictEqual((await collectDirtyFiles(dir)).sort(), ['big5.txt', 'text.txt', 'untracked.txt']);
+});
+
+test('discardChanges: restores tracked files and deletes untracked ones, even staged (issue #94)', async (t) => {
+	const dir = await makeRepo(t);
+	fs.appendFileSync(path.join(dir, 'text.txt'), 'local edit\n');
+	fs.writeFileSync(path.join(dir, 'untracked.txt'), 'new\n');
+	fs.writeFileSync(path.join(dir, 'staged-untracked.txt'), 'staged by patch generation\n');
+	await git.add({ fs, dir, filepath: 'staged-untracked.txt' });
+
+	await discardChanges(dir);
+
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'text.txt'), 'utf8'), 'line1\nline2\n');
+	assert.strictEqual(fs.existsSync(path.join(dir, 'untracked.txt')), false);
+	assert.strictEqual(fs.existsSync(path.join(dir, 'staged-untracked.txt')), false);
+	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+test('readTrunkInfo: returns the HEAD oid and its committer date (issue #94)', async (t) => {
+	const dir = await makeRepo(t);
+	const { trunkOid, trunkDate } = await readTrunkInfo(dir);
+	assert.strictEqual(trunkOid, await git.resolveRef({ fs, dir, ref: 'HEAD' }));
+	const { commit } = await git.readCommit({ fs, dir, oid: trunkOid });
+	assert.strictEqual(trunkDate, new Date(commit.committer.timestamp * 1000).toISOString());
+});

--- a/test/update-plan.test.cjs
+++ b/test/update-plan.test.cjs
@@ -1,0 +1,128 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	STALE_THRESHOLD_DAYS,
+	SKIP_INSTALL_MESSAGE,
+	trunkAgeInfo,
+	planUpdateSteps,
+	updateStepStatuses,
+	updateOutcome
+} = require('../src/renderer/update-plan.cjs');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-05T12:00:00Z');
+
+function daysAgo(days) {
+	return new Date(NOW - days * DAY_MS).toISOString();
+}
+
+test('trunkAgeInfo: a 13-day-old snapshot is not stale (issue #94)', () => {
+	const info = trunkAgeInfo({ trunkDate: daysAgo(13), now: NOW });
+	assert.strictEqual(info.known, true);
+	assert.strictEqual(info.ageDays, 13);
+	assert.strictEqual(info.stale, false);
+});
+
+test('trunkAgeInfo: a 15-day-old snapshot is stale (issue #94)', () => {
+	const info = trunkAgeInfo({ trunkDate: daysAgo(15), now: NOW });
+	assert.strictEqual(info.stale, true);
+	assert.strictEqual(info.ageDays, 15);
+});
+
+test('trunkAgeInfo: exactly the threshold is not yet stale (issue #94)', () => {
+	const info = trunkAgeInfo({ trunkDate: daysAgo(STALE_THRESHOLD_DAYS), now: NOW });
+	assert.strictEqual(info.ageDays, STALE_THRESHOLD_DAYS);
+	assert.strictEqual(info.stale, false);
+});
+
+test('trunkAgeInfo: missing or invalid dates are never stale (issue #94)', () => {
+	for (const trunkDate of [undefined, null, '', 'not-a-date']) {
+		const info = trunkAgeInfo({ trunkDate, now: NOW });
+		assert.strictEqual(info.known, false, `trunkDate=${String(trunkDate)}`);
+		assert.strictEqual(info.stale, false);
+		assert.strictEqual(info.ageDays, null);
+		assert.strictEqual(info.label, '');
+	}
+});
+
+test('trunkAgeInfo: label names the snapshot date (issue #94)', () => {
+	const info = trunkAgeInfo({ trunkDate: '2026-06-12T00:00:00Z', now: NOW });
+	assert.match(info.label, /^trunk as of /);
+	assert.match(info.label, /2026/);
+});
+
+test('trunkAgeInfo: a future date clamps to age 0, not negative (issue #94)', () => {
+	const info = trunkAgeInfo({ trunkDate: daysAgo(-1), now: NOW });
+	assert.strictEqual(info.ageDays, 0);
+	assert.strictEqual(info.stale, false);
+});
+
+test('planUpdateSteps: install runs when the lockfile changed (issue #94)', () => {
+	const steps = planUpdateSteps({ lockfileChanged: true });
+	assert.deepStrictEqual(steps.map((s) => s.key), ['fetch', 'install', 'build']);
+	assert.strictEqual(steps[1].skipped, false);
+});
+
+test('planUpdateSteps: install is skipped, with the exact message, when the lockfile did not change (issue #94)', () => {
+	const steps = planUpdateSteps({ lockfileChanged: false });
+	assert.strictEqual(steps[1].skipped, true);
+	assert.strictEqual(steps[1].skipMessage, SKIP_INSTALL_MESSAGE);
+	assert.strictEqual(SKIP_INSTALL_MESSAGE, 'Dependencies unchanged — skipping npm install');
+});
+
+test('updateStepStatuses: while building, fetch is complete and a skipped install shows as skipped (issue #94)', () => {
+	const steps = planUpdateSteps({ lockfileChanged: false });
+	const statuses = updateStepStatuses(steps, 'building');
+	assert.deepStrictEqual(statuses, [
+		{ key: 'fetch', status: 'complete' },
+		{ key: 'install', status: 'skipped' },
+		{ key: 'build', status: 'current' }
+	]);
+});
+
+test('updateStepStatuses: while installing, later steps are pending (issue #94)', () => {
+	const steps = planUpdateSteps({ lockfileChanged: true });
+	const statuses = updateStepStatuses(steps, 'installing');
+	assert.deepStrictEqual(statuses, [
+		{ key: 'fetch', status: 'complete' },
+		{ key: 'install', status: 'current' },
+		{ key: 'build', status: 'pending' }
+	]);
+});
+
+test('updateStepStatuses: done marks every non-skipped step complete (issue #94)', () => {
+	const steps = planUpdateSteps({ lockfileChanged: false });
+	const statuses = updateStepStatuses(steps, 'done');
+	assert.deepStrictEqual(statuses.map((s) => s.status), ['complete', 'skipped', 'complete']);
+});
+
+test('updateOutcome: fetch failure is a plain failure, not incomplete (issue #94)', () => {
+	assert.strictEqual(updateOutcome({ fetchOk: false }), 'failed-fetch');
+});
+
+test('updateOutcome: already up to date (issue #94)', () => {
+	assert.strictEqual(updateOutcome({ fetchOk: true, upToDate: true }), 'up-to-date');
+});
+
+test('updateOutcome: trunk moved but install failed -> incomplete (issue #94)', () => {
+	assert.strictEqual(
+		updateOutcome({ fetchOk: true, upToDate: false, moved: true, installNeeded: true, installCode: 1, buildCode: 0 }),
+		'incomplete'
+	);
+});
+
+test('updateOutcome: trunk moved but build failed -> incomplete (issue #94)', () => {
+	assert.strictEqual(
+		updateOutcome({ fetchOk: true, upToDate: false, moved: true, installNeeded: false, buildCode: 2 }),
+		'incomplete'
+	);
+});
+
+test('updateOutcome: full chain success (issue #94)', () => {
+	assert.strictEqual(
+		updateOutcome({ fetchOk: true, upToDate: false, moved: true, installNeeded: true, installCode: 0, buildCode: 0 }),
+		'done'
+	);
+});


### PR DESCRIPTION
Closes #94.

Sites were pinned forever to the trunk of the day they were cloned — the shallow single-branch clone was never fetched again, so patches aged against a frozen snapshot and stopped applying on Trac. This implements the core update path from the issue; replay-on-top and the conflict UI (mockups 5–6) are deferred to a follow-up.

## Trunk age, everywhere it matters

- Each site records its trunk snapshot's commit date (`readCommit` of HEAD — offline, no network probe). The site header shows **"trunk as of \<date\>"** next to the created date.
- Past 14 days, an amber notice appears above the action row — worded in patch terms ("patches you create now may not apply on Trac"), not git terms — and a dot shows on the site in the sidebar before it's even opened.
- The patch modal warns when generating a patch from a stale site.

## Update to latest trunk — the whole chain, as the issue frames it

1. **Fetch and reset** (main process, new `git:update-trunk` IPC streaming over an `updateId`, same idiom as `installId`): depth-1 re-fetch, index hygiene for files a previous patch generation left staged, `writeRef` + forced checkout. Untracked local files survive.
2. **npm install, only if `package-lock.json` changed** between the two tips (blob-oid comparison before touching the worktree). The skipped step is named — "Dependencies unchanged — skipping npm install" — not hidden.
3. **Rebuild**, streaming to the existing Terminal.

Steps 2–3 reuse the existing npm machinery (engine retry, exit-code signaling, kill), chained in the renderer exactly like the dev-server start.

## Dirty trees and failure states

- Updating a dirty tree opens a modal: **Save changes as a patch** (default — a local `.diff`, nothing sent to Trac) or **Discard changes**. Saving then updates on a clean tree.
- If trunk moved but install/build failed (or the app quit mid-chain), a persisted **"update incomplete"** state survives restart: red banner ("the code is new but the built assets are old") with a retry that runs install unconditionally, plus a red sidebar dot.

## One deliberate deviation from the issue text

The issue suggests diffing patches against the remote trunk ref. This PR keeps the diff base at local HEAD: diffing local edits against a *moved* remote trunk would embed reversed upstream changes and foreign context into the patch, and it would apply nowhere. The route to Trac-applicable patches is the staleness notice + the update action, after which HEAD == origin/trunk and the two definitions coincide. This is documented at the diff site, and CLAUDE.md's wrong claim (that the base was `origin/trunk`) is corrected.

## Testing

- Decision logic is extracted into pure modules (`src/renderer/update-plan.cjs`, `src/git-update.cjs`) per the repo convention; 25 new tests, 138/138 passing.
- The full isomorphic-git sequence (shallow re-fetch against GitHub, lockfile blob comparison, index hygiene, forced checkout preserving untracked files, commit-date read) was smoke-tested end-to-end on a real shallow clone rewound 26 commits.
- Manual verification on a real wordpress-develop site: rewind with `git fetch --depth=1 origin <old-oid> && git update-ref refs/heads/trunk <old-oid> && git checkout -f trunk`, relaunch, and run the update — once with a lockfile-changing gap (install runs) and once without (skip message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)