### PR TITLE
Finish the lint baseline and widen the CI check to the whole repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,16 @@
-# ESLint over the files a PR actually touches.
+# ESLint over the whole repo.
 #
-# Scoped to changed files on purpose. The repo had no linter until now, so `eslint .`
-# reports ~85 pre-existing findings; running it repo-wide would fail every PR for code
-# the author never touched. Linting only the diff means new code is held to the standard
-# from day one while the backlog gets cleared separately — the same trade gutenberg makes
-# with its lint suppression files.
+# This used to lint only the files a PR touched, because the linter arrived on top of a
+# backlog of pre-existing findings and running it repo-wide would have failed every PR for
+# code the author never wrote. That backlog is now clear (#117), so the check covers
+# everything and can be made a required one.
 #
-# Not a required check yet. Once the backlog is clear this can move to `eslint .` on both
-# pull_request and push, and then be required.
+# Kept in git history rather than in a flag: the changed-files job is the right shape again
+# if a future rule ever lands with a backlog behind it. `git log -- .github/workflows/lint.yml`
+# has it.
+#
+# Runs on push as well as pull_request so trunk carries a status of its own — a branch
+# protection rule has nothing to require otherwise.
 #
 # Nothing here needs secrets, and it deliberately never executes the PR's code:
 # `npm ci --ignore-scripts` skips lifecycle scripts (this repo's postinstall pulls the
@@ -17,6 +20,8 @@ name: Lint
 
 on:
   pull_request:
+  push:
+    branches: [ trunk ]
 
 permissions:
   contents: read
@@ -29,10 +34,8 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      # Full history: the changed-file list is computed against the merge base.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           # Keeps the job's GITHUB_TOKEN out of .git/config. Lower stakes than in
           # ai-review.yml — nothing here reads the tree back out to an attacker-facing
           # channel — but leaving a token on disk that a later change could expose is not
@@ -47,22 +50,5 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Collect changed JavaScript files
-        id: changed
-        run: |
-          # ACMR: added/copied/modified/renamed. Deleted files have nothing to lint.
-          # Three-dot compares against the merge base, so unrelated commits that landed
-          # on the base branch after this PR opened are not attributed to it.
-          git diff --name-only --diff-filter=ACMR \
-            "origin/${{ github.base_ref }}...HEAD" \
-            -- '*.js' '*.jsx' '*.cjs' '*.mjs' > changed.txt
-          echo "count=$(wc -l < changed.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
-          echo "Changed JavaScript files:"
-          cat changed.txt
-
       - name: ESLint
-        if: steps.changed.outputs.count != '0'
-        # --no-warn-ignored: a PR may touch a generated file (src/renderer/bundle.js) that
-        # the config ignores. Passing it explicitly would otherwise be a warning, and
-        # --max-warnings=0 would turn that into a failure.
-        run: xargs npx eslint --max-warnings=0 --no-warn-ignored < changed.txt
+        run: npx eslint . --max-warnings=0

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,4 +80,29 @@ export default [
 			globals: { ...globals.node },
 		},
 	},
+
+	{
+		// Files whose stdout *is* their interface, so `no-console` is simply wrong
+		// there. The runners are spawned as child processes (process.execPath +
+		// ELECTRON_RUN_AS_NODE=1) and main.js reads their stdout/stderr back and
+		// streams it to the renderer — deleting a console call would delete the
+		// message. Everything under scripts/ is a CLI entry point that reports to
+		// the terminal it was run from.
+		//
+		// Scoped to these files rather than switched off globally: in main.js,
+		// preload.js and the renderer a stray console statement really is a
+		// leftover, and the rule should keep catching it. scripts/ is a glob
+		// because every file in there is an entry point; if a non-CLI helper ever
+		// lands beside them, list the entry points instead.
+		files: [
+			'src/install-runner.js',
+			'src/script-runner.js',
+			'src/server-runner.js',
+			'src/playground-web-runner.js',
+			'scripts/**/*.cjs',
+		],
+		rules: {
+			'no-console': 'off',
+		},
+	},
 ];

--- a/src/kill-tree.js
+++ b/src/kill-tree.js
@@ -21,6 +21,10 @@
 /**
  * Pure decision: how to kill the tree rooted at `pid` on `platform`.
  * Returns null for a pid that cannot identify a live process.
+ *
+ * @param {string} platform
+ * @param {number} pid
+ * @return {?Object}
  */
 function killTreePlan(platform, pid) {
 	if (!Number.isInteger(pid) || pid <= 0) return null;
@@ -34,6 +38,14 @@ function killTreePlan(platform, pid) {
  * Applies killTreePlan to a ChildProcess. Never throws: this runs during
  * quit, where a failure to kill one child must not stop the sweep of the rest.
  * Returns true when a kill was attempted.
+ *
+ * @param {?Object}  child
+ * @param {Object}   [deps]           Injection points, so the tests can assert
+ *                                    the plan without spawning anything.
+ * @param {string}   [deps.platform]
+ * @param {Function} [deps.spawnSync]
+ * @param {Function} [deps.kill]
+ * @return {boolean}
  */
 function killChildTree(child, {
 	platform = process.platform,

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -51,9 +51,9 @@ function createEngineMismatchDetector() {
 function shouldRetryWithRelaxedEngines({ code, signal, sawEngineMismatch, alreadyRelaxed, cancelled }) {
 	if (alreadyRelaxed) return false;
 	if (cancelled) return false;
-	// A non-null signal means the process was terminated rather than exiting.
+	// A signal means the process was terminated rather than exiting on its own.
 	// Windows kills surface as a plain non-zero code, hence the `cancelled` flag.
-	if (signal != null) return false;
+	if (signal) return false;
 	if (code === 0) return false;
 	return Boolean(sawEngineMismatch);
 }

--- a/src/renderer/dev-server-command.cjs
+++ b/src/renderer/dev-server-command.cjs
@@ -47,6 +47,9 @@ function planDevServerStart(flags = {}) {
  * Formats a duration in whole seconds for the "Starting dev server…" counter:
  * '42s' under a minute, '3m 05s' above. The counter exists so a contributor on
  * a slow machine can tell a boot in progress from a hang (issue #73).
+ *
+ * @param {number} seconds
+ * @return {string}
  */
 function formatElapsed(seconds) {
 	const total = Math.max(0, Math.floor(Number(seconds) || 0));

--- a/src/renderer/path-basename.cjs
+++ b/src/renderer/path-basename.cjs
@@ -4,7 +4,12 @@
 // `C:\...` path in the sidebar for any site without a stored label (#87).
 'use strict';
 
-/** Last path segment on any platform; the input itself when there is none. */
+/**
+ * Last path segment on any platform; the input itself when there is none.
+ *
+ * @param {*} p
+ * @return {string}
+ */
 function pathBasename(p) {
 	const s = String(p ?? '');
 	return s.split(/[\\/]/).filter(Boolean).pop() || s;


### PR DESCRIPTION
Closes #117.

CI linted only the files a PR touched. That was the right call when the linter landed on top of a backlog, but it meant new code was held to the standard while everything else drifted, and the check could not be made required.

## The console findings are not debt

17 of the 27 remaining findings were `no-console` in the runner modules and the build scripts. Those runners are spawned as child processes (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`) and `main.js` reads their stdout/stderr back to stream it to the renderer — their console output *is* the transport. Deleting a call would delete the message.

So this is a lint-config gap, fixed with one config block scoped to those four runners plus `scripts/**/*.cjs`. The rule stays on in `main.js`, `preload.js` and the renderer, where a stray console statement really is a leftover. Verified both directions: a temporary `console.log` in `main.js` still fails lint while `server-runner.js` passes.

## The genuine debt

- `@param`/`@return` tags on `kill-tree.js` (7), `dev-server-command.cjs` (1), `path-basename.cjs` (1).
- One loose equality in `npm-runner.js`. It becomes a truthiness check rather than `!== null`, because `!== null` would change behaviour for an `undefined` signal (early return instead of falling through). No caller passes `undefined` today — the only production call site is a `close` handler — but truthiness keeps the fix behaviourally identical to what was there.

## The workflow

Now `npx eslint . --max-warnings=0`, and it runs on push to trunk as well as on pull requests so the default branch carries a status of its own — a protection rule has nothing to require otherwise.

The changed-files job is dropped rather than kept behind a flag; it stays in `git log -- .github/workflows/lint.yml`, which the header comment points at. It is the right shape again if a future rule ever lands with a backlog behind it.

## Testing

- `npm run lint` exits 0 with no output.
- `npm test` — 147/147.
- The narrowness check described above.

## Follow-ups, not in this PR

- **Making the check required** is a branch-protection setting, not a file. Worth doing once this merges and the push run has reported on trunk.
- `npm run build:once` produces a ~320-line diff in the committed `src/renderer/index.js`, containing `isUpdating` logic from #111 — the committed bundle is out of sync with its source on trunk. Left alone here to keep this diff readable; filed as #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
