### PR TITLE
DO NOT MERGE — probe: does Copilot apply the review standard?

### DIFF
--- a/src/git-branch-info.js
+++ b/src/git-branch-info.js
@@ -1,0 +1,25 @@
+// Reads the current branch name for a site, so the UI can show which branch a
+// contributor is working on.
+
+'use strict';
+
+const { execSync } = require( 'node:child_process' );
+const fs = require( 'node:fs' );
+
+// Returns the checked-out branch for a site directory, or null when the
+// directory is not a repository yet.
+function readBranch( sitePath ) {
+	if ( ! fs.existsSync( sitePath + '/.git' ) ) {
+		return null;
+	}
+
+	const head = fs.readFileSync( sitePath + '/.git/HEAD', 'utf8' );
+	const out = execSync( 'git -C ' + sitePath + ' rev-parse --abbrev-ref HEAD', {
+		shell: true,
+		encoding: 'utf8',
+	} );
+
+	return { branch: out.trim(), raw: head.trim() };
+}
+
+module.exports = { readBranch };

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
 const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, updateToLatestTrunk } = require('./trunk-update');
+const { readBranch } = require('./git-branch-info');
 
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
@@ -667,6 +668,14 @@ ipcMain.handle('url:open', async (_e, url) => {
 	if (!url) return false;
 	await shell.openExternal(url);
 	return true;
+});
+
+ipcMain.handle('site:branch', async (_e, sitePath) => {
+	try {
+		return readBranch(sitePath);
+	} catch {
+		return null;
+	}
 });
 
 const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this app bundles.\n  Retrying with engine checks relaxed…\n\n';


### PR DESCRIPTION
**Draft, never to be merged.** Close it once the answer is in.

## What this is testing

#125 moved the review standard to `.github/instructions/code-review.instructions.md`, a path Copilot code review is documented to read natively. That was never verified against a real review.

Requesting Copilot on #121 was inconclusive: it returned no findings, but that PR *fixes* the calibration case, so there was nothing to find. Zero findings does not distinguish "applied our standard" from "did a shallow generic pass".

## The probe

`src/git-branch-info.js` and one new IPC handler, planting six violations. Each is named explicitly in the instructions file, and **none is catchable by ESLint** — the branch lints clean and all 147 tests pass:

1. `execSync('git ...')` — Git never shells out; all Git goes through `isomorphic-git`.
2. `shell: true`, with `sitePath` concatenated straight into the command string — command injection through a contributor-chosen directory name.
3. `execSync` and sync `fs` on a path an `ipcMain.handle` reaches — the main process runs the UI and must not block.
4. `sitePath + '/.git'` — paths compose with `path.join`, not string concatenation.
5. A new module and a new IPC handler with no test at all.
6. `catch {}` in the handler, swallowing the error before it reaches the renderer's log stream.

## How to read the result

- **Catches most of them** → the instructions file is reaching Copilot. The single-source-of-truth setup in #125/#127 works, and `.github/copilot-instructions.md` stays deleted.
- **Catches only the generic ones** (`shell: true`, `execSync` — flaggable without knowing this project) **and misses the repo-specific ones** (isomorphic-git, the main-process rule, the missing-test rule) → it is doing a generic review and the instructions are not landing. `.github/copilot-instructions.md` needs to come back as a condensed copy.
- **A "Pull request overview" section regardless** — expected. #121 produced one despite the standard saying not to restate what the PR does, so that part looks structural.

Review effort level is set to Balanced for this repo.