### PR TITLE
Clear the pre-existing lint backlog in index.jsx, main.js, and preload.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,7 @@ const os = require('os');
 const crypto = require('crypto');
 const fs = require('fs');
 const fse = require('fs-extra');
-const https = require('https');
 const nodeHttp = require('http');
-const extract = require('extract-zip');
 const git = require('isomorphic-git');
 const http = require('isomorphic-git/http/node');
 const JsDiff = require('diff');
@@ -30,7 +28,6 @@ const {
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 
-const WORDPRESS_ZIP_URL = 'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip';
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
 // Provide a PATH shim so npm's spawned scripts can find a 'node' binary that maps to Electron's Node
@@ -133,7 +130,7 @@ const playgroundServers = {};
 const wpDebugWatchers = {};
 /** @type {Record<string, { server: import('smtp-server').SMTPServer, port: number }>} */
 const smtpServers = {};
-/** @type {{ child: import('child_process').ChildProcess, url?: string } | null */
+/** @type {{ child: import('child_process').ChildProcess, url?: string } | null} */
 let playgroundWebServer = null;
 
 function smtpStoreKey(sitePath) {
@@ -176,11 +173,10 @@ async function ensureSmtpServerForSite(sitePath) {
         onData(stream, session, callback) {
             const chunks = [];
 			stream.on('error', (err) => {
-				console.error('[SMTP] stream error', err && err.stack ? err.stack : String(err));
+				logError('smtp', `stream error: ${err && err.stack ? err.stack : String(err)}`);
 				try { callback(err); } catch {}
 			});
 			stream.on('data', (d) => {
-				console.log(`Got a data chunk!`);
 				chunks.push(Buffer.from(d));
 			});
             stream.on('end', async () => {
@@ -206,7 +202,7 @@ async function ensureSmtpServerForSite(sitePath) {
                         })(),
                         raw: raw.toString('utf8')
                     };
-                    console.log(`[SMTP] New email for site ${sitePath}: subject="${msg.subject}" from="${msg.from}" to="${msg.to}"`);
+                    logEvent('smtp', `New email for site ${sitePath}: subject="${msg.subject}" from="${msg.from}" to="${msg.to}"`);
                     await appendSiteEmail(sitePath, msg);
                     broadcastToAll('smtp:new-email', { sitePath, message: msg });
                 } catch (e) {
@@ -222,7 +218,7 @@ async function ensureSmtpServerForSite(sitePath) {
                         headers: {},
                         raw: raw.toString('utf8')
                     };
-                    console.log(`[SMTP] New email for site ${sitePath}: (unparsed) size=${raw.length} bytes`);
+                    logError('smtp', `Failed to parse email for site ${sitePath} (size=${raw.length} bytes): ${e && e.message ? e.message : String(e)}`);
                     await appendSiteEmail(sitePath, msg);
                     broadcastToAll('smtp:new-email', { sitePath, message: msg });
                 }
@@ -303,7 +299,7 @@ async function createMinimalPatchForDir(dir) {
         if (head === 0 && workdir === 2 && stage === 0) {
             try {
                 await git.add({ fs, dir, filepath });
-            } catch (e) {
+            } catch {
                 // Ignore errors for files that can't be added (e.g., in .gitignore)
             }
         }
@@ -311,7 +307,7 @@ async function createMinimalPatchForDir(dir) {
 
     // Compare working tree vs HEAD (which points to trunk tip after clone)
     const matrixAfterAdd = await git.statusMatrix({ fs, dir });
-    const changed = matrixAfterAdd.filter(([filepath, head, workdir, stage]) => head !== workdir);
+    const changed = matrixAfterAdd.filter(([, head, workdir]) => head !== workdir);
     let patch = '';
     for (const [filepath, head, workdir] of changed) {
         const abs = require('path').join(dir, filepath);
@@ -434,7 +430,7 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		const m = meta[sitePath] || {};
 
 		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed) };
-	} catch (e) {
+	} catch {
 		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false };
 	}
 });
@@ -786,10 +782,10 @@ function playgroundLogScope(sitePath) {
 ipcMain.handle('playground:start', async (event, sitePath) => {
 	// Ensure a per-site SMTP server is running alongside the dev server and get its port
 	const smtp = await ensureSmtpServerForSite(sitePath).catch(() => null);
-	const buildDir = path.join(sitePath, 'build');
 	if (playgroundServers[sitePath]?.child) {
 		return { ok: true, url: playgroundServers[sitePath].url };
 	}
+	const buildDir = path.join(sitePath, 'build');
 	const runnerPath = path.join(__dirname, 'server-runner.js');
 	const logScope = playgroundLogScope(sitePath);
 	logEvent(logScope, `starting server for ${buildDir} (smtp port ${(smtp && smtp.port) ? smtp.port : 25})`);
@@ -914,7 +910,7 @@ ipcMain.handle('playground-web:available', async () => {
     return false;
 });
 
-ipcMain.handle('playground-web:start', async (event) => {
+ipcMain.handle('playground-web:start', async () => {
     if (playgroundWebServer?.child) {
         return { ok: true, url: playgroundWebServer.url || 'http://127.0.0.1:39372/' };
     }
@@ -923,7 +919,7 @@ ipcMain.handle('playground-web:start', async (event) => {
     const expectedUrl = 'http://127.0.0.1:39372/';
     const reachable = await new Promise((resolve) => {
         try {
-            const req = nodeHttp.get(expectedUrl, (res) => { try { req.destroy(); } catch {}; resolve(true); });
+            const req = nodeHttp.get(expectedUrl, () => { try { req.destroy(); } catch {}; resolve(true); });
             req.on('error', () => { try { req.destroy(); } catch {}; resolve(false); });
             req.setTimeout(1000, () => { try { req.destroy(); } catch {}; resolve(false); });
         } catch { resolve(false); }
@@ -937,7 +933,7 @@ ipcMain.handle('playground-web:start', async (event) => {
         path.join(app.getAppPath(), 'local-playground-web'),
         path.join(__dirname, '..', 'local-playground-web')
     ];
-    let webDir = webDirCandidates.find((p) => { try { return fs.existsSync(p); } catch { return false; } });
+    const webDir = webDirCandidates.find((p) => { try { return fs.existsSync(p); } catch { return false; } });
     if (!webDir) {
         return { ok: false, error: 'local-playground-web directory not found.' };
     }
@@ -1009,7 +1005,7 @@ ipcMain.handle('playground-web:start', async (event) => {
         // Fallback readiness probe if CLI output is not captured
         const probe = () => {
             try {
-                const req = nodeHttp.get(expectedUrl, (res) => {
+                const req = nodeHttp.get(expectedUrl, () => {
                     try { req.destroy(); } catch {}
                     if (!resolved) {
                         resolved = true;
@@ -1085,11 +1081,11 @@ ipcMain.handle('smtp:stop', async (_e, sitePath) => {
 
 // --- WordPress debug.log tailing ---
 function startWpDebugTail(sitePath, webContents) {
-	const wpContentDir = path.join(sitePath, 'build', 'wp-content');
-	const filePath = path.join(wpContentDir, 'debug.log');
 	if (wpDebugWatchers[sitePath]?.fileWatcher || wpDebugWatchers[sitePath]?.dirWatcher) {
 		return true;
 	}
+	const wpContentDir = path.join(sitePath, 'build', 'wp-content');
+	const filePath = path.join(wpContentDir, 'debug.log');
 	wpDebugWatchers[sitePath] = { filePath, lastSize: 0 };
 	const state = wpDebugWatchers[sitePath];
 
@@ -1158,36 +1154,3 @@ ipcMain.handle('wp-debug:stop', async (_event, sitePath) => {
 	return true;
 });
 
-function downloadFile(url, dest, onProgress) {
-	return new Promise((resolve, reject) => {
-		const file = fs.createWriteStream(dest);
-		let receivedBytes = 0;
-		let totalBytes = 0;
-
-		https.get(url, (response) => {
-			if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
-				// handle redirect
-				return https.get(response.headers.location, (res2) => handleResponse(res2));
-			}
-			handleResponse(response);
-		}).on('error', (err) => {
-			fs.unlink(dest, () => reject(err));
-		});
-
-		function handleResponse(response) {
-			if (response.statusCode !== 200) {
-				fs.unlink(dest, () => reject(new Error(`Failed to get '${url}' (${response.statusCode})`)));
-				return;
-			}
-			totalBytes = parseInt(response.headers['content-length'] || '0', 10);
-			response.on('data', (chunk) => {
-				receivedBytes += chunk.length;
-				if (onProgress && totalBytes) {
-					onProgress({ receivedBytes, totalBytes, percent: (receivedBytes / totalBytes) * 100 });
-				}
-			});
-			response.pipe(file);
-			file.on('finish', () => file.close(resolve));
-		}
-	});
-}

--- a/src/preload.js
+++ b/src/preload.js
@@ -72,7 +72,7 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	startWpDebug: async (sitePath, onData) => {
 		const handler = (_e, payload) => {
-			if (payload.sitePath === sitePath) onData && onData(payload.data);
+			if (payload.sitePath === sitePath && onData) onData(payload.data);
 		};
 		ipcRenderer.on('wp:debug-log:data', handler);
 		await ipcRenderer.invoke('wp-debug:start', sitePath);
@@ -84,17 +84,17 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	startServer: async (sitePath, onLog, onUrl, onStopped) => {
 		const logHandler = (_e, payload) => {
-			if (payload.sitePath === sitePath) onLog && onLog(payload);
+			if (payload.sitePath === sitePath && onLog) onLog(payload);
 		};
 		const urlHandler = (_e, payload) => {
-			if (payload.sitePath === sitePath) onUrl && onUrl(payload.url);
+			if (payload.sitePath === sitePath && onUrl) onUrl(payload.url);
 		};
 		const stoppedHandler = (_e, payload) => {
 			if (payload.sitePath === sitePath) {
 				ipcRenderer.removeListener('playground:log', logHandler);
 				ipcRenderer.removeListener('playground:url', urlHandler);
 				ipcRenderer.removeListener('playground:stopped', stoppedHandler);
-				onStopped && onStopped();
+				if (onStopped) onStopped();
 			}
 		};
 		ipcRenderer.on('playground:log', logHandler);
@@ -114,13 +114,13 @@ contextBridge.exposeInMainWorld('api', {
 	}
 ,
 	startPlaygroundWeb: async (onLog, onUrl, onStopped) => {
-		const logHandler = (_e, payload) => { onLog && onLog(payload); };
-		const urlHandler = (_e, payload) => { onUrl && onUrl(payload.url); };
+		const logHandler = (_e, payload) => { if (onLog) onLog(payload); };
+		const urlHandler = (_e, payload) => { if (onUrl) onUrl(payload.url); };
 		const stoppedHandler = (_e, payload) => {
 			ipcRenderer.removeListener('playground-web:log', logHandler);
 			ipcRenderer.removeListener('playground-web:url', urlHandler);
 			ipcRenderer.removeListener('playground-web:stopped', stoppedHandler);
-			onStopped && onStopped(payload);
+			if (onStopped) onStopped(payload);
 		};
 		ipcRenderer.on('playground-web:log', logHandler);
 		ipcRenderer.on('playground-web:url', urlHandler);
@@ -157,13 +157,13 @@ contextBridge.exposeInMainWorld('api', {
 	}
 ,
 	onNewEmail: (sitePath, handler) => {
-		const h = (_e, payload) => { if (payload.sitePath === sitePath) handler && handler(payload.message); };
+		const h = (_e, payload) => { if (payload.sitePath === sitePath && handler) handler(payload.message); };
 		ipcRenderer.on('smtp:new-email', h);
 		return () => ipcRenderer.removeListener('smtp:new-email', h);
 	}
 ,
 	onSmtpStarted: (sitePath, handler) => {
-		const h = (_e, payload) => { if (payload.sitePath === sitePath) handler && handler(payload.port); };
+		const h = (_e, payload) => { if (payload.sitePath === sitePath && handler) handler(payload.port); };
 		ipcRenderer.on('smtp:started', h);
 		return () => ipcRenderer.removeListener('smtp:started', h);
 	}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -27,6 +27,12 @@ const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
 const CREATE_SITE_LOCATION_INPUT_ID = 'create-site-location-input';
 const CREATE_SITE_LOCATION_HELP_ID = 'create-site-location-help';
 const CREATE_SITE_MODAL_STYLE_ID = 'create-site-modal-theme';
+
+function formatEmailDate(email) {
+  if (email.sentAt) return new Date(email.sentAt).toLocaleString();
+  if (email.date) return new Date(email.date).toLocaleString();
+  return '';
+}
 const FEEDBACK_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLScnMxicyDxZO2OoaS5ela8FArYWjCyLfC3hxRBBRSF7XLPzKg/viewform';
 
 function useSites() {
@@ -78,7 +84,7 @@ function App() {
   const appendSetupLog = useCallback((siteTarget, message) => {
     const key = siteTarget ? String(siteTarget) : '';
     if (!key) return;
-    const chunk = message != null ? String(message) : '';
+    const chunk = message !== null && message !== undefined ? String(message) : '';
     if (!chunk) return;
     let resolvedKey = key;
     const aliasMap = setupLogAliasRef.current;
@@ -175,7 +181,7 @@ function App() {
       if (s.phase === 'cloning') setDownloadPhase('Cloning repository…');
       else if (s.phase === 'done') { setDownloadPhase(''); clearPendingSites(); setTerminalMsgs(''); }
     });
-    return () => { unsubProg && unsubProg(); unsubStat && unsubStat(); };
+    return () => { if (unsubProg) unsubProg(); if (unsubStat) unsubStat(); };
   }, [addPendingSite, appendSetupLog, clearPendingSites]);
 
   const chooseAndSetup = useCallback(() => {
@@ -409,6 +415,9 @@ function App() {
         [sitePath]: { ...(meta?.[sitePath] || {}), label: newLabel }
       }));
     } catch (err) {
+      // Pre-existing UX convention in this file; replacing every alert()/confirm()
+      // with an in-app notice is a separate, larger UX change than a lint cleanup should make.
+      // eslint-disable-next-line no-alert
       alert(String(err));
     }
   }, [setSiteMeta]);
@@ -501,12 +510,13 @@ function App() {
           />
         </div>
         <div style={{ flex: 1, overflowY: 'auto', padding: sidebarCollapsed ? '12px 8px' : '12px 16px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {sortedSites.length > 0 ? sortedSites.map((sitePath) => {
+          {sortedSites.length === 0 && !sidebarCollapsed ? (
+            <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.7)' }}>No sites yet.</div>
+          ) : null}
+          {sortedSites.map((sitePath) => {
             const meta = siteMeta?.[sitePath] || {};
             const siteName = (meta.label && meta.label.trim()) || pathBasename(sitePath);
-            const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : '';
             const isActive = activeSite === sitePath;
-            const statusLabel = meta.initialized ? 'Initialized' : 'Not initialized';
             return (
               <Button
                 key={sitePath}
@@ -533,9 +543,7 @@ function App() {
                 )}
               </Button>
             );
-          }) : (!sidebarCollapsed ? (
-            <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.7)' }}>No sites yet.</div>
-          ) : null)}
+          })}
         </div>
         <div
           style={{
@@ -581,9 +589,11 @@ function App() {
                   <div style={{ display:'flex', alignItems:'center', gap:8, justifyContent:'space-between' }}>
                     <div style={{ fontWeight: 600 }}>Playground web server</div>
                     <div style={{ fontSize:12, color:'#666' }}>
-                      {webStarting ? 'Starting…' : (webUrl ? (
+                      {webStarting ? 'Starting…' : null}
+                      {!webStarting && webUrl ? (
                         <a href={webUrl} onClick={(e)=>{ e.preventDefault(); window.api.openExternal(webUrl); }}>{webUrl}</a>
-                      ) : 'Stopped')}
+                      ) : null}
+                      {!webStarting && !webUrl ? 'Stopped' : null}
                     </div>
                   </div>
                   {webError ? (<div style={{ marginTop:6, color:'#C00', fontSize:12 }}>{webError}</div>) : null}
@@ -643,6 +653,7 @@ function App() {
           onRequestClose={closeCreateModal}
           shouldCloseOnClickOutside={!createSubmitting}
         >
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Escape-to-close/Enter-to-submit on the modal form is standard, intentional behavior. */}
           <form
             onSubmit={handleCreateModalSubmit}
             onKeyDown={handleCreateModalKeyDown}
@@ -655,6 +666,7 @@ function App() {
               onChange={(value) => setCreateSiteName(value)}
               disabled={createSubmitting}
               placeholder="My WordPress site"
+              // eslint-disable-next-line jsx-a11y/no-autofocus -- intentional: this is the first field of a just-opened modal.
               autoFocus
             />
             <label htmlFor={CREATE_SITE_LOCATION_INPUT_ID} style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.02em', color: '#1d2327' }}>Site location</label>
@@ -664,6 +676,7 @@ function App() {
                 id={CREATE_SITE_LOCATION_INPUT_ID}
                 type="file"
                 webkitdirectory=""
+                // eslint-disable-next-line react/no-unknown-property -- non-standard but required alongside webkitdirectory for cross-browser directory pickers.
                 directory=""
                 multiple
                 onChange={handleCreateDirInputChange}
@@ -698,7 +711,6 @@ function App() {
 }
 
 function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onForget, onDelete, onRename, isPending = false, setupLogs = '' }) {
-  const safeOnRename = onRename || (() => {});
   // state
   const [serverUrl, setServerUrl] = useState('');
   const [starting, setStarting] = useState(false);
@@ -715,7 +727,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   const smtpStartedUnsubRef = useRef(null);
   const [isEmailOpen, setIsEmailOpen] = useState(false);
   const [activeEmail, setActiveEmail] = useState(null);
-  const [emailViewTab, setEmailViewTab] = useState('rendered');
+  const [, setEmailViewTab] = useState('rendered');
   const [building, setBuilding] = useState(false);
   const [hasNodeModules, setHasNodeModules] = useState(false);
   const [installFailed, setInstallFailed] = useState(false);
@@ -781,14 +793,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     try {
       setRenaming(true);
       setRenameError('');
-      await safeOnRename(sitePath, trimmed);
+      if (onRename) await onRename(sitePath, trimmed);
       setRenameModalOpen(false);
     } catch (err) {
       setRenameError(String(err));
     } finally {
       setRenaming(false);
     }
-  }, [renameValue, safeOnRename, sitePath]);
+  }, [onRename, renameValue, sitePath]);
 
   const handleRenameSubmit = useCallback((event) => {
     event.preventDefault();
@@ -820,6 +832,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
       copyTimeoutRef.current = setTimeout(() => setPathCopied(false), 1500);
     } catch (err) {
+      // eslint-disable-next-line no-alert -- see the note above onRename.
       alert('Unable to copy path: ' + (err?.message ?? String(err)));
     }
   }, [sitePath]);
@@ -1245,11 +1258,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
       return;
     }
     window.api.startWpDebug(sitePath,(d)=>appendRuntime(d || ''));
-    try { const { port, emails } = await window.api.getEmails(sitePath); if (port) setSmtpPort(port); setEmails(emails||[]); } catch {}
+    try { const { port, emails: fetchedEmails } = await window.api.getEmails(sitePath); if (port) setSmtpPort(port); setEmails(fetchedEmails||[]); } catch {}
   }, [appendRuntime, ensureStick, killCurrent, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails, stopDevServer]);
 
   const toggleDevServer = async ()=>{
     if (!running) {
+      // eslint-disable-next-line no-alert -- see the note above onRename.
       if (!skipInit && !hasBuilt) { alert('Please complete the first full build before starting the dev server. You can also skip the wizard.'); return; }
       const state = terminalStateRef.current;
       if (state.running) {
@@ -1332,6 +1346,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   };
   const isServerStarting = waitingForWatch || (starting && !serverUrl);
   const isDevProcessActive = running || isServerStarting;
+  let devServerButtonLabel = 'Start dev server';
+  if (isDevProcessActive) devServerButtonLabel = isServerStarting ? 'Starting dev server...' : 'Stop dev server';
   // Elapsed-seconds counter for the starting state, so a slow boot is
   // distinguishable from a hang (issue #73).
   const [startElapsed, setStartElapsed] = useState(0);
@@ -1347,6 +1363,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     await window.api.setSkipInitWizard(sitePath, true);
     setSkipInit(true);
   }, [sitePath]);
+  // eslint-disable-next-line no-alert -- see the note above onRename.
   const confirmAnd = async (m,a)=>{ if(window.confirm(m)) await a(); };
 
   const openPatchModal = async ()=>{
@@ -1372,13 +1389,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     try {
       const res = await window.api.savePatch(sitePath);
       if (res && res.ok && res.filePath) {
+        // eslint-disable-next-line no-alert -- see the note above onRename.
         alert(`Diff saved to: ${res.filePath}`);
       } else if (res && res.canceled) {
         // User canceled, do nothing
       } else {
+        // eslint-disable-next-line no-alert -- see the note above onRename.
         alert(`Error saving diff: ${res && res.error ? res.error : 'Unknown error'}`);
       }
     } catch (e) {
+      // eslint-disable-next-line no-alert -- see the note above onRename.
       alert(`Error saving diff: ${e && e.message ? e.message : String(e)}`);
     }
   };
@@ -1441,6 +1461,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     installFailed
   });
 
+  let installLabel = 'Install npm dependencies';
+  if (stepState.install.done) installLabel = 'Dependencies installed';
+  else if (installFailed) installLabel = 'Retry npm install';
+
   const baseSteps = [
     {
       key: 'download',
@@ -1461,7 +1485,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           variant={stepState.install.done ? 'secondary' : 'primary'}
           onClick={runInstallWithTerminal}
           disabled={stepState.install.disabled}
-        >{stepState.install.done ? 'Dependencies installed' : installFailed ? 'Retry npm install' : 'Install npm dependencies'}</Button>
+        >{installLabel}</Button>
       )
     },
     {
@@ -1496,9 +1520,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           >{running ? 'Stop dev server' : 'Start dev server and finish the wizard'}</Button>
           {starting || serverUrl ? (
             <span style={{ fontSize: 12 }}>
-              {starting ? `Starting… (${formatElapsed(startElapsed)})` : (serverUrl ? (
+              {starting ? `Starting… (${formatElapsed(startElapsed)})` : null}
+              {!starting && serverUrl ? (
                 <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
-              ) : null)}
+              ) : null}
             </span>
           ) : null}
         </div>
@@ -1654,7 +1679,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
                   }}
                 />
               ) : null}
-              <span style={{ fontWeight: 600 }}>{isDevProcessActive ? (isServerStarting ? 'Starting dev server...' : 'Stop dev server') : 'Start dev server'}</span>
+              <span style={{ fontWeight: 600 }}>{devServerButtonLabel}</span>
             </Button>
             <Button
               variant="secondary"
@@ -1718,7 +1743,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               const when = m.sentAt || m.date; const whenStr = when ? new Date(when).toLocaleString() : '';
               return (
                 <div key={m.id}
+                  role="button"
+                  tabIndex={0}
                   onClick={()=>openEmail(m)}
+                  onKeyDown={(e)=>{ if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openEmail(m); } }}
                   style={{ padding:'8px 10px', cursor:'pointer', borderBottom:'1px solid #eee', display:'flex', gap:8 }}
                 >
                   <div style={{ flex:'0 0 180px', color:'#555', fontSize:12 }}>{whenStr}</div>
@@ -1738,6 +1766,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           onRequestClose={closeRenameModal}
           shouldCloseOnClickOutside={!renaming}
         >
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- Escape-to-close/Enter-to-submit on the modal form is standard, intentional behavior. */}
           <form
             onSubmit={handleRenameSubmit}
             onKeyDown={handleRenameFormKeyDown}
@@ -1749,6 +1778,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               value={renameValue}
               onChange={(value) => setRenameValue(value)}
               disabled={renaming}
+              // eslint-disable-next-line jsx-a11y/no-autofocus -- intentional: this is the only field of a just-opened modal.
               autoFocus
             />
             {renameError ? <div style={{ color: '#d63638', fontSize: 12 }}>{renameError}</div> : null}
@@ -1770,7 +1800,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
           <div style={{ display:'flex', flexDirection:'column', height:'80vh', gap:12 }}>
             {!patchLoading && (
               <div style={{ padding:'12px 16px', background:'#f0f6fc', border:'1px solid #d0d7de', borderRadius:6, fontSize:14, lineHeight:1.5, color:'#24292f' }}>
-                <strong>Next steps:</strong> Save this patch and submit it to the relevant WordPress Trac ticket at <a href="#" onClick={(e) => { e.preventDefault(); window.api.openExternal('https://core.trac.wordpress.org'); }} style={{color:'#0969da', cursor:'pointer'}}>core.trac.wordpress.org</a>
+                <strong>Next steps:</strong> Save this patch and submit it to the relevant WordPress Trac ticket at <button type="button" onClick={() => window.api.openExternal('https://core.trac.wordpress.org')} style={{color:'#0969da', cursor:'pointer', background:'none', border:'none', padding:0, font:'inherit', textDecoration:'underline'}}>core.trac.wordpress.org</button>
               </div>
             )}
             <div style={{ position:'relative', flex:1, minHeight:0 }}>
@@ -1820,7 +1850,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               <div><strong>From:</strong> {activeEmail.from || ''}</div>
               <div><strong>To:</strong> {activeEmail.to || ''}</div>
               {activeEmail.cc ? (<div><strong>CC:</strong> {activeEmail.cc}</div>) : null}
-              <div><strong>Date:</strong> {activeEmail.sentAt ? new Date(activeEmail.sentAt).toLocaleString() : (activeEmail.date ? new Date(activeEmail.date).toLocaleString() : '')}</div>
+              <div><strong>Date:</strong> {formatEmailDate(activeEmail)}</div>
             </div>
             <TabPanel className="email-tabs" activeClass="is-active" onSelect={(n)=>setEmailViewTab(n)} tabs={[{name:'rendered',title:'Rendered'},{name:'raw',title:'Raw'}]}>
               {(tab)=> tab.name==='rendered' ? (


### PR DESCRIPTION
## Summary

- The repo had no linter until #112, so `eslint .` reports pre-existing findings across files nobody had touched since — 57 of them concentrated in `src/renderer/index.jsx`, `src/main.js`, and `src/preload.js`. These three kept blocking #111's lint check on lines that PR never modified.
- Clears all of them in these three files. `lint.yml` still only lints changed files, but once eslint eventually moves to the full repo, these three won't be part of the remaining work.
- Mechanical fixes (unused vars/imports, nested ternaries, `no-unused-expressions`, `no-shadow`, `eqeqeq`, `prefer-const`, JSDoc `@param`) preserve behavior exactly.
- Judgment calls, each documented inline:
  - `console.*` in the SMTP handler → the existing `logEvent`/`logError` helpers from `./logging`, matching the rest of the main process.
  - `alert()`/`confirm()` are left in place with justified `eslint-disable` comments — replacing this file's whole alert-based UX convention is a separate, larger change than a lint cleanup should make.
  - Two dead zip-download-era leftovers removed: `downloadFile()` and `WORDPRESS_ZIP_URL` (and their now-unused `https`/`extract-zip` imports) — the app clones via git now, nothing calls either.
  - A couple of genuine accessibility gaps fixed: the email list row gets a keyboard handler alongside its click handler, and an anchor styled as a button became a real `<button>`.

## Test plan

- [x] `npx eslint --max-warnings=0 --no-warn-ignored src/renderer/index.jsx src/main.js src/preload.js` — clean
- [x] `npm test` — 113/113 passing
- [x] `npx eslint .` — remaining findings are all outside these three files (untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)