### PR TITLE
List and apply a ticket's Trac attachments

### DIFF
--- a/src/github-prs.js
+++ b/src/github-prs.js
@@ -30,28 +30,39 @@ const REQUEST_TIMEOUT_MS = 15000;
  * is data the caller classifies — only on a transport failure or timeout.
  * Modelled on the never-reject readiness probe in main.js.
  *
- * The `deps` seam (net client and timers) exists only so the response,
- * transport-error, timeout, and settle-once paths can be exercised without the
- * network or a real 15s wait; production callers pass nothing and get Electron's
- * `net` and the global timers.
+ * `opts` carries both test doubles and request options. The doubles (net client
+ * and timers) exist only so the response, transport-error, timeout, and
+ * settle-once paths can be exercised without the network or a real 15s wait;
+ * production callers pass none and get Electron's `net` and the global timers.
+ * `partition` + `useSessionCookies` let a caller ride a specific session's
+ * cookies — the Trac attachment fetch reuses the session that passed the
+ * proof-of-work challenge, so its `_hcc` cookie authorises the download; net
+ * does not send session cookies unless asked, hence the explicit flag.
  *
- * @param {string} url
- * @param {Object} [headers]
- * @param {Object} [deps]
+ * @param {string}  url
+ * @param {Object}  [headers]
+ * @param {Object}  [opts]
+ * @param {string}  [opts.partition]
+ * @param {boolean} [opts.useSessionCookies]
  * @return {Promise<{status: number, headers: Object, body: string}>}
  */
-function httpGet(url, headers = {}, deps = {}) {
+function httpGet(url, headers = {}, opts = {}) {
 	// Required lazily, not at module load: requiring `electron` outside Electron
 	// resolves the binary and can spawn its installer on a cold checkout, and the
 	// standalone tests inject their own client and must never reach it.
-	const netImpl = deps.net || require('electron').net;
-	const setTimeoutImpl = deps.setTimeout || setTimeout;
-	const clearTimeoutImpl = deps.clearTimeout || clearTimeout;
+	const netImpl = opts.net || require('electron').net;
+	const setTimeoutImpl = opts.setTimeout || setTimeout;
+	const clearTimeoutImpl = opts.clearTimeout || clearTimeout;
 	return new Promise((resolve, reject) => {
 		let settled = false;
 		const finish = (fn, arg) => { if (!settled) { settled = true; fn(arg); } };
 
-		const request = netImpl.request({ method: 'GET', url });
+		const requestOptions = { method: 'GET', url };
+		if (opts.partition) {
+			requestOptions.partition = opts.partition;
+			requestOptions.useSessionCookies = opts.useSessionCookies !== false;
+		}
+		const request = netImpl.request(requestOptions);
 		request.setHeader('User-Agent', USER_AGENT);
 		for (const [key, value] of Object.entries(headers)) request.setHeader(key, value);
 

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, update
 const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
+const { openAndScrape, fetchAttachment } = require('./trac-view');
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
 const { deleteRegisteredSite } = require('./site-registry');
 const { getStore } = require('./settings-store');
@@ -517,6 +518,30 @@ ipcMain.handle('git:fetch-pr-diff', async (_e, number) => {
         return await fetchPrDiff(number);
     } catch (e) {
         return { ok: false, status: 'error', error: String(e) };
+    }
+});
+
+// Trac attachments (#109/#11). Read on demand: opening a real Trac window can
+// show the proof-of-work challenge, so it happens when the contributor asks,
+// not on every ticket. See src/trac-view.js for the window and scrape.
+ipcMain.handle('trac:list-attachments', async (_e, sitePath) => {
+    try {
+        const s = await getStore();
+        const ticketId = ((s.get('siteMeta') || {})[sitePath] || {}).tracTicket;
+        if (!ticketId) return { ok: true, status: 'no-ticket', items: [] };
+        const result = await openAndScrape(ticketId);
+        return { ok: true, ...result };
+    } catch (e) {
+        logError('trac:list-attachments', String(e && e.stack ? e.stack : e));
+        return { ok: false, status: 'error', items: [], error: String(e) };
+    }
+});
+
+ipcMain.handle('trac:fetch-attachment', async (_e, url) => {
+    try {
+        return await fetchAttachment(url);
+    } catch (e) {
+        return { ok: false, error: String(e) };
     }
 });
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -86,6 +86,10 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	fetchPrDiff: (number) => ipcRenderer.invoke('git:fetch-pr-diff', number)
 ,
+	listTracAttachments: (sitePath) => ipcRenderer.invoke('trac:list-attachments', sitePath)
+,
+	fetchTracAttachment: (url) => ipcRenderer.invoke('trac:fetch-attachment', url)
+,
 	applyPatch: async (sitePath, options, onLog, onDone) => {
 		const { applyId } = await ipcRenderer.invoke('git:apply-patch', sitePath, options);
 		const logHandler = (_e, payload) => {

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1660,20 +1660,31 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     if (!tracTicket) {
       setTicketPatches(null);
       // Attachments are per-ticket and loaded on demand; a stale list from the
-      // previous ticket must not linger.
+      // previous ticket must not linger, and a scrape dropped by the generation
+      // bump below must not leave a stuck spinner.
       setTracAttachments(null);
+      setTracAttachmentsLoading(false);
       loadedTicketRef.current = null;
       return;
     }
     if (!isActive || loadedTicketRef.current === tracTicket) return;
     // A new ticket on the active site: drop any attachments the previous one
-    // loaded, then fetch its PRs. Marked loaded before the fetch resolves, on
-    // purpose: a failed initial fetch is not retried on every re-activation
-    // (which could keep spending a rate-limited quota) — Refresh is the retry.
+    // loaded (and clear its loading flag, so a scrape dropped by the generation
+    // bump cannot leave a stuck spinner with no button to recover), then fetch
+    // its PRs. Marked loaded before the fetch resolves, on purpose: a failed
+    // initial fetch is not retried on every re-activation (which could keep
+    // spending a rate-limited quota) — Refresh is the retry.
     setTracAttachments(null);
+    setTracAttachmentsLoading(false);
     loadedTicketRef.current = tracTicket;
     loadTicketPatches();
   }, [tracTicket, isActive, loadTicketPatches]);
+
+  // A Trac scrape can run up to 90s. Bump a generation on every ticket change so
+  // a scrape that resolves after the ticket has moved on is dropped, rather than
+  // shown under the wrong ticket or clearing a newer request's loading flag.
+  const scrapeGenRef = useRef(0);
+  useEffect(() => { scrapeGenRef.current += 1; }, [tracTicket]);
 
   // Fetches a PR's diff and drops into the same preview the file picker uses,
   // so applying a PR and applying a downloaded patch are one path from here on.
@@ -1704,15 +1715,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // Opens the real Trac ticket (the user clears the challenge once if shown),
   // scrapes its attachment list, and shows it in-app. On demand, not on link.
   const loadTracAttachments = async () => {
+    const gen = scrapeGenRef.current;
     setApplyError('');
     setTracAttachmentsLoading(true);
     try {
       const res = await window.api.listTracAttachments(sitePath);
+      if (gen !== scrapeGenRef.current) return; // ticket changed mid-scrape; drop the stale result
       setTracAttachments(res && res.ok ? res : { status: 'error', items: [] });
     } catch {
+      if (gen !== scrapeGenRef.current) return;
       setTracAttachments({ status: 'error', items: [] });
     } finally {
-      setTracAttachmentsLoading(false);
+      if (gen === scrapeGenRef.current) setTracAttachmentsLoading(false);
     }
   };
 
@@ -2410,11 +2424,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ marginTop: 10, fontSize: 13, color: '#6c6f72' }}>This ticket has no attachments.</div>
               ) : null}
 
-              {tracAttachments && (tracAttachments.status === 'challenge-timeout' || tracAttachments.status === 'error') ? (
+              {tracAttachments && (tracAttachments.status === 'challenge-timeout' || tracAttachments.status === 'error' || tracAttachments.status === 'closed') ? (
                 <div style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
-                  {tracAttachments.status === 'challenge-timeout'
-                    ? 'Trac’s human-check did not complete in time. Try again, and click “I am human” if it appears.'
-                    : 'Could not read the attachments from Trac.'}
+                  {(() => {
+                    if (tracAttachments.status === 'challenge-timeout') return 'Trac’s human-check did not complete in time. Try again, and click “I am human” if it appears.';
+                    if (tracAttachments.status === 'closed') return 'The Trac window was closed before the attachments finished loading. Click “Show Trac attachments” to try again.';
+                    return `Could not read the attachments from Trac.${tracAttachments.error ? ` (${tracAttachments.error})` : ''}`;
+                  })()}
                 </div>
               ) : null}
 

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -818,6 +818,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [ticketPatches, setTicketPatches] = useState(null);
   const [ticketPatchesLoading, setTicketPatchesLoading] = useState(false);
   const [fetchingPr, setFetchingPr] = useState(null);
+  // Trac attachments (#11): loaded on demand, since opening a real Trac window
+  // can surface the proof-of-work challenge. null until the user asks.
+  const [tracAttachments, setTracAttachments] = useState(null);
+  const [tracAttachmentsLoading, setTracAttachmentsLoading] = useState(false);
+  const [fetchingAttachment, setFetchingAttachment] = useState(null);
   // Trunk update path (#94)
   const [trunkDate, setTrunkDate] = useState(null);
   const [updateIncomplete, setUpdateIncomplete] = useState(false);
@@ -1654,13 +1659,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   useEffect(() => {
     if (!tracTicket) {
       setTicketPatches(null);
+      // Attachments are per-ticket and loaded on demand; a stale list from the
+      // previous ticket must not linger.
+      setTracAttachments(null);
       loadedTicketRef.current = null;
       return;
     }
     if (!isActive || loadedTicketRef.current === tracTicket) return;
-    // Marked loaded before the fetch resolves, on purpose: a failed initial
-    // fetch is not retried on every re-activation (which could keep spending a
-    // rate-limited quota) — the Refresh button is the retry.
+    // A new ticket on the active site: drop any attachments the previous one
+    // loaded, then fetch its PRs. Marked loaded before the fetch resolves, on
+    // purpose: a failed initial fetch is not retried on every re-activation
+    // (which could keep spending a rate-limited quota) — Refresh is the retry.
+    setTracAttachments(null);
     loadedTicketRef.current = tracTicket;
     loadTicketPatches();
   }, [tracTicket, isActive, loadTicketPatches]);
@@ -1688,6 +1698,45 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       setApplyError(String(e));
     } finally {
       setFetchingPr(null);
+    }
+  };
+
+  // Opens the real Trac ticket (the user clears the challenge once if shown),
+  // scrapes its attachment list, and shows it in-app. On demand, not on link.
+  const loadTracAttachments = async () => {
+    setApplyError('');
+    setTracAttachmentsLoading(true);
+    try {
+      const res = await window.api.listTracAttachments(sitePath);
+      setTracAttachments(res && res.ok ? res : { status: 'error', items: [] });
+    } catch {
+      setTracAttachments({ status: 'error', items: [] });
+    } finally {
+      setTracAttachmentsLoading(false);
+    }
+  };
+
+  // Downloads an attachment through the challenge-passing session and hands it
+  // to the same preview the PR and file paths use.
+  const previewAttachment = async (att) => {
+    setApplyError('');
+    setFetchingAttachment(att.url);
+    try {
+      const res = await window.api.fetchTracAttachment(att.url);
+      if (!res || !res.ok) {
+        setApplyError(res?.error || `Could not download ${att.filename}.`);
+        return;
+      }
+      const preview = await window.api.previewPatch(sitePath, res.text);
+      if (!preview || !preview.ok) {
+        setApplyError(preview?.error || 'Could not read that patch.');
+        return;
+      }
+      setApplyPreview({ ...preview, label: att.filename, text: res.text });
+    } catch (e) {
+      setApplyError(String(e));
+    } finally {
+      setFetchingAttachment(null);
     }
   };
 
@@ -2286,7 +2335,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 </Button>
               </div>
               <div style={{ marginTop: 4, fontSize: 12, color: '#6c6f72' }}>
-                See the work that already exists on this ticket before adding your own. Trac attachments are not listed yet — open the ticket for those.
+                See the work that already exists on this ticket before adding your own.
               </div>
 
               {ticketPatchesLoading && !ticketPatches ? (
@@ -2326,6 +2375,72 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         onClick={() => previewPr(pr)}
                         style={{ flex: '0 0 auto' }}
                       >Apply…</Button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            <div style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                <div style={{ fontWeight: 600, fontSize: 13, color: '#1d2327' }}>Trac attachments</div>
+                {tracAttachments ? (
+                  <Button variant="link" onClick={loadTracAttachments} disabled={tracAttachmentsLoading} style={{ fontSize: 12 }}>
+                    {tracAttachmentsLoading ? 'Checking…' : 'Refresh'}
+                  </Button>
+                ) : null}
+              </div>
+              <div style={{ marginTop: 4, fontSize: 12, color: '#6c6f72' }}>
+                Patch files are sometimes attached on Trac instead of a PR. Reading them opens the ticket so you can pass its human-check once.
+              </div>
+
+              {!tracAttachments && !tracAttachmentsLoading ? (
+                <div style={{ marginTop: 10 }}>
+                  <Button variant="secondary" onClick={loadTracAttachments} disabled={isApplying || isUpdating || installing || building} style={{ padding: '8px 14px', borderRadius: 10 }}>
+                    Show Trac attachments
+                  </Button>
+                </div>
+              ) : null}
+
+              {tracAttachmentsLoading ? (
+                <div style={{ marginTop: 10, display: 'flex', alignItems: 'center', gap: 8, color: '#3c434a', fontSize: 13 }}><Spinner /> Opening the ticket on Trac…</div>
+              ) : null}
+
+              {tracAttachments && tracAttachments.status === 'no-attachments' ? (
+                <div style={{ marginTop: 10, fontSize: 13, color: '#6c6f72' }}>This ticket has no attachments.</div>
+              ) : null}
+
+              {tracAttachments && (tracAttachments.status === 'challenge-timeout' || tracAttachments.status === 'error') ? (
+                <div style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
+                  {tracAttachments.status === 'challenge-timeout'
+                    ? 'Trac’s human-check did not complete in time. Try again, and click “I am human” if it appears.'
+                    : 'Could not read the attachments from Trac.'}
+                </div>
+              ) : null}
+
+              {tracAttachments && tracAttachments.items && tracAttachments.items.length ? (
+                <div style={{ marginTop: 10, border: '1px solid #ddd', borderRadius: 6, overflow: 'hidden' }}>
+                  {tracAttachments.items.map((att) => (
+                    <div key={att.url} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderBottom: '1px solid #f0f0f1' }}>
+                      <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+                        <div style={{ fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <Button variant="link" onClick={() => window.api.openExternal(att.url)} style={{ fontSize: 13 }}>{att.filename}</Button>
+                        </div>
+                        <div style={{ fontSize: 11, color: '#6c6f72' }}>
+                          {[att.author && `by ${att.author}`, att.dateText, att.sizeText].filter(Boolean).join(' · ')}
+                        </div>
+                      </div>
+                      {att.applyable ? (
+                        <Button
+                          variant="secondary"
+                          isBusy={fetchingAttachment === att.url}
+                          disabled={isApplying || isUpdating || installing || building || Boolean(applyPreview) || fetchingAttachment !== null}
+                          onClick={() => previewAttachment(att)}
+                          style={{ flex: '0 0 auto' }}
+                        >Apply…</Button>
+                      ) : (
+                        <span style={{ flex: '0 0 auto', fontSize: 11, color: '#6c6f72' }}>not a patch</span>
+                      )}
                     </div>
                   ))}
                 </div>

--- a/src/trac-attachments.cjs
+++ b/src/trac-attachments.cjs
@@ -38,6 +38,23 @@ function toRawUrl(pathOrUrl) {
 }
 
 /**
+ * The normalized href iff the URL is exactly the secure Trac origin. Host alone
+ * is not enough: the embedded view carries a session cookie earned by clearing
+ * Trac's proof-of-work, and an http downgrade on the same host would leak it on
+ * an untrusted network. Returns null for anything that is not
+ * `https://core.trac.wordpress.org/…`, so callers fail closed.
+ *
+ * @param {string} url
+ * @return {string|null}
+ */
+function secureTracUrl(url) {
+	let parsed;
+	try { parsed = new URL(url); } catch { return null; }
+	if (parsed.protocol !== 'https:' || parsed.hostname !== TRAC_HOST) return null;
+	return parsed.href;
+}
+
+/**
  * @param {string} chunk HTML of one `<dt>…</dt>` (plus its `<dd>` if present).
  * @param {string} id
  * @return {{filename: string, url: string, author: string, dateText: string, sizeText: string, applyable: boolean}|null}
@@ -47,16 +64,13 @@ function parseOne(chunk, id) {
 	// the id guard keeps stray links (e.g. to other tickets) out.
 	const link = new RegExp(`href="((?:https?://[^"]+)?/(?:raw-)?attachment/ticket/${id}/([^"?]+))"`).exec(chunk);
 	if (!link) return null;
-	const url = toRawUrl(link[1]);
-	// The parser must never emit an off-host URL: an absolute href on another
-	// host would pass the id-shaped path check, and the filename is rendered as
-	// an openExternal link. Rejecting the row here means a poisoned ticket page
-	// cannot get an attacker URL in front of the user.
-	try {
-		if (new URL(url).hostname !== TRAC_HOST) return null;
-	} catch {
-		return null;
-	}
+	// The parser must never emit an off-host or plaintext URL: an absolute href
+	// on another host — or an http downgrade of this one — would pass the
+	// id-shaped path check, and the filename is rendered as an openExternal link
+	// (and later fetched with the session cookie). Rejecting the row here means a
+	// poisoned ticket page cannot get such a URL in front of the user.
+	const url = secureTracUrl(toRawUrl(link[1]));
+	if (!url) return null;
 	const filename = decodeURIComponent(link[2]);
 
 	// Author: the trac-author anchor, or its text. Falls back to empty.
@@ -114,4 +128,4 @@ function parseAttachments(attachmentsHtml, ticketId) {
 	return rows;
 }
 
-module.exports = { toRawUrl, parseAttachments };
+module.exports = { toRawUrl, parseAttachments, secureTracUrl };

--- a/src/trac-attachments.cjs
+++ b/src/trac-attachments.cjs
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * Reading the attachment list off a Trac ticket page (issue #109 / #11).
+ *
+ * On many tickets — good-first-bugs especially — the work a contributor wants
+ * to try is a `.diff` attached to the ticket, not a pull request. Trac serves
+ * that list only inside a real browser (everything else meets the proof-of-work
+ * interstitial), so the embedded view scrapes the `#attachments` block's HTML
+ * and hands it here to turn into rows.
+ *
+ * Parsing is done by regex over the HTML string, not with DOM selectors,
+ * precisely so it can be unit tested under `node --test` without a browser —
+ * the same approach core's own `grunt-patch-wordpress` takes. The Trac
+ * attachment markup has been stable for years, which is what makes this
+ * tractable; the fragile part is contained here and covered by fixtures.
+ *
+ * Each attachment appears as a `<dt>…</dt>` inside the block, carrying a link to
+ * `/attachment/ticket/<id>/<file>` (and usually a raw link too), the author,
+ * a date, and a size. Missing pieces degrade to empty strings rather than
+ * dropping the row — a filename with a working download link is useful even
+ * without its metadata.
+ */
+
+/**
+ * The canonical raw download URL for an attachment path. Trac serves the file
+ * itself under `raw-attachment`; the `attachment` path is the HTML view. Same
+ * transform core's grunt-patch-wordpress uses.
+ *
+ * @param {string} pathOrUrl
+ * @return {string}
+ */
+const TRAC_HOST = 'core.trac.wordpress.org';
+
+function toRawUrl(pathOrUrl) {
+	const abs = pathOrUrl.startsWith('http') ? pathOrUrl : `https://${TRAC_HOST}${pathOrUrl}`;
+	return abs.replace('/attachment/ticket/', '/raw-attachment/ticket/');
+}
+
+/**
+ * @param {string} chunk HTML of one `<dt>…</dt>` (plus its `<dd>` if present).
+ * @param {string} id
+ * @return {{filename: string, url: string, author: string, dateText: string, sizeText: string, applyable: boolean}|null}
+ */
+function parseOne(chunk, id) {
+	// The attachment link names the file. Accept both the view and raw forms;
+	// the id guard keeps stray links (e.g. to other tickets) out.
+	const link = new RegExp(`href="((?:https?://[^"]+)?/(?:raw-)?attachment/ticket/${id}/([^"?]+))"`).exec(chunk);
+	if (!link) return null;
+	const url = toRawUrl(link[1]);
+	// The parser must never emit an off-host URL: an absolute href on another
+	// host would pass the id-shaped path check, and the filename is rendered as
+	// an openExternal link. Rejecting the row here means a poisoned ticket page
+	// cannot get an attacker URL in front of the user.
+	try {
+		if (new URL(url).hostname !== TRAC_HOST) return null;
+	} catch {
+		return null;
+	}
+	const filename = decodeURIComponent(link[2]);
+
+	// Author: the trac-author anchor, or its text. Falls back to empty.
+	const authorMatch = /class="trac-author[^"]*"[^>]*>([^<]+)</.exec(chunk)
+		|| /added by\s+<[^>]*>([^<]+)</.exec(chunk);
+	const author = authorMatch ? authorMatch[1].trim() : '';
+
+	// Prefer an absolute timestamp from a title attribute over relative text
+	// ("15 months ago"), which cannot be sorted or aged.
+	const absDate = /title="See timeline at ([^"]+)"/.exec(chunk)
+		|| /\(((?:0?[1-9]|1[0-2])\/\d{1,2}\/\d{4}[^)]*)\)/.exec(chunk);
+	const relDate = /([\d]+\s+(?:years?|months?|weeks?|days?|hours?|minutes?)\s+ago)/.exec(chunk);
+	const dateMatch = absDate || relDate;
+	const dateText = dateMatch ? dateMatch[1].trim() : '';
+
+	const sizeMatch = /\(\s*([\d.]+\s*[KMG]?B)\s*\)/i.exec(chunk);
+	const sizeText = sizeMatch ? sizeMatch[1].replace(/\s+/g, ' ').trim() : '';
+
+	return {
+		filename,
+		url,
+		author,
+		dateText,
+		sizeText,
+		// Only unified diffs can be applied; a .txt or .zip is listed context.
+		applyable: /\.(diff|patch)$/i.test(filename)
+	};
+}
+
+/**
+ * Parses the scraped `#attachments` block into attachment rows, newest markup
+ * order preserved (Trac lists oldest-first). Deduplicates by filename, since
+ * each attachment carries both a raw and a view link.
+ *
+ * @param {string}        attachmentsHtml outerHTML of `#attachments`, or ''.
+ * @param {number|string} ticketId
+ * @return {Array}
+ */
+function parseAttachments(attachmentsHtml, ticketId) {
+	const html = typeof attachmentsHtml === 'string' ? attachmentsHtml : '';
+	const id = String(ticketId).replace(/[^0-9]/g, '');
+	if (!html || !id) return [];
+
+	// Split on <dt> so each attachment's metadata stays with its link. The
+	// leading segment before the first <dt> (heading) yields no link and drops.
+	const chunks = html.split(/<dt[\s>]/i);
+	const seen = new Set();
+	const rows = [];
+	for (const chunk of chunks) {
+		const row = parseOne(chunk, id);
+		if (!row || seen.has(row.filename)) continue;
+		seen.add(row.filename);
+		rows.push(row);
+	}
+	return rows;
+}
+
+module.exports = { toRawUrl, parseAttachments };

--- a/src/trac-view.js
+++ b/src/trac-view.js
@@ -19,7 +19,7 @@
  */
 
 const { BrowserWindow, session } = require('electron');
-const { parseAttachments } = require('./trac-attachments.cjs');
+const { parseAttachments, secureTracUrl } = require('./trac-attachments.cjs');
 const { httpGet } = require('./github-prs');
 
 const TRAC_HOST = 'core.trac.wordpress.org';
@@ -43,11 +43,10 @@ function ticketUrl(id) {
 function pinToTrac(wc) {
 	wc.setWindowOpenHandler(() => ({ action: 'deny' }));
 	const stayOnTrac = (event, url) => {
-		try {
-			if (new URL(url).hostname !== TRAC_HOST) event.preventDefault();
-		} catch {
-			event.preventDefault();
-		}
+		// Pinned to the exact https Trac origin, not just the host: a redirect or
+		// <meta refresh> to http://core.trac.wordpress.org would otherwise keep
+		// this window — and its session cookie — on a plaintext origin.
+		if (!secureTracUrl(url)) event.preventDefault();
 	};
 	// will-navigate covers link clicks and script navigation; will-redirect
 	// covers HTTP 3xx and <meta refresh>, which do not fire will-navigate and
@@ -130,13 +129,15 @@ async function openAndScrape(ticketId) {
  * @return {Promise<{ok: true, text: string}|{ok: false, error: string}>}
  */
 async function fetchAttachment(url) {
-	let parsed;
-	try { parsed = new URL(url); } catch { return { ok: false, error: 'Invalid attachment URL' }; }
-	if (parsed.hostname !== TRAC_HOST) return { ok: false, error: 'Only core.trac.wordpress.org attachments are allowed' };
+	// Validate to the exact https Trac origin and send the normalized address,
+	// not the caller's string: the request rides the session cookie, so the URL
+	// fetched has to be the one that passed the check.
+	const safe = secureTracUrl(url);
+	if (!safe) return { ok: false, error: 'Only https core.trac.wordpress.org attachments are allowed' };
 
 	let res;
 	try {
-		res = await httpGet(url, { Accept: 'text/plain' }, { partition: TRAC_PARTITION, useSessionCookies: true });
+		res = await httpGet(safe, { Accept: 'text/plain' }, { partition: TRAC_PARTITION, useSessionCookies: true });
 	} catch (e) {
 		return { ok: false, error: String(e && e.message ? e.message : e) };
 	}

--- a/src/trac-view.js
+++ b/src/trac-view.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/**
+ * The embedded Trac ticket view (issue #109 / #11).
+ *
+ * Trac answers non-browser clients with a proof-of-work interstitial, so the
+ * only way to read a ticket's attachment list is a real Chromium window where
+ * the user clears the challenge once. This opens such a window, waits for the
+ * real ticket page, scrapes the `#attachments` block, and closes — the window
+ * is a means, not the UI. The scraped list is parsed by the pure
+ * trac-attachments.cjs module and shown natively in the app.
+ *
+ * Security: the window renders remote, untrusted content, so it gets no preload
+ * (the page cannot reach the app), runs sandboxed with context isolation, and
+ * is pinned to core.trac.wordpress.org. The only thing that crosses back is the
+ * `#attachments` HTML, read by the main process via executeJavaScript. A
+ * downloaded attachment is likewise untrusted and flows through the same apply
+ * engine (#11), which defends against path traversal.
+ */
+
+const { BrowserWindow, session } = require('electron');
+const { parseAttachments } = require('./trac-attachments.cjs');
+const { httpGet } = require('./github-prs');
+
+const TRAC_HOST = 'core.trac.wordpress.org';
+const TRAC_PARTITION = 'persist:trac';
+const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/experimental-wp-dev-env)';
+// How long to wait for the ticket page to appear. The hashcash runs
+// automatically in a few seconds; the extra headroom covers the escalated
+// "I am human" checkbox, which needs a human click.
+const READY_TIMEOUT_MS = 90000;
+const POLL_MS = 800;
+
+function ticketUrl(id) {
+	return `https://${TRAC_HOST}/ticket/${id}`;
+}
+
+/**
+ * Locks a window's webContents to the Trac host: no popups, no navigating away.
+ *
+ * @param {import('electron').WebContents} wc
+ */
+function pinToTrac(wc) {
+	wc.setWindowOpenHandler(() => ({ action: 'deny' }));
+	const stayOnTrac = (event, url) => {
+		try {
+			if (new URL(url).hostname !== TRAC_HOST) event.preventDefault();
+		} catch {
+			event.preventDefault();
+		}
+	};
+	// will-navigate covers link clicks and script navigation; will-redirect
+	// covers HTTP 3xx and <meta refresh>, which do not fire will-navigate and
+	// would otherwise move this pinned window off the Trac origin.
+	wc.on('will-navigate', stayOnTrac);
+	wc.on('will-redirect', stayOnTrac);
+}
+
+/**
+ * Opens the ticket, waits for the real page (showing the window only if the
+ * challenge needs the user), scrapes the attachment list, and closes.
+ *
+ * @param {number|string} ticketId
+ * @return {Promise<{status: string, items: Array, error?: string}>}
+ */
+async function openAndScrape(ticketId) {
+	const id = String(ticketId).replace(/[^0-9]/g, '');
+	if (!id) return { status: 'error', items: [], error: 'No ticket number' };
+
+	const tracSession = session.fromPartition(TRAC_PARTITION);
+	const win = new BrowserWindow({
+		width: 1000,
+		height: 800,
+		show: false,
+		title: `Trac #${id}`,
+		webPreferences: {
+			contextIsolation: true,
+			nodeIntegration: false,
+			sandbox: true,
+			partition: TRAC_PARTITION
+		}
+	});
+	pinToTrac(win.webContents);
+	// A persistent User-Agent that identifies the app, on this session only.
+	tracSession.setUserAgent(USER_AGENT);
+
+	let shown = false;
+	const showOnce = () => {
+		// Once the challenge needs interaction, the window has to be visible.
+		if (!shown && !win.isDestroyed()) { shown = true; win.show(); }
+	};
+
+	try {
+		await win.loadURL(ticketUrl(id));
+
+		// Poll until the real ticket page is present. The challenge page has no
+		// #ticket; when the hashcash (or the user) clears it, Trac reloads to
+		// the real page and #ticket appears.
+		const deadline = Date.now() + READY_TIMEOUT_MS;
+		let ready = false;
+		while (Date.now() < deadline) {
+			if (win.isDestroyed()) return { status: 'closed', items: [] };
+			const hasTicket = await win.webContents.executeJavaScript('!!document.querySelector("#ticket")').catch(() => false);
+			if (hasTicket) { ready = true; break; }
+			showOnce();
+			await new Promise((r) => setTimeout(r, POLL_MS));
+		}
+
+		if (!ready) {
+			return { status: 'challenge-timeout', items: [] };
+		}
+
+		const html = await win.webContents
+			.executeJavaScript('(document.querySelector("#attachments") || {}).outerHTML || ""')
+			.catch(() => '');
+		const items = parseAttachments(html, id);
+		return { status: items.length ? 'ok' : 'no-attachments', items };
+	} catch (e) {
+		return { status: 'error', items: [], error: String(e && e.message ? e.message : e) };
+	} finally {
+		if (!win.isDestroyed()) win.destroy();
+	}
+}
+
+/**
+ * Downloads one attachment through the challenge-passing session, so its cookie
+ * authorises the request.
+ *
+ * @param {string} url A raw-attachment URL on the Trac host.
+ * @return {Promise<{ok: true, text: string}|{ok: false, error: string}>}
+ */
+async function fetchAttachment(url) {
+	let parsed;
+	try { parsed = new URL(url); } catch { return { ok: false, error: 'Invalid attachment URL' }; }
+	if (parsed.hostname !== TRAC_HOST) return { ok: false, error: 'Only core.trac.wordpress.org attachments are allowed' };
+
+	let res;
+	try {
+		res = await httpGet(url, { Accept: 'text/plain' }, { partition: TRAC_PARTITION, useSessionCookies: true });
+	} catch (e) {
+		return { ok: false, error: String(e && e.message ? e.message : e) };
+	}
+	if (res.status !== 200) {
+		return { ok: false, error: `Trac returned ${res.status} — try opening the ticket again to pass the check.` };
+	}
+	return { ok: true, text: res.body };
+}
+
+module.exports = { openAndScrape, fetchAttachment, ticketUrl };

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1157,6 +1157,19 @@ test('git:list-ticket-patches returns no-ticket without calling github-prs when 
 	assert.deepEqual(fetchLinkedPrs.calls, []);
 });
 
+// --- Trac attachments (#109 / #11) ---------------------------------------
+
+test('trac:fetch-attachment goes through trac-view', async () => {
+	const fetchAttachment = spy(async () => ({ ok: true, text: 'DIFF' }));
+	const main = loadMain({ stubs: { ...silentLogging(), './trac-view': { fetchAttachment, openAndScrape: async () => ({}) } } });
+	const url = 'https://core.trac.wordpress.org/raw-attachment/ticket/1/a.diff';
+
+	const result = await main.invoke('trac:fetch-attachment', url);
+
+	assert.deepEqual(fetchAttachment.calls, [[url]]);
+	assert.deepEqual(result, { ok: true, text: 'DIFF' });
+});
+
 // --- the harness's own guard ---------------------------------------------
 
 // Requiring the real `electron` package is not a harmless fallback: its
@@ -1209,7 +1222,8 @@ const WIRED = new Set([
 	'git:preview-patch',
 	'git:apply-patch',
 	'git:fetch-pr-diff',
-	'git:list-ticket-patches'
+	'git:list-ticket-patches',
+	'trac:fetch-attachment'
 ]);
 
 // Channels with no module to reach: they read or write electron-store, drive a
@@ -1247,7 +1261,8 @@ const NO_DELEGATION = new Map([
 // Channels that do delegate, but whose call sits behind something this harness
 // cannot stand in for yet. Each one is a known hole, not an oversight.
 const NOT_REACHABLE = new Map([
-	['wordpress:setup', 'calls ensureAutocrlf and readTrunkInfo only after cloning wordpress-develop over the network']
+	['wordpress:setup', 'calls ensureAutocrlf and readTrunkInfo only after cloning wordpress-develop over the network'],
+	['trac:list-attachments', 'reads electron-store for the ticket before it can open the Trac window']
 ]);
 
 const CLASSIFIED = [...WIRED, ...NO_DELEGATION.keys(), ...NOT_REACHABLE.keys()];

--- a/test/trac-attachments.test.cjs
+++ b/test/trac-attachments.test.cjs
@@ -2,7 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { toRawUrl, parseAttachments } = require('../src/trac-attachments.cjs');
+const { toRawUrl, parseAttachments, secureTracUrl } = require('../src/trac-attachments.cjs');
 
 // A representative #attachments block, modelled on WordPress Trac's markup and
 // the real attachments on ticket #37578 (three .diff files plus a .txt). Built
@@ -107,6 +107,27 @@ test('parseAttachments: an off-host absolute attachment href is rejected (issue 
 		37578
 	);
 	assert.deepStrictEqual(rows, []);
+});
+
+// Same host, but http:// — a downgrade of the origin that carries the session
+// cookie. It must not become a row.
+test('parseAttachments: a same-host http (non-https) attachment href is rejected (issue #11)', () => {
+	const rows = parseAttachments(
+		'<div id="attachments"><dt><a href="http://core.trac.wordpress.org/attachment/ticket/37578/x.diff">x.diff</a></dt></div>',
+		37578
+	);
+	assert.deepStrictEqual(rows, []);
+});
+
+test('secureTracUrl: accepts only the exact https Trac origin (issue #11)', () => {
+	assert.strictEqual(
+		secureTracUrl('https://core.trac.wordpress.org/raw-attachment/ticket/1/a.diff'),
+		'https://core.trac.wordpress.org/raw-attachment/ticket/1/a.diff'
+	);
+	assert.strictEqual(secureTracUrl('http://core.trac.wordpress.org/raw-attachment/ticket/1/a.diff'), null);
+	assert.strictEqual(secureTracUrl('https://evil.example.com/raw-attachment/ticket/1/a.diff'), null);
+	assert.strictEqual(secureTracUrl('https://core.trac.wordpress.org.evil.com/a.diff'), null);
+	assert.strictEqual(secureTracUrl('not a url'), null);
 });
 
 test('parseAttachments: links to other tickets are ignored (issue #11)', () => {

--- a/test/trac-attachments.test.cjs
+++ b/test/trac-attachments.test.cjs
@@ -1,0 +1,124 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { toRawUrl, parseAttachments } = require('../src/trac-attachments.cjs');
+
+// A representative #attachments block, modelled on WordPress Trac's markup and
+// the real attachments on ticket #37578 (three .diff files plus a .txt). Built
+// from the documented structure; hardened against live markup during the manual
+// pass. Kept verbatim so the test breaks loudly if the real markup drifts.
+const BLOCK = `<div id="attachments">
+  <h2 class="foldable">Attachments <span class="trac-count">(4)</span></h2>
+  <div class="attachments">
+    <dl class="attachments">
+      <dt>
+        <a class="trac-rawlink" href="/raw-attachment/ticket/37578/37578-01.diff" title="Download"></a>
+        <a href="/attachment/ticket/37578/37578-01.diff" title="View attachment">37578-01.diff</a>
+        <span class="trac-args">(1.7 KB) - added by <a class="trac-author" href="/query?status=!closed&amp;owner=Jonnyauk">Jonnyauk</a> <a class="timeline" href="/timeline?from=2015" title="See timeline at 09/12/2015 10:15:00 AM">10 years</a> ago.</span>
+      </dt>
+      <dd>New filters for Dashboard Recent Activity widget.</dd>
+      <dt>
+        <a class="trac-rawlink" href="/raw-attachment/ticket/37578/good%20first%20bug%201.txt" title="Download"></a>
+        <a href="/attachment/ticket/37578/good%20first%20bug%201.txt" title="View attachment">good first bug 1.txt</a>
+        <span class="trac-args">(606 bytes) - added by <a class="trac-author" href="/query?owner=vedantsonone1234">vedantsonone1234</a> <a class="timeline" href="/timeline" title="See timeline at 04/03/2025 02:00:00 PM">16 months</a> ago.</span>
+      </dt>
+      <dd>notes</dd>
+      <dt>
+        <a class="trac-rawlink" href="/raw-attachment/ticket/37578/37578.diff" title="Download"></a>
+        <a href="/attachment/ticket/37578/37578.diff" title="View attachment">37578.diff</a>
+        <span class="trac-args">(1.7 KB) - added by <a class="trac-author" href="/query?owner=pmbaldha">pmbaldha</a> <a class="timeline" title="See timeline at 05/15/2025 09:30:00 AM">15 months</a> ago.</span>
+      </dt>
+      <dd>Added a patch using the existing filter.</dd>
+      <dt>
+        <a class="trac-rawlink" href="/raw-attachment/ticket/37578/37578-1.diff" title="Download"></a>
+        <a href="/attachment/ticket/37578/37578-1.diff" title="View attachment">37578-1.diff</a>
+        <span class="trac-args">(1.8 KB) - added by <a class="trac-author" href="/query?owner=pmbaldha">pmbaldha</a> <a class="timeline" title="See timeline at 05/16/2025 11:00:00 AM">15 months</a> ago.</span>
+      </dt>
+      <dd>PHPDoc Comment update.</dd>
+    </dl>
+  </div>
+</div>`;
+
+test('toRawUrl: the view path becomes the raw download path (issue #11)', () => {
+	assert.strictEqual(
+		toRawUrl('/attachment/ticket/37578/37578.diff'),
+		'https://core.trac.wordpress.org/raw-attachment/ticket/37578/37578.diff'
+	);
+	// An already-raw or absolute URL is left as the raw form.
+	assert.strictEqual(
+		toRawUrl('https://core.trac.wordpress.org/raw-attachment/ticket/37578/37578.diff'),
+		'https://core.trac.wordpress.org/raw-attachment/ticket/37578/37578.diff'
+	);
+});
+
+test('parseAttachments: every attachment is found once, with a raw download URL (issue #11)', () => {
+	const rows = parseAttachments(BLOCK, 37578);
+	assert.deepStrictEqual(rows.map((r) => r.filename), [
+		'37578-01.diff', 'good first bug 1.txt', '37578.diff', '37578-1.diff'
+	]);
+	// Deduped despite each attachment carrying both a raw and a view link.
+	assert.strictEqual(rows.length, 4);
+	assert.strictEqual(rows[0].url, 'https://core.trac.wordpress.org/raw-attachment/ticket/37578/37578-01.diff');
+});
+
+test('parseAttachments: only .diff/.patch are applyable (issue #11)', () => {
+	const rows = parseAttachments(BLOCK, 37578);
+	const byName = Object.fromEntries(rows.map((r) => [r.filename, r.applyable]));
+	assert.strictEqual(byName['37578.diff'], true);
+	assert.strictEqual(byName['37578-1.diff'], true);
+	assert.strictEqual(byName['good first bug 1.txt'], false);
+});
+
+test('parseAttachments: author, size and an absolute date are extracted (issue #11)', () => {
+	const rows = parseAttachments(BLOCK, 37578);
+	const diff = rows.find((r) => r.filename === '37578.diff');
+	assert.strictEqual(diff.author, 'pmbaldha');
+	assert.strictEqual(diff.sizeText, '1.7 KB');
+	// Absolute timestamp from the title, not the "15 months ago" relative text.
+	assert.strictEqual(diff.dateText, '05/15/2025 09:30:00 AM');
+});
+
+test('parseAttachments: an encoded filename is decoded (issue #11)', () => {
+	const rows = parseAttachments(BLOCK, 37578);
+	assert.ok(rows.some((r) => r.filename === 'good first bug 1.txt'), 'the %20 spaces decode');
+});
+
+// A row missing its metadata should still be usable — the filename and a working
+// download link are the load-bearing parts.
+test('parseAttachments: a bare attachment link still yields a row (issue #11)', () => {
+	const rows = parseAttachments(
+		'<div id="attachments"><dl><dt><a href="/attachment/ticket/62281/62281.diff">62281.diff</a></dt></dl></div>',
+		62281
+	);
+	assert.strictEqual(rows.length, 1);
+	assert.strictEqual(rows[0].filename, '62281.diff');
+	assert.strictEqual(rows[0].url, 'https://core.trac.wordpress.org/raw-attachment/ticket/62281/62281.diff');
+	assert.strictEqual(rows[0].author, '');
+	assert.strictEqual(rows[0].applyable, true);
+});
+
+// A poisoned ticket page could carry an absolute href on another host that
+// still matches the id-shaped path. It must not become a row — the filename is
+// rendered as an openExternal link.
+test('parseAttachments: an off-host absolute attachment href is rejected (issue #11)', () => {
+	const rows = parseAttachments(
+		'<div id="attachments"><dt><a href="https://evil.example.com/attachment/ticket/37578/x.diff">x.diff</a></dt></div>',
+		37578
+	);
+	assert.deepStrictEqual(rows, []);
+});
+
+test('parseAttachments: links to other tickets are ignored (issue #11)', () => {
+	const rows = parseAttachments(
+		'<div id="attachments"><dt><a href="/attachment/ticket/99999/other.diff">other.diff</a></dt></div>',
+		37578
+	);
+	assert.deepStrictEqual(rows, []);
+});
+
+test('parseAttachments: an empty or attachment-less block yields nothing, not a throw (issue #11)', () => {
+	assert.deepStrictEqual(parseAttachments('', 37578), []);
+	assert.deepStrictEqual(parseAttachments(null, 37578), []);
+	assert.deepStrictEqual(parseAttachments('<div id="attachments"><p>No attachments.</p></div>', 37578), []);
+});


### PR DESCRIPTION
Part of #110. Refs #109, #11. **Stacked on #136** (base is that branch), which stacks on #135 → #123. Review order: #123 → #135 → #136 → this. The whole flow merges once the stack is complete.

## Why

PRs are only half of "the work already on a ticket". On many tickets — good-first-bugs especially — the patch a contributor wants to try is a `.diff` **attached to the ticket**, not a PR (verified live: ticket #37578 has three `.diff` attachments and one PR; before this, the app showed only the PR). This adds the attachment half, under the PR list, loaded on demand.

## What this does

A **"Show Trac attachments"** button under the linked-PR list. Because Trac serves the attachment list only to a real browser (everything else hits the proof-of-work interstitial), clicking it opens the real ticket in an embedded window where the contributor clears the challenge **once**, the app scrapes the `#attachments` block, and the window closes — it is a means, not the UI. The attachments appear as a native in-app list (filename · author · date · size), each `.diff`/`.patch` with **Apply…**; non-patches (e.g. a `.txt`) are shown but marked "not a patch". Applying downloads the file through that same challenge-passing session and hands it to the existing preview → apply engine, so an attachment, a PR and a chosen file are one path from the preview onward.

On demand, not on link: opening a Trac window can surface the challenge, so it happens when the contributor asks, not for every ticket. The persistent session means the challenge is passed once, not per open.

## Verified end to end against live Trac (#37578)

A deterministic Electron harness exercised the real `trac-view.js`:
- the window passes the challenge unattended;
- the parser reads the **real** markup — 4 attachments with authors and **absolute timestamps**, the `.txt` correctly marked not-a-patch;
- **the raw-attachment download is authorised by the session cookie** — a real `wp-admin/includes/dashboard.php` diff (1701 bytes) comes back. This was the one load-bearing runtime assumption, now confirmed.

Also confirmed in the running app: the panel renders, the attachment list populates from the live scrape, and the PR apply→preview wiring works.

## Security (the app's first remote, untrusted content — AGENTS.md)

- The window: `contextIsolation`, no `nodeIntegration`, `sandbox`, a dedicated `persist:trac` partition, and **no preload** — the page cannot reach the app or Node; only the `#attachments` HTML crosses back, read from the main process via `executeJavaScript`.
- Navigation pinned to `core.trac.wordpress.org` against **both `will-navigate` and `will-redirect`** (the latter catches 3xx / `<meta refresh>`).
- The parser **never emits an off-host URL**, and `fetchAttachment` re-checks the host before sending the session cookie — so a poisoned ticket page cannot get an attacker link in front of the user or leak the cookie off-host.
- The downloaded diff is untrusted → flows through #135's apply engine, which defends against path traversal.

## Testing

- `test/trac-attachments.test.cjs` — the pure parser: dedup, encoded names, off-host and cross-ticket rejection, absolute-date extraction, missing-metadata rows, empty input. The fixture matches the live markup (confirmed by the harness above).
- `npm test` / `npm run test:electron`: **229/229** both runtimes. `npm run lint`: clean.
- `src/trac-view.js`'s window/net glue is untested, consistent with the other `net` client (`github-prs.js`) — no repo precedent for mocking BrowserWindow; the logic lives in the covered pure parser.

## Self-review (per AGENTS.md)

Ran the review with the judgement pass on fresh context. It returned **2 `[fix here]` (both 🔵), both fixed before this PR:**
- Navigation lock covered only `will-navigate` → added `will-redirect` (3xx / meta-refresh could otherwise move the pinned window off-origin).
- The link regex accepted an absolute off-host href (Apply was safe, but the filename rendered as an `openExternal` link) → the parser now rejects any non-Trac-host URL, with a test.

Reviewer verified clean: window config, `setWindowOpenHandler`, host re-check before the cookie fetch, poll-loop lifecycle with `isDestroyed` guards + `destroy()` in `finally`, additive `electron-store` (no migration), no new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)