### PR TITLE
Mark which patch on a ticket is the latest, PR or attachment

### DIFF
--- a/src/latest-patch.cjs
+++ b/src/latest-patch.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * Deciding which patch on a ticket is the most recent — a pull request or a
+ * Trac attachment (issue #109 / #11).
+ *
+ * A contributor arriving at a ticket wants to try the latest fix. Usually that
+ * is a PR, and the PR list loads on its own, so the answer is known
+ * immediately. Attachments load on demand (opening Trac costs the challenge),
+ * so "latest" can only be judged across what is currently loaded: PRs alone
+ * until the contributor asks for attachments, then both. When an uploaded patch
+ * turns out to be newer than any PR, the UI says so explicitly rather than
+ * leaving it buried under the attachments button.
+ *
+ * Kept pure and dependency-free so the comparison is unit tested without a DOM:
+ * the renderer imports it, `node --test` requires it directly (same convention
+ * as patch-plan.cjs / patch-sources.cjs).
+ *
+ * Caveat, deliberate: a PR is dated by `updatedAt`, which also bumps on
+ * comments, so "latest" means "most recently touched", not "newest commit".
+ * That matches the common case (an active PR is usually the freshest thing) and
+ * is the only date the list already carries.
+ */
+
+/**
+ * Milliseconds for an attachment's upload time, or NaN when it cannot be known.
+ * The absolute timestamp scraped from Trac's title attribute is a US-format
+ * date string ("MM/DD/YYYY hh:mm:ss AM"); a relative fallback ("15 months
+ * ago") is not comparable and must not win.
+ *
+ * The string carries no timezone, so it is anchored to UTC by hand rather than
+ * left to Date.parse, which would read it in the machine's local zone. That
+ * anchoring is what keeps the comparison machine-independent: two contributors
+ * in different timezones must see the same patch marked latest. The absolute
+ * instant may be off by the true Trac offset, but "which is newer" stays
+ * consistent, which is the point.
+ *
+ * @param {Object} attachment
+ * @return {number}
+ */
+function attachmentDateMs(attachment) {
+	const text = attachment && typeof attachment.dateText === 'string' ? attachment.dateText : '';
+	const m = /^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{2}):(\d{2})\s*(AM|PM)?/i.exec(text.trim());
+	if (!m) return NaN;
+	const [, mon, day, year, hh, mm, ss, ampm] = m;
+	let hour = Number(hh);
+	if (ampm) {
+		const pm = ampm.toUpperCase() === 'PM';
+		if (pm && hour !== 12) hour += 12;
+		if (!pm && hour === 12) hour = 0;
+	}
+	return Date.UTC(Number(year), Number(mon) - 1, Number(day), hour, Number(mm), Number(ss));
+}
+
+/**
+ * Milliseconds for a PR's last activity, or NaN when absent.
+ *
+ * @param {Object} pr
+ * @return {number}
+ */
+function prDateMs(pr) {
+	const text = pr && typeof pr.updatedAt === 'string' ? pr.updatedAt : '';
+	return text ? Date.parse(text) : NaN;
+}
+
+/**
+ * The most recent patch across the loaded sources, or null if none is datable.
+ *
+ * Only applyable attachments (patch files) compete — a .txt is context, not a
+ * fix. `attachments` being undefined means they have not been loaded yet, so
+ * the answer is drawn from PRs alone; that is the normal, pre-attachment state.
+ *
+ * @param {Object} root0
+ * @param {Array}  [root0.prs]
+ * @param {Array}  [root0.attachments]
+ * @return {{kind: 'pr'|'attachment', key: (number|string), whenMs: number}|null}
+ */
+function pickLatest({ prs, attachments } = {}) {
+	let best = null;
+	const consider = (kind, key, whenMs) => {
+		if (!Number.isFinite(whenMs)) return;
+		if (!best || whenMs > best.whenMs) best = { kind, key, whenMs };
+	};
+
+	for (const pr of Array.isArray(prs) ? prs : []) {
+		consider('pr', pr.number, prDateMs(pr));
+	}
+	for (const att of Array.isArray(attachments) ? attachments : []) {
+		if (!att.applyable) continue;
+		consider('attachment', att.url || att.filename, attachmentDateMs(att));
+	}
+	return best;
+}
+
+module.exports = { attachmentDateMs, prDateMs, pickLatest };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -20,6 +20,7 @@ import { computeSetupStepState } from './setup-steps.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
 import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, APPLY_STATE_TO_STEP } from './update-plan.cjs';
+import { pickLatest } from '../latest-patch.cjs';
 import { parseTicketRef, ticketUrl } from './trac-ticket.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
@@ -1571,6 +1572,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const applySteps = planApplySteps({ needsInstall: applyNeedsInstall });
   const applyStepStates = updateStepStatuses(applySteps, applyState, APPLY_STATE_TO_STEP);
 
+  // The single most recent patch across whatever is loaded — PRs always, Trac
+  // attachments once the contributor has opened them (#11). Drives the "Latest"
+  // pill and the "latest is a patch file" note.
+  const latestPatch = pickLatest({ prs: ticketPatches?.items, attachments: tracAttachments?.items });
+  const latestIsAttachment = latestPatch?.kind === 'attachment';
+  const latestPill = (isLatest) => (isLatest ? (
+    <span style={{ display: 'inline-flex', alignItems: 'center', padding: '1px 7px', borderRadius: 999, fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', background: '#e7f1ff', color: '#0b5d95', marginLeft: 8 }}>
+      Latest
+    </span>
+  ) : null);
+
   const finishApply = (message) => {
     terminalStateRef.current.running = false;
     terminalKillRef.current = null;
@@ -2377,6 +2389,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         <div style={{ fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           <Button variant="link" onClick={() => window.api.openExternal(pr.url)} style={{ fontSize: 13 }}>#{pr.number}</Button>
                           {' '}{pr.title}
+                          {latestPill(latestPatch?.kind === 'pr' && latestPatch.key === pr.number)}
                         </div>
                         <div style={{ fontSize: 11, color: '#6c6f72' }}>
                           {pr.state === 'closed' ? 'closed' : 'open'}{pr.updatedAt ? ` · updated ${new Date(pr.updatedAt).toLocaleDateString()}` : ''}
@@ -2394,6 +2407,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 </div>
               ) : null}
             </div>
+
+            {latestIsAttachment ? (
+              <div style={{ marginTop: 12, padding: '8px 10px', background: '#e7f1ff', border: '1px solid #9ec5f0', borderRadius: 6, fontSize: 12, color: '#0b5d95' }}>
+                The most recent patch on this ticket is a file attachment, not a pull request — see Trac attachments below.
+              </div>
+            ) : null}
 
             <div style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
@@ -2441,6 +2460,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                       <div style={{ flex: '1 1 auto', minWidth: 0 }}>
                         <div style={{ fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           <Button variant="link" onClick={() => window.api.openExternal(att.url)} style={{ fontSize: 13 }}>{att.filename}</Button>
+                          {latestPill(latestPatch?.kind === 'attachment' && latestPatch.key === att.url)}
                         </div>
                         <div style={{ fontSize: 11, color: '#6c6f72' }}>
                           {[att.author && `by ${att.author}`, att.dateText, att.sizeText].filter(Boolean).join(' · ')}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1578,7 +1578,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const latestPatch = pickLatest({ prs: ticketPatches?.items, attachments: tracAttachments?.items });
   const latestIsAttachment = latestPatch?.kind === 'attachment';
   const latestPill = (isLatest) => (isLatest ? (
-    <span style={{ display: 'inline-flex', alignItems: 'center', padding: '1px 7px', borderRadius: 999, fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', background: '#e7f1ff', color: '#0b5d95', marginLeft: 8 }}>
+    <span style={{ display: 'inline-flex', alignItems: 'center', flex: '0 0 auto', padding: '1px 7px', borderRadius: 999, fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', background: '#e7f1ff', color: '#0b5d95', marginLeft: 8 }}>
       Latest
     </span>
   ) : null);
@@ -2386,9 +2386,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   {ticketPatches.items.map((pr) => (
                     <div key={pr.number} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderBottom: '1px solid #f0f0f1' }}>
                       <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-                        <div style={{ fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          <Button variant="link" onClick={() => window.api.openExternal(pr.url)} style={{ fontSize: 13 }}>#{pr.number}</Button>
-                          {' '}{pr.title}
+                        <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+                          <span style={{ flex: '0 1 auto', minWidth: 0, fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            <Button variant="link" onClick={() => window.api.openExternal(pr.url)} style={{ fontSize: 13 }}>#{pr.number}</Button>
+                            {' '}{pr.title}
+                          </span>
                           {latestPill(latestPatch?.kind === 'pr' && latestPatch.key === pr.number)}
                         </div>
                         <div style={{ fontSize: 11, color: '#6c6f72' }}>
@@ -2458,8 +2460,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   {tracAttachments.items.map((att) => (
                     <div key={att.url} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderBottom: '1px solid #f0f0f1' }}>
                       <div style={{ flex: '1 1 auto', minWidth: 0 }}>
-                        <div style={{ fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          <Button variant="link" onClick={() => window.api.openExternal(att.url)} style={{ fontSize: 13 }}>{att.filename}</Button>
+                        <div style={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
+                          <span style={{ flex: '0 1 auto', minWidth: 0, fontSize: 13, color: '#1d2327', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            <Button variant="link" onClick={() => window.api.openExternal(att.url)} style={{ fontSize: 13 }}>{att.filename}</Button>
+                          </span>
                           {latestPill(latestPatch?.kind === 'attachment' && latestPatch.key === att.url)}
                         </div>
                         <div style={{ fontSize: 11, color: '#6c6f72' }}>

--- a/test/latest-patch.test.cjs
+++ b/test/latest-patch.test.cjs
@@ -1,0 +1,82 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { attachmentDateMs, pickLatest } = require('../src/latest-patch.cjs');
+
+const pr = (number, updatedAt) => ({ number, updatedAt });
+const att = (filename, dateText, applyable = true) => ({ filename, url: `https://core.trac.wordpress.org/raw-attachment/ticket/1/${filename}`, dateText, applyable });
+
+test('attachmentDateMs: a US-format absolute date parses, a relative one does not (issue #11)', () => {
+	assert.ok(Number.isFinite(attachmentDateMs(att('a.diff', '05/15/2025 01:11:28 PM'))));
+	assert.ok(Number.isNaN(attachmentDateMs(att('a.diff', '15 months ago'))));
+	assert.ok(Number.isNaN(attachmentDateMs(att('a.diff', ''))));
+});
+
+// Anchored to UTC by hand, so the result does not depend on the machine's
+// timezone — two contributors must agree on which patch is latest. PM/AM and
+// the 12 o'clock edge are the parts most likely to be got wrong.
+test('attachmentDateMs: parses to a fixed UTC instant, timezone-independent (issue #11)', () => {
+	assert.strictEqual(attachmentDateMs(att('a.diff', '05/15/2025 01:11:28 PM')), Date.UTC(2025, 4, 15, 13, 11, 28));
+	assert.strictEqual(attachmentDateMs(att('a.diff', '05/15/2025 12:00:00 AM')), Date.UTC(2025, 4, 15, 0, 0, 0));
+	assert.strictEqual(attachmentDateMs(att('a.diff', '05/15/2025 12:30:00 PM')), Date.UTC(2025, 4, 15, 12, 30, 0));
+	assert.strictEqual(attachmentDateMs(att('a.diff', '08/05/2016 01:43:44 AM')), Date.UTC(2016, 7, 5, 1, 43, 44));
+});
+
+// The common case: attachments not loaded yet, so the newest PR is the latest.
+test('pickLatest: with only PRs, the most recently updated PR wins (issue #11)', () => {
+	const latest = pickLatest({ prs: [pr(1, '2026-01-01T00:00:00Z'), pr(2, '2026-08-06T00:00:00Z')] });
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 2 });
+});
+
+test('pickLatest: nothing loaded yields null, not a throw (issue #11)', () => {
+	assert.strictEqual(pickLatest({}), null);
+	assert.strictEqual(pickLatest({ prs: [], attachments: [] }), null);
+});
+
+// Once attachments load, a newer uploaded patch wins over the PR — this is the
+// case the feature exists to surface.
+test('pickLatest: a newer attachment beats the PR once loaded (issue #11)', () => {
+	const latest = pickLatest({
+		prs: [pr(9026, '2025-01-01T00:00:00Z')],
+		attachments: [att('37578-1.diff', '05/16/2025 11:00:00 AM')]
+	});
+	assert.strictEqual(latest.kind, 'attachment');
+	assert.strictEqual(latest.key, 'https://core.trac.wordpress.org/raw-attachment/ticket/1/37578-1.diff');
+});
+
+test('pickLatest: a newer PR beats older attachments (issue #11)', () => {
+	const latest = pickLatest({
+		prs: [pr(9026, '2026-06-07T00:00:00Z')],
+		attachments: [att('old.diff', '05/16/2025 11:00:00 AM')]
+	});
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 9026 });
+});
+
+test('pickLatest: a non-patch attachment never wins, even if newest (issue #11)', () => {
+	const latest = pickLatest({
+		prs: [pr(9026, '2025-01-01T00:00:00Z')],
+		attachments: [att('notes.txt', '08/01/2026 10:00:00 AM', false), att('fix.diff', '05/16/2025 11:00:00 AM')]
+	});
+	// The .txt is newer but not applyable; the .diff wins among attachments,
+	// still beating the older PR.
+	assert.strictEqual(latest.kind, 'attachment');
+	assert.ok(String(latest.key).endsWith('fix.diff'));
+});
+
+test('pickLatest: an attachment with only a relative date cannot win (issue #11)', () => {
+	const latest = pickLatest({
+		prs: [pr(9026, '2025-01-01T00:00:00Z')],
+		attachments: [att('fix.diff', '2 days ago')]
+	});
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 9026 });
+});
+
+test('pickLatest: attachments-only (no PRs cite the ticket) still picks the newest patch (issue #11)', () => {
+	const latest = pickLatest({
+		prs: [],
+		attachments: [att('a.diff', '01/01/2020 10:00:00 AM'), att('b.diff', '02/02/2021 10:00:00 AM')]
+	});
+	assert.strictEqual(latest.kind, 'attachment');
+	assert.ok(String(latest.key).endsWith('b.diff'));
+});


### PR DESCRIPTION
Part of #110. Refs #109, #11. **Stacked on #139** (base is that branch), which stacks on #136 → #135 → #123. Review order: #123 → #135 → #136 → #139 → this.

## Why

A contributor arriving at a ticket wants to try the latest fix. The panel listed PRs and Trac attachments as two separate sections, but nothing said which one — across both — was the most recent. Usually it's a PR (visible immediately); but sometimes the newest fix is a `.diff` uploaded to Trac, and that was buried under the attachments button with no signal.

## What this does

- The newest known patch carries a **"Latest" pill**, whether it's a PR row or a Trac-attachment row.
- When the newest is an attachment, a note says so explicitly: *"The most recent patch on this ticket is a file attachment, not a pull request."*
- Because attachments load on demand, "latest" is judged across what's loaded: **PRs alone until the contributor opens attachments** (the normal case), then both. Opening attachments isn't forced on every ticket — the verdict simply completes once they're looked at.

## How

The comparison is a pure module (`src/latest-patch.cjs`), unit tested. A PR is dated by `updatedAt`, an attachment by its scraped upload time. A `.txt` never competes; a relative-only date ("15 months ago") can't win. The attachment timestamp is **anchored to UTC by hand** rather than parsed in the machine's local zone, so two contributors in different timezones see the same patch marked latest — a consistent answer is the whole point.

## Testing

- `test/latest-patch.test.cjs` — PR-wins (normal), attachment-wins-once-loaded (the case the feature exists for), `.txt` excluded, relative-date can't win, attachments-only, empty→null, and the UTC-determinism of the date parse (PM/AM and the 12-o'clock edge).
- `npm test` / `npm run test:electron`: **238/238** both runtimes. `npm run lint`: clean.

## Self-review (per AGENTS.md)

Ran the review with the judgement pass on fresh context. It returned **0 `[fix here]` · 1 `[follow-up]`** — the follow-up was the timezone skew (PR date is UTC ISO, attachment date was parsed in local time), which two contributors could see differently. **Fixed before this PR** by anchoring the attachment parse to UTC, with a determinism test. The reviewer verified the key/equality logic (exactly one row marked, right row), NaN/`.txt` exclusion, null-safety, and stale-state reset on ticket switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)