### PR TITLE
Name where a patch goes, and let a mentor carry it (#166)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,8 @@ const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
 const { deleteRegisteredSite, revealRegisteredSite } = require('./site-registry');
 const { getStore } = require('./settings-store');
 const { parseTicketRef } = require('./renderer/trac-ticket.cjs');
+const { parseHandle } = require('./wporg-handle.cjs');
+const { parseEventName, buildProvenanceHeader, handoffFilename } = require('./patch-provenance.cjs');
 const { describeRefused } = require('./safe-log');
 const { detectEditors, knownEditorName, isLaunchableEditorPath, openSiteInEditor } = require('./editor-launch');
 
@@ -382,12 +384,43 @@ ipcMain.handle('git:create-patch', async (_e, sitePath) => {
     }
 });
 
-ipcMain.handle('git:save-patch', async (_e, sitePath) => {
+// Saving a patch, with or without the provenance a mentor handoff needs (#166).
+//
+// `{ handoff: true }` is the only difference: the file gets the header from
+// patch-provenance.cjs and a name that says whose work it is, so someone else
+// can push it and the props still land on the person who wrote it. Every other
+// caller — the Trac destination, the save-before-update prompt — passes nothing
+// and gets the bare diff under the name it has always had, because that is what
+// gets attached to a ticket.
+ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
     try {
+        const handoff = Boolean(options && options.handoff);
         const patch = await createMinimalPatchForDir(sitePath);
+
+        // The header describes what was diffed, so it is read from the same
+        // recorded state the status handler reports, not asked of the caller:
+        // the renderer should not be able to put a different handle or a
+        // different base on someone's patch than the one this site has.
+        let header = '';
+        let name = 'wordpress.patch';
+        if (handoff) {
+            const s = await getStore();
+            const meta = (s.get('siteMeta') || {})[sitePath] || {};
+            const { wporgHandle: handle = null, contributionEvent: event = null } = s.get('preferences') || {};
+            header = buildProvenanceHeader({
+                handle,
+                event,
+                ticketId: meta.tracTicket,
+                trunkOid: meta.trunkOid,
+                trunkDate: meta.trunkDate,
+                generatedAt: new Date().toISOString()
+            });
+            name = handoffFilename({ handle, ticketId: meta.tracTicket });
+        }
+
         const { filePath, canceled } = await dialog.showSaveDialog({
-            title: 'Save Diff File',
-            defaultPath: path.join(os.homedir(), 'wordpress.patch'),
+            title: handoff ? 'Save Patch for Handoff' : 'Save Diff File',
+            defaultPath: path.join(os.homedir(), name),
             filters: [
                 { name: 'Patch Files', extensions: ['patch', 'diff'] },
                 { name: 'All Files', extensions: ['*'] }
@@ -398,7 +431,7 @@ ipcMain.handle('git:save-patch', async (_e, sitePath) => {
             return { ok: false, canceled: true };
         }
 
-        await fs.promises.writeFile(filePath, patch, 'utf8');
+        await fs.promises.writeFile(filePath, header + patch, 'utf8');
         return { ok: true, filePath };
     } catch (e) {
         return { ok: false, error: String(e) };
@@ -1077,6 +1110,60 @@ ipcMain.handle('editor:open', async (_e, sitePath) => {
 		spawn,
 		onRefused: (reason, description) => logEvent('editor', `refused to open ${description} — ${reason}`)
 	});
+});
+
+// --- Who the patch came from, and where (#166) ---
+//
+// Both fields are stored beside the editor choice and for the same reason: they
+// are facts about the contributor and their afternoon, asked once, not
+// properties of a checkout. They exist so a handed-off patch can say who wrote
+// it and at which event; nothing here contacts wordpress.org, and the handle is
+// never checked against a real account — an unverified name is what a props
+// line is anyway.
+
+async function setPreference(key, value) {
+	const s = await getStore();
+	s.set('preferences', { ...(s.get('preferences') || {}), [key]: value });
+}
+
+ipcMain.handle('provenance:get', async () => {
+	const s = await getStore();
+	const { wporgHandle, contributionEvent } = s.get('preferences') || {};
+	return {
+		ok: true,
+		handle: typeof wporgHandle === 'string' ? wporgHandle : null,
+		event: typeof contributionEvent === 'string' ? contributionEvent : null
+	};
+});
+
+// Validation happens here rather than only in the window, because these values
+// become a filename and lines in a file other people read. An empty ref clears
+// the field, so "forget it" needs no second channel — the same shape
+// `sites:set-ticket` uses.
+ipcMain.handle('provenance:set-handle', async (_e, ref) => {
+	if (typeof ref === 'string' && ref.trim() === '') {
+		await setPreference('wporgHandle', null);
+		return { ok: true, handle: null };
+	}
+
+	const parsed = parseHandle(ref);
+	if (!parsed.ok) return { ok: false, error: parsed.error };
+
+	await setPreference('wporgHandle', parsed.handle);
+	return { ok: true, handle: parsed.handle };
+});
+
+ipcMain.handle('provenance:set-event', async (_e, ref) => {
+	if (typeof ref === 'string' && ref.trim() === '') {
+		await setPreference('contributionEvent', null);
+		return { ok: true, event: null };
+	}
+
+	const parsed = parseEventName(ref);
+	if (!parsed.ok) return { ok: false, error: parsed.error };
+
+	await setPreference('contributionEvent', parsed.name);
+	return { ok: true, event: parsed.name };
 });
 
 // The fallback that needs no configuration at all — see site-registry.js for why

--- a/src/patch-provenance.cjs
+++ b/src/patch-provenance.cjs
@@ -1,0 +1,198 @@
+'use strict';
+
+/**
+ * The provenance a handed-off patch carries (issue #166).
+ *
+ * The mentor handoff exists for the contributor who will not create a GitHub
+ * account today: they save a patch, someone else pushes it, and the props still
+ * have to land on them. That only works if the file says who made it, against
+ * what, and when — so a header goes in the file itself rather than only in its
+ * name, which survives exactly until the first person renames the download.
+ *
+ * #166 defines the format and #107 adopts it, rather than the two inventing one
+ * each. Everything here is therefore about the shape of those lines, not about
+ * when they are added: today only the handoff save prepends them, because a
+ * patch attached to Trac conventionally carries no header and widening that is
+ * #107's call.
+ *
+ * Prepending is safe for every reader in this app and for the ones outside it.
+ * `git apply` and `patch` scan forward to the first file header and ignore what
+ * precedes it; this app's own reader, `scanSections` in patch-plan.cjs, reacts
+ * only to `diff --git` and `Index:` lines. `#` is the comment marker Trac and
+ * Subversion patches already use, so nothing downstream has to learn a new one.
+ *
+ * Pure and dependency-free apart from the ticket URL helper, so `node --test`
+ * can require it directly.
+ */
+
+const { ticketUrl } = require('./renderer/trac-ticket.cjs');
+const { isHandle } = require('./wporg-handle.cjs');
+
+const TITLE = '# WordPress Contributor Toolkit patch';
+
+// Enough of a commit to identify it, the length git itself abbreviates to.
+const SHORT_OID_LENGTH = 7;
+
+// A header line is a line. Anything that could end this one and start another —
+// or a value long enough to bury the diff — is not something a header field
+// gets to do. src/safe-log.js makes the same argument about the log file;
+// `describeRefused` is not reused here because these values are not refusals:
+// a field this rejects is dropped from the header rather than described in it.
+const CONTROL_CHARACTERS = /[\x00-\x1f\x7f-\x9f\u2028\u2029]/g;
+const MAX_FIELD_LENGTH = 120;
+
+// "WordCamp Europe 2026 Contributor Day" fits with room to spare. Past this it
+// is not an event name any more, and the header is not the place for a story.
+const MAX_EVENT_LENGTH = 80;
+
+/**
+ * A string safe to put after `# Field: `, or null if there is nothing to say.
+ *
+ * @param {unknown} value
+ * @return {string|null}
+ */
+function field(value) {
+	if (typeof value !== 'string') return null;
+	const oneLine = value.replace(CONTROL_CHARACTERS, ' ').trim();
+	if (!oneLine) return null;
+	return oneLine.length <= MAX_FIELD_LENGTH ? oneLine : oneLine.slice(0, MAX_FIELD_LENGTH);
+}
+
+/**
+ * The calendar day of an ISO timestamp. The clock time is noise for every
+ * question this header answers — is this newer than mine, what trunk is it on.
+ *
+ * @param {unknown} iso
+ * @return {string|null}
+ */
+function day(iso) {
+	const value = field(iso);
+	if (!value) return null;
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return null;
+	return parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Reading what a contributor typed when asked where they are contributing from
+ * — "WordCamp Europe 2026", "Madrid WordPress Meetup", a company's own
+ * contributor day.
+ *
+ * It is free text on purpose. There is no canonical list of these, most of them
+ * are named the day they happen, and an event this app has never heard of is
+ * exactly the one a first-time contributor is at. So the only rules are the
+ * ones the header itself imposes: one line, and short enough to stay a label.
+ *
+ * @param {string} input
+ * @return {{ok: true, name: string}|{ok: false, error: string}}
+ */
+function parseEventName(input) {
+	const raw = typeof input === 'string' ? input.trim() : '';
+	if (!raw) return { ok: false, error: 'Enter the event name, or leave it empty.' };
+	if (CONTROL_CHARACTERS.test(raw)) {
+		// `test` on a /g regex advances lastIndex; reset it so the next call
+		// does not start reading from where this one stopped.
+		CONTROL_CHARACTERS.lastIndex = 0;
+		return { ok: false, error: 'The event name has to fit on one line.' };
+	}
+	CONTROL_CHARACTERS.lastIndex = 0;
+	if (raw.length > MAX_EVENT_LENGTH) {
+		return { ok: false, error: `Keep the event name under ${MAX_EVENT_LENGTH} characters.` };
+	}
+	return { ok: true, name: raw };
+}
+
+/**
+ * A ticket id, or null. Both the header and the filename want the number and
+ * neither wants to guess at a half-parsed one.
+ *
+ * @param {unknown} ticketId
+ * @return {number|null}
+ */
+function ticketNumber(ticketId) {
+	const id = Number(ticketId);
+	return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
+/**
+ * The header block for a handed-off patch, newline-terminated and ending in a
+ * blank line, or '' when there is nothing worth saying.
+ *
+ * Every field is optional and an unknown one is left out rather than written as
+ * "unknown": a mentor reading this needs to be able to trust the lines that are
+ * there, and a site that has never been updated genuinely has no base revision
+ * recorded.
+ *
+ * @param {Object}        details
+ * @param {string}        [details.handle]      WordPress.org handle, already validated.
+ * @param {string}        [details.event]       Where it was written — a WordCamp, a meetup.
+ * @param {number|string} [details.ticketId]
+ * @param {string}        [details.trunkOid]
+ * @param {string}        [details.trunkDate]   ISO timestamp of the base commit.
+ * @param {string}        [details.generatedAt] ISO timestamp for "now".
+ * @return {string}
+ */
+function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, generatedAt } = {}) {
+	const lines = [];
+
+	const contributor = field(handle);
+	if (contributor) lines.push(`# Contributor: ${contributor} (wordpress.org)`);
+
+	// Next to the contributor because it is part of the same answer: who made
+	// this, and where. A mentor collecting patches at a contributor day is
+	// looking at a folder of files from one room on one afternoon, and the
+	// organisers of that room are who this line is ultimately for.
+	const where = field(event);
+	if (where) lines.push(`# Event: ${where}`);
+
+	const ticket = ticketNumber(ticketId);
+	if (ticket) lines.push(`# Ticket: ${ticketUrl(ticket)}`);
+
+	const oid = field(trunkOid);
+	const based = day(trunkDate);
+	if (oid || based) {
+		const base = [oid ? oid.slice(0, SHORT_OID_LENGTH) : null, based].filter(Boolean).join(', ');
+		lines.push(`# Base: trunk @ ${base}`);
+	}
+
+	const generated = day(generatedAt);
+	if (generated) lines.push(`# Generated: ${generated}`);
+
+	if (!lines.length) return '';
+	return `${[TITLE, ...lines].join('\n')}\n\n`;
+}
+
+/**
+ * The name a handed-off patch is saved under. The handle is in the filename as
+ * well as the header because it is what a mentor sorts a folder of these by;
+ * the header is what survives a rename.
+ *
+ * The Trac-conventional sequence name (`59234.2.diff`) is deliberately not here
+ * — that needs to know what is already attached to the ticket, which is #107's
+ * scope.
+ *
+ * @param {Object}        details
+ * @param {string}        [details.handle]
+ * @param {number|string} [details.ticketId]
+ * @return {string}
+ */
+function handoffFilename({ handle, ticketId } = {}) {
+	// Only a stored handle reaches the filename — it is a path component, and a
+	// value that never passed `parseHandle` is not one this should be repairing.
+	// Falling back to the name the app has always used is the honest failure: a
+	// patch still gets saved, it just carries no claim about who made it.
+	if (!isHandle(handle)) return 'wordpress.patch';
+
+	const ticket = ticketNumber(ticketId);
+	return ticket ? `${ticket}.${handle}.diff` : `${handle}.diff`;
+}
+
+module.exports = {
+	TITLE,
+	SHORT_OID_LENGTH,
+	MAX_FIELD_LENGTH,
+	MAX_EVENT_LENGTH,
+	parseEventName,
+	buildProvenanceHeader,
+	handoffFilename
+};

--- a/src/preload.js
+++ b/src/preload.js
@@ -56,6 +56,14 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	openInEditor: (sitePath) => ipcRenderer.invoke('editor:open', sitePath)
 ,
+	// Who the patch came from and where, app-wide (#166). An empty ref forgets
+	// the field it is passed to.
+	getProvenance: () => ipcRenderer.invoke('provenance:get')
+,
+	setWporgHandle: (ref) => ipcRenderer.invoke('provenance:set-handle', ref)
+,
+	setContributionEvent: (ref) => ipcRenderer.invoke('provenance:set-event', ref)
+,
 	showSiteInFileManager: (sitePath) => ipcRenderer.invoke('dir:show', sitePath)
 ,
 	markSiteInitialized: (sitePath) => ipcRenderer.invoke('sites:mark-initialized', sitePath)
@@ -85,7 +93,10 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	getPatch: (sitePath) => ipcRenderer.invoke('git:get-patch', sitePath)
 ,
-	savePatch: (sitePath) => ipcRenderer.invoke('git:save-patch', sitePath)
+	// With `{ handoff: true }` the saved file carries the provenance header and a
+	// name that says whose work it is (#166); without options it is the bare
+	// diff, which is what gets attached to a ticket.
+	savePatch: (sitePath, options) => ipcRenderer.invoke('git:save-patch', sitePath, options)
 ,
 	isWorktreeDirty: (sitePath) => ipcRenderer.invoke('git:worktree-dirty', sitePath)
 ,

--- a/src/renderer/diff-highlight.cjs
+++ b/src/renderer/diff-highlight.cjs
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * Reading a unified diff as coloured lines (issue #166).
+ *
+ * The patch pane is where a first-time contributor checks their own work before
+ * sending it anywhere, and a wall of monospace makes the two questions that
+ * matter — what did I add, what did I remove — into a character-by-character
+ * hunt. Colour answers both at a glance.
+ *
+ * A diff needs no language parsing for this: the first character of each line
+ * is the whole grammar. So there is no syntax highlighter here and no
+ * dependency; PHP inside the patch stays uncoloured, which is the right
+ * trade — what is being reviewed is the change, not the language.
+ *
+ * Pure and DOM-free so `node --test` can require it: the renderer turns the
+ * classified lines into spans, and this file decides nothing about colour.
+ */
+
+// Lines that describe the patch rather than the code: the separator and file
+// names jsdiff emits, and the git forms a downloaded PR or Trac attachment
+// arrives with.
+const META_PREFIXES = [
+	'diff --git ',
+	'index ',
+	'Index:',
+	'new file mode',
+	'deleted file mode',
+	'old mode',
+	'new mode',
+	'rename from',
+	'rename to',
+	'similarity index',
+	'GIT binary patch',
+	'Binary files'
+];
+
+// Past this, colouring stops and the pane renders as plain text. One element
+// per line is cheap until it is thousands of them, and a patch that large is
+// not being read line by line anyway.
+const MAX_HIGHLIGHTED_LINES = 4000;
+
+/**
+ * What a single line of a patch is.
+ *
+ * `header` is this app's own provenance block (#166) — the only lines that
+ * start with `#` at column 0, since every line of the diff proper starts with a
+ * space, a `+`, a `-`, a `@` or one of the meta prefixes.
+ *
+ * @param {string} line
+ * @return {'header'|'hunk'|'meta'|'add'|'del'|'context'}
+ */
+function classifyLine(line) {
+	if (line.startsWith('#')) return 'header';
+	if (line.startsWith('@@')) return 'hunk';
+	// Before the add/delete check: `---` and `+++` are file names, not a removed
+	// and an added line, and colouring them as changes is the classic way a diff
+	// view lies about its first two rows.
+	if (line.startsWith('---') || line.startsWith('+++') || line.startsWith('===')) return 'meta';
+	if (META_PREFIXES.some((prefix) => line.startsWith(prefix))) return 'meta';
+	if (line.startsWith('+')) return 'add';
+	if (line.startsWith('-')) return 'del';
+	return 'context';
+}
+
+/**
+ * The patch, line by line, each with what it is. Returns null when the text is
+ * too long to be worth painting — the caller renders it as-is.
+ *
+ * @param {string} text
+ * @return {Array<{text: string, kind: string}>|null}
+ */
+function highlightDiff(text) {
+	if (typeof text !== 'string' || text === '') return null;
+
+	const lines = text.split('\n');
+	if (lines.length > MAX_HIGHLIGHTED_LINES) return null;
+
+	return lines.map((line) => ({ text: line, kind: classifyLine(line) }));
+}
+
+module.exports = {
+	META_PREFIXES,
+	MAX_HIGHLIGHTED_LINES,
+	classifyLine,
+	highlightDiff
+};

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -899,8 +899,14 @@ const DIFF_LINE_STYLES = {
 // The patch, painted. An empty line still needs to occupy one: `\n` is appended
 // per line rather than joining, so the last line of a patch that ends in a
 // newline does not silently gain or lose one.
+//
+// Memoised on the text, because this renders inside SiteRow — which re-renders
+// on every chunk a running dev server or watch task streams into its log. The
+// patch has not changed; without this, each chunk re-splits it and hands React
+// thousands of fresh spans to reconcile, on the same thread that has to paint
+// the log.
 function DiffText({ text }) {
-  const lines = highlightDiff(text);
+  const lines = useMemo(() => highlightDiff(text), [text]);
   if (!lines) return text;
   return lines.map((line, index) => (
     // A diff line has no identity beyond its position, and the whole pane is
@@ -3277,7 +3283,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                           variant="secondary"
                           onClick={rememberContributor}
                           isBusy={handleSaving}
-                          disabled={handleSaving || !handleInput.trim()}
+                          // Empty is a valid answer only when there is
+                          // something to clear — a shared laptop at a
+                          // contributor day, the next person taking over.
+                          // Before the first answer it would just be a button
+                          // that does nothing.
+                          disabled={handleSaving || (!handleInput.trim() && !wporg?.handle)}
                           style={{ justifyContent:'center' }}
                         >Remember this</Button>
                         {handleError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{handleError}</div> : null}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -22,7 +22,8 @@ import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, APPLY_STATE_TO_STEP } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
-import { ticketUrl } from './trac-ticket.cjs';
+import { ticketUrl, attachUrl } from './trac-ticket.cjs';
+import { highlightDiff } from './diff-highlight.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // Per-status wording for the update chain card (#94), following the issue's
@@ -122,6 +123,61 @@ function useEditorChoice() {
   return { chosen, detected, loadDetected, remember };
 }
 
+// Who this contributor is and where they are contributing from (#166), held
+// once for the same reason the editor choice is: both are facts about the
+// person, not about a checkout, so answering them in one site's patch modal
+// must not leave every other site still asking.
+function useContributorProvenance() {
+  const [handle, setHandle] = useState(null);
+  const [event, setEvent] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api.getProvenance()
+      .then((res) => {
+        if (cancelled) return;
+        setHandle(res?.handle || null);
+        setEvent(res?.event || null);
+      })
+      // "nothing answered yet" is an ordinary state; "the store could not be
+      // read" is not, and the two must not look the same in the log. Same
+      // argument as useEditorChoice above.
+      // eslint-disable-next-line no-console -- reaches the log file, see the note in useEditorChoice.
+      .catch((err) => console.error('Could not read the remembered contributor details:', err));
+    return () => { cancelled = true; };
+  }, []);
+
+  // An empty ref forgets the field. A rejected invoke comes back as a refusal
+  // rather than being raised: the caller shows the message next to the input.
+  const rememberHandle = useCallback(async (ref) => {
+    let result;
+    try {
+      result = await window.api.setWporgHandle(ref);
+    } catch (err) {
+      // eslint-disable-next-line no-console -- see the note above.
+      console.error('Could not remember that WordPress.org handle:', err);
+      return { ok: false, error: String(err?.message ?? err) };
+    }
+    if (result?.ok) setHandle(result.handle || null);
+    return result;
+  }, []);
+
+  const rememberEvent = useCallback(async (ref) => {
+    let result;
+    try {
+      result = await window.api.setContributionEvent(ref);
+    } catch (err) {
+      // eslint-disable-next-line no-console -- see the note above.
+      console.error('Could not remember that event:', err);
+      return { ok: false, error: String(err?.message ?? err) };
+    }
+    if (result?.ok) setEvent(result.event || null);
+    return result;
+  }, []);
+
+  return { handle, event, rememberHandle, rememberEvent };
+}
+
 function useSites() {
   const [sites, setSites] = useState([]);
   const [siteMeta, setSiteMeta] = useState({});
@@ -138,6 +194,7 @@ function App() {
   const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
   // One choice for the window, shared by every site row.
   const editorChoice = useEditorChoice();
+  const wporg = useContributorProvenance();
   const [downloadPhase, setDownloadPhase] = useState('');
   // Directories whose clone is still running. An array rather than a single
   // path because the main process may settle on a different (deduplicated)
@@ -742,6 +799,7 @@ function App() {
                       onDelete={onDelete}
                       onRename={onRename}
                       editor={editorChoice}
+                      wporg={wporg}
                       isPending={pendingSites.includes(s)}
                       setupLogs={setupLogsBySite[s] || ''}
                       isActive={activeSite === s}
@@ -824,7 +882,58 @@ function App() {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onForget, onDelete, onRename, editor, isPending = false, setupLogs = '', isActive = false }) {
+// What each kind of patch line looks like (#166). The classification is in
+// diff-highlight.cjs; the colours are here because they are a property of this
+// pane, not of a diff. Added and removed lines carry a wash as well as a
+// foreground colour so the two are still distinguishable without colour vision
+// — the sign in column 0 is the other half of that, and it is never hidden.
+const DIFF_LINE_STYLES = {
+  add: { color: '#7ee787', background: 'rgba(46,160,67,0.18)' },
+  del: { color: '#ffa198', background: 'rgba(248,81,73,0.18)' },
+  hunk: { color: '#d2a8ff' },
+  meta: { color: '#79c0ff' },
+  header: { color: '#8b949e', fontStyle: 'italic' },
+  context: {}
+};
+
+// The patch, painted. An empty line still needs to occupy one: `\n` is appended
+// per line rather than joining, so the last line of a patch that ends in a
+// newline does not silently gain or lose one.
+function DiffText({ text }) {
+  const lines = highlightDiff(text);
+  if (!lines) return text;
+  return lines.map((line, index) => (
+    // A diff line has no identity beyond its position, and the whole pane is
+    // replaced when the patch changes.
+    <span key={index} style={{ display: 'block', ...DIFF_LINE_STYLES[line.kind] }}>
+      {line.text || ' '}
+    </span>
+  ));
+}
+
+// One destination for a finished patch (#166): what it is, what it costs to
+// use, and what happens afterwards. The costs are the point — they are what the
+// app used to leave the contributor to find out on their own — so every
+// destination states one, in the same place and the same shape, rather than the
+// cheap one being presented as the obvious choice.
+function DestinationCard({ title, cost, after, children }) {
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:8, padding:'14px 16px', border:'1px solid #dcdcde', borderRadius:10, background:'#fff' }}>
+      <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>{title}</div>
+      <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>{cost}</div>
+      <div style={{ fontSize:12, color:'#6c6f72', lineHeight:1.5 }}>{after}</div>
+      {/*
+        The actions follow the prose rather than being pushed to the bottom of
+        the row: the cards carry different numbers of controls, so bottom-
+        aligning them lines up nothing and leaves a hole above the shorter
+        card's button.
+      */}
+      <div style={{ paddingTop:4, display:'flex', flexDirection:'column', gap:8 }}>{children}</div>
+    </div>
+  );
+}
+
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onForget, onDelete, onRename, editor, wporg, isPending = false, setupLogs = '', isActive = false }) {
   // Kept in a ref so loadStatus's dependency list stays [sitePath] — a
   // recreated callback prop must not retrigger the status-loading effect.
   const metaPatchRef = useRef(onSiteMetaPatch);
@@ -839,6 +948,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [isPatchOpen, setIsPatchOpen] = useState(false);
   const [patchText, setPatchText] = useState('');
   const [patchLoading, setPatchLoading] = useState(false);
+  // What the last save did, reported in the modal rather than in an alert:
+  // the destination panel is where the contributor is looking, and the path
+  // matters — it is the file they are about to upload or hand over (#166).
+  const [patchSaved, setPatchSaved] = useState(null);
+  const [patchSaveError, setPatchSaveError] = useState('');
+  const [handleInput, setHandleInput] = useState('');
+  const [eventInput, setEventInput] = useState('');
+  const [handleError, setHandleError] = useState('');
+  const [handleSaving, setHandleSaving] = useState(false);
+  const [editingHandle, setEditingHandle] = useState(false);
   const [emails, setEmails] = useState([]);
   const [smtpPort, setSmtpPort] = useState(0);
   const newEmailUnsubRef = useRef(null);
@@ -2054,6 +2173,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setIsPatchOpen(true);
     setPatchLoading(true);
     setPatchText('');
+    // Last time's outcome belongs to last time's patch.
+    setPatchSaved(null);
+    setPatchSaveError('');
+    setHandleError('');
+    setEditingHandle(false);
     try {
       const res = await window.api.getPatch(sitePath);
       if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
@@ -2069,21 +2193,76 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     try { await navigator.clipboard.writeText(patchText); } catch {}
   };
 
-  const savePatch = async ()=>{
+  // Naming destinations for a patch that does not exist would be noise, and
+  // both of the states that produce one are already spelled out in the pane
+  // below: `getPatch` returns the literal 'No changes.', and its failures are
+  // put in the same box prefixed with 'Error'.
+  const patchHasChanges = Boolean(patchText)
+    && patchText.trim() !== 'No changes.'
+    && !patchText.startsWith('Error');
+
+  // Saving the file, for every destination that needs one (#166). `handoff`
+  // asks the main process for the provenance header and the name that carries
+  // the handle; without it this is the plain diff the Save button has always
+  // produced. Returns the path so a caller can say what it did next — the Trac
+  // route saves and then opens the attach page.
+  const savePatchFile = async (options) => {
+    setPatchSaved(null);
+    setPatchSaveError('');
     try {
-      const res = await window.api.savePatch(sitePath);
+      const res = await window.api.savePatch(sitePath, options);
       if (res && res.ok && res.filePath) {
-        // eslint-disable-next-line no-alert -- see the note above onRename.
-        alert(`Diff saved to: ${res.filePath}`);
-      } else if (res && res.canceled) {
-        // User canceled, do nothing
-      } else {
-        // eslint-disable-next-line no-alert -- see the note above onRename.
-        alert(`Error saving diff: ${res && res.error ? res.error : 'Unknown error'}`);
+        setPatchSaved(res.filePath);
+        return res.filePath;
       }
+      if (res && res.canceled) return null;
+      setPatchSaveError(res && res.error ? res.error : 'Unknown error');
     } catch (e) {
-      // eslint-disable-next-line no-alert -- see the note above onRename.
-      alert(`Error saving diff: ${e && e.message ? e.message : String(e)}`);
+      setPatchSaveError(e && e.message ? e.message : String(e));
+    }
+    return null;
+  };
+
+  const savePatch = () => savePatchFile();
+
+  // The Trac destination in full: save the file, then open the ticket's attach
+  // page so the contributor uploads it themselves. Nothing is posted from here
+  // — that would mean carrying a wordpress.org session, which #166 rules out.
+  // The page is opened only after a file exists, so the browser never lands on
+  // an attach form with nothing to attach.
+  const saveForTrac = async () => {
+    const filePath = await savePatchFile();
+    if (filePath && tracTicket) window.api.openExternal(attachUrl(tracTicket));
+  };
+
+  const saveForHandoff = async () => {
+    if (!wporg?.handle) return;
+    await savePatchFile({ handoff: true });
+  };
+
+  // Both fields are written in one go, because they are asked in one form. The
+  // event is optional: an empty box means "not at an event", which is also how
+  // it is cleared once the WordCamp is over.
+  const rememberContributor = async () => {
+    if (!wporg) return;
+    setHandleSaving(true);
+    setHandleError('');
+    try {
+      const named = await wporg.rememberHandle(handleInput);
+      if (!named?.ok) {
+        setHandleError(named?.error || 'Could not save that username.');
+        return;
+      }
+      const at = await wporg.rememberEvent(eventInput);
+      if (!at?.ok) {
+        setHandleError(at?.error || 'Could not save that event.');
+        return;
+      }
+      setHandleInput('');
+      setEventInput('');
+      setEditingHandle(false);
+    } finally {
+      setHandleSaving(false);
     }
   };
 
@@ -2485,7 +2664,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               onClick={openPatchModal}
               disabled={isUpdating}
               style={{ padding: '10px 16px', borderRadius: 10 }}
-            >Submit patch</Button>
+            >Create patch</Button>
             {running && serverUrl ? (
               <Button
                 variant="secondary"
@@ -2986,11 +3165,139 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 This site&apos;s WordPress code is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
               </div>
             )}
-            {!patchLoading && (
+            {!patchLoading && !patchHasChanges && (
               <div style={{ padding:'12px 16px', background:'#f0f6fc', border:'1px solid #d0d7de', borderRadius:6, fontSize:14, lineHeight:1.5, color:'#24292f' }}>
-                <strong>Next steps:</strong> Save this patch and submit it to the relevant WordPress Trac ticket at <button type="button" onClick={() => window.api.openExternal('https://core.trac.wordpress.org')} style={{color:'#0969da', cursor:'pointer', background:'none', border:'none', padding:0, font:'inherit', textDecoration:'underline'}}>core.trac.wordpress.org</button>
+                There is nothing to send yet — this site has no changes against its copy of trunk.
               </div>
             )}
+            {/*
+              Where the patch goes, named at the moment it exists (#166), each
+              destination with what it costs — a tool that emits a file and stops
+              leaves the contributor to work that out alone.
+
+              Opening a pull request is not offered here. It is the destination
+              that actually gets reviewed, but there is no path to one from a
+              .diff that this app can walk: GitHub cannot ingest a patch file,
+              and every manual route needs a GitHub credential. Sending someone
+              to a handbook page is not an action on the patch in front of them,
+              so the card became noise. #167 is the version that can act.
+            */}
+            {!patchLoading && patchHasChanges && (
+              <div>
+                <div style={{ display:'flex', alignItems:'baseline', gap:8, marginBottom:8 }}>
+                  <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Where this patch goes</div>
+                  <div style={{ fontSize:12, color:'#6c6f72' }}>Nothing is uploaded and no account is asked for here.</div>
+                </div>
+                <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(260px, 1fr))', gap:12, alignItems:'stretch' }}>
+                  <DestinationCard
+                    title="Attach to Trac"
+                    cost="A WordPress.org account — needed anyway, for props and to comment."
+                    after="No automated checks. Often followed by a request to open a pull request."
+                  >
+                    {tracTicket ? (
+                      <Button variant="primary" onClick={saveForTrac} style={{ justifyContent:'center' }}>
+                        Save, then open #{tracTicket}
+                      </Button>
+                    ) : (
+                      <>
+                        <div style={{ fontSize:12, color:'#6c6f72' }}>
+                          No ticket is linked to this site, so there is nowhere to attach it yet.
+                        </div>
+                        <TextControl
+                          value={ticketInput}
+                          onChange={(value) => { setTicketInput(value); setTicketError(''); }}
+                          onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
+                          disabled={ticketSaving}
+                          placeholder="Ticket number or URL, e.g. 62281"
+                          aria-label="Trac ticket number or URL"
+                        />
+                        <Button
+                          variant="secondary"
+                          onClick={linkTicket}
+                          isBusy={ticketSaving}
+                          disabled={ticketSaving || !ticketInput.trim()}
+                          style={{ justifyContent:'center' }}
+                        >Link ticket</Button>
+                        {ticketError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{ticketError}</div> : null}
+                      </>
+                    )}
+                  </DestinationCard>
+
+                  <DestinationCard
+                    title="Hand it to a mentor"
+                    cost="No accounts at all. The patch carries your WordPress.org username, and the event you are at."
+                    after="Someone else pushes it; the props still land on you."
+                  >
+                    {wporg?.handle && !editingHandle ? (
+                      <>
+                        <Button variant="primary" onClick={saveForHandoff} style={{ justifyContent:'center' }}>
+                          Save patch as {wporg.handle}
+                        </Button>
+                        {/*
+                          The event is shown on every save rather than only when
+                          it is set: a remembered WordCamp from last year would
+                          otherwise keep stamping patches with nobody seeing it.
+                        */}
+                        <div style={{ fontSize:12, color:'#6c6f72' }}>
+                          {wporg.event ? <>The patch will say it was written at <strong>{wporg.event}</strong>.</> : 'No event on the patch.'}
+                        </div>
+                        <Button
+                          variant="link"
+                          onClick={() => {
+                            setHandleInput(wporg.handle);
+                            setEventInput(wporg.event || '');
+                            setHandleError('');
+                            setEditingHandle(true);
+                          }}
+                          style={{ fontSize:12 }}
+                        >Change these</Button>
+                      </>
+                    ) : (
+                      <>
+                        <div style={{ fontSize:12, color:'#6c6f72' }}>
+                          Asked once and remembered for every site — these are facts about you, not about this checkout.
+                        </div>
+                        <TextControl
+                          value={handleInput}
+                          onChange={(value) => { setHandleInput(value); setHandleError(''); }}
+                          onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); rememberContributor(); } }}
+                          disabled={handleSaving}
+                          placeholder="WordPress.org username, e.g. janedoe"
+                          aria-label="WordPress.org username"
+                        />
+                        <TextControl
+                          value={eventInput}
+                          onChange={(value) => { setEventInput(value); setHandleError(''); }}
+                          onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); rememberContributor(); } }}
+                          disabled={handleSaving}
+                          placeholder="Event, e.g. WordCamp Europe 2026 (optional)"
+                          aria-label="Event this patch was written at"
+                        />
+                        <Button
+                          variant="secondary"
+                          onClick={rememberContributor}
+                          isBusy={handleSaving}
+                          disabled={handleSaving || !handleInput.trim()}
+                          style={{ justifyContent:'center' }}
+                        >Remember this</Button>
+                        {handleError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{handleError}</div> : null}
+                      </>
+                    )}
+                  </DestinationCard>
+                </div>
+              </div>
+            )}
+            {/*
+              Outside the destinations block on purpose: the plain Save button
+              over the diff is still there when there is nothing to send, and an
+              outcome that renders nowhere is the alert this replaced.
+            */}
+            {patchSaved ? (
+              <div style={{ fontSize:13, color:'#0f5132' }}>Saved to {patchSaved}</div>
+            ) : null}
+            {patchSaveError ? (
+              <div role="alert" style={{ fontSize:13, color:'#d63638' }}>Could not save the patch: {patchSaveError}</div>
+            ) : null}
             <div style={{ position:'relative', flex:1, minHeight:0 }}>
               {patchLoading ? (
                 <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:16 }}>
@@ -3018,7 +3325,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     />
                   </div>
                   <pre style={{ margin:0, whiteSpace:'pre-wrap', background:'#111', color:'#eee', padding:12, borderRadius:6, height:'100%', overflowY:'auto' }}>
-                    {patchText && patchText.trim().length ? patchText : 'No changes.'}
+                    {patchText && patchText.trim().length ? <DiffText text={patchText} /> : 'No changes.'}
                   </pre>
                 </>
               )}

--- a/src/renderer/trac-ticket.cjs
+++ b/src/renderer/trac-ticket.cjs
@@ -30,6 +30,25 @@ function ticketUrl(id) {
 }
 
 /**
+ * The page that attaches a file to a ticket (issue #166).
+ *
+ * This is the whole of the "attach to Trac" destination: a deep link, opened in
+ * the contributor's browser, where they are already signed in or will be asked
+ * to sign in by wordpress.org rather than by this app. Posting the file here
+ * automatically would mean carrying a wordpress.org session, which is the one
+ * thing #166 rules out — and one manual click is a step a first-time
+ * contributor should see anyway.
+ *
+ * `?action=new` is Trac's own attach form; without it the same path lists the
+ * attachments that are already there.
+ *
+ * @param {number|string} id
+ */
+function attachUrl(id) {
+	return `https://${TRAC_HOST}/attachment/ticket/${id}/?action=new`;
+}
+
+/**
  * @param {string} digits
  */
 function fromDigits(digits) {
@@ -87,5 +106,6 @@ module.exports = {
 	TRAC_HOST,
 	MAX_TICKET_ID,
 	ticketUrl,
+	attachUrl,
 	parseTicketRef
 };

--- a/src/wporg-handle.cjs
+++ b/src/wporg-handle.cjs
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Reading what a contributor typed when asked for their WordPress.org handle
+ * (issue #166).
+ *
+ * The handle is what makes the mentor handoff work: the patch carries it, so
+ * whoever pushes the work can hand the props back to the person who did it.
+ * That is the whole reason it is asked for, and the reason it is asked for
+ * once, app-wide — it is a fact about the contributor, not a property of a
+ * checkout, the same reasoning the editor preference already follows.
+ *
+ * People arrive from a browser, so the input is as likely to be a pasted
+ * profile URL or an `@handle` copied out of Slack as it is the bare handle.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM or an Electron process: the renderer bundle imports it, main.js requires
+ * it, `node --test` requires it directly (same convention as trac-ticket.cjs).
+ */
+
+const PROFILES_HOST = 'profiles.wordpress.org';
+
+// WordPress.org sanitizes a username down to this before it becomes the
+// profile slug: letters, digits, and the three separators, never leading or
+// trailing. Matched case-insensitively and stored lowercase, because that is
+// the form profiles.wordpress.org serves and the form props are written in.
+const HANDLE = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/i;
+
+// Longer than any real handle, short enough that the value stays a plausible
+// filename component and a single header line.
+const MAX_HANDLE_LENGTH = 60;
+
+const NOT_A_HANDLE =
+	'Enter your WordPress.org username, like janedoe, or your profiles.wordpress.org URL.';
+
+/**
+ * Whether a value is already a stored handle — the canonical form `parseHandle`
+ * produces, not free-form input. Callers that put a handle somewhere structural
+ * (a filename, a header line) ask this rather than re-deriving the charset.
+ *
+ * @param {unknown} value
+ */
+function isHandle(value) {
+	return typeof value === 'string'
+		&& value.length <= MAX_HANDLE_LENGTH
+		&& value === value.toLowerCase()
+		&& HANDLE.test(value);
+}
+
+/**
+ * Canonical profile URL for a handle.
+ *
+ * @param {string} handle
+ */
+function profileUrl(handle) {
+	return `https://${PROFILES_HOST}/${handle}/`;
+}
+
+/**
+ * @param {string} candidate
+ */
+function fromHandle(candidate) {
+	if (candidate.length > MAX_HANDLE_LENGTH || !HANDLE.test(candidate)) {
+		return { ok: false, error: NOT_A_HANDLE };
+	}
+	const handle = candidate.toLowerCase();
+	return { ok: true, handle, url: profileUrl(handle) };
+}
+
+/**
+ * Resolves free-form input to a WordPress.org handle. Accepts `janedoe`,
+ * `@janedoe` and any profiles.wordpress.org URL; rejects everything else with
+ * a message meant for the contributor, not for a log.
+ *
+ * @param {string} input
+ * @return {{ok: true, handle: string, url: string}|{ok: false, error: string}}
+ */
+function parseHandle(input) {
+	const raw = typeof input === 'string' ? input.trim() : '';
+	if (!raw) return { ok: false, error: 'Enter your WordPress.org username.' };
+
+	const bare = raw.replace(/^@/, '');
+
+	// Only take the URL branch when the input actually looks like one. `new URL`
+	// is lenient enough that a bare word parses as a hostname, which would report
+	// a wrong *host* rather than the real problem — the same trap trac-ticket.cjs
+	// documents. A handle can contain dots, so a dotted string is not enough to
+	// call it a URL: it needs a scheme or a path.
+	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
+	if (!hasScheme && !raw.includes('/')) return fromHandle(bare);
+
+	let parsed;
+	try {
+		parsed = new URL(hasScheme ? raw : `https://${raw}`);
+	} catch {
+		return { ok: false, error: NOT_A_HANDLE };
+	}
+
+	if (parsed.hostname.toLowerCase() !== PROFILES_HOST) {
+		return { ok: false, error: `Only ${PROFILES_HOST} profile links are supported.` };
+	}
+
+	// Reading the handle off the path drops any query or fragment for free.
+	const match = /^\/([^/]+)\/?$/.exec(parsed.pathname);
+	if (!match) return { ok: false, error: NOT_A_HANDLE };
+
+	// A percent-escape the URL parser left in place — the handle charset has
+	// none, so an undecodable one is simply not a handle.
+	let slug;
+	try {
+		slug = decodeURIComponent(match[1]);
+	} catch {
+		return { ok: false, error: NOT_A_HANDLE };
+	}
+	return fromHandle(slug);
+}
+
+module.exports = {
+	PROFILES_HOST,
+	MAX_HANDLE_LENGTH,
+	isHandle,
+	profileUrl,
+	parseHandle
+};

--- a/test/diff-highlight.test.cjs
+++ b/test/diff-highlight.test.cjs
@@ -1,0 +1,86 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { MAX_HIGHLIGHTED_LINES, classifyLine, highlightDiff } = require('../src/renderer/diff-highlight.cjs');
+
+test('classifyLine: added and removed code are the two the reader is looking for (issue #166)', () => {
+	assert.strictEqual(classifyLine('+\t$a = 2;'), 'add');
+	assert.strictEqual(classifyLine('-\t$a = 1;'), 'del');
+	assert.strictEqual(classifyLine(' \t// unchanged'), 'context');
+	assert.strictEqual(classifyLine(''), 'context');
+});
+
+// The classic diff-viewer bug: `---` and `+++` name the files being compared,
+// and painting them red and green puts two fake changes at the top of every
+// patch.
+test('classifyLine: the file-name lines are not a deletion and an addition (issue #166)', () => {
+	assert.strictEqual(classifyLine('--- a/src/wp-includes/post.php'), 'meta');
+	assert.strictEqual(classifyLine('+++ b/src/wp-includes/post.php'), 'meta');
+});
+
+test('classifyLine: hunk headers are their own thing (issue #166)', () => {
+	assert.strictEqual(classifyLine('@@ -288,7 +288,7 @@'), 'hunk');
+	assert.strictEqual(classifyLine('@@ -1 +1 @@ class Foo {'), 'hunk');
+});
+
+// Both shapes this app has to render: what it generates itself, and what it
+// downloads from a pull request or a Trac attachment (#11).
+test('classifyLine: the metadata of a generated and of a git patch both read as metadata (issue #166)', () => {
+	const meta = [
+		'===================================================================',
+		'diff --git a/src/wp-includes/post.php b/src/wp-includes/post.php',
+		'index 1111111..2222222 100644',
+		'Index: src/wp-includes/post.php',
+		'new file mode 100644',
+		'deleted file mode 100644',
+		'rename from src/old.php',
+		'rename to src/new.php',
+		'similarity index 96%',
+		'Binary files a/image.png and b/image.png differ',
+		'GIT binary patch'
+	];
+	for (const line of meta) {
+		assert.strictEqual(classifyLine(line), 'meta', `line: ${line}`);
+	}
+});
+
+// The provenance block this app prepends to a handed-off patch. Nothing in the
+// diff proper starts at column 0 with a `#`, so the marker is unambiguous.
+test('classifyLine: the provenance header is not part of the diff (issue #166)', () => {
+	assert.strictEqual(classifyLine('# WordPress Contributor Toolkit patch'), 'header');
+	assert.strictEqual(classifyLine('# Contributor: janedoe (wordpress.org)'), 'header');
+	// A PHP comment inside the patch is a diff line first: it carries the
+	// space, `+` or `-` marker, so it never reaches the header branch.
+	assert.strictEqual(classifyLine('+# not a header, an added shell comment'), 'add');
+	assert.strictEqual(classifyLine(' # not a header, an unchanged one'), 'context');
+});
+
+test('highlightDiff: every line comes back, in order, with its kind (issue #166)', () => {
+	const patch = [
+		'--- a/src/x.php',
+		'+++ b/src/x.php',
+		'@@ -1,2 +1,2 @@',
+		' <?php',
+		'-$a = 1;',
+		'+$a = 2;'
+	].join('\n');
+
+	assert.deepStrictEqual(highlightDiff(patch).map((l) => l.kind), [
+		'meta', 'meta', 'hunk', 'context', 'del', 'add'
+	]);
+	assert.deepStrictEqual(highlightDiff(patch).map((l) => l.text), patch.split('\n'));
+});
+
+// A patch big enough that one element per line stops being free is also one
+// nobody is reading line by line. The caller falls back to plain text.
+test('highlightDiff: a patch past the line budget is not painted at all (issue #166)', () => {
+	assert.strictEqual(highlightDiff('+x\n'.repeat(MAX_HIGHLIGHTED_LINES + 1)), null);
+	assert.notStrictEqual(highlightDiff('+x\n'.repeat(10)), null);
+});
+
+test('highlightDiff: nothing to paint is null, not an empty line (issue #166)', () => {
+	assert.strictEqual(highlightDiff(''), null);
+	assert.strictEqual(highlightDiff(null), null);
+	assert.strictEqual(highlightDiff(undefined), null);
+});

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -625,6 +625,43 @@ test('git:save-patch without options is the bare diff under the name it always h
 	assert.equal(path.basename(main.calls.showSaveDialog[0].defaultPath), 'wordpress.patch');
 });
 
+// The two tests above stop at the dialog, so neither sees what is written. This
+// one runs the real patch-provenance module all the way to the file, because
+// the header being *above* the diff is the whole of its usefulness: the same
+// lines appended after it would land inside the last hunk's context and stop
+// the patch applying anywhere.
+test('git:save-patch with handoff writes the header above the diff, and it still parses', async (t) => {
+	const dir = await fixtureRepo(t);
+	const target = path.join(dir, '..', `handoff-${process.pid}.diff`);
+	t.after(() => fs.rmSync(target, { force: true }));
+
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				siteMeta: { [dir]: { tracTicket: 62281 } },
+				preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' }
+			}).stubs
+		}
+	});
+	main.dialogResults.showSaveDialog = { canceled: false, filePath: target };
+
+	const result = await main.invoke('git:save-patch', dir, { handoff: true });
+	assert.equal(result.ok, true, result.error);
+
+	const written = fs.readFileSync(target, 'utf8');
+	assert.ok(written.startsWith('# WordPress Contributor Toolkit patch\n'), written.slice(0, 200));
+	assert.ok(written.includes('# Contributor: janedoe (wordpress.org)'));
+	assert.ok(written.includes('# Event: WordCamp Europe 2026'));
+	assert.ok(written.indexOf('# Generated:') < written.indexOf('---'), 'the header has to precede the diff');
+
+	// The app reads its own patches back when someone applies one, so a mentor's
+	// copy of this file has to survive the round trip.
+	const parsed = require('../src/patch-plan.cjs').parsePatchFiles(written);
+	assert.equal(parsed.ok, true, parsed.error);
+	assert.deepEqual(parsed.files.map((f) => f.path), ['text.txt']);
+});
+
 // --- provenance:* -> src/wporg-handle.cjs + src/patch-provenance.cjs (#166) ---
 
 // The handle becomes a filename and a line in a file other people read, so it

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -549,6 +549,167 @@ test('git:create-patch and git:save-patch generate the patch the same way', asyn
 	}
 });
 
+// --- git:save-patch -> src/patch-provenance.cjs (#166) -------------------
+
+// A repository the patch path can actually run against, so the handler reaches
+// the provenance step instead of stopping at the first git call.
+async function fixtureRepo(t) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-handoff-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\n');
+	await git.add({ fs, dir, filepath: 'text.txt' });
+	const head = await git.commit({ fs, dir, message: 'init', author: { name: 'test', email: 'test@example.com' } });
+	// Without it the handler falls back to fetching wordpress-develop.
+	await git.writeRef({ fs, dir, ref: 'refs/remotes/origin/trunk', value: head });
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\nline2\n');
+	return dir;
+}
+
+// The header is what makes a handed-off patch worth handing off: without it the
+// file says nothing about who wrote it, and the props go to whoever pushes it.
+// The values come from the store rather than from the caller, so the renderer
+// cannot put someone else's handle or another site's base on a patch.
+test('git:save-patch with handoff asks patch-provenance for the header and the name', async (t) => {
+	const dir = await fixtureRepo(t);
+	const buildProvenanceHeader = spy(() => '# header\n\n');
+	const handoffFilename = spy(() => '62281.janedoe.diff');
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				siteMeta: { [dir]: { tracTicket: 62281, trunkOid: 'abcdef1234567890', trunkDate: '2026-08-05T09:14:00.000Z' } },
+				preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' }
+			}).stubs,
+			'./patch-provenance.cjs': { buildProvenanceHeader, handoffFilename }
+		}
+	});
+
+	// The dialog is canceled by default, which is far enough: both calls happen
+	// before it, and nothing is written to the contributor's disk.
+	await main.invoke('git:save-patch', dir, { handoff: true });
+
+	assert.equal(buildProvenanceHeader.calls.length, 1);
+	const details = buildProvenanceHeader.calls[0][0];
+	assert.equal(details.handle, 'janedoe');
+	assert.equal(details.event, 'WordCamp Europe 2026');
+	assert.equal(details.ticketId, 62281);
+	assert.equal(details.trunkOid, 'abcdef1234567890');
+	assert.equal(details.trunkDate, '2026-08-05T09:14:00.000Z');
+	assert.ok(details.generatedAt, 'the header has to be able to say when this was made');
+
+	assert.deepEqual(handoffFilename.calls, [[{ handle: 'janedoe', ticketId: 62281 }]]);
+	assert.equal(main.calls.showSaveDialog.length, 1);
+	assert.equal(path.basename(main.calls.showSaveDialog[0].defaultPath), '62281.janedoe.diff');
+});
+
+// The other callers — the Trac destination and the save-before-update prompt —
+// produce the file that gets attached to a ticket, which carries no header by
+// convention. A handler that headed every patch would change what those two do.
+test('git:save-patch without options is the bare diff under the name it always had', async (t) => {
+	const dir = await fixtureRepo(t);
+	const buildProvenanceHeader = spy(() => '# header\n\n');
+	const handoffFilename = spy(() => 'should-not-be-used.diff');
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({ preferences: { wporgHandle: 'janedoe' } }).stubs,
+			'./patch-provenance.cjs': { buildProvenanceHeader, handoffFilename }
+		}
+	});
+
+	await main.invoke('git:save-patch', dir);
+
+	assert.deepEqual(buildProvenanceHeader.calls, []);
+	assert.deepEqual(handoffFilename.calls, []);
+	assert.equal(path.basename(main.calls.showSaveDialog[0].defaultPath), 'wordpress.patch');
+});
+
+// --- provenance:* -> src/wporg-handle.cjs + src/patch-provenance.cjs (#166) ---
+
+// The handle becomes a filename and a line in a file other people read, so it
+// is validated in the main process and not only in the window.
+test('provenance:set-handle validates through wporg-handle before storing anything', async () => {
+	const parseHandle = spy(() => ({ ok: false, error: 'nope' }));
+	const settings = fakeSettingsStore();
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...settings.stubs, './wporg-handle.cjs': { parseHandle } }
+	});
+
+	const result = await main.invoke('provenance:set-handle', 'jane doe');
+
+	assert.deepEqual(result, { ok: false, error: 'nope' });
+	assert.deepEqual(parseHandle.calls, [['jane doe']]);
+	assert.equal(settings.values.preferences, undefined, 'a refused handle must not be written');
+});
+
+test('provenance:set-handle stores the canonical handle the module returned, not what was typed', async () => {
+	const parseHandle = spy(() => ({ ok: true, handle: 'janedoe' }));
+	const settings = fakeSettingsStore();
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...settings.stubs, './wporg-handle.cjs': { parseHandle } }
+	});
+
+	assert.deepEqual(await main.invoke('provenance:set-handle', 'https://profiles.wordpress.org/JaneDoe/'), { ok: true, handle: 'janedoe' });
+	assert.equal(settings.values.preferences.wporgHandle, 'janedoe');
+});
+
+// The event goes into the same header, so it is validated in the same place —
+// and by the module that owns the header's line rules.
+test('provenance:set-event validates through patch-provenance before storing anything', async () => {
+	const parseEventName = spy(() => ({ ok: false, error: 'one line please' }));
+	const settings = fakeSettingsStore();
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...settings.stubs, './patch-provenance.cjs': { parseEventName } }
+	});
+
+	const result = await main.invoke('provenance:set-event', 'WordCamp\n# Contributor: someoneelse');
+
+	assert.deepEqual(result, { ok: false, error: 'one line please' });
+	assert.deepEqual(parseEventName.calls, [['WordCamp\n# Contributor: someoneelse']]);
+	assert.equal(settings.values.preferences, undefined, 'a refused event must not be written');
+});
+
+// Same shape as `sites:set-ticket`: clearing needs no second channel, and it
+// must not be routed through the parser, which refuses an empty string. The
+// event is the field this matters most for — a WordCamp ends.
+test('provenance:set-handle and set-event forget the field on an empty ref', async () => {
+	const parseHandle = spy(() => ({ ok: false, error: 'nope' }));
+	const parseEventName = spy(() => ({ ok: false, error: 'nope' }));
+	const settings = fakeSettingsStore({ preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' } });
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./wporg-handle.cjs': { parseHandle },
+			'./patch-provenance.cjs': { parseEventName }
+		}
+	});
+
+	assert.deepEqual(await main.invoke('provenance:set-handle', '   '), { ok: true, handle: null });
+	assert.deepEqual(await main.invoke('provenance:set-event', ''), { ok: true, event: null });
+	assert.equal(settings.values.preferences.wporgHandle, null);
+	assert.equal(settings.values.preferences.contributionEvent, null);
+	assert.deepEqual(parseHandle.calls, []);
+	assert.deepEqual(parseEventName.calls, []);
+});
+
+// One read for both, because the window asks once on load.
+test('provenance:get reads the remembered handle and event', async () => {
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({ preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' } }).stubs
+		}
+	});
+
+	assert.deepEqual(await main.invoke('provenance:get'), {
+		ok: true,
+		handle: 'janedoe',
+		event: 'WordCamp Europe 2026'
+	});
+});
+
 // --- npm:* -> src/npm-runner.js + src/kill-tree.js -----------------------
 
 // The npm handlers run the real runNpmWithEngineRetry, which calls
@@ -1369,7 +1530,9 @@ const WIRED = new Set([
 	'editor:list',
 	'editor:choose',
 	'editor:open',
-	'dir:show'
+	'dir:show',
+	'provenance:set-handle',
+	'provenance:set-event'
 ]);
 
 // Channels with no module to reach: they read or write electron-store, drive a
@@ -1387,6 +1550,7 @@ const NO_DELEGATION = new Map([
 	['dialog:choose-dir', 'opens the directory dialog'],
 	['dialog:choose-patch-file', 'opens the file-open dialog and reads the chosen file'],
 	['playground-web:available', 'checks a path on disk'],
+	['provenance:get', 'electron-store read'],
 	['smtp:get', 'electron-store read'],
 	['smtp:clear', 'electron-store write'],
 	['smtp:start', 'starts the in-process SMTP server'],

--- a/test/patch-provenance.test.cjs
+++ b/test/patch-provenance.test.cjs
@@ -1,0 +1,170 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	TITLE,
+	MAX_FIELD_LENGTH,
+	MAX_EVENT_LENGTH,
+	parseEventName,
+	buildProvenanceHeader,
+	handoffFilename
+} = require('../src/patch-provenance.cjs');
+const { parsePatchFiles } = require('../src/patch-plan.cjs');
+
+const FULL = {
+	handle: 'janedoe',
+	event: 'WordCamp Europe 2026',
+	ticketId: 62281,
+	trunkOid: '59a1c3e8f0d2b4a6c8e0f2d4b6a8c0e2f4d6b8a0',
+	trunkDate: '2026-08-05T09:14:00.000Z',
+	generatedAt: '2026-08-07T16:42:31.000Z'
+};
+
+test('buildProvenanceHeader: every field, in the format #107 is meant to adopt (issue #166)', () => {
+	assert.strictEqual(
+		buildProvenanceHeader(FULL),
+		[
+			'# WordPress Contributor Toolkit patch',
+			'# Contributor: janedoe (wordpress.org)',
+			'# Event: WordCamp Europe 2026',
+			'# Ticket: https://core.trac.wordpress.org/ticket/62281',
+			'# Base: trunk @ 59a1c3e, 2026-08-05',
+			'# Generated: 2026-08-07',
+			'',
+			''
+		].join('\n')
+	);
+});
+
+test('buildProvenanceHeader: the title line is there whenever any field is (issue #166)', () => {
+	assert.ok(buildProvenanceHeader({ handle: 'janedoe' }).startsWith(`${TITLE}\n`));
+});
+
+// A site that has never been updated has no recorded base, and a site with no
+// linked ticket has no ticket. Saying "unknown" would make the lines that *are*
+// there worth less.
+test('buildProvenanceHeader: an unknown field is left out, not written as unknown (issue #166)', () => {
+	const header = buildProvenanceHeader({ handle: 'janedoe', generatedAt: FULL.generatedAt });
+	assert.strictEqual(
+		header,
+		`${TITLE}\n# Contributor: janedoe (wordpress.org)\n# Generated: 2026-08-07\n\n`
+	);
+	assert.ok(!header.includes('unknown'));
+});
+
+test('buildProvenanceHeader: a base with only one half of it still says that half (issue #166)', () => {
+	assert.ok(buildProvenanceHeader({ trunkOid: FULL.trunkOid }).includes('# Base: trunk @ 59a1c3e\n'));
+	assert.ok(buildProvenanceHeader({ trunkDate: FULL.trunkDate }).includes('# Base: trunk @ 2026-08-05\n'));
+});
+
+test('buildProvenanceHeader: nothing to say produces no header at all (issue #166)', () => {
+	assert.strictEqual(buildProvenanceHeader(), '');
+	assert.strictEqual(buildProvenanceHeader({}), '');
+	assert.strictEqual(buildProvenanceHeader({ handle: '   ', ticketId: 0, trunkDate: 'not a date' }), '');
+});
+
+// The header sits above a diff. A value that can end its line can write header
+// lines of its own, or fake a `diff --git` line and change what the patch reads
+// as — so a field is one line or it is not a field.
+test('buildProvenanceHeader: a field cannot break out of its line (issue #166)', () => {
+	const header = buildProvenanceHeader({
+		handle: 'jane\ndiff --git a/wp-config.php b/wp-config.php\n# Contributor: someoneelse',
+		generatedAt: FULL.generatedAt
+	});
+	const lines = header.trimEnd().split('\n');
+	assert.strictEqual(lines.length, 3, header);
+	for (const line of lines) assert.ok(line.startsWith('#'), `line: ${line}`);
+});
+
+test('buildProvenanceHeader: a field is bounded so it cannot bury the diff (issue #166)', () => {
+	const header = buildProvenanceHeader({ handle: 'a'.repeat(500) });
+	assert.ok(header.includes(`# Contributor: ${'a'.repeat(MAX_FIELD_LENGTH)} (wordpress.org)`));
+	assert.ok(!header.includes('a'.repeat(MAX_FIELD_LENGTH + 1)));
+});
+
+// The reason a header is safe to prepend at all: this app reads its own patches
+// back through patch-plan.cjs when someone applies one, and a mentor's copy of
+// the file has to survive that round trip.
+test('a headed patch still parses as the same patch (issue #166)', () => {
+	const diff = [
+		'diff --git a/src/wp-includes/post.php b/src/wp-includes/post.php',
+		'index 1111111..2222222 100644',
+		'--- a/src/wp-includes/post.php',
+		'+++ b/src/wp-includes/post.php',
+		'@@ -1,3 +1,3 @@',
+		' <?php',
+		'-$a = 1;',
+		'+$a = 2;',
+		' // end',
+		''
+	].join('\n');
+
+	const bare = parsePatchFiles(diff);
+	const headed = parsePatchFiles(buildProvenanceHeader(FULL) + diff);
+
+	assert.strictEqual(bare.ok, true);
+	assert.strictEqual(headed.ok, true, headed.error);
+	assert.deepStrictEqual(
+		headed.files.map((f) => [f.path, f.change]),
+		bare.files.map((f) => [f.path, f.change])
+	);
+});
+
+// Most patches are not written at an event, and a header line saying so would
+// be noise on every one of them.
+test('buildProvenanceHeader: no event means no event line (issue #166)', () => {
+	const header = buildProvenanceHeader({ handle: 'janedoe', generatedAt: FULL.generatedAt });
+	assert.ok(!header.includes('# Event:'), header);
+});
+
+test('parseEventName: an event name is free text, because the real ones are (issue #166)', () => {
+	for (const name of ['WordCamp Europe 2026', 'Madrid WordPress Meetup', 'Contributor Day @ WCEU', 'ある勉強会']) {
+		assert.deepStrictEqual(parseEventName(name), { ok: true, name });
+	}
+	assert.deepStrictEqual(parseEventName('  WordCamp Europe 2026  '), { ok: true, name: 'WordCamp Europe 2026' });
+});
+
+test('parseEventName: empty input is a refusal the caller can phrase as optional (issue #166)', () => {
+	for (const empty of ['', '   ', null, undefined, 42]) {
+		assert.strictEqual(parseEventName(empty).ok, false);
+	}
+});
+
+// The value goes into a header line above a diff, so the same rule as every
+// other field: one line, bounded. Here it is refused rather than repaired,
+// because unlike the others it is being typed by someone who can retype it.
+test('parseEventName: a value that would break the header is refused (issue #166)', () => {
+	assert.strictEqual(parseEventName('WordCamp\n# Contributor: someoneelse').ok, false);
+	assert.strictEqual(parseEventName('a'.repeat(MAX_EVENT_LENGTH + 1)).ok, false);
+	assert.strictEqual(parseEventName('a'.repeat(MAX_EVENT_LENGTH)).ok, true);
+});
+
+// A /g regex remembers where its last match ended, so a shared one used with
+// `test` refuses every other call unless lastIndex is reset.
+test('parseEventName: repeated calls give the same answer (issue #166)', () => {
+	for (let i = 0; i < 4; i += 1) {
+		assert.strictEqual(parseEventName('WordCamp Europe 2026').ok, true, `call ${i}`);
+		assert.strictEqual(parseEventName('WordCamp\nEurope').ok, false, `call ${i}`);
+	}
+});
+
+test('handoffFilename: ticket and handle, the way a mentor sorts a folder of these (issue #166)', () => {
+	assert.strictEqual(handoffFilename({ handle: 'janedoe', ticketId: 62281 }), '62281.janedoe.diff');
+	assert.strictEqual(handoffFilename({ handle: 'janedoe', ticketId: '62281' }), '62281.janedoe.diff');
+});
+
+test('handoffFilename: no ticket linked still names the contributor (issue #166)', () => {
+	assert.strictEqual(handoffFilename({ handle: 'janedoe' }), 'janedoe.diff');
+	assert.strictEqual(handoffFilename({ handle: 'janedoe', ticketId: null }), 'janedoe.diff');
+});
+
+// A filename is a path component. Anything that did not come out of parseHandle
+// falls back rather than being repaired here.
+test('handoffFilename: a handle that never passed validation does not reach the path (issue #166)', () => {
+	const bad = ['../../etc/passwd', 'jane/doe', 'jane doe', 'JaneDoe', '', null, undefined, 42];
+	for (const handle of bad) {
+		assert.strictEqual(handoffFilename({ handle, ticketId: 62281 }), 'wordpress.patch', `handle: ${handle}`);
+	}
+	assert.strictEqual(handoffFilename(), 'wordpress.patch');
+});

--- a/test/trac-ticket.test.cjs
+++ b/test/trac-ticket.test.cjs
@@ -2,7 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { TRAC_HOST, MAX_TICKET_ID, ticketUrl, parseTicketRef } = require('../src/renderer/trac-ticket.cjs');
+const { TRAC_HOST, MAX_TICKET_ID, ticketUrl, attachUrl, parseTicketRef } = require('../src/renderer/trac-ticket.cjs');
 
 test('parseTicketRef: a bare number is a ticket (issue #109)', () => {
 	const res = parseTicketRef('62281');
@@ -105,4 +105,22 @@ test('parseTicketRef: ticket 0 and implausibly long numbers are rejected (issue 
 test('parseTicketRef: leading zeros resolve to the same ticket (issue #109)', () => {
 	assert.strictEqual(parseTicketRef('0062281').id, 62281);
 	assert.strictEqual(parseTicketRef('0062281').url, ticketUrl(62281));
+});
+
+// The "attach to Trac" destination is this link and nothing else (issue #166):
+// no upload, no session, one click the contributor makes themselves.
+test('attachUrl: points at the ticket the site is working, on the attach form (issue #166)', () => {
+	assert.strictEqual(
+		attachUrl(62281),
+		'https://core.trac.wordpress.org/attachment/ticket/62281/?action=new'
+	);
+	assert.strictEqual(attachUrl('62281'), attachUrl(62281));
+});
+
+// openExternal refuses anything that is not http(s) (src/external-url.js), and
+// the attach link has to keep passing that gate on the host Trac serves.
+test('attachUrl: stays https on the Trac host (issue #166)', () => {
+	const parsed = new URL(attachUrl(62281));
+	assert.strictEqual(parsed.protocol, 'https:');
+	assert.strictEqual(parsed.hostname, TRAC_HOST);
 });

--- a/test/wporg-handle.test.cjs
+++ b/test/wporg-handle.test.cjs
@@ -1,0 +1,90 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { PROFILES_HOST, MAX_HANDLE_LENGTH, profileUrl, parseHandle } = require('../src/wporg-handle.cjs');
+
+test('parseHandle: a bare username is a handle (issue #166)', () => {
+	const res = parseHandle('janedoe');
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.handle, 'janedoe');
+	assert.strictEqual(res.url, 'https://profiles.wordpress.org/janedoe/');
+});
+
+test('parseHandle: the @ people copy out of a chat message is not an error (issue #166)', () => {
+	assert.strictEqual(parseHandle('@janedoe').handle, 'janedoe');
+	assert.strictEqual(parseHandle('  @janedoe  ').handle, 'janedoe');
+});
+
+test('parseHandle: the separators WordPress.org allows survive (issue #166)', () => {
+	for (const handle of ['jane-doe', 'jane_doe', 'jane.doe', 'jane1', '1jane', 'j']) {
+		assert.strictEqual(parseHandle(handle).handle, handle, `handle: ${handle}`);
+	}
+});
+
+test('parseHandle: a profile URL resolves, in the shapes an address bar produces (issue #166)', () => {
+	const forms = [
+		'https://profiles.wordpress.org/janedoe/',
+		'https://profiles.wordpress.org/janedoe',
+		'http://profiles.wordpress.org/janedoe/',
+		'profiles.wordpress.org/janedoe/',
+		'https://profiles.wordpress.org/janedoe/?foo=1#bar'
+	];
+	for (const form of forms) {
+		assert.strictEqual(parseHandle(form).handle, 'janedoe', `form: ${form}`);
+	}
+});
+
+test('parseHandle: every accepted form yields the same canonical profile URL (issue #166)', () => {
+	const forms = ['janedoe', '@janedoe', 'JaneDoe', 'profiles.wordpress.org/janedoe/'];
+	for (const form of forms) {
+		assert.strictEqual(parseHandle(form).url, profileUrl('janedoe'), `form: ${form}`);
+	}
+});
+
+// The handle rides in a filename and in a patch header line, so it is stored in
+// the one casing profiles.wordpress.org serves rather than however it was typed.
+test('parseHandle: a handle is stored lowercase (issue #166)', () => {
+	assert.strictEqual(parseHandle('JaneDoe').handle, 'janedoe');
+});
+
+test('parseHandle: empty input asks for a username rather than reporting a parse failure (issue #166)', () => {
+	for (const empty of ['', '   ', null, undefined, 42]) {
+		const res = parseHandle(empty);
+		assert.strictEqual(res.ok, false);
+		assert.strictEqual(res.error, 'Enter your WordPress.org username.');
+	}
+});
+
+// Anything that would end up in a filename or break the one-line header. The
+// point is that these are refused here, not sanitized somewhere downstream.
+test('parseHandle: characters outside the handle charset are refused (issue #166)', () => {
+	const bad = [
+		'jane doe',
+		'jane/doe',
+		'jane\\doe',
+		'../../etc/passwd',
+		'jane\ndoe',
+		'jane#doe',
+		'-janedoe',
+		'janedoe-',
+		'.janedoe',
+		'jane%20doe',
+		'a'.repeat(MAX_HANDLE_LENGTH + 1)
+	];
+	for (const input of bad) {
+		assert.strictEqual(parseHandle(input).ok, false, `input: ${JSON.stringify(input)}`);
+	}
+});
+
+test('parseHandle: a profile link on another host names the host it wants (issue #166)', () => {
+	const res = parseHandle('https://example.com/janedoe/');
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.error, `Only ${PROFILES_HOST} profile links are supported.`);
+});
+
+test('parseHandle: a profiles URL that is not a profile is refused (issue #166)', () => {
+	assert.strictEqual(parseHandle('https://profiles.wordpress.org/').ok, false);
+	assert.strictEqual(parseHandle('https://profiles.wordpress.org/janedoe/activity/').ok, false);
+	assert.strictEqual(parseHandle('https://profiles.wordpress.org/%zz/').ok, false);
+});


### PR DESCRIPTION
Closes #166.

The patch flow ended the moment the diff existed. A button labelled **Submit patch** produced a file, offered Copy and Save, and went quiet — pointing at the Trac *homepage* even though the site already knew its ticket (#109). Nothing was submitted, and the destination that actually gets reviewed, along with the accounts it costs, went unnamed until after the contributor had left the venue.

## What this does

- **Names the destinations** at the moment the patch exists, each with its real cost. Attaching to Trac saves the file and deep-links *this site's* ticket attach page; when no ticket is linked, the card says so and links one inline, reusing the #109 flow. Nothing is uploaded and no account is asked for.
- **Mentor handoff** — zero accounts. The saved patch carries a provenance header (handle, event, ticket, base revision, date) so someone else can push the work and the props still land on whoever wrote it. The wordpress.org handle and the event are stored app-wide, beside the editor choice: facts about the contributor, not properties of a checkout.
- **`Submit patch` → `Create patch`.** It makes a file; it does not submit one.
- **Colours the patch pane** by line kind — added, removed, hunk, metadata, header. No highlighter dependency: in a diff the first character is the whole grammar.

## Decisions worth flagging

**The provenance header is defined here, and #107 adopts it** — that was #166's open question. Format:

```
# WordPress Contributor Toolkit patch
# Contributor: janedoe (wordpress.org)
# Event: WordCamp Europe 2026
# Ticket: https://core.trac.wordpress.org/ticket/62281
# Base: trunk @ 59a1c3e, 2026-08-05
# Generated: 2026-08-07
```

Safe to prepend: `git apply` and `patch` scan forward to the first file header, and this app's own reader (`scanSections` in `patch-plan.cjs`) reacts only to `diff --git` / `Index:`. A test round-trips a headed patch back through `parsePatchFiles`. The header goes on the handoff file only — a patch attached to Trac carries none by convention, and widening that is #107's call.

**Opening a pull request is not offered.** There is no path from a `.diff` to a PR this app can walk without a GitHub credential: GitHub cannot ingest a patch file, and every manual route costs an account and a fork. A card that only linked a handbook page was not an action on the patch in front of you, so it was dropped rather than kept as decoration. That destination is #167, which can actually act.

**Trac-conventional filenames stay #107's.** The handoff file is `62281.janedoe.diff`; the Trac save is still `wordpress.patch`.

## Review

Ran the review in `.github/instructions/code-review.instructions.md` with the judgement pass in fresh context, per AGENTS.md. `npm run lint` and `npm test` clean before and after.

**3 findings — all fixed, none deferred** (see the second commit):

- 🟡 performance — the diff colouring recomputed on every `SiteRow` render, so a running dev server's log chunks rebuilt thousands of spans per chunk. Memoised on the patch text.
- 🔵 tests — nothing exercised what the handoff save actually writes; both tests stopped at the save dialog. Added one that writes a real file and asserts the header precedes the diff and still parses. Verified by mutation: it fails on `patch + header`.
- 🔵 architecture — the main process treats an empty ref as "forget my handle", but no renderer path could send one. The button now submits an empty box when there is something to clear.

Checked and clean by the reviewer: the new `preferences` keys are additive, so no store migration is owed; both write channels validate through their parser before any `set`; the header cannot be broken out of; `handoffFilename` gates on a validated handle before it reaches a path component; `attachUrl` stays https on the Trac host, so it survives `external-url.js`.

## Testing

`npm test` — 417 pass. New suites: `test/patch-provenance.test.cjs`, `test/wporg-handle.test.cjs`, `test/diff-highlight.test.cjs`, plus wiring tests for the new channels and the handoff save.

By hand, on a site with a linked ticket and local edits: Create patch → both destinations named → Trac card opens the right ticket → handoff saves `<ticket>.<handle>.diff` with the header → that file applies back through "Apply a patch or PR".

🤖 Generated with [Claude Code](https://claude.com/claude-code)