### PR TITLE
Give every pull request a testable description a reviewer can read in five minutes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,17 +9,33 @@ collapsed sections is what they read first: keep it short, and put depth in the
 not apply — an empty heading is worse than no heading.
 -->
 
-## Problem
+## Why
 
-<!-- What breaks, or what is missing, and who it happens to. Be concrete: the
-error message, the sequence that triggers it, what the contributor sees. If it
-is a feature, say what someone cannot do today. Two or three sentences. -->
+<!-- Two or three sentences. Which of these you are writing depends on the change:
 
-## Solution
+FIXING SOMETHING — what breaks, for whom, and how it is triggered. The error
+message, the sequence that produces it, what the contributor sees instead of
+what they expected.
+
+BUILDING SOMETHING — what a contributor cannot do today, and what they do
+instead. The workaround is the argument: "starting a second ticket means another
+clone and another install" says more than "we should support branches". If an
+issue already made this case, one line and a link is enough — do not re-argue it.
+
+CHANGING HOW WE WORK — process, tooling, docs. What went wrong often enough to be
+worth a rule.
+-->
+
+## What changes
 
 <!-- The approach, not a tour of the diff. What you changed at the level of
 ideas, and the one or two decisions a reviewer would otherwise have to
-reverse-engineer. Alternatives you rejected go in the collapsed section below. -->
+reverse-engineer. Alternatives you rejected go in the collapsed section below.
+
+For a fix, name the root cause — not just the symptom that goes away.
+
+For a feature, say what is deliberately NOT in it. A reviewer who cannot tell a
+missing piece from a rejected one will ask about every one of them. -->
 
 ## How to test this
 
@@ -39,7 +55,14 @@ current head commit; force-pushing invalidates earlier ones. -->
 **What must not have happened:**
 
 <!-- The silent regressions. Work quietly discarded, node_modules quietly
-rebuilt, a patch quietly missing a file. Name what would be easy not to notice. -->
+rebuilt, a patch quietly missing a file. Name what would be easy not to notice.
+
+Fixing something? Add the steps that used to reproduce the bug, so a reviewer can
+watch them fail to reproduce it. And say which test covers it — the standard here
+is that a bugfix's test fails on the old code, so name it and say you checked.
+
+Building something? Walk the path a contributor actually takes, not the shortest
+path to the new code. Include what happens when they do it wrong. -->
 
 ## Risks and limitations
 
@@ -85,7 +108,11 @@ settled a question. -->
 <details>
 <summary>Screenshots or recording</summary>
 
-<!-- Required for anything with a visible surface. Before and after, or a short
-recording of the flow. Delete this block only if nothing on screen changed. -->
+<!-- Required for anything with a visible surface — and a new feature almost
+always has one. Before and after for a change; a short recording of the flow for
+something new, because a still frame cannot show that a ticket switch takes
+seconds rather than a rebuild.
+
+Delete this block only if nothing on screen changed, and say so where it was. -->
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,91 @@
+<!--
+Title format: [Action] [what] [where or why]
+  good — "Fix the patch panel's empty diff after a trunk update"
+  bad  — "Fix bug", "Update component", "Changes"
+
+A reviewer should understand this PR in five minutes. Everything above the
+collapsed sections is what they read first: keep it short, and put depth in the
+<details> blocks rather than deleting it. Delete the sections that genuinely do
+not apply — an empty heading is worse than no heading.
+-->
+
+## Problem
+
+<!-- What breaks, or what is missing, and who it happens to. Be concrete: the
+error message, the sequence that triggers it, what the contributor sees. If it
+is a feature, say what someone cannot do today. Two or three sentences. -->
+
+## Solution
+
+<!-- The approach, not a tour of the diff. What you changed at the level of
+ideas, and the one or two decisions a reviewer would otherwise have to
+reverse-engineer. Alternatives you rejected go in the collapsed section below. -->
+
+## How to test this
+
+<!-- Required on every PR, including ones with a green suite — this app fails in
+places `node --test` cannot reach. See AGENTS.md for the full shape.
+
+Platforms: any / macOS / Windows — and say why if it is not "any".
+Buildkite builds signed artifacts for every branch with an open PR, so this can
+be driven on a real machine without a local build. Check the build matches the
+current head commit; force-pushing invalidates earlier ones. -->
+
+**Starting state:**
+
+1.
+2.
+
+**What must not have happened:**
+
+<!-- The silent regressions. Work quietly discarded, node_modules quietly
+rebuilt, a patch quietly missing a file. Name what would be easy not to notice. -->
+
+## Risks and limitations
+
+<!-- Known gaps, what you deliberately did not do, what could not be tested by
+hand and why. An honest limitation here is worth more than silence — it is the
+thing a reviewer would otherwise find and have to ask about. -->
+
+## Related
+
+<!-- Fixes #123 / Part of #123 / Follow-up to #123. Use the GitHub keyword when
+this actually closes the issue, so it closes on merge. -->
+
+---
+
+<details>
+<summary>Design decisions and alternatives considered</summary>
+
+<!-- Why this shape and not the obvious one. Approaches rejected, and what ruled
+them out. If you departed from what an issue asked for, this is where you say so
+and why — do not let a reviewer discover it from the diff. -->
+
+</details>
+
+<details>
+<summary>Review outcome (required — see AGENTS.md)</summary>
+
+<!-- Counts first, e.g. "3 [fix here] · 1 [follow-up] — all 3 fixed", then what
+was fixed and what was deferred with its reason. A deferral is a decision, not
+an omission. Put the headline count in one line up in "Risks and limitations" if
+it changes how the PR should be read. -->
+
+</details>
+
+<details>
+<summary>Implementation notes</summary>
+
+<!-- Anything a future reader would want and a reviewer does not need up front:
+file-by-file detail, benchmarks, upstream quirks, links to the API docs that
+settled a question. -->
+
+</details>
+
+<details>
+<summary>Screenshots or recording</summary>
+
+<!-- Required for anything with a visible surface. Before and after, or a short
+recording of the flow. Delete this block only if nothing on screen changed. -->
+
+</details>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,16 @@ long as you do not pass a `--body` that replaces it. Fill it in rather than writ
 structure.
 
 The rule it is built around: **a reviewer understands the change in five minutes.** So what stays
-visible is Problem, Solution, How to test this, Risks, Related — and everything else goes in a
+visible is Why, What changes, How to test this, Risks, Related — and everything else goes in a
 `<details>` block, collapsed by default. Depth is not the enemy of a readable PR; depth *in the way*
 is. Do not delete detail to hit the five minutes, move it.
+
+**One template, not one per kind of change.** GitHub shows no picker when a pull request is opened —
+selecting among several requires appending `?template=name.md` to the URL, which nobody remembers,
+so the default loads anyway. The template is written to serve a fix, a feature and a process change
+equally, and calls out the three places where they genuinely differ: a fix names its root cause and
+the test that fails without it, a feature names what it deliberately leaves out and shows its
+surface, and either way the testing steps follow the path a contributor actually takes.
 
 That includes the review outcome AGENTS.md requires below: it lives in a collapsed block, with the
 headline count surfaced in **Risks and limitations** when it changes how the PR should be read.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,27 @@ its place, so skipping it means a human reviewer is the first reader of the diff
 That file carries the procedure as well as the standard. Follow it rather than improvising a
 review.
 
+### The pull request description follows the template
+
+[`.github/pull_request_template.md`](.github/pull_request_template.md) is the shape, and GitHub
+loads it into every new pull request automatically — including ones opened with `gh pr create`, as
+long as you do not pass a `--body` that replaces it. Fill it in rather than writing your own
+structure.
+
+The rule it is built around: **a reviewer understands the change in five minutes.** So what stays
+visible is Problem, Solution, How to test this, Risks, Related — and everything else goes in a
+`<details>` block, collapsed by default. Depth is not the enemy of a readable PR; depth *in the way*
+is. Do not delete detail to hit the five minutes, move it.
+
+That includes the review outcome AGENTS.md requires below: it lives in a collapsed block, with the
+headline count surfaced in **Risks and limitations** when it changes how the PR should be read.
+
+Titles are `[Action] [what] [where or why]` — "Fix the patch panel's empty diff after a trunk
+update", not "Fix bug".
+
+If the diff is over ~800 lines, the first question is whether it should be two pull requests. A
+stacked pair reviews faster than one that nobody wants to start.
+
 ### Every pull request says how to test it by hand
 
 A **How to test this** section is required, not optional, and a green test suite does not replace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,33 @@ its place, so skipping it means a human reviewer is the first reader of the diff
 That file carries the procedure as well as the standard. Follow it rather than improvising a
 review.
 
+### Every pull request says how to test it by hand
+
+A **How to test this** section is required, not optional, and a green test suite does not replace
+it. This app's failures live where the unit tests cannot go: a real clone of `wordpress-develop`, a
+`node_modules` that takes minutes to install, an OS file dialog, a Windows path with a space in it.
+The suite proves the logic; only a person driving the app proves the feature.
+
+Write it for someone who did not write the change and does not know where the button is. That means:
+
+- **A starting state.** "A site with a linked ticket and an uncommitted edit", not "a site". Say how
+  to reach it if it is not the state the app opens in.
+- **Numbered steps naming what to click**, in the words on screen.
+- **The expected result after each step that has one**, stated so it can come out false. "The patch
+  contains only `wp-login.php`" — not "the patch looks right".
+- **What must NOT have happened.** Most of this project's regressions are silent: work quietly
+  discarded, `node_modules` quietly rebuilt, a patch quietly missing a file. Name the thing that
+  would be easy not to notice.
+- **The platforms it needs.** Default to "any" and say so; call out macOS or Windows explicitly when
+  the change touches paths, spawning, line endings, or signing. Buildkite builds signed artifacts
+  for every branch with an open PR, so a reviewer can test on a real machine without building —
+  check the build matches the current head commit, since force-pushing invalidates earlier ones.
+- **What cannot be tested by hand, and why.** An honest "the mid-switch recovery needs a checkout to
+  fail part-way, which I could not stage" is worth more than silence.
+
+If a change genuinely has no user-visible surface — a refactor, a CI fix — say that, and give the
+command that demonstrates it instead. The section is never simply absent.
+
 For the human-facing version of all this — the CI checks each PR runs and the guardrails in prose —
 see [`CONTRIBUTING.md`](CONTRIBUTING.md). It points back here; it does not restate the standard.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,10 @@ honest; you own the result even though the agent produced it.
 
 GitHub fills every new pull request with
 [the template](.github/pull_request_template.md); steps 3 and 4 have their place in it already.
-It is built so a reviewer gets the change in five minutes — Problem, Solution, How to test this,
+It is built so a reviewer gets the change in five minutes — Why, What changes, How to test this,
 Risks, Related stay visible and everything deeper goes in a collapsed `<details>` block. Move detail
-out of the way rather than dropping it.
+out of the way rather than dropping it. The same template covers a fix, a feature and a process
+change; it flags the few places where the three want different things.
 
 Nothing enforces steps 1–4. Skipping them means a human reviewer is the first person to read the
 diff — which is exactly the cost this process exists to avoid.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,5 +112,11 @@ honest; you own the result even though the agent produced it.
    [AGENTS.md](AGENTS.md#every-pull-request-says-how-to-test-it-by-hand).
 5. Optionally **assign Copilot** as a second reader against the same standard.
 
+GitHub fills every new pull request with
+[the template](.github/pull_request_template.md); steps 3 and 4 have their place in it already.
+It is built so a reviewer gets the change in five minutes — Problem, Solution, How to test this,
+Risks, Related stay visible and everything deeper goes in a collapsed `<details>` block. Move detail
+out of the way rather than dropping it.
+
 Nothing enforces steps 1–4. Skipping them means a human reviewer is the first person to read the
 diff — which is exactly the cost this process exists to avoid.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,12 @@ honest; you own the result even though the agent produced it.
 2. **Fix or consciously defer** every finding — a deferral is a decision, not an omission.
 3. **Summarise the outcome in the PR description**: what the checks reported, what you fixed, and
    what you left as a follow-up and why.
-4. Optionally **assign Copilot** as a second reader against the same standard.
+4. **Write a "How to test this" section** — a starting state, numbered steps naming what to click,
+   the expected result of each, and what must *not* have happened. Required on every PR, including
+   ones with green tests: this app fails in places the suite cannot reach, and a reviewer should
+   never have to guess how to drive the change. The shape is spelled out in
+   [AGENTS.md](AGENTS.md#every-pull-request-says-how-to-test-it-by-hand).
+5. Optionally **assign Copilot** as a second reader against the same standard.
 
-Nothing enforces steps 1–3. Skipping them means a human reviewer is the first person to read the
+Nothing enforces steps 1–4. Skipping them means a human reviewer is the first person to read the
 diff — which is exactly the cost this process exists to avoid.


### PR DESCRIPTION
## Why

Two things keep going wrong on pull requests here, and neither is anybody's fault — nothing in the
repo says otherwise.

**Nobody says how to test the change by hand.** This app fails in the places `node --test` cannot
reach: a real clone of `wordpress-develop`, a `node_modules` that takes minutes to install, an OS
file dialog, a Windows path with a space in it. A green suite is not evidence the feature works, and
a reviewer who has to guess how to drive the change usually does not drive it at all.

**The descriptions are hard to read.** Detail arrives in the order it was discovered rather than the
order a reviewer needs it, so the first screen is rarely the part that explains the change. The cost
is not that the detail exists — it is that it sits in front of the summary.

## What changes

A pull request template, plus the two rules it encodes, written down where agents and humans both
read them.

`.github/pull_request_template.md` — GitHub loads it into every new PR, including ones opened with
`gh pr create` (as long as no `--body` replaces it). The organising rule is **a reviewer understands
the change in five minutes**: Why, What changes, How to test this, Risks, Related stay visible, and
everything deeper goes into a `<details>` block collapsed by default. Depth is not the enemy of a
readable PR; depth *in the way* is — so detail moves rather than disappears.

`AGENTS.md` gains two subsections under "Before opening a pull request": the shape of the
description, and the manual-testing requirement spelled out (starting state, numbered steps in the
words on screen, expected results stated so they can come out false, **what must not have happened**,
platforms, and what could not be tested by hand). `CONTRIBUTING.md` gets the human-facing pointer and
a fourth step in the pre-PR checklist.

**Deliberately not in this PR:** any enforcement. No workflow fails a PR with a missing section — the
same reasoning that keeps AI review off CI here (a public repo, no credentials) applies, and a bot
that checks for a heading measures headings, not testability.

## How to test this

**Platforms:** any — nothing here executes.

**Starting state:** a clone of this branch, and a browser signed in to GitHub.

1. Open <https://github.com/WordPress/experimental-wp-dev-env/compare/trunk...juanmaguitar/pr-description-template>
   and click **Create pull request**. → The description box is pre-filled with the template: Why,
   What changes, How to test this, Risks and limitations, Related, then four collapsed blocks.
   **Close the tab without opening the PR.**
2. Expand one of the `<details>` blocks in the preview of
   [`.github/pull_request_template.md`](.github/pull_request_template.md). → The guidance inside is
   an HTML comment, so it never appears in the rendered description a reviewer reads.
3. Read this PR's own description against the template. → It follows it — this is the first PR
   written to the new shape, and the "How to test this" you are reading now is the section the rule
   requires.
4. From a checkout of this branch, run `gh pr create` on a throwaway branch. → The body opens
   pre-filled with the same template, confirming it is not a web-UI-only feature.

**What must not have happened:**

- No second template file. GitHub shows **no picker** when a PR is opened — several templates in
  `.github/PULL_REQUEST_TEMPLATE/` are only reachable by appending `?template=name.md` to the URL, so
  the default loads anyway and the rest are never seen. `ls .github/` should show one template and no
  `PULL_REQUEST_TEMPLATE/` directory.
- The review standard did not move or gain a copy.
  `.github/instructions/code-review.instructions.md` is untouched; if it had been restated in the
  template it would drift, which is the failure mode this repo has already designed against.
- No behaviour change. `git diff --stat trunk...HEAD` touches three Markdown files and nothing under
  `src/`.

## Risks and limitations

Nothing enforces any of this, so it holds only as long as people follow it — the honest ceiling of a
convention in a repo that deliberately runs no credentialed bots.

A template is a guess about what reviewers need. If a section turns out to be dead weight in
practice, deleting it is a one-line PR and preferable to leaving a heading everybody skips.

The "five minutes" is a target, not a measurement. A 1,500-line PR will not hit it whatever the
description says — which is why the template ends by asking whether a diff over ~800 lines should
have been two.

## Related

Follow-up to #168, where these commits were originally written. They affect every PR rather than that
one, so they are split out to review and merge independently — which is also the advice the template
itself gives.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**One template, not one per kind of change.** The first draft was written for bugfixes — `## Problem`
/ `## Solution` — and a feature PR does not have a problem in that sense. The obvious fix is separate
`bug.md` and `feature.md` templates under `.github/PULL_REQUEST_TEMPLATE/`. GitHub's documentation
rules this out: there is no picker UI at PR-creation time, and selecting a non-default template means
appending `?template=name.md` to the URL by hand. In practice the default would load every time and
the second file would be dead. So the headings became `## Why` and `## What changes`, which fit a fix,
a feature and a process change, and the template calls out the three places where those genuinely
want different things: a fix names its root cause and the test that fails without it, a feature names
what it deliberately leaves out and shows its surface, and the testing steps follow the path a
contributor actually takes.

**Guidance inside the sections, not a separate style guide.** The hints live in HTML comments in the
template itself, at the moment they are needed. A style document nobody opens while writing a PR
description does not change any PR description.

**The rule lives in `AGENTS.md`, not only in the template.** An agent drafting a PR body may never
open the template file; it does read `AGENTS.md`. The template is the shape, `AGENTS.md` is the
requirement, `CONTRIBUTING.md` points at both without restating either.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

No `/self-review` pass. The standard's five dimensions — architecture, security, performance,
cross-platform, tests — have no purchase on three Markdown files with no executable content; running
it here would produce a paragraph saying so.

What was checked instead: that GitHub actually auto-loads a root `pull_request_template.md` (it
does, including via `gh pr create`), that multiple templates require an explicit `?template=`
parameter (they do — the reason there is one file), and that nothing here duplicates the review
standard.

</details>

<details>
<summary>Implementation notes</summary>

Three commits, in the order the thinking went:

1. **Require a "How to test this" section on every pull request** — the rule, in `AGENTS.md` and
   `CONTRIBUTING.md`, before any template existed.
2. **Add a pull request template built for a five-minute review** — the template, and the
   visible-versus-collapsed split.
3. **Make the template fit features, not just fixes** — the `Problem`/`Solution` → `Why`/`What
   changes` rename, after the second commit's own template proved bug-shaped when used on a feature
   PR (#168).

The collapsed blocks are Design decisions and alternatives considered, Review outcome, Implementation
notes, and Screenshots or recording. Review outcome is collapsed rather than dropped because
`AGENTS.md` requires it while a reviewer rarely needs it in the first minute — the headline count
surfaces in **Risks and limitations** when it changes how the PR should be read.

The **Screenshots or recording** block is deleted from this description rather than left empty:
nothing in the app changed, and the only visible surface is GitHub's own PR form, which step 1 above
walks you to directly.

</details>
