### PR TITLE
Drop "first" from the full-build checklist copy

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -54756,7 +54756,7 @@ Try "help" for the list of supported commands.
     const toggleDevServer = async () => {
       if (!running) {
         if (!skipInit && !hasBuilt) {
-          alert("Please complete the first full build before starting the dev server. You can also skip the wizard.");
+          alert("Please complete the full build before starting the dev server. You can also skip the wizard.");
           return;
         }
         const state = terminalStateRef.current;
@@ -55109,8 +55109,8 @@ Saved your changes to ${res.filePath} and reset the working tree.
       },
       {
         key: "build",
-        label: "Run first full build",
-        description: "Compile WordPress Core once to generate the initial dist files.",
+        label: "Run full build",
+        description: "Compile WordPress Core to generate the dist files. Later updates rebuild automatically.",
         ...stepState.build,
         action: /* @__PURE__ */ (0, import_jsx_runtime61.jsx)(
           button_default,
@@ -55119,7 +55119,7 @@ Saved your changes to ${res.filePath} and reset the working tree.
             variant: hasBuilt ? "secondary" : "primary",
             onClick: runBuildWithTerminal,
             disabled: stepState.build.disabled,
-            children: hasBuilt ? "First build complete" : "Run first full build"
+            children: hasBuilt ? "Build complete" : "Run full build"
           }
         )
       },

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1305,7 +1305,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   const toggleDevServer = async ()=>{
     if (!running) {
-      if (!skipInit && !hasBuilt) { alert('Please complete the first full build before starting the dev server. You can also skip the wizard.'); return; }
+      if (!skipInit && !hasBuilt) { alert('Please complete the full build before starting the dev server. You can also skip the wizard.'); return; }
       const state = terminalStateRef.current;
       if (state.running) {
         writeToTerminal('A command is already running. Press Ctrl+C to stop it.\n');
@@ -1670,8 +1670,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     },
     {
       key: 'build',
-      label: 'Run first full build',
-      description: 'Compile WordPress Core once to generate the initial dist files.',
+      label: 'Run full build',
+      description: 'Compile WordPress Core to generate the dist files. Later updates rebuild automatically.',
       ...stepState.build,
       action: (
         <Button
@@ -1679,7 +1679,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           variant={hasBuilt ? 'secondary' : 'primary'}
           onClick={runBuildWithTerminal}
           disabled={stepState.build.disabled}
-        >{hasBuilt ? 'First build complete' : 'Run first full build'}</Button>
+        >{hasBuilt ? 'Build complete' : 'Run full build'}</Button>
       )
     },
     {


### PR DESCRIPTION
Stacked on #111 — merge that first; this shows only the copy diff.

Now that the trunk update chain rebuilds automatically, "Run first full build" reads as if later builds were also the user's job. The one-time framing is already carried by the "Initial setup checklist" heading, so the copy drops "first"/"once"/"initial" and says explicitly where later builds come from:

- Step title: "Run first full build" → **"Run full build"**
- Description: "Compile WordPress Core once to generate the initial dist files." → **"Compile WordPress Core to generate the dist files. Later updates rebuild automatically."**
- Button: "First build complete" → **"Build complete"**
- Dev-server gate alert: "complete the first full build" → "complete the full build"

Copy-only; no logic changes. Stacked on the update-path branch because the new description's claim ("later updates rebuild automatically") is only true with #111's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)