### PR TITLE
Tell contributors on any agent where the review lives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,31 @@
 Instructions for AI coding agents working in this repository. Tool-neutral and canonical —
 `CLAUDE.md` points here rather than repeating it.
 
-The review standard is separate, in
+## Where things are, whatever agent you use
+
+Two files, and neither is specific to one tool despite what their paths suggest:
+
+**The review standard** —
 [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).
-It lives at that path because Copilot code review reads `.github/instructions/*.instructions.md`
-natively and follows no links, so that is the only way it gets the standard without a second copy
-being maintained alongside it.
+The five dimensions, this project's invariants, the procedure to run them, and the reporting
+format. Read it directly if your agent has not already.
+
+It sits under `.github/instructions/` because Copilot code review reads that directory natively and
+follows no links out of it. Anywhere better-named would have meant maintaining a condensed second
+copy for Copilot, which would drift. Every other agent reaches it from here.
+
+**The review as a skill** — [`.claude/skills/self-review/`](.claude/skills/self-review/), a thin
+`SKILL.md` wrapper over the file above. The directory name is historical, not a restriction: it is
+the only path both Claude Code and Copilot read for project skills, so it stays there. In Claude
+Code it is `/self-review`.
+
+If your agent supports skills but looks elsewhere (`.agents/skills/`, `.github/skills/`, or its own
+convention), point it at that directory — or skip it entirely and follow the instructions file,
+which is where all the content actually lives. The wrapper only adds two things: run the judgement
+pass in a fresh context, and report without touching GitHub.
+
+There is deliberately no per-tool copy of any of this. If you find yourself writing one, the thing
+to fix is the pointer, not the number of copies.
 
 ## What this is
 


### PR DESCRIPTION
## Why

The review standard sits at `.github/instructions/code-review.instructions.md` and the skill wrapping it at `.claude/skills/self-review/`. Both paths read as vendor-specific, and a contributor using Cursor, Codex or Gemini has no reason to open either.

Both are deliberate, and neither is a statement about who the content is for:

- `.github/instructions/` is the only directory Copilot code review reads natively, and it follows no links out of it. A better-named path would have meant maintaining a condensed second copy for Copilot.
- `.claude/skills/` is, per GitHub's own docs, one of the three directories Copilot picks up project skills from — and the only one of those that Claude Code also reads. Moving it to `.agents/skills/` would trade Claude Code for nothing.

What those agents *do* read is `AGENTS.md`.

## What changes

A section at the top of `AGENTS.md` saying where both files are, why they sit where they do, and that the skill is optional — the content lives in the instructions file and following it directly works for any agent.

It also states the rule the last few changes kept bumping into: when a tool cannot see one of these, fix the pointer rather than adding a copy for it. That is what keeps this from growing a per-vendor file per contributor.

## Self-review

Documentation only, no JavaScript changed. `npm run lint` clean, 158 tests pass. No findings across the five dimensions.