### PR TITLE
Add an .agents/skills self-review wrapper for open-standard agents

### DIFF
--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: self-review
+description: Review the current branch against this repo's architecture, security, performance, cross-platform and test-coverage rules before opening a PR. Use when the user asks to self-review, review my changes, check my branch before a PR, or says they are about to open a PR.
+---
+
+# Self-review
+
+Run the repo's review standard against the working branch, **before** the PR exists.
+
+Nothing runs this in CI. It is the only review a change gets before a human reads it, which is why
+it happens now rather than after: a finding fixed here costs one message, the same finding on the PR
+costs a review cycle.
+
+## Procedure
+
+**Read [`.github/instructions/code-review.instructions.md`](../../../.github/instructions/code-review.instructions.md)
+and follow it.** It is the specification for this task, not background reading — it carries the
+procedure (establish the diff, run `npm run lint` and `npm test`, then the five dimensions) as well
+as the invariants and the reporting bar. Do not restate it here; run it.
+
+That file is the single copy of the standard. It lives under `.github/instructions/` so Copilot code
+review picks it up natively; every other agent, this one included, reaches it from here. Changes to
+how reviews work go there, not into this wrapper.
+
+Two things this skill adds on top, both agent-neutral — apply whichever your agent can:
+
+**Run the judgement pass in a fresh context.** The diff and the deterministic layer
+(`npm run lint`, `npm test`) run inline. The five dimensions should be reviewed by a context that
+did not write the change — a subagent, or a separate pass given only the diff and the instructions
+file. If the session that wrote the code also grades it, it reviews its own reasoning and finds it
+sound.
+
+**Report, don't apply.** Surface findings in the chat. No GitHub comments, no files written — the PR
+does not exist yet. Then offer; the author decides what is a real finding.
+
+## Notes
+
+- This is the same skill as [`.claude/skills/self-review/`](../../../.claude/skills/self-review/),
+  placed here because agents built on the Agent Skills open standard (Command Code and others)
+  discover skills under `.agents/skills/` rather than `.claude/skills/`. Both are thin wrappers over
+  the one instructions file — neither is a second copy of the standard.
+- The repo-specific knowledge this adds over a generic review: Electron's bundled Node,
+  `isomorphic-git`, `electron-store`, loopback binding, the Windows spawn shims.
+- If a finding reveals a rule the instructions file does not yet cover, say so. It is meant to
+  accumulate what the project learns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,18 +16,23 @@ It sits under `.github/instructions/` because Copilot code review reads that dir
 follows no links out of it. Anywhere better-named would have meant maintaining a condensed second
 copy for Copilot, which would drift. Every other agent reaches it from here.
 
-**The review as a skill** — [`.claude/skills/self-review/`](.claude/skills/self-review/), a thin
-`SKILL.md` wrapper over the file above. The directory name is historical, not a restriction: it is
-the only path both Claude Code and Copilot read for project skills, so it stays there. In Claude
-Code it is `/self-review`.
+**The review as a skill** — a thin `SKILL.md` wrapper over the file above, in two locations because
+no single skills directory is read by every agent:
 
-If your agent supports skills but looks elsewhere (`.agents/skills/`, `.github/skills/`, or its own
-convention), point it at that directory — or skip it entirely and follow the instructions file,
-which is where all the content actually lives. The wrapper only adds two things: run the judgement
-pass in a fresh context, and report without touching GitHub.
+- [`.claude/skills/self-review/`](.claude/skills/self-review/) — Claude Code and Copilot. In Claude
+  Code it is `/self-review`.
+- [`.agents/skills/self-review/`](.agents/skills/self-review/) — the Agent Skills open-standard path
+  that Command Code and others scan.
 
-There is deliberately no per-tool copy of any of this. If you find yourself writing one, the thing
-to fix is the pointer, not the number of copies.
+Both are pointers to the one instructions file, not copies of the standard. If your agent looks
+somewhere else again (`.github/skills/`, `.cursor/skills/`, `.codex/skills/`, or its own
+convention), add a wrapper there or skip it entirely and follow the instructions file — that is
+where all the content lives. The wrapper only adds two things: run the judgement pass in a fresh
+context, and report without touching GitHub.
+
+There is deliberately no per-tool copy of the *standard*. A wrapper is a few lines that defer to it;
+duplicating the standard itself is the thing to avoid — if you find yourself doing that, fix the
+pointer, not the number of copies.
 
 ## What this is
 


### PR DESCRIPTION
## What

Adds a thin `self-review` skill wrapper at **`.agents/skills/self-review/SKILL.md`**, alongside the existing `.claude/skills/self-review/`, and updates `AGENTS.md` to reflect both locations.

## Why

The skill lived only at `.claude/skills/`, which Claude Code and Copilot read — but Command Code and other agents implementing the [Agent Skills open standard](https://agentskills.io) scan `.agents/skills/` instead. So `/self-review` returns **"No commands found"** on those agents, even though the skill and the standard it points to are right there in the repo.

The `SKILL.md` format was already portable (the `name`/`description` frontmatter *is* the open standard). The only thing missing was a copy of the **pointer** in a directory those agents scan.

## Not a second copy of the standard

The single source of truth remains `.github/instructions/code-review.instructions.md`. Both wrappers are thin pointers to it — this PR adds a pointer, not a duplicate of the review standard, consistent with the no-duplication rule in `AGENTS.md`. The new wrapper is written **agent-neutrally**: it describes the fresh-context judgement pass and report-don't-apply behaviours without naming a Claude-specific subagent or built-in command.

## Changes

- `.agents/skills/self-review/SKILL.md` — new wrapper (relative links to the instructions file and the Claude wrapper verified to resolve).
- `AGENTS.md` — "review as a skill" section now lists both wrapper locations and explains why (no single skills directory is read by every agent); the no-duplication rule is sharpened to target the *standard*, not the wrappers.

## Scope note

Follow-up to #141 (which documents the guardrails). Kept separate: #141 is docs; this is the config change that makes the skill actually discoverable on non-Claude agents.

## Self-review

Docs/config only — no code paths touched. `npm run lint` is clean. Nothing here executes in CI beyond the existing lint/test matrix, which has no new code to exercise.