### PR TITLE
Don't ask for a Trac ticket while creating a site

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -867,10 +867,6 @@ ipcMain.handle('wordpress:setup', async (event, destDir, options = {}) => {
 			createdAt: existingMeta.createdAt || new Date().toISOString(),
 			label: existingMeta.label || siteLabel
 		};
-		const ticket = parseTicketRef(options.tracTicket);
-		if (ticket.ok && !Object.prototype.hasOwnProperty.call(existingMeta, 'tracTicket')) {
-			meta[siteDir].tracTicket = ticket.id;
-		}
 		try {
 			const { trunkOid, trunkDate } = await readTrunkInfo(siteDir);
 			meta[siteDir].trunkOid = trunkOid;

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -22,7 +22,7 @@ import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, APPLY_STATE_TO_STEP } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
-import { parseTicketRef, ticketUrl } from './trac-ticket.cjs';
+import { ticketUrl } from './trac-ticket.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // Per-status wording for the update chain card (#94), following the issue's
@@ -44,7 +44,6 @@ const RENAME_INPUT_ID = 'rename-site-name-input';
 const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
 const CREATE_SITE_LOCATION_INPUT_ID = 'create-site-location-input';
 const CREATE_SITE_LOCATION_HELP_ID = 'create-site-location-help';
-const CREATE_SITE_TICKET_INPUT_ID = 'create-site-ticket-input';
 // Why the ticket's PR list could not be read, worded for the contributor.
 const TICKET_PATCH_STATUS_MESSAGE = {
   'rate-limited': 'GitHub is rate-limiting this connection.',
@@ -102,7 +101,6 @@ function App() {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [createSiteName, setCreateSiteName] = useState('');
   const [createSiteDir, setCreateSiteDir] = useState('');
-  const [createSiteTicket, setCreateSiteTicket] = useState('');
   const [createSiteError, setCreateSiteError] = useState('');
   const [createSubmitting, setCreateSubmitting] = useState(false);
   const [setupLogsBySite, setSetupLogsBySite] = useState({});
@@ -214,7 +212,6 @@ function App() {
   const chooseAndSetup = useCallback(() => {
     setCreateSiteName('');
     setCreateSiteDir('');
-    setCreateSiteTicket('');
     setCreateSiteError('');
     setCreateModalOpen(true);
   }, []);
@@ -295,15 +292,6 @@ function App() {
       return;
     }
 
-    // The ticket is optional (#109), but a typo in one that was typed should
-    // be corrected here rather than silently dropped after a five-minute clone.
-    const ticketTyped = createSiteTicket.trim();
-    const ticket = ticketTyped ? parseTicketRef(ticketTyped) : null;
-    if (ticket && !ticket.ok) {
-      setCreateSiteError(ticket.error);
-      return;
-    }
-
     const cleanFolder = sanitizeSiteFolder(nameTrimmed);
     const targetDir = resolveTargetDir(createSiteDir, cleanFolder);
     let finalSitePath = targetDir;
@@ -316,15 +304,13 @@ function App() {
         ...(prev[targetDir] || {}),
         label: nameTrimmed,
         createdAt: prev[targetDir]?.createdAt || placeholderCreatedAt,
-        initialized: false,
-        tracTicket: ticket ? ticket.id : null
+        initialized: false
       }
     }));
     setActiveSite(targetDir);
     setCreateModalOpen(false);
     setCreateSiteName('');
     setCreateSiteDir('');
-    setCreateSiteTicket('');
 
     try {
       setCreateSubmitting(true);
@@ -332,7 +318,7 @@ function App() {
       setTerminalMsgs('');
       addPendingSite(targetDir);
       appendSetupLog(targetDir, 'Starting site setup…\n');
-      const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed, tracTicket: ticket ? String(ticket.id) : '' });
+      const createdPath = await window.api.setupWordPress(createSiteDir, { siteName: cleanFolder, siteLabel: nameTrimmed });
       if (createdPath) {
         finalSitePath = createdPath;
         if (createdPath !== targetDir) {
@@ -376,7 +362,7 @@ function App() {
       clearPendingSites();
       setCreateSubmitting(false);
     }
-  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, createSiteTicket, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
+  }, [addPendingSite, appendSetupLog, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder, setSiteMeta, setSites]);
 
   const closeCreateModal = useCallback(() => {
     if (createSubmitting) return;
@@ -759,15 +745,6 @@ function App() {
             <div id={CREATE_SITE_LOCATION_HELP_ID} style={{ fontSize: 12, color: '#3c434a', marginTop: -4 }}>
               Choose the parent folder where you want this new site created. We&apos;ll add a new directory inside it for the project.
             </div>
-            <TextControl
-              id={CREATE_SITE_TICKET_INPUT_ID}
-              label="What are you working on? (optional)"
-              value={createSiteTicket}
-              onChange={(value) => setCreateSiteTicket(value)}
-              disabled={createSubmitting}
-              placeholder="Trac ticket number or URL, e.g. 62281"
-              help="You can add this later, or change it at any time."
-            />
             {createSiteError ? (
               <div style={{ color: '#d63638', fontSize: 12 }}>{createSiteError}</div>
             ) : null}


### PR DESCRIPTION
Fixes #164. Stacked on #142 — review the [two-file diff](https://github.com/WordPress/experimental-wp-dev-env/compare/juanmaguitar/apply-panel-polish...juanmaguitar/remove-trac-ticket-on-creation), not the base.

## What and why

The **Create WordPress Core site** modal asked for a Trac ticket alongside the site name and location. That is the moment someone is least likely to have an answer — they may be creating the site precisely so they can go find something to work on — and the field made the modal look longer and more demanding than it is.

It was also a second entry point for an association the site row already handles, better: link, change and unlink, at any point in the site's life. This removes the creation-time shortcut and leaves that panel as the only way in.

## Changes

- `src/renderer/index.jsx` — the field, its state, its resets and its creation-time validation are gone; `parseTicketRef` is no longer needed in the renderer (the panel validates in the main process), so the import narrows to `ticketUrl`.
- `src/main.js` — with the renderer no longer passing one, the `options.tracTicket` branch of the `wordpress:setup` handler had no caller left. Removed rather than kept as dead code. `parseTicketRef` stays imported: `sites:set-ticket` still uses it.

The post-creation path — `sites:set-ticket`, `trac-ticket.cjs`, the ticket panel in `SiteRow` — is byte-identical.

## Review

Ran the pass in `.github/instructions/code-review.instructions.md`, judgement dimensions dispatched to a fresh context per `/self-review`.

- `npm run lint` — clean. `npm test` — 337/337.
- **0 [fix here] · 0 [follow-up].** No findings across the five dimensions.

Three things the review verified rather than assumed, since they were the plausible failure modes:

- Nothing else in `src/`, `test/` or the docs expects a ticket at creation time — no test exercised `wordpress:setup` with `options.tracTicket`, so the deletion orphans no assertion.
- Dropping `tracTicket: null` from the optimistic `setSiteMeta` patch cannot resurrect a stale ticket when a site is re-created at the same path: `sites:forget` and `sites:delete` both delete the meta entry, and the renderer refreshes wholesale from the store before a re-create can spread it.
- No test added, deliberately: this removes a feature rather than adding one, the removed main-process branch had none, and there is no renderer-component harness in the repo. The behaviour that survives — validating and persisting a ticket — is already covered by the `sites:set-ticket` tests and `test/trac-ticket.test.cjs`.

## Testing

Open **Create WordPress Core site**: only Site name and Site location. Create a site, then link a ticket from its row and confirm it saves, opens in Trac and unlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)