### PR TITLE
Let a site know which Trac ticket it is being used for

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, update
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
 const { deleteRegisteredSite } = require('./site-registry');
 const { getStore } = require('./settings-store');
+const { parseTicketRef } = require('./renderer/trac-ticket.cjs');
 
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
@@ -545,9 +546,9 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 			}
 		} catch {}
 
-		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(m.updateIncomplete) };
+		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(m.updateIncomplete), tracTicket: m.tracTicket || null };
 	} catch {
-		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false };
+		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false, tracTicket: null };
 	}
 });
 
@@ -631,6 +632,10 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 			? options.siteLabel.trim()
 			: uniqueName;
 		meta[siteDir] = { initialized: false, createdAt: new Date().toISOString(), label: siteLabel };
+		// "What are you working on?" is optional at creation (#109); an
+		// unparseable answer is dropped rather than failing the clone.
+		const ticket = parseTicketRef(options.tracTicket);
+		if (ticket.ok) meta[siteDir].tracTicket = ticket.id;
 		try {
 			const { trunkOid, trunkDate } = await readTrunkInfo(siteDir);
 			meta[siteDir].trunkOid = trunkOid;
@@ -687,6 +692,27 @@ ipcMain.handle('sites:set-label', async (_e, sitePath, label) => {
 	meta[sitePath] = { ...(meta[sitePath] || {}), label: trimmed || null };
 	s.set('siteMeta', meta);
 	return true;
+});
+
+// Which Trac ticket a site is being used to work on (#109). Stored as a plain
+// number in siteMeta: the association is local and offline, so linking a
+// ticket never depends on Trac being reachable.
+ipcMain.handle('sites:set-ticket', async (_e, sitePath, ref) => {
+	try {
+		// Empty means unlink — the panel's Unlink button and a cleared field
+		// both land here, and neither is an error.
+		const raw = typeof ref === 'string' ? ref.trim() : '';
+		if (!raw) {
+			await mergeSiteMeta(sitePath, { tracTicket: null });
+			return { ok: true, ticket: null };
+		}
+		const parsed = parseTicketRef(raw);
+		if (!parsed.ok) return { ok: false, error: parsed.error };
+		await mergeSiteMeta(sitePath, { tracTicket: parsed.id });
+		return { ok: true, ticket: parsed.id };
+	} catch (e) {
+		return { ok: false, error: String(e) };
+	}
 });
 
 // Only the schemes the app actually uses reach the OS — see external-url.js for

--- a/src/main.js
+++ b/src/main.js
@@ -705,6 +705,9 @@ ipcMain.handle('sites:set-label', async (_e, sitePath, label) => {
 // ticket never depends on Trac being reachable.
 ipcMain.handle('sites:set-ticket', async (_e, sitePath, ref) => {
 	try {
+		const s = await getStore();
+		const sites = s.get('sites') || [];
+		if (!sites.includes(sitePath)) return { ok: false, error: 'Site is not registered' };
 		// Empty means unlink — the panel's Unlink button and a cleared field
 		// both land here, and neither is an error.
 		const raw = typeof ref === 'string' ? ref.trim() : '';
@@ -1302,4 +1305,3 @@ ipcMain.handle('wp-debug:stop', async (_event, sitePath) => {
 	stopWpDebugTail(sitePath);
 	return true;
 });
-

--- a/src/main.js
+++ b/src/main.js
@@ -631,11 +631,17 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 		const siteLabel = typeof options.siteLabel === 'string' && options.siteLabel.trim().length
 			? options.siteLabel.trim()
 			: uniqueName;
-		meta[siteDir] = { initialized: false, createdAt: new Date().toISOString(), label: siteLabel };
-		// "What are you working on?" is optional at creation (#109); an
-		// unparseable answer is dropped rather than failing the clone.
+		const existingMeta = meta[siteDir] || {};
+		meta[siteDir] = {
+			...existingMeta,
+			initialized: false,
+			createdAt: existingMeta.createdAt || new Date().toISOString(),
+			label: existingMeta.label || siteLabel
+		};
 		const ticket = parseTicketRef(options.tracTicket);
-		if (ticket.ok) meta[siteDir].tracTicket = ticket.id;
+		if (ticket.ok && !Object.prototype.hasOwnProperty.call(existingMeta, 'tracTicket')) {
+			meta[siteDir].tracTicket = ticket.id;
+		}
 		try {
 			const { trunkOid, trunkDate } = await readTrunkInfo(siteDir);
 			meta[siteDir].trunkOid = trunkOid;

--- a/src/preload.js
+++ b/src/preload.js
@@ -52,6 +52,8 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	setSiteLabel: (sitePath, label) => ipcRenderer.invoke('sites:set-label', sitePath, label)
 ,
+	setSiteTicket: (sitePath, ref) => ipcRenderer.invoke('sites:set-ticket', sitePath, ref)
+,
 	subscribeSetupProgress: (handler) => {
 		const h = (_e, payload) => handler && handler(payload);
 		ipcRenderer.on('download:progress', h);

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -20,6 +20,7 @@ import { computeSetupStepState } from './setup-steps.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
 import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE } from './update-plan.cjs';
+import { parseTicketRef, ticketUrl } from './trac-ticket.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // Per-status wording for the update chain card (#94), following the issue's
@@ -41,6 +42,8 @@ const RENAME_INPUT_ID = 'rename-site-name-input';
 const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
 const CREATE_SITE_LOCATION_INPUT_ID = 'create-site-location-input';
 const CREATE_SITE_LOCATION_HELP_ID = 'create-site-location-help';
+const CREATE_SITE_TICKET_INPUT_ID = 'create-site-ticket-input';
+const TRAC_TICKET_LISTS_URL = 'https://core.trac.wordpress.org/tickets/good-first-bugs';
 const CREATE_SITE_MODAL_STYLE_ID = 'create-site-modal-theme';
 
 function formatEmailDate(email) {
@@ -91,6 +94,7 @@ function App() {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [createSiteName, setCreateSiteName] = useState('');
   const [createSiteDir, setCreateSiteDir] = useState('');
+  const [createSiteTicket, setCreateSiteTicket] = useState('');
   const [createSiteError, setCreateSiteError] = useState('');
   const [createSubmitting, setCreateSubmitting] = useState(false);
   const [setupLogsBySite, setSetupLogsBySite] = useState({});
@@ -202,6 +206,7 @@ function App() {
   const chooseAndSetup = useCallback(() => {
     setCreateSiteName('');
     setCreateSiteDir('');
+    setCreateSiteTicket('');
     setCreateSiteError('');
     setCreateModalOpen(true);
   }, []);
@@ -282,6 +287,15 @@ function App() {
       return;
     }
 
+    // The ticket is optional (#109), but a typo in one that was typed should
+    // be corrected here rather than silently dropped after a five-minute clone.
+    const ticketTyped = createSiteTicket.trim();
+    const ticket = ticketTyped ? parseTicketRef(ticketTyped) : null;
+    if (ticket && !ticket.ok) {
+      setCreateSiteError(ticket.error);
+      return;
+    }
+
     const cleanFolder = sanitizeSiteFolder(nameTrimmed);
     const targetDir = resolveTargetDir(createSiteDir, cleanFolder);
     let finalSitePath = targetDir;
@@ -294,13 +308,15 @@ function App() {
         ...(prev[targetDir] || {}),
         label: nameTrimmed,
         createdAt: prev[targetDir]?.createdAt || placeholderCreatedAt,
-        initialized: false
+        initialized: false,
+        tracTicket: ticket ? ticket.id : null
       }
     }));
     setActiveSite(targetDir);
     setCreateModalOpen(false);
     setCreateSiteName('');
     setCreateSiteDir('');
+    setCreateSiteTicket('');
 
     try {
       setCreateSubmitting(true);
@@ -308,7 +324,7 @@ function App() {
       setTerminalMsgs('');
       addPendingSite(targetDir);
       appendSetupLog(targetDir, 'Starting site setup…\n');
-      const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
+      const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed, tracTicket: ticket ? String(ticket.id) : '' });
       if (createdPath) {
         finalSitePath = createdPath;
         if (createdPath !== targetDir) {
@@ -352,7 +368,7 @@ function App() {
       clearPendingSites();
       setCreateSubmitting(false);
     }
-  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, createSiteTicket, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
 
   const closeCreateModal = useCallback(() => {
     if (createSubmitting) return;
@@ -734,6 +750,15 @@ function App() {
             <div id={CREATE_SITE_LOCATION_HELP_ID} style={{ fontSize: 12, color: '#3c434a', marginTop: -4 }}>
               Choose the parent folder where you want this new site created. We&apos;ll add a new directory inside it for the project.
             </div>
+            <TextControl
+              id={CREATE_SITE_TICKET_INPUT_ID}
+              label="What are you working on? (optional)"
+              value={createSiteTicket}
+              onChange={(value) => setCreateSiteTicket(value)}
+              disabled={createSubmitting}
+              placeholder="Trac ticket number or URL, e.g. 62281"
+              help="You can add this later, or change it at any time."
+            />
             {createSiteError ? (
               <div style={{ color: '#d63638', fontSize: 12 }}>{createSiteError}</div>
             ) : null}
@@ -777,6 +802,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [skipInit, setSkipInit] = useState(false);
   const [statusLoading, setStatusLoading] = useState(true);
   const [waitingForWatch, setWaitingForWatch] = useState(false);
+  // Trac ticket association (#109)
+  const [tracTicket, setTracTicket] = useState(null);
+  const [ticketInput, setTicketInput] = useState('');
+  const [ticketError, setTicketError] = useState('');
+  const [ticketSaving, setTicketSaving] = useState(false);
   // Trunk update path (#94)
   const [trunkDate, setTrunkDate] = useState(null);
   const [updateIncomplete, setUpdateIncomplete] = useState(false);
@@ -907,10 +937,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       setSkipInit(Boolean(s?.skipInitWizard));
       setTrunkDate(s?.trunkDate || null);
       setUpdateIncomplete(Boolean(s?.updateIncomplete));
+      setTracTicket(s?.tracTicket || null);
       if (metaPatchRef.current) {
         // A null trunkDate here means the git read failed (e.g. clone still
         // running) — keep whatever the sidebar already shows in that case.
-        const patch = { updateIncomplete: Boolean(s?.updateIncomplete) };
+        const patch = { updateIncomplete: Boolean(s?.updateIncomplete), tracTicket: s?.tracTicket || null };
         if (s?.trunkDate) patch.trunkDate = s.trunkDate;
         metaPatchRef.current(sitePath, patch);
       }
@@ -918,6 +949,29 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     finally { setStatusLoading(false); }
   }, [sitePath]);
   useEffect(()=>{ loadStatus(); }, [loadStatus]);
+
+  // Linking and unlinking are the same write (#109): an empty ref clears the
+  // association, so Unlink needs no second channel.
+  const saveTicket = useCallback(async (ref) => {
+    setTicketSaving(true);
+    setTicketError('');
+    try {
+      const res = await window.api.setSiteTicket(sitePath, ref);
+      if (!res?.ok) {
+        setTicketError(res?.error || 'Could not save the ticket.');
+        return;
+      }
+      setTracTicket(res.ticket);
+      setTicketInput('');
+      if (metaPatchRef.current) metaPatchRef.current(sitePath, { tracTicket: res.ticket });
+    } catch (e) {
+      setTicketError(String(e));
+    } finally {
+      setTicketSaving(false);
+    }
+  }, [sitePath]);
+  const linkTicket = useCallback(() => saveTicket(ticketInput), [saveTicket, ticketInput]);
+  const unlinkTicket = useCallback(() => saveTicket(''), [saveTicket]);
 
   const runInstall = useCallback((options = {}) => {
     const { onLog, onDone } = options;
@@ -2022,6 +2076,53 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
         </div>
       ) : null}
+      <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
+        <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Trac ticket</div>
+        {tracTicket ? (
+          <div style={{ marginTop: 12, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', padding: '2px 8px', borderRadius: 999, fontSize: 11, fontWeight: 600, letterSpacing: '0.02em', background: '#f0f0f1', color: '#1d2327' }}>
+              #{tracTicket}
+            </span>
+            <Button variant="link" onClick={() => window.api.openExternal(ticketUrl(tracTicket))}>Open in Trac</Button>
+            <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketSaving}>Unlink</Button>
+          </div>
+        ) : (
+          <>
+            <div style={{ marginTop: 4, fontSize: 13, color: '#3c434a' }}>
+              Tell the app which ticket you are working on. It is stored with the site, so it survives restarts, and you can change or remove it at any time.
+            </div>
+            <div style={{ marginTop: 12, display: 'flex', alignItems: 'flex-start', gap: 8, flexWrap: 'wrap' }}>
+              <div style={{ minWidth: 260 }}>
+                <TextControl
+                  value={ticketInput}
+                  onChange={(value) => { setTicketInput(value); setTicketError(''); }}
+                  onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
+                  disabled={ticketSaving}
+                  placeholder="Ticket number or URL, e.g. 62281"
+                  aria-label="Trac ticket number or URL"
+                />
+              </div>
+              <Button
+                variant="secondary"
+                onClick={linkTicket}
+                isBusy={ticketSaving}
+                disabled={ticketSaving || !ticketInput.trim()}
+                style={{ padding: '10px 16px', borderRadius: 10 }}
+              >Link ticket</Button>
+            </div>
+          </>
+        )}
+        {ticketError ? (
+          <div style={{ marginTop: 8, color: '#d63638', fontSize: 12 }}>{ticketError}</div>
+        ) : null}
+        {tracTicket ? null : (
+          <div style={{ marginTop: 8 }}>
+            <Button variant="link" onClick={() => window.api.openExternal(TRAC_TICKET_LISTS_URL)} style={{ fontSize: 12 }}>
+              Not sure yet? Browse good first bugs on Trac
+            </Button>
+          </div>
+        )}
+      </div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div>
           <div style={{ fontWeight: 600, marginBottom: 8 }}>Terminal</div>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2113,7 +2113,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           </>
         )}
         {ticketError ? (
-          <div style={{ marginTop: 8, color: '#d63638', fontSize: 12 }}>{ticketError}</div>
+          <div role="alert" style={{ marginTop: 8, color: '#d63638', fontSize: 12 }}>{ticketError}</div>
         ) : null}
         {tracTicket ? null : (
           <div style={{ marginTop: 8 }}>

--- a/src/renderer/trac-ticket.cjs
+++ b/src/renderer/trac-ticket.cjs
@@ -56,10 +56,19 @@ function parseTicketRef(input) {
 	if (/^\d+$/.test(bare)) return fromDigits(bare);
 
 	// Anything else has to be a ticket URL. Accept it without a scheme too —
-	// copying the host out of an address bar often drops it.
+	// copying the host out of an address bar often drops it. But `new URL` is
+	// lenient: `new URL('https://abc')` succeeds because `abc` is a legal
+	// hostname, so a bare word would reach the host check and be reported as a
+	// wrong *host* rather than as not-a-ticket. Only take the URL branch when
+	// the input actually looks like one — a scheme, a path or a dotted host.
+	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
+	if (!hasScheme && !raw.includes('/') && !raw.includes('.')) {
+		return { ok: false, error: NOT_A_TICKET };
+	}
+
 	let parsed;
 	try {
-		parsed = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`);
+		parsed = new URL(hasScheme ? raw : `https://${raw}`);
 	} catch {
 		return { ok: false, error: NOT_A_TICKET };
 	}

--- a/src/renderer/trac-ticket.cjs
+++ b/src/renderer/trac-ticket.cjs
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Reading what a contributor typed when asked which Trac ticket they are
+ * working on (issue #109). They arrive from a browser, so the input is as
+ * likely to be a pasted URL — with a comment anchor, a trailing slash or a
+ * ?format= query still attached — as it is a bare number.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly
+ * (same convention as setup-steps.cjs and update-plan.cjs).
+ */
+
+const TRAC_HOST = 'core.trac.wordpress.org';
+
+// Core is in the 60,000s and climbing slowly. Seven digits is far past any
+// real ticket, so it rejects a pasted timestamp or phone number while leaving
+// decades of headroom.
+const MAX_TICKET_ID = 9999999;
+
+const NOT_A_TICKET = 'Enter a ticket number like 62281, or a core.trac.wordpress.org ticket URL.';
+
+/**
+ * Canonical URL for a ticket id.
+ *
+ * @param {number|string} id
+ */
+function ticketUrl(id) {
+	return `https://${TRAC_HOST}/ticket/${id}`;
+}
+
+/**
+ * @param {string} digits
+ */
+function fromDigits(digits) {
+	const id = Number(digits);
+	if (!Number.isSafeInteger(id) || id < 1 || id > MAX_TICKET_ID) {
+		return { ok: false, error: NOT_A_TICKET };
+	}
+	return { ok: true, id, url: ticketUrl(id) };
+}
+
+/**
+ * Resolves free-form input to a ticket id. Accepts `62281`, `#62281` and any
+ * core Trac ticket URL; rejects everything else with a message meant for the
+ * contributor, not for a log.
+ *
+ * @param {string} input
+ * @return {{ok: true, id: number, url: string}|{ok: false, error: string}}
+ */
+function parseTicketRef(input) {
+	const raw = typeof input === 'string' ? input.trim() : '';
+	if (!raw) return { ok: false, error: 'Enter a ticket number or URL.' };
+
+	const bare = raw.replace(/^#/, '');
+	if (/^\d+$/.test(bare)) return fromDigits(bare);
+
+	// Anything else has to be a ticket URL. Accept it without a scheme too —
+	// copying the host out of an address bar often drops it.
+	let parsed;
+	try {
+		parsed = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`);
+	} catch {
+		return { ok: false, error: NOT_A_TICKET };
+	}
+
+	if (parsed.hostname.toLowerCase() !== TRAC_HOST) {
+		return { ok: false, error: `Only ${TRAC_HOST} tickets are supported.` };
+	}
+
+	// Reading the id off the path drops ?format= and #comment: for free.
+	const match = /^\/ticket\/(\d+)\/?$/.exec(parsed.pathname);
+	if (!match) return { ok: false, error: NOT_A_TICKET };
+	return fromDigits(match[1]);
+}
+
+module.exports = {
+	TRAC_HOST,
+	MAX_TICKET_ID,
+	ticketUrl,
+	parseTicketRef
+};

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -926,15 +926,30 @@ test('playground-web:stop ends the web server tree rather than signalling the ch
 // --- ticket handler (#109) -----------------------------------------------
 
 test('sites:set-ticket validates the reference through trac-ticket', async () => {
-	// A ref trac-ticket rejects returns before any store write, so this proves
-	// the wire without reaching getStore.
+	const settings = fakeSettingsStore({ sites: ['/sites/wp'] });
 	const parseTicketRef = spy(() => ({ ok: false, error: 'not a ticket' }));
-	const main = loadMain({ stubs: { ...silentLogging(), './renderer/trac-ticket.cjs': { parseTicketRef } } });
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...settings.stubs, './renderer/trac-ticket.cjs': { parseTicketRef } }
+	});
 
 	const result = await main.invoke('sites:set-ticket', '/sites/wp', '62281');
 
 	assert.deepEqual(parseTicketRef.calls, [['62281']]);
 	assert.deepEqual(result, { ok: false, error: 'not a ticket' });
+});
+
+test('sites:set-ticket refuses unregistered site paths before writing metadata', async () => {
+	const settings = fakeSettingsStore({ sites: ['/sites/wp'] });
+	const parseTicketRef = spy(() => ({ ok: true, id: 62281 }));
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...settings.stubs, './renderer/trac-ticket.cjs': { parseTicketRef } }
+	});
+
+	const result = await main.invoke('sites:set-ticket', '/sites/unknown', '62281');
+
+	assert.deepEqual(result, { ok: false, error: 'Site is not registered' });
+	assert.deepEqual(parseTicketRef.calls, []);
+	assert.deepEqual(settings.values.siteMeta, {});
 });
 
 // --- the harness's own guard ---------------------------------------------

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -923,6 +923,20 @@ test('playground-web:stop ends the web server tree rather than signalling the ch
 	assert.deepEqual(cp.children[0].kill.calls, []);
 });
 
+// --- ticket handler (#109) -----------------------------------------------
+
+test('sites:set-ticket validates the reference through trac-ticket', async () => {
+	// A ref trac-ticket rejects returns before any store write, so this proves
+	// the wire without reaching getStore.
+	const parseTicketRef = spy(() => ({ ok: false, error: 'not a ticket' }));
+	const main = loadMain({ stubs: { ...silentLogging(), './renderer/trac-ticket.cjs': { parseTicketRef } } });
+
+	const result = await main.invoke('sites:set-ticket', '/sites/wp', '62281');
+
+	assert.deepEqual(parseTicketRef.calls, [['62281']]);
+	assert.deepEqual(result, { ok: false, error: 'not a ticket' });
+});
+
 // --- the harness's own guard ---------------------------------------------
 
 // Requiring the real `electron` package is not a harmless fallback: its
@@ -970,7 +984,8 @@ const WIRED = new Set([
 	'playground:start',
 	'playground:stop',
 	'playground-web:start',
-	'playground-web:stop'
+	'playground-web:stop',
+	'sites:set-ticket'
 ]);
 
 // Channels with no module to reach: they read or write electron-store, drive a

--- a/test/trac-ticket.test.cjs
+++ b/test/trac-ticket.test.cjs
@@ -65,6 +65,16 @@ test('parseTicketRef: non-numeric and malformed input is rejected (issue #109)',
 	}
 });
 
+// Input that names no host must get the generic message, not the host one:
+// `new URL('https://abc')` succeeds, so without a guard a bare word is wrongly
+// reported as an unsupported *host*.
+test('parseTicketRef: input that is not a URL gets the generic message, not the host one (issue #109)', () => {
+	const generic = 'Enter a ticket number like 62281, or a core.trac.wordpress.org ticket URL.';
+	for (const bad of ['abc', '62281abc', '#abc', 'not a url', 'https://']) {
+		assert.strictEqual(parseTicketRef(bad).error, generic, `wrong message for: ${bad}`);
+	}
+});
+
 test('parseTicketRef: a non-Trac host is named as the reason (issue #109)', () => {
 	const res = parseTicketRef('https://github.com/WordPress/wordpress-develop/pull/7990');
 	assert.strictEqual(res.ok, false);

--- a/test/trac-ticket.test.cjs
+++ b/test/trac-ticket.test.cjs
@@ -1,0 +1,98 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { TRAC_HOST, MAX_TICKET_ID, ticketUrl, parseTicketRef } = require('../src/renderer/trac-ticket.cjs');
+
+test('parseTicketRef: a bare number is a ticket (issue #109)', () => {
+	const res = parseTicketRef('62281');
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.id, 62281);
+	assert.strictEqual(res.url, 'https://core.trac.wordpress.org/ticket/62281');
+});
+
+test('parseTicketRef: the # a contributor types out of habit is not an error (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('#62281').id, 62281);
+});
+
+test('parseTicketRef: surrounding whitespace from a paste is trimmed (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('  62281  ').id, 62281);
+	assert.strictEqual(parseTicketRef(' #62281 ').id, 62281);
+});
+
+test('parseTicketRef: a plain ticket URL resolves (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('https://core.trac.wordpress.org/ticket/62281').id, 62281);
+});
+
+// The three shapes an address bar actually produces: a comment anchor from
+// clicking a comment permalink, a trailing slash, and the ?format= query the
+// app itself would append.
+test('parseTicketRef: a comment anchor, trailing slash and query are all dropped (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('https://core.trac.wordpress.org/ticket/62281#comment:3').id, 62281);
+	assert.strictEqual(parseTicketRef('https://core.trac.wordpress.org/ticket/62281/').id, 62281);
+	assert.strictEqual(parseTicketRef('https://core.trac.wordpress.org/ticket/62281?format=csv').id, 62281);
+	assert.strictEqual(parseTicketRef('https://core.trac.wordpress.org/ticket/62281/?replyto=2#comment:3').id, 62281);
+});
+
+test('parseTicketRef: http and a missing scheme both resolve (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('http://core.trac.wordpress.org/ticket/62281').id, 62281);
+	assert.strictEqual(parseTicketRef('core.trac.wordpress.org/ticket/62281').id, 62281);
+});
+
+test('parseTicketRef: every accepted form yields the same canonical https URL (issue #109)', () => {
+	const forms = [
+		'62281',
+		'#62281',
+		'core.trac.wordpress.org/ticket/62281',
+		'http://core.trac.wordpress.org/ticket/62281/#comment:3'
+	];
+	for (const form of forms) {
+		assert.strictEqual(parseTicketRef(form).url, ticketUrl(62281), `form: ${form}`);
+	}
+});
+
+test('parseTicketRef: empty input asks for a ticket rather than reporting a parse failure (issue #109)', () => {
+	for (const empty of ['', '   ', null, undefined, 62281]) {
+		const res = parseTicketRef(empty);
+		assert.strictEqual(res.ok, false);
+		assert.strictEqual(res.error, 'Enter a ticket number or URL.');
+	}
+});
+
+test('parseTicketRef: non-numeric and malformed input is rejected (issue #109)', () => {
+	for (const bad of ['abc', '62281abc', '#', '#abc', '62281 62282', 'not a url', 'https://']) {
+		assert.strictEqual(parseTicketRef(bad).ok, false, `should reject: ${bad}`);
+	}
+});
+
+test('parseTicketRef: a non-Trac host is named as the reason (issue #109)', () => {
+	const res = parseTicketRef('https://github.com/WordPress/wordpress-develop/pull/7990');
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.error, `Only ${TRAC_HOST} tickets are supported.`);
+});
+
+// A Trac URL that is not a ticket — the ticket lists the panel links to are the
+// most likely paste.
+test('parseTicketRef: a Trac URL that is not a ticket is rejected (issue #109)', () => {
+	for (const bad of [
+		'https://core.trac.wordpress.org/report/5',
+		'https://core.trac.wordpress.org/query?status=new',
+		'https://core.trac.wordpress.org/ticket/',
+		'https://core.trac.wordpress.org/ticket/62281/attachment/patch.diff'
+	]) {
+		assert.strictEqual(parseTicketRef(bad).ok, false, `should reject: ${bad}`);
+	}
+});
+
+test('parseTicketRef: ticket 0 and implausibly long numbers are rejected (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('0').ok, false);
+	assert.strictEqual(parseTicketRef(String(MAX_TICKET_ID + 1)).ok, false);
+	// A pasted millisecond timestamp is the realistic version of "too long".
+	assert.strictEqual(parseTicketRef('1785947321000').ok, false);
+	assert.strictEqual(parseTicketRef(String(MAX_TICKET_ID)).ok, true);
+});
+
+test('parseTicketRef: leading zeros resolve to the same ticket (issue #109)', () => {
+	assert.strictEqual(parseTicketRef('0062281').id, 62281);
+	assert.strictEqual(parseTicketRef('0062281').url, ticketUrl(62281));
+});


### PR DESCRIPTION
Closes #109. First step of #110, following [Option A](https://github.com/WordPress/experimental-wp-dev-env/issues/110#issuecomment-5193816406).

## Why

The app knows *where* a site is and *what state its build is in*, but not *what the contributor is working on* — and Core work is organised around Trac tickets, not directories. That gap is why a generated patch carries no ticket number (#107), why there is nowhere to show a ticket's existing patches, and why applying someone else's patch (#11) has no context to start from.

## What this does

A site can now be associated with a Trac ticket:

- asked optionally at creation — *"What are you working on?"*
- set, changed or cleared later from a new panel on the site screen
- stored in `siteMeta`, so it survives restarts

Parsing accepts what a contributor actually types or pastes: a bare number, a number with a `#`, and any core Trac ticket URL with a comment anchor, trailing slash or `?format=` query still attached. Anything else is rejected with a message aimed at the contributor rather than at a log.

The panel sits between the action row and the Terminal; nothing else on the page moves.

## What this deliberately does not do

**No network.** Linking a ticket never depends on Trac being reachable.

That is a design decision, not an omission. While building this I measured every documented Trac read path — `?format=csv`, the ticket HTML, `raw-attachment/ticket/<id>/<file>`, and even `robots.txt` — and all of them currently return **403 behind a proof-of-work interstitial** for any client that is not a browser (SHA-256 hashcash, `_hcc` cookie, escalating to an "I am human" checkbox on repeat hits; a spoofed browser User-Agent gets a bare nginx 403 instead). This also breaks core's own `grunt patch`, which has parsed that page for years.

So *showing* a ticket's patches needs a fetch strategy of its own and lands separately. Two things shape it:

- A Contributor Day room shares one NAT IP — exactly the pattern that escalates Trac's challenge to interactive, and that exhausts unauthenticated GitHub's 60 requests/hour. Any network path has to degrade to opening the contributor's own browser, where the challenge clears itself.
- The real fix is upstream: [meta #8202](https://meta.trac.wordpress.org/ticket/8202) proposes a `ticket/` JSON endpoint returning exactly the attachment data (filename, author, date, size) that panel wants. The follow-up should keep its fetch source swappable so it can adopt that endpoint when it lands.

Also out of scope here: applying patches (#11), the ticket number in the patch header (#107), tickets as branches (#108), opening PRs from the app (#118).

## Testing

- `test/trac-ticket.test.cjs` — 14 tests over every accepted and rejected input form. `parseTicketRef` is a pure, dependency-free module so it runs under `node --test` with no DOM, following the `setup-steps.cjs` / `update-plan.cjs` convention.
- `npm test` and `npm run test:electron`: **172/172 pass** on both.
- `npm run lint` (now repo-wide after #119): clean.

Manual: create a site with and without a ticket; link, unlink and re-link from the panel; paste `62281`, `#62281` and a URL with `#comment:3`; restart the app and confirm the ticket survives; confirm "Open in Trac" opens the external browser.

### Fixed after manual testing

Manual testing surfaced a wrong-message bug: a bare word like `abc` (and `62281abc`, `#abc`) was rejected with *"Only core.trac.wordpress.org tickets are supported"* — pointing the contributor at a host they never named. `new URL('https://abc')` succeeds because a bare word is a legal hostname, so non-URL input slipped past into the host check instead of falling to the generic message. Fixed to only treat input as a URL when it has a scheme, a path separator or a dotted host; everything else now gets *"Enter a ticket number like 62281, or a core.trac.wordpress.org ticket URL."* A github.com URL still correctly names the host as the reason. The reproducing test asserts the message, not just rejection — the gap the original suite missed.

Rebased onto trunk after #122, so no generated bundle is included — the diff is five source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
