### PR TITLE
Test preload's per-run IPC listener plumbing

### DIFF
--- a/test/preload-listeners.test.cjs
+++ b/test/preload-listeners.test.cjs
@@ -1,0 +1,289 @@
+'use strict';
+
+// src/preload.js is the only place that decides which renderer callback an
+// install or script event belongs to, and the only place that unsubscribes when
+// a run ends. Both decisions live in closures that never leave the module, so
+// nothing else in the suite can reach them (#149).
+//
+// Two failure modes are what this file pins:
+//
+//  - cross-run bleed. The `on()` listeners are per-run but the channel is
+//    global: every install's log handler sees every other install's log events
+//    and is expected to drop them by comparing ids. Deleting that comparison
+//    changes nothing a user sees until two runs overlap, and then one run's
+//    output lands in the other's terminal.
+//  - listener leak. Both handlers are removed by the done handler, and only for
+//    the run it belongs to. Removing one but not the other, or removing them
+//    only when the run succeeded, leaves a dead listener on a global channel for
+//    the lifetime of the window. That is the shape of #86, and #43 is in this
+//    same bridge.
+//
+// The module needs `electron` at import time, which is what left it untested.
+// Nothing else about it needs Electron, so the seam is the same Module._load
+// hook test/ipc-wiring.test.cjs uses for main.js — no production code changes
+// for the sake of the test. The require is inert here: exposeInMainWorld just
+// hands the api object back.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+
+const PRELOAD_PATH = path.join(__dirname, '..', 'src', 'preload.js');
+
+// True for the real `electron` package under any specifier that reaches it, the
+// same test as in test/ipc-wiring.test.cjs and for the same reason: requiring it
+// is not inert. node_modules/electron/index.js resolves the binary path at module
+// scope and spawns the installer when it is missing, so a cold checkout would
+// start a download into the directory test/electron-node-version.test.cjs spawns
+// from — concurrently, since node --test runs files in parallel. preload.js only
+// requires 'electron' today, so the narrow check would be enough; it is written
+// wide because the day it requires a src/ helper that pulls electron in turn (as
+// src/logging.js does), a narrow check fails silently and only on a cold checkout.
+function isElectronPackage(request, resolvedId) {
+	if (request === 'electron' || request.startsWith('electron/')) return true;
+	return typeof resolvedId === 'string'
+		&& resolvedId.includes(`${path.sep}node_modules${path.sep}electron${path.sep}`);
+}
+
+// Stands in for ipcRenderer, and records rather than dispatches. `emit` is the
+// main process's `event.sender.send`: it runs every listener currently
+// subscribed to the channel, which is what makes a stale listener observable —
+// a removed one simply is not called.
+function createIpcRenderer({ invokeResults = {} } = {}) {
+	const listeners = new Map();
+	const invocations = [];
+
+	return {
+		invocations,
+		async invoke(channel, ...args) {
+			invocations.push({ channel, args });
+			const result = invokeResults[channel];
+			return typeof result === 'function' ? result(...args) : result;
+		},
+		on(channel, listener) {
+			if (!listeners.has(channel)) listeners.set(channel, []);
+			listeners.get(channel).push(listener);
+		},
+		removeListener(channel, listener) {
+			const registered = listeners.get(channel);
+			if (!registered) return;
+			const at = registered.indexOf(listener);
+			if (at !== -1) registered.splice(at, 1);
+		},
+		listenerCount(channel) {
+			return (listeners.get(channel) || []).length;
+		},
+		// A copy, so a handler unsubscribing mid-dispatch cannot shorten the list
+		// being iterated — Electron's own EventEmitter dispatches this way, and the
+		// done handler removes itself while it runs.
+		emit(channel, payload) {
+			for (const listener of [...(listeners.get(channel) || [])]) listener({}, payload);
+		}
+	};
+}
+
+// Loads preload.js against a fake `electron` and returns the api object it
+// exposed, plus the ipcRenderer it was given. The module is dropped from the
+// cache each time so every test gets its own listener table.
+function loadPreload(options = {}) {
+	const ipcRenderer = createIpcRenderer(options);
+	let api;
+	const electron = {
+		contextBridge: {
+			exposeInMainWorld(key, value) {
+				assert.equal(key, 'api');
+				api = value;
+			}
+		},
+		ipcRenderer
+	};
+
+	const originalLoad = Module._load;
+	Module._load = function (request, parent, isMain) {
+		if (isElectronPackage(request)) return electron;
+		let id;
+		try {
+			id = Module._resolveFilename(request, parent, isMain);
+		} catch {
+			return originalLoad.apply(this, arguments);
+		}
+		if (isElectronPackage(request, id)) return electron;
+		return originalLoad.apply(this, arguments);
+	};
+
+	delete require.cache[require.resolve(PRELOAD_PATH)];
+	try {
+		require(PRELOAD_PATH);
+	} finally {
+		Module._load = originalLoad;
+		delete require.cache[require.resolve(PRELOAD_PATH)];
+	}
+
+	assert.ok(api, 'preload.js did not expose an api object');
+	return { api, ipcRenderer };
+}
+
+// Records what a renderer callback pair was handed.
+function recorder() {
+	const logs = [];
+	const done = [];
+	return { logs, done, onLog: (p) => logs.push(p), onDone: (p) => done.push(p) };
+}
+
+// The two run kinds differ only in their channel names and the key they
+// correlate on, so they are described as data and share the assertions below. A
+// third per-run subscription (updateTrunk) has the same shape; it is out of
+// scope for #149 and deliberately not covered here.
+const RUNS = [
+	{
+		name: 'runNpmInstall',
+		idKey: 'installId',
+		invokeChannel: 'npm:install',
+		logChannel: 'npm:install:log',
+		doneChannel: 'npm:install:done',
+		start: (api, callbacks) => api.runNpmInstall('/sites/wp', callbacks.onLog, callbacks.onDone)
+	},
+	{
+		name: 'runNpmScript',
+		idKey: 'runId',
+		invokeChannel: 'npm:run-script',
+		logChannel: 'npm:run-script:log',
+		doneChannel: 'npm:run-script:done',
+		start: (api, callbacks) => api.runNpmScript('/sites/wp', 'build', [], callbacks.onLog, callbacks.onDone)
+	}
+];
+
+// Hands out a fresh id per invoke, so two overlapping runs in one test get
+// different ones without the test having to sequence the invokes itself.
+function idSequence(idKey, ids) {
+	let next = 0;
+	return () => ({ [idKey]: ids[next++] });
+}
+
+for (const run of RUNS) {
+	test(`${run.name} drops events belonging to another run`, async () => {
+		const { api, ipcRenderer } = loadPreload({
+			invokeResults: { [run.invokeChannel]: idSequence(run.idKey, ['mine']) }
+		});
+		const mine = recorder();
+
+		await run.start(api, mine);
+
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'someone-else', type: 'stdout', data: 'not mine\n' });
+		ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'someone-else', code: 0 });
+
+		assert.deepEqual(mine.logs, [], 'another run\'s output reached this run\'s callback');
+		assert.deepEqual(mine.done, [], 'another run\'s completion reached this run\'s callback');
+
+		// The foreign done event must not have unsubscribed this run either —
+		// otherwise the run goes silent from here on.
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'mine', type: 'stdout', data: 'mine\n' });
+		assert.deepEqual(mine.logs, [{ [run.idKey]: 'mine', type: 'stdout', data: 'mine\n' }]);
+	});
+
+	// Both exit codes, because the removal sits inside the done handler and a
+	// version that unsubscribed only on success would still pass a happy-path
+	// test — while leaking a listener on exactly the runs contributors hit most.
+	for (const code of [0, 1]) {
+		test(`${run.name} removes both listeners when the run ends with code ${code}`, async () => {
+			const { api, ipcRenderer } = loadPreload({
+				invokeResults: { [run.invokeChannel]: idSequence(run.idKey, ['mine']) }
+			});
+			const mine = recorder();
+
+			await run.start(api, mine);
+			assert.equal(ipcRenderer.listenerCount(run.logChannel), 1);
+			assert.equal(ipcRenderer.listenerCount(run.doneChannel), 1);
+
+			ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'mine', code });
+
+			assert.deepEqual(mine.done, [{ [run.idKey]: 'mine', code }]);
+			assert.equal(ipcRenderer.listenerCount(run.logChannel), 0, 'log listener outlived the run');
+			assert.equal(ipcRenderer.listenerCount(run.doneChannel), 0, 'done listener outlived the run');
+
+			// And nothing arriving afterwards can still reach the callbacks.
+			ipcRenderer.emit(run.logChannel, { [run.idKey]: 'mine', type: 'stdout', data: 'late\n' });
+			ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'mine', code });
+			assert.deepEqual(mine.logs, []);
+			assert.deepEqual(mine.done, [{ [run.idKey]: 'mine', code }]);
+		});
+	}
+
+	test(`${run.name} keeps two overlapping runs apart`, async () => {
+		const { api, ipcRenderer } = loadPreload({
+			invokeResults: { [run.invokeChannel]: idSequence(run.idKey, ['first', 'second']) }
+		});
+		const first = recorder();
+		const second = recorder();
+
+		await run.start(api, first);
+		await run.start(api, second);
+
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'first', type: 'stdout', data: 'a\n' });
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'second', type: 'stderr', data: 'b\n' });
+
+		assert.deepEqual(first.logs, [{ [run.idKey]: 'first', type: 'stdout', data: 'a\n' }]);
+		assert.deepEqual(second.logs, [{ [run.idKey]: 'second', type: 'stderr', data: 'b\n' }]);
+
+		// Finishing the first run unsubscribes the first run only. Removing by
+		// channel rather than by handler would take the second run's listeners
+		// with it and leave a live run with no output.
+		ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'first', code: 0 });
+		assert.equal(ipcRenderer.listenerCount(run.logChannel), 1);
+		assert.equal(ipcRenderer.listenerCount(run.doneChannel), 1);
+
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'second', type: 'stdout', data: 'c\n' });
+		ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'second', code: 0 });
+
+		assert.equal(second.logs.length, 2);
+		assert.deepEqual(second.done, [{ [run.idKey]: 'second', code: 0 }]);
+		assert.deepEqual(first.done, [{ [run.idKey]: 'first', code: 0 }]);
+		assert.equal(ipcRenderer.listenerCount(run.logChannel), 0);
+		assert.equal(ipcRenderer.listenerCount(run.doneChannel), 0);
+	});
+
+	// The callbacks are optional in the signature, and the done handler reads
+	// `onDone` only after it has already unsubscribed — but a caller passing
+	// neither must not leave the listeners behind on a global channel.
+	test(`${run.name} still unsubscribes when no callbacks were given`, async () => {
+		const { api, ipcRenderer } = loadPreload({
+			invokeResults: { [run.invokeChannel]: idSequence(run.idKey, ['mine']) }
+		});
+
+		await run.start(api, {});
+
+		ipcRenderer.emit(run.logChannel, { [run.idKey]: 'mine', type: 'stdout', data: 'x\n' });
+		ipcRenderer.emit(run.doneChannel, { [run.idKey]: 'mine', code: 0 });
+
+		assert.equal(ipcRenderer.listenerCount(run.logChannel), 0);
+		assert.equal(ipcRenderer.listenerCount(run.doneChannel), 0);
+	});
+}
+
+// The guard for the paragraph above isElectronPackage: if the stub ever stops
+// covering a path, this fails here rather than as a mystery download in another
+// file's test on a cold checkout.
+test('the harness never loads the real electron package', () => {
+	loadPreload();
+
+	const loaded = Object.keys(require.cache)
+		.filter((file) => file.includes(`${path.sep}node_modules${path.sep}electron${path.sep}`));
+
+	assert.deepEqual(loaded, [], 'the real electron package was required; the stub did not cover this path');
+});
+
+// The renderer needs the id to kill a running script (`npm:kill` takes a runId),
+// so it has to come back out of the bridge.
+test('runNpmScript returns the run id to the caller', async () => {
+	const { api } = loadPreload({ invokeResults: { 'npm:run-script': () => ({ runId: 'r1' }) } });
+
+	assert.deepEqual(await api.runNpmScript('/sites/wp', 'build', [], () => {}, () => {}), { runId: 'r1' });
+});
+
+// Both run kinds subscribe only after the invoke has answered with an id, so
+// anything the child writes before that answer reaches no callback. `startServer`
+// in the same file does the opposite deliberately ("Invoke AFTER listeners are
+// attached so early logs/URL are captured"), which is what the fix would look
+// like here. Left as a note rather than a test: asserting the current ordering
+// would pin the gap shut, and closing it is not #149.


### PR DESCRIPTION
Closes #149.

The preload bridge subscribes per-run listeners for npm installs and script runs, filters events by run id, and must remove both listeners when a run finishes. None of it was tested, and a leak or cross-run bleed here is a proven bug class in this repo — #86 was a listener leak and #43 lives in this same bridge.

12 tests against a fake `ipcRenderer` pin the contract: another run’s log and done events never reach the callback, a foreign done event does not unsubscribe a live run, two overlapping runs stay apart, and both listeners are removed on completion with a zero exit code and with a failure code. The seam is the module-load stub the wiring suite already establishes, including its guard that the real `electron` package is never required.

No production code changes — the behaviour was already correct, so this is a pinning-only change. Mutation-checked: dropping the id filter, dropping a `removeListener`, or unsubscribing only on success each fail the new tests.

## Review

`.github/instructions/code-review.instructions.md` run against the branch: 1 finding, fixed here — an assertion had pinned a known gap shut (listeners subscribe only after the invoke resolves, so events arriving in that window are lost). Asserting it would have made a future fix look like a regression, so it is a comment naming the gap instead. Deliberately left out: the trunk-update bridge has the same per-run shape and is equally untested, which is out of scope for this issue.

`npm test` and `npm run test:electron` both 192/192, lint clean.