### PR TITLE
Open a pull request from the app, without a push credential on disk

### DIFF
--- a/src/github-auth.cjs
+++ b/src/github-auth.cjs
@@ -1,0 +1,238 @@
+'use strict';
+
+/**
+ * Signing in to GitHub by device code (#167).
+ *
+ * The contributor never types a password into this app and this app never
+ * writes a push credential to disk. It shows a short code; the browser takes
+ * that code to github.com, where the sign-in actually happens; and the app
+ * polls until GitHub says the authorization went through.
+ *
+ * Device flow is the only one of the three options that fits. Reusing an
+ * existing `gh` CLI login is excellent for contributors who already have one
+ * and useless for the first-timers this app is for. Pasting a personal access
+ * token works everywhere and needs nothing registered, but it sends a newcomer
+ * on a detour through token settings and scope choices, and it forces the app
+ * to hold a long-lived credential.
+ *
+ * The client ID ships inside the binary, which is fine: device flow uses no
+ * client secret, so nothing secret is distributed and there is nothing to leak.
+ * What matters is who owns the application — an individually-owned one would
+ * put that person's name on every contributor's consent screen and make every
+ * install depend on one account continuing to exist. The application this ID
+ * belongs to is owned by the WordPress organisation.
+ *
+ * Pure logic over an injected request function: no `electron` import, so
+ * `node --test` exercises every poll outcome without a network or a real wait.
+ */
+
+const { postJson, getJson } = require('./github-http.cjs');
+
+// The WordPress organisation's OAuth application, "WordPress Contributor
+// Toolkit". An empty value here means this build has no sign-in configured,
+// which `requestDeviceCode` reports as its own outcome rather than letting it
+// surface as GitHub's indistinguishable 404.
+const CLIENT_ID = 'Ov23liJ2H1gdqF2dTpMe';
+
+// `public_repo` is fork, push and pull request on a public repository — the
+// narrowest scope that can do this job. Anything wider would be asking a
+// first-time contributor to grant more than the task needs.
+const SCOPES = 'public_repo';
+
+const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const VIEWER_URL = 'https://api.github.com/user';
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+// GitHub's documented floor when it has not said otherwise, and what it adds to
+// the interval each time it answers `slow_down`.
+const DEFAULT_INTERVAL_SECONDS = 5;
+const SLOW_DOWN_BUMP_SECONDS = 5;
+
+/**
+ * The environment variable wins so a second application can be tested against
+ * without a rebuild; the constant is what ships.
+ *
+ * @return {string}
+ */
+function getClientId() {
+	const fromEnv = process.env.WP_DEV_ENV_GITHUB_CLIENT_ID;
+	return (typeof fromEnv === 'string' && fromEnv.trim()) || CLIENT_ID;
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Asks GitHub for a code to show the contributor.
+ *
+ * @param {Object}   [deps]
+ * @param {Function} [deps.post]     Stands in for postJson.
+ * @param {Function} [deps.now]      Stands in for Date.now.
+ * @param {string}   [deps.clientId]
+ * @return {Promise<{ok: true, userCode: string, verificationUri: string, deviceCode: string, interval: number, expiresAt: number}|{ok: false, reason: string, error: string}>}
+ */
+async function requestDeviceCode(deps = {}) {
+	const post = deps.post || postJson;
+	const now = deps.now || Date.now;
+	// Present-but-empty is a real answer — "this build has no application" — so the
+	// key's presence decides, not its truthiness.
+	const clientId = 'clientId' in deps ? deps.clientId : getClientId();
+
+	if (!clientId) {
+		return {
+			ok: false,
+			reason: 'not-configured',
+			error: 'This build has no GitHub application configured, so it cannot sign you in.'
+		};
+	}
+
+	let res;
+	try {
+		res = await post(DEVICE_CODE_URL, { client_id: clientId, scope: SCOPES });
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+
+	// A 404 here is the application not having device flow enabled, which is
+	// otherwise indistinguishable from a wrong client ID — naming it is the
+	// difference between a fixable message and half an hour of guessing.
+	if (res.status === 404) {
+		return {
+			ok: false,
+			reason: 'not-configured',
+			error: 'GitHub does not recognise this application, or device flow is not enabled on it.'
+		};
+	}
+	if (res.status !== 200 || !res.json || !res.json.device_code) {
+		const detail = res.json && res.json.error_description ? res.json.error_description : `GitHub returned ${res.status}`;
+		return { ok: false, reason: 'error', error: detail };
+	}
+
+	const json = res.json;
+	const interval = Number(json.interval) > 0 ? Number(json.interval) : DEFAULT_INTERVAL_SECONDS;
+	// GitHub's own expiry is the one that decides, but it is expressed as a
+	// duration and every later comparison wants an instant.
+	const expiresIn = Number(json.expires_in) > 0 ? Number(json.expires_in) : 900;
+	return {
+		ok: true,
+		userCode: String(json.user_code || ''),
+		verificationUri: String(json.verification_uri || 'https://github.com/login/device'),
+		deviceCode: String(json.device_code),
+		interval,
+		expiresAt: now() + expiresIn * 1000
+	};
+}
+
+/**
+ * Waits for the contributor to finish in the browser.
+ *
+ * Every documented state is its own outcome rather than a generic failure,
+ * because they call for different things from the UI: declining is a choice
+ * that should cost nothing, an expired code wants a fresh one, and a spent
+ * network wants the patch file offered instead.
+ *
+ * @param {Object}   root0
+ * @param {string}   root0.deviceCode
+ * @param {number}   root0.interval    Seconds, as GitHub reports them.
+ * @param {number}   root0.expiresAt   Epoch milliseconds.
+ * @param {Object}   [deps]
+ * @param {Function} [deps.isCanceled] Polled between attempts; true stops the wait.
+ * @return {Promise<{ok: true, token: string}|{ok: false, reason: string, error: string}>}
+ */
+async function pollForToken({ deviceCode, interval, expiresAt }, deps = {}) {
+	const post = deps.post || postJson;
+	const wait = deps.sleep || sleep;
+	const now = deps.now || Date.now;
+	const isCanceled = deps.isCanceled || (() => false);
+	// Present-but-empty is a real answer — "this build has no application" — so the
+	// key's presence decides, not its truthiness.
+	const clientId = 'clientId' in deps ? deps.clientId : getClientId();
+
+	let waitSeconds = Number(interval) > 0 ? Number(interval) : DEFAULT_INTERVAL_SECONDS;
+
+	for (;;) {
+		if (isCanceled()) return { ok: false, reason: 'canceled', error: 'Sign-in was canceled.' };
+		await wait(waitSeconds * 1000);
+		if (isCanceled()) return { ok: false, reason: 'canceled', error: 'Sign-in was canceled.' };
+		// Checked after the wait rather than before it, so a code that expires
+		// mid-sleep is reported as expired instead of being polled once more.
+		if (now() >= expiresAt) {
+			return { ok: false, reason: 'expired', error: 'The code expired before it was entered.' };
+		}
+
+		let res;
+		try {
+			res = await post(ACCESS_TOKEN_URL, {
+				client_id: clientId,
+				device_code: deviceCode,
+				grant_type: GRANT_TYPE
+			});
+		} catch (e) {
+			// A transport failure mid-poll is not a decision: the contributor may
+			// simply have lost the network, and the authorization is still valid.
+			return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+		}
+
+		const json = res.json || {};
+		if (json.access_token) return { ok: true, token: String(json.access_token) };
+
+		switch (json.error) {
+			case 'authorization_pending':
+				break;
+			case 'slow_down':
+				// GitHub's own number when it sends one, and its documented bump
+				// when it does not. Polling faster than it asks gets the device
+				// code rejected outright.
+				waitSeconds = Number(json.interval) > 0 ? Number(json.interval) : waitSeconds + SLOW_DOWN_BUMP_SECONDS;
+				break;
+			case 'expired_token':
+				return { ok: false, reason: 'expired', error: 'The code expired before it was entered.' };
+			case 'access_denied':
+				return { ok: false, reason: 'denied', error: 'The authorization was declined on GitHub.' };
+			default:
+				return {
+					ok: false,
+					reason: 'error',
+					error: json.error_description || json.error || `GitHub returned ${res.status}`
+				};
+		}
+	}
+}
+
+/**
+ * Who the token belongs to. The login is the fork's owner and the only part of
+ * the sign-in the renderer is ever told.
+ *
+ * @param {string} token
+ * @param {Object} [deps]
+ * @return {Promise<{ok: true, login: string}|{ok: false, reason: string, error: string}>}
+ */
+async function fetchViewer(token, deps = {}) {
+	const get = deps.get || getJson;
+	let res;
+	try {
+		res = await get(VIEWER_URL, { token });
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+	if (res.status === 401) {
+		return { ok: false, reason: 'unauthorized', error: 'That sign-in is no longer valid.' };
+	}
+	if (res.status !== 200 || !res.json || !res.json.login) {
+		return { ok: false, reason: 'error', error: `GitHub returned ${res.status}` };
+	}
+	return { ok: true, login: String(res.json.login) };
+}
+
+module.exports = {
+	CLIENT_ID,
+	SCOPES,
+	DEVICE_CODE_URL,
+	ACCESS_TOKEN_URL,
+	getClientId,
+	requestDeviceCode,
+	pollForToken,
+	fetchViewer
+};

--- a/src/github-auth.cjs
+++ b/src/github-auth.cjs
@@ -38,10 +38,16 @@ const { postForm, getJson } = require('./github-http.cjs');
 // surface as GitHub's indistinguishable 404.
 const CLIENT_ID = 'Ov23liJ2H1gdqF2dTpMe';
 
-// `public_repo` is fork, push and pull request on a public repository — the
-// narrowest scope that can do this job. Anything wider would be asking a
-// first-time contributor to grant more than the task needs.
-const SCOPES = 'public_repo';
+// `repo`, not the `public_repo` this flow morally needs. The narrower scope is
+// documented to cover writes to public repositories, and GitHub does not
+// honour it where it counts: creating a ref answers `X-Accepted-OAuth-Scopes:
+// repo` — only the full scope — while the object endpoints (blobs, trees,
+// commits) demand no scope at all. Verified by hand on 2026-08-08, on a fork
+// and on an ordinary personal repository alike: a `public_repo` token uploads
+// the whole change and then 404s on the branch, the last write of the flow.
+// So the consent screen asks for more than this app will ever touch, and the
+// comment you are reading is the apology.
+const SCOPES = 'repo';
 
 const DEVICE_CODE_URL = 'https://github.com/login/device/code';
 const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -206,15 +212,17 @@ async function pollForToken({ deviceCode, interval, expiresAt }, deps = {}) {
 }
 
 /**
- * True when a token's granted scopes can push to a public repository. `repo`
- * contains `public_repo`, so either satisfies.
+ * True when a token's granted scopes can create a branch. Only `repo` counts:
+ * `public_repo` is documented to cover public-repository writes and is not
+ * accepted by ref creation (see the note on SCOPES above), so treating it as
+ * sufficient here would wave through exactly the token that fails at the last
+ * write.
  *
  * @param {string} header The X-OAuth-Scopes response header.
  * @return {boolean}
  */
 function scopesCanPush(header) {
-	const granted = String(header).split(',').map((s) => s.trim());
-	return granted.includes('public_repo') || granted.includes('repo');
+	return String(header).split(',').map((s) => s.trim()).includes('repo');
 }
 
 /**
@@ -257,7 +265,7 @@ async function fetchViewer(token, deps = {}) {
 		return {
 			ok: false,
 			reason: 'insufficient-scope',
-			error: 'GitHub granted this sign-in no access to public repositories — an older authorization of this app was likely reused. Revoke "WordPress Contributor Toolkit" under github.com → Settings → Applications, then sign in here again.'
+			error: 'GitHub granted this sign-in less access than opening a pull request needs — an older authorization of this app was likely reused. Revoke "WordPress Contributor Toolkit" under github.com → Settings → Applications, then sign in here again.'
 		};
 	}
 	return { ok: true, login: String(res.json.login) };

--- a/src/github-auth.cjs
+++ b/src/github-auth.cjs
@@ -26,7 +26,11 @@
  * `node --test` exercises every poll outcome without a network or a real wait.
  */
 
-const { postJson, getJson } = require('./github-http.cjs');
+// postForm, not postJson: the github.com/login/* endpoints' documented request
+// format is URL-encoded parameters. The scope grant rides in that body, and a
+// scope that fails to arrive produces a token that signs in fine and cannot
+// push — a failure that surfaces at the last write of the whole flow.
+const { postForm, getJson } = require('./github-http.cjs');
 
 // The WordPress organisation's OAuth application, "WordPress Contributor
 // Toolkit". An empty value here means this build has no sign-in configured,
@@ -68,13 +72,13 @@ function sleep(ms) {
  * Asks GitHub for a code to show the contributor.
  *
  * @param {Object}   [deps]
- * @param {Function} [deps.post]     Stands in for postJson.
+ * @param {Function} [deps.post]     Stands in for postForm.
  * @param {Function} [deps.now]      Stands in for Date.now.
  * @param {string}   [deps.clientId]
  * @return {Promise<{ok: true, userCode: string, verificationUri: string, deviceCode: string, interval: number, expiresAt: number}|{ok: false, reason: string, error: string}>}
  */
 async function requestDeviceCode(deps = {}) {
-	const post = deps.post || postJson;
+	const post = deps.post || postForm;
 	const now = deps.now || Date.now;
 	// Present-but-empty is a real answer — "this build has no application" — so the
 	// key's presence decides, not its truthiness.
@@ -142,7 +146,7 @@ async function requestDeviceCode(deps = {}) {
  * @return {Promise<{ok: true, token: string}|{ok: false, reason: string, error: string}>}
  */
 async function pollForToken({ deviceCode, interval, expiresAt }, deps = {}) {
-	const post = deps.post || postJson;
+	const post = deps.post || postForm;
 	const wait = deps.sleep || sleep;
 	const now = deps.now || Date.now;
 	const isCanceled = deps.isCanceled || (() => false);
@@ -202,8 +206,30 @@ async function pollForToken({ deviceCode, interval, expiresAt }, deps = {}) {
 }
 
 /**
- * Who the token belongs to. The login is the fork's owner and the only part of
- * the sign-in the renderer is ever told.
+ * True when a token's granted scopes can push to a public repository. `repo`
+ * contains `public_repo`, so either satisfies.
+ *
+ * @param {string} header The X-OAuth-Scopes response header.
+ * @return {boolean}
+ */
+function scopesCanPush(header) {
+	const granted = String(header).split(',').map((s) => s.trim());
+	return granted.includes('public_repo') || granted.includes('repo');
+}
+
+/**
+ * Who the token belongs to — and what it was actually granted. The login is
+ * the fork's owner and the only part of the sign-in the renderer is ever told.
+ *
+ * The scope check exists because what GitHub grants is not always what was
+ * asked: a device-flow sign-in against an application the account authorized
+ * before can reuse the old grant with the old scopes. A token without push
+ * then fails in the worst possible place — the Git object endpoints accept it,
+ * so blobs, trees and the commit all succeed, and the 404 lands on the very
+ * last write, the branch. Verified by hand: same fork, same call, a
+ * `public_repo` token succeeds where the reused grant's token 404s. Naming it
+ * at sign-in, with the remedy, is the difference between a checkbox and a
+ * dead end.
  *
  * @param {string} token
  * @param {Object} [deps]
@@ -222,6 +248,17 @@ async function fetchViewer(token, deps = {}) {
 	}
 	if (res.status !== 200 || !res.json || !res.json.login) {
 		return { ok: false, reason: 'error', error: `GitHub returned ${res.status}` };
+	}
+	// Only judged when GitHub states the scopes: the header is how OAuth
+	// tokens carry them, and its absence (some token types omit it) is not
+	// evidence of anything.
+	const scopes = res.headers && res.headers['x-oauth-scopes'];
+	if (typeof scopes === 'string' && !scopesCanPush(scopes)) {
+		return {
+			ok: false,
+			reason: 'insufficient-scope',
+			error: 'GitHub granted this sign-in no access to public repositories — an older authorization of this app was likely reused. Revoke "WordPress Contributor Toolkit" under github.com → Settings → Applications, then sign in here again.'
+		};
 	}
 	return { ok: true, login: String(res.json.login) };
 }

--- a/src/github-http.cjs
+++ b/src/github-http.cjs
@@ -140,6 +140,30 @@ async function postJson(url, payload, opts = {}) {
 }
 
 /**
+ * A form-encoded POST with a JSON answer — the shape of GitHub's OAuth
+ * endpoints under github.com/login/*, whose documented request format is
+ * URL-encoded parameters even though they answer JSON when asked. The API
+ * proper (api.github.com) takes JSON and uses postJson above; sending the
+ * login endpoints their documented format instead of relying on them
+ * tolerating JSON keeps the scope grant — the part that decides whether the
+ * token can push at all — out of the realm of undocumented behaviour.
+ *
+ * @param {string} url
+ * @param {Object} params
+ * @param {Object} [opts]
+ * @return {Promise<{status: number, headers: Object, body: string, json: Object|null}>}
+ */
+async function postForm(url, params, opts = {}) {
+	const res = await httpRequest('POST', url, {
+		Accept: 'application/json',
+		'Content-Type': 'application/x-www-form-urlencoded'
+	}, { ...opts, body: new URLSearchParams(params || {}).toString() });
+	let json = null;
+	try { json = JSON.parse(res.body); } catch { json = null; }
+	return { ...res, json };
+}
+
+/**
  * A JSON GET, in the same shape as postJson so callers can treat the two alike.
  *
  * @param {string} url
@@ -153,4 +177,4 @@ async function getJson(url, opts = {}) {
 	return { ...res, json };
 }
 
-module.exports = { USER_AGENT, REQUEST_TIMEOUT_MS, httpRequest, httpGet, postJson, getJson };
+module.exports = { USER_AGENT, REQUEST_TIMEOUT_MS, httpRequest, httpGet, postJson, postForm, getJson };

--- a/src/github-http.cjs
+++ b/src/github-http.cjs
@@ -50,6 +50,15 @@ const REQUEST_TIMEOUT_MS = 15000;
  * @param {boolean} [opts.useSessionCookies]
  * @return {Promise<{status: number, headers: Object, body: string}>}
  */
+// Opt-in wire log for the one bug that survives every reproduction: set
+// WP_DEV_ENV_HTTP_LOG=1 and every GitHub request prints its method, URL and
+// status to the terminal the app was started from. Never the token, never the
+// body — the shape of the traffic, not its contents.
+function wireLog(line) {
+	// eslint-disable-next-line no-console -- deliberate: this is the debug channel, enabled explicitly by env var.
+	if (process.env.WP_DEV_ENV_HTTP_LOG) console.log(`[github-http] ${line}`);
+}
+
 function httpRequest(method, url, headers = {}, opts = {}) {
 	// Required lazily, not at module load: requiring `electron` outside Electron
 	// resolves the binary and can spawn its installer on a cold checkout, and the
@@ -61,6 +70,7 @@ function httpRequest(method, url, headers = {}, opts = {}) {
 		let settled = false;
 		const finish = (fn, arg) => { if (!settled) { settled = true; fn(arg); } };
 
+		wireLog(`→ ${method} ${url}${opts.token ? ' (authorized)' : ''}`);
 		const requestOptions = { method, url };
 		// A token-bearing request never follows a redirect: whether Chromium's
 		// stack would re-send the Authorization header to a different host is
@@ -95,6 +105,7 @@ function httpRequest(method, url, headers = {}, opts = {}) {
 				for (const [key, value] of Object.entries(response.headers || {})) {
 					lowerHeaders[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
 				}
+				wireLog(`← ${response.statusCode} ${method} ${url}${lowerHeaders['x-github-request-id'] ? ` [${lowerHeaders['x-github-request-id']}]` : ''}`);
 				finish(resolve, { status: response.statusCode, headers: lowerHeaders, body: Buffer.concat(chunks).toString('utf8') });
 			});
 			response.on('error', (e) => { clearTimeoutImpl(timer); finish(reject, e); });

--- a/src/github-http.cjs
+++ b/src/github-http.cjs
@@ -32,6 +32,19 @@ const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress
 const REQUEST_TIMEOUT_MS = 15000;
 
 /**
+ * Opt-in wire log for the one bug that survives every reproduction: set
+ * WP_DEV_ENV_HTTP_LOG=1 and every GitHub request prints its method, URL and
+ * status to the terminal the app was started from. Never the token, never the
+ * body — the shape of the traffic, not its contents.
+ *
+ * @param {string} line
+ */
+function wireLog(line) {
+	// eslint-disable-next-line no-console -- deliberate: this is the debug channel, enabled explicitly by env var.
+	if (process.env.WP_DEV_ENV_HTTP_LOG) console.log(`[github-http] ${line}`);
+}
+
+/**
  * A single request over Electron net.
  *
  * `opts` carries both test doubles and request options. `partition` +
@@ -50,15 +63,6 @@ const REQUEST_TIMEOUT_MS = 15000;
  * @param {boolean} [opts.useSessionCookies]
  * @return {Promise<{status: number, headers: Object, body: string}>}
  */
-// Opt-in wire log for the one bug that survives every reproduction: set
-// WP_DEV_ENV_HTTP_LOG=1 and every GitHub request prints its method, URL and
-// status to the terminal the app was started from. Never the token, never the
-// body — the shape of the traffic, not its contents.
-function wireLog(line) {
-	// eslint-disable-next-line no-console -- deliberate: this is the debug channel, enabled explicitly by env var.
-	if (process.env.WP_DEV_ENV_HTTP_LOG) console.log(`[github-http] ${line}`);
-}
-
 function httpRequest(method, url, headers = {}, opts = {}) {
 	// Required lazily, not at module load: requiring `electron` outside Electron
 	// resolves the binary and can spawn its installer on a cold checkout, and the

--- a/src/github-http.cjs
+++ b/src/github-http.cjs
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * The one HTTP call this app makes to GitHub.
+ *
+ * Requests ride Electron's `net` rather than a new HTTP dependency: it uses the
+ * Chromium network stack, so it honours the same proxy and TLS configuration
+ * the rest of the app already relies on, and adds nothing to install.
+ *
+ * This started as `httpGet` inside github-prs.js, which is a module about
+ * *reading* pull requests. Opening one (#167) needs POST, a request body and an
+ * Authorization header, so the primitive moved here and grew a method — the
+ * alternative was a second, subtly different request function in the module
+ * that writes.
+ *
+ * Two properties are deliberate and every caller depends on them:
+ *
+ * It never rejects on an HTTP status. A 403 from a spent rate limit, a 404 from
+ * an application without device flow enabled and a 422 from a branch that
+ * already exists are all *data* the caller classifies and turns into something
+ * a contributor can act on. Only a transport failure or a timeout rejects.
+ *
+ * And the network client and the timers are injectable, so the response,
+ * transport-error, timeout and settle-once paths are all exercised by
+ * `node --test` without a network or a real 15-second wait. Production callers
+ * pass none of that and get Electron's `net` and the global timers.
+ */
+
+// GitHub rejects API requests with no User-Agent; an identifying one is also
+// the honest thing to send.
+const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/experimental-wp-dev-env)';
+const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * A single request over Electron net.
+ *
+ * `opts` carries both test doubles and request options. `partition` +
+ * `useSessionCookies` let a caller ride a specific session's cookies — the Trac
+ * attachment fetch reuses the session that passed the proof-of-work challenge,
+ * so its `_hcc` cookie authorises the download; net does not send session
+ * cookies unless asked, hence the explicit flag.
+ *
+ * @param {string}  method
+ * @param {string}  url
+ * @param {Object}  [headers]
+ * @param {Object}  [opts]
+ * @param {string}  [opts.body]              Serialised request body, already stringified.
+ * @param {string}  [opts.token]             Sent as `Authorization: Bearer`; omitted entirely when absent.
+ * @param {string}  [opts.partition]
+ * @param {boolean} [opts.useSessionCookies]
+ * @return {Promise<{status: number, headers: Object, body: string}>}
+ */
+function httpRequest(method, url, headers = {}, opts = {}) {
+	// Required lazily, not at module load: requiring `electron` outside Electron
+	// resolves the binary and can spawn its installer on a cold checkout, and the
+	// standalone tests inject their own client and must never reach it.
+	const netImpl = opts.net || require('electron').net;
+	const setTimeoutImpl = opts.setTimeout || setTimeout;
+	const clearTimeoutImpl = opts.clearTimeout || clearTimeout;
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const finish = (fn, arg) => { if (!settled) { settled = true; fn(arg); } };
+
+		const requestOptions = { method, url };
+		// A token-bearing request never follows a redirect: whether Chromium's
+		// stack would re-send the Authorization header to a different host is
+		// not a question worth having an answer to. No GitHub endpoint this app
+		// calls redirects, so in practice this changes nothing — until the day
+		// something in the path does, when it fails closed instead of forwarding
+		// a credential.
+		if (opts.token) requestOptions.redirect = 'error';
+		if (opts.partition) {
+			requestOptions.partition = opts.partition;
+			requestOptions.useSessionCookies = opts.useSessionCookies !== false;
+		}
+		const request = netImpl.request(requestOptions);
+		request.setHeader('User-Agent', USER_AGENT);
+		// Set before the caller's headers rather than after, so an explicit
+		// Authorization in `headers` is the one that wins — there is no case for
+		// a token silently overriding what a call site spelled out.
+		if (opts.token) request.setHeader('Authorization', `Bearer ${opts.token}`);
+		for (const [key, value] of Object.entries(headers)) request.setHeader(key, value);
+
+		const timer = setTimeoutImpl(() => {
+			try { request.abort(); } catch {}
+			finish(reject, new Error(`Timed out after ${REQUEST_TIMEOUT_MS}ms`));
+		}, REQUEST_TIMEOUT_MS);
+
+		request.on('response', (response) => {
+			const chunks = [];
+			response.on('data', (chunk) => chunks.push(chunk));
+			response.on('end', () => {
+				clearTimeoutImpl(timer);
+				const lowerHeaders = {};
+				for (const [key, value] of Object.entries(response.headers || {})) {
+					lowerHeaders[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
+				}
+				finish(resolve, { status: response.statusCode, headers: lowerHeaders, body: Buffer.concat(chunks).toString('utf8') });
+			});
+			response.on('error', (e) => { clearTimeoutImpl(timer); finish(reject, e); });
+		});
+		request.on('error', (e) => { clearTimeoutImpl(timer); finish(reject, e); });
+		if (opts.body !== undefined && opts.body !== null) request.write(opts.body);
+		request.end();
+	});
+}
+
+/**
+ * @param {string} url
+ * @param {Object} [headers]
+ * @param {Object} [opts]
+ * @return {Promise<{status: number, headers: Object, body: string}>}
+ */
+function httpGet(url, headers = {}, opts = {}) {
+	return httpRequest('GET', url, headers, opts);
+}
+
+/**
+ * A JSON POST, which is every write this app makes: request body serialised,
+ * response parsed, and both content types stated.
+ *
+ * The response is returned alongside the parsed body rather than instead of it
+ * — the status and headers are what the failure classification reads, and a
+ * body that is not JSON (an HTML error page from a proxy) has to be survivable
+ * rather than an exception.
+ *
+ * @param {string} url
+ * @param {Object} payload
+ * @param {Object} [opts]
+ * @return {Promise<{status: number, headers: Object, body: string, json: Object|null}>}
+ */
+async function postJson(url, payload, opts = {}) {
+	const res = await httpRequest('POST', url, {
+		Accept: 'application/json',
+		'Content-Type': 'application/json'
+	}, { ...opts, body: JSON.stringify(payload || {}) });
+	let json = null;
+	try { json = JSON.parse(res.body); } catch { json = null; }
+	return { ...res, json };
+}
+
+/**
+ * A JSON GET, in the same shape as postJson so callers can treat the two alike.
+ *
+ * @param {string} url
+ * @param {Object} [opts]
+ * @return {Promise<{status: number, headers: Object, body: string, json: Object|null}>}
+ */
+async function getJson(url, opts = {}) {
+	const res = await httpGet(url, { Accept: 'application/vnd.github+json' }, opts);
+	let json = null;
+	try { json = JSON.parse(res.body); } catch { json = null; }
+	return { ...res, json };
+}
+
+module.exports = { USER_AGENT, REQUEST_TIMEOUT_MS, httpRequest, httpGet, postJson, getJson };

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -15,15 +15,16 @@
  * arrive as five commits with four intermediate states that never compiled.
  * Blobs → tree → commit produces the one commit a reviewer expects.
  *
- * Two things in here exist because of a fork that already exists and is months
- * stale — the case unit tests can only approximate and the one that will
- * actually be hit at a contributor day:
+ * Two things in here exist because of what a real first run taught (all of it
+ * verified by hand on 2026-08-08):
  *
- *   - the commit is based on the local checkout's HEAD, and a stale fork does
- *     not contain that commit at all, so creating a ref from it would 422. The
- *     sync step is load-bearing, not hygiene.
- *   - a fork that has diverged cannot be fast-forwarded, so the base falls back
- *     to the fork's own trunk tip and the result says so, rather than failing.
+ *   - the branch bases on the fork's trunk tip, never on the local checkout's
+ *     HEAD — `git/refs` refuses a commit parented anywhere else, and the fork
+ *     answers 200 for *any* commit in the fork network, so "does the fork have
+ *     it" cannot even be asked honestly. See resolveBase.
+ *   - basing on the tip replaces whole files, so a checkout that is behind
+ *     trunk must not touch a file upstream also changed — that would silently
+ *     revert other people's work. See staleTouchedPaths.
  *
  * Every failure is typed, because every failure has the same fallback — the
  * patch file, which is always still there — but not the same explanation.
@@ -225,20 +226,28 @@ async function ensureFork({ token, login }, deps = {}) {
 }
 
 /**
- * Which commit the new branch is based on.
+ * Which commit the new branch is based on: the fork's trunk tip, always.
  *
- * The honest answer is the local checkout's HEAD: that is what the contributor
- * edited, and basing on anything else would silently fold in upstream changes
- * they have not seen. A fresh fork contains it. A stale one does not, so the
- * fork's trunk is fast-forwarded first; a fork that has diverged cannot be, and
- * then the fork's own tip is the best available base — reported as
- * `exact: false` so the caller can say the pull request may show more than the
- * contributor changed.
+ * An earlier version based the branch on the local checkout's HEAD whenever
+ * `GET git/commits/{sha}` on the fork answered 200 — and that answer is a lie.
+ * Forks share their upstream's object store, so the fork serves *any* commit
+ * in the network, reachable from its own refs or not. Worse, verified by hand
+ * on 2026-08-08: `POST git/refs` refuses (404, not 422) a freshly API-created
+ * commit whose parent is anything but the current branch tip — even a
+ * plainly-reachable ancestor. The tip is not merely the safest base; it is
+ * the only one GitHub will let a branch point at.
+ *
+ * Basing on the tip has one sharp edge the caller must handle: the tree API
+ * replaces whole files, so a contributor whose checkout is behind trunk would
+ * silently revert any upstream change to a file they also touched. That is
+ * what `staleTouchedPaths` below is for — openPullRequest refuses that case
+ * and sends the contributor to the app's own "Update to latest trunk" flow
+ * instead of opening a pull request that undoes other people's work.
  *
  * @param {Object} root0
  * @param {string} root0.token
  * @param {string} root0.login
- * @param {string} root0.baseSha
+ * @param {string} root0.baseSha The local checkout's HEAD, for the exact flag.
  * @param {Object} [deps]
  * @return {Promise<{ok: true, sha: string, exact: boolean}|{ok: false, reason: string, error: string}>}
  */
@@ -247,28 +256,69 @@ async function resolveBase({ token, login, baseSha }, deps = {}) {
 	const post = deps.post || postJson;
 	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
 
-	const hasCommit = async (sha) => {
-		const res = await get(`${repo}/git/commits/${sha}`, { token });
-		return res.status === 200;
-	};
-
 	try {
-		if (baseSha && (await hasCommit(baseSha))) return { ok: true, sha: baseSha, exact: true };
-
-		// 409 here is a diverged fork, which is a normal state for someone who
-		// has contributed before — not a failure to report.
+		// Always fast-forward first, so "the tip" means today's trunk and not
+		// wherever the fork was left. 409 here is a diverged fork, which is a
+		// normal state for someone who has contributed before — not a failure
+		// to report; the branch then bases on the fork's own tip.
 		await post(`${repo}/merge-upstream`, { branch: BASE_BRANCH }, { token });
-
-		if (baseSha && (await hasCommit(baseSha))) return { ok: true, sha: baseSha, exact: true };
 
 		const ref = await get(`${repo}/git/ref/heads/${BASE_BRANCH}`, { token });
 		if (ref.status !== 200 || !ref.json || !ref.json.object || !ref.json.object.sha) {
 			return failure(ref, 'Could not read your fork’s trunk');
 		}
-		return { ok: true, sha: String(ref.json.object.sha), exact: false };
+		const tip = String(ref.json.object.sha);
+		return { ok: true, sha: tip, exact: tip === baseSha };
 	} catch (e) {
 		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
 	}
+}
+
+/**
+ * Which of the contributor's files upstream has also changed since the local
+ * checkout's HEAD. Non-empty means opening the pull request would replace
+ * those files wholesale and silently revert the upstream work.
+ *
+ * Asked per file through the contents API rather than once through compare:
+ * compare caps its file list at 300, and a checkout a few weeks old is behind
+ * by more than that repo-wide — a cap that silently hides exactly the clash
+ * being looked for. The contributor's own file count is small.
+ *
+ * A path answers with its blob sha at each of the two commits; any difference
+ * — content, or existing on one side only — is a clash. An error reading
+ * either side counts as a clash too: the check exists to prevent silent
+ * damage, so it fails closed.
+ *
+ * @param {Object}   root0
+ * @param {string}   root0.token
+ * @param {string}   root0.login
+ * @param {string}   root0.baseSha Local checkout's HEAD.
+ * @param {string}   root0.tipSha  The fork's trunk tip.
+ * @param {string[]} root0.paths   Repo-relative paths the contributor changed.
+ * @param {Object}   [deps]
+ * @return {Promise<{ok: true, clashes: string[]}|{ok: false, reason: string, error: string}>}
+ */
+async function staleTouchedPaths({ token, login, baseSha, tipSha, paths }, deps = {}) {
+	const get = deps.get || getJson;
+	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+
+	const blobShaAt = async (path, ref) => {
+		const res = await get(`${repo}/contents/${encodeURI(path)}?ref=${ref}`, { token });
+		if (res.status === 404) return null;
+		if (res.status !== 200 || !res.json || !res.json.sha) throw new Error(`GitHub returned ${res.status} for ${path}`);
+		return String(res.json.sha);
+	};
+
+	const clashes = [];
+	try {
+		for (const path of paths) {
+			const [atBase, atTip] = await Promise.all([blobShaAt(path, baseSha), blobShaAt(path, tipSha)]);
+			if (atBase !== atTip) clashes.push(path);
+		}
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+	return { ok: true, clashes };
 }
 
 /**
@@ -445,6 +495,31 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 	const base = await resolveBase({ token, login, baseSha }, deps);
 	if (!base.ok) return at('syncing', base);
 
+	// A stale checkout is fine — the branch bases on today's trunk and carries
+	// the contributor's files on top — except where upstream also changed one
+	// of those same files. There the tree API's whole-file replacement would
+	// silently revert other people's work, so that case stops here, pointed at
+	// the app's own update flow rather than at a pull request that undoes
+	// commits its author never saw.
+	if (!base.exact) {
+		const stale = await staleTouchedPaths({
+			token,
+			login,
+			baseSha,
+			tipSha: base.sha,
+			paths: files.map((f) => f.path)
+		}, deps);
+		if (!stale.ok) return at('syncing', stale);
+		if (stale.clashes.length > 0) {
+			return {
+				ok: false,
+				reason: 'stale',
+				error: `Trunk has moved under ${stale.clashes.length === 1 ? 'a file you edited' : 'files you edited'} (${stale.clashes.slice(0, 3).join(', ')}${stale.clashes.length > 3 ? ', …' : ''}). Update this site to the latest trunk, check your changes still apply, and try again.`,
+				stage: 'syncing'
+			};
+		}
+	}
+
 	// The tree the commit inherits from, read off the base commit rather than
 	// assumed: a commit sha and its tree sha are different objects, and passing
 	// the wrong one silently produces a tree with no history behind it.
@@ -489,6 +564,7 @@ module.exports = {
 	branchNameFor,
 	ensureFork,
 	resolveBase,
+	staleTouchedPaths,
 	createTree,
 	commitAndBranch,
 	createPullRequest,

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -38,10 +38,12 @@ const UPSTREAM_REPO = 'wordpress-develop';
 const BASE_BRANCH = 'trunk';
 const API = 'https://api.github.com';
 
-// Forking is asynchronous: the POST returns 202 and the repository appears a
-// moment later. GitHub's own guidance is to poll; these bounds are ~90 seconds,
-// which covers a repository of this size without hanging the panel forever.
-const FORK_POLL_ATTEMPTS = 30;
+// Forking is asynchronous: the POST returns 202 and the repository fills in
+// afterwards. GitHub documents up to five minutes for a large repository, and
+// wordpress-develop is one — the first real run took minutes to become ready.
+// These bounds are that documented worst case; the progress label says what
+// the wait is, so a long one reads as work rather than a hang.
+const FORK_POLL_ATTEMPTS = 100;
 const FORK_POLL_INTERVAL_MS = 3000;
 
 // How many `-2`, `-3`… suffixes to try before giving up on a branch name. A
@@ -150,39 +152,57 @@ async function ensureFork({ token, login }, deps = {}) {
 		error: `You already have a repository named ${UPSTREAM_REPO} that is not a fork of ${UPSTREAM_OWNER}/${UPSTREAM_REPO}, so there is nowhere to push this. The patch file still works.`
 	});
 
+	// Ready means the fork's own trunk ref answers — not that the repo
+	// metadata exists. Forks share their upstream's object store, so on a fork
+	// that is still initialising every blob, tree and commit write *succeeds*
+	// while the fork's own ref database is not there yet, and the failure
+	// surfaces at the very last write — the branch — as an opaque 404. Found
+	// by hand on the first real run against this repository, which is big
+	// enough for that window to be minutes wide.
+	const readRefs = () => get(`${forkUrl}/git/ref/heads/${BASE_BRANCH}`, { token });
+
 	let existing;
 	try {
 		existing = await get(forkUrl, { token });
 	} catch (e) {
 		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
 	}
-	if (existing.status === 200) return isOurFork(existing.json) ? { ok: true, created: false } : notAFork();
-	if (existing.status !== 404) return failure(existing, 'Could not check for your fork');
+	if (existing.status === 200 && !isOurFork(existing.json)) return notAFork();
+	if (existing.status !== 200 && existing.status !== 404) return failure(existing, 'Could not check for your fork');
 
-	let created;
-	try {
-		created = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, {}, { token });
-	} catch (e) {
-		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
-	}
-	if (created.status !== 202 && created.status !== 200) return failure(created, 'Could not fork wordpress-develop');
-
-	for (let i = 0; i < attempts; i++) {
-		await wait(FORK_POLL_INTERVAL_MS);
-		let poll;
+	let created = false;
+	if (existing.status === 404) {
+		let forked;
 		try {
-			poll = await get(forkUrl, { token });
+			forked = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, {}, { token });
 		} catch (e) {
 			return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
 		}
-		if (poll.status === 200) return { ok: true, created: true };
-		if (poll.status !== 404) return failure(poll, 'Could not read your fork');
+		if (forked.status !== 202 && forked.status !== 200) return failure(forked, 'Could not fork wordpress-develop');
+		created = true;
+	}
+
+	// One wait loop for both cases: a fork this call just made, and one from an
+	// earlier attempt that is still initialising — which is exactly the state a
+	// contributor retrying after the first try "failed" arrives in.
+	try {
+		for (let i = 0; i < attempts; i++) {
+			const ref = await readRefs();
+			if (ref.status === 200) return { ok: true, created };
+			// 404 is the fork still initialising, the state this loop exists to
+			// wait out. Anything else — a token revoked mid-wait, a spent rate
+			// limit — will not resolve by waiting, so it is reported as itself.
+			if (ref.status !== 404) return failure(ref, 'Could not read your fork');
+			await wait(FORK_POLL_INTERVAL_MS);
+		}
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
 	}
 
 	return {
 		ok: false,
 		reason: 'error',
-		error: 'Your fork is taking longer than expected to appear on GitHub. It may exist by now — try again in a minute.'
+		error: 'Your fork is still being set up on GitHub — for a repository this size that can take a few minutes. Try again shortly; the patch file still works.'
 	};
 }
 
@@ -318,6 +338,17 @@ async function commitAndBranch({ token, login, ticketId, message, treeSha, paren
 			const branch = branchNameFor(ticketId, attempt);
 			const ref = await post(`${repo}/git/refs`, { ref: `refs/heads/${branch}`, sha }, { token });
 			if (ref.status === 201) return { ok: true, branch, sha };
+			// A 404 here is the fork's ref database still initialising — the
+			// residual window the readiness gate in ensureFork cannot fully
+			// close, since the commit just succeeded against the shared object
+			// store. "Not Found" told the contributor nothing.
+			if (ref.status === 404) {
+				return {
+					ok: false,
+					reason: 'error',
+					error: 'Your fork is still being set up on GitHub. Try again in a minute — the patch file still works.'
+				};
+			}
 			// 422 is how GitHub says the reference already exists — the only
 			// status worth another name. Anything else is a real failure and
 			// retrying it nine more times would only slow down the report.

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -74,13 +74,31 @@ function classifyFailure(res) {
 }
 
 /**
+ * The trailing diagnostic exists because a failure here has already survived
+ * three wrong theories: the status, GitHub's request id and the scopes GitHub
+ * says the presented token had make the error self-describing enough to take
+ * to GitHub support — or to disprove the next theory without another round
+ * trip through a contributor.
+ *
  * @param {{status: number, headers: Object, json: Object|null}} res
  * @param {string}                                               what
  * @return {{ok: false, reason: string, error: string}}
  */
 function failure(res, what) {
 	const detail = res.json && res.json.message ? res.json.message : `GitHub returned ${res.status}`;
-	return { ok: false, reason: classifyFailure(res), error: `${what}: ${detail}` };
+	return { ok: false, reason: classifyFailure(res), error: `${what}: ${detail}${describeResponse(res)}` };
+}
+
+/**
+ * @param {{status: number, headers: Object}} res
+ * @return {string}
+ */
+function describeResponse(res) {
+	const headers = res.headers || {};
+	const parts = [`status ${res.status}`];
+	if (headers['x-oauth-scopes'] !== undefined) parts.push(`token scopes: ${headers['x-oauth-scopes'] || '(none)'}`);
+	if (headers['x-github-request-id']) parts.push(`request ${headers['x-github-request-id']}`);
+	return ` [${parts.join('; ')}]`;
 }
 
 /**
@@ -346,7 +364,7 @@ async function commitAndBranch({ token, login, ticketId, message, treeSha, paren
 				return {
 					ok: false,
 					reason: 'error',
-					error: 'Your fork is still being set up on GitHub. Try again in a minute — the patch file still works.'
+					error: `Your fork is still being set up on GitHub. Try again in a minute — the patch file still works.${describeResponse(ref)}`
 				};
 			}
 			// 422 is how GitHub says the reference already exists — the only

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -36,6 +36,24 @@ const { ticketUrl } = require('./renderer/trac-ticket.cjs');
 
 const UPSTREAM_OWNER = 'WordPress';
 const UPSTREAM_REPO = 'wordpress-develop';
+
+/**
+ * Which repository the flow targets. `WP_DEV_ENV_GITHUB_UPSTREAM=owner/repo`
+ * points the whole sequence — fork, branch and pull request — at a sandbox, so
+ * the flow can be exercised end to end without a single watcher of
+ * wordpress-develop hearing about it. Same pattern as the client-ID override:
+ * an environment variable for testing, the constant for what ships. The
+ * sandbox needs a `trunk` branch and must not be owned by the signed-in
+ * account, since an account cannot fork its own repository.
+ *
+ * @return {{owner: string, repo: string}}
+ */
+function upstream() {
+	const raw = process.env.WP_DEV_ENV_GITHUB_UPSTREAM;
+	const match = typeof raw === 'string' && /^([^/\s]+)\/([^/\s]+)$/.exec(raw.trim());
+	if (match) return { owner: match[1], repo: match[2] };
+	return { owner: UPSTREAM_OWNER, repo: UPSTREAM_REPO };
+}
 const BASE_BRANCH = 'trunk';
 const API = 'https://api.github.com';
 
@@ -156,7 +174,8 @@ async function ensureFork({ token, login }, deps = {}) {
 	const post = deps.post || postJson;
 	const wait = deps.sleep || sleep;
 	const attempts = deps.forkPollAttempts || FORK_POLL_ATTEMPTS;
-	const forkUrl = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const up = upstream();
+	const forkUrl = `${API}/repos/${login}/${up.repo}`;
 
 	// A repository under the fork's name is only usable if it actually is a
 	// fork of upstream. A contributor who happens to own an unrelated
@@ -164,11 +183,11 @@ async function ensureFork({ token, login }, deps = {}) {
 	// alternative is writing a branch and a commit into their project and
 	// failing at the very end with an opaque 422.
 	const isOurFork = (json) => Boolean(json && json.fork)
-		&& [json.parent, json.source].some((repo) => repo && repo.full_name === `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`);
+		&& [json.parent, json.source].some((repo) => repo && repo.full_name === `${up.owner}/${up.repo}`);
 	const notAFork = () => ({
 		ok: false,
 		reason: 'error',
-		error: `You already have a repository named ${UPSTREAM_REPO} that is not a fork of ${UPSTREAM_OWNER}/${UPSTREAM_REPO}, so there is nowhere to push this. The patch file still works.`
+		error: `You already have a repository named ${up.repo} that is not a fork of ${up.owner}/${up.repo}, so there is nowhere to push this. The patch file still works.`
 	});
 
 	// Ready means the fork's own trunk ref answers — not that the repo
@@ -193,7 +212,7 @@ async function ensureFork({ token, login }, deps = {}) {
 	if (existing.status === 404) {
 		let forked;
 		try {
-			forked = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, {}, { token });
+			forked = await post(`${API}/repos/${up.owner}/${up.repo}/forks`, {}, { token });
 		} catch (e) {
 			return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
 		}
@@ -254,7 +273,7 @@ async function ensureFork({ token, login }, deps = {}) {
 async function resolveBase({ token, login, baseSha }, deps = {}) {
 	const get = deps.get || getJson;
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const repo = `${API}/repos/${login}/${upstream().repo}`;
 
 	try {
 		// Always fast-forward first, so "the tip" means today's trunk and not
@@ -300,7 +319,7 @@ async function resolveBase({ token, login, baseSha }, deps = {}) {
  */
 async function staleTouchedPaths({ token, login, baseSha, tipSha, paths }, deps = {}) {
 	const get = deps.get || getJson;
-	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const repo = `${API}/repos/${login}/${upstream().repo}`;
 
 	const blobShaAt = async (path, ref) => {
 		const res = await get(`${repo}/contents/${encodeURI(path)}?ref=${ref}`, { token });
@@ -342,7 +361,7 @@ async function staleTouchedPaths({ token, login, baseSha, tipSha, paths }, deps 
  */
 async function createTree({ token, login, baseTreeSha, files }, deps = {}) {
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const repo = `${API}/repos/${login}/${upstream().repo}`;
 	const entries = [];
 
 	try {
@@ -390,7 +409,7 @@ async function createTree({ token, login, baseTreeSha, files }, deps = {}) {
  */
 async function commitAndBranch({ token, login, ticketId, message, treeSha, parentSha }, deps = {}) {
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const repo = `${API}/repos/${login}/${upstream().repo}`;
 
 	try {
 		const commit = await post(`${repo}/git/commits`, {
@@ -444,7 +463,8 @@ async function commitAndBranch({ token, login, ticketId, message, treeSha, paren
 async function createPullRequest({ token, login, branch, title, body }, deps = {}) {
 	const post = deps.post || postJson;
 	try {
-		const res = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls`, {
+		const up = upstream();
+		const res = await post(`${API}/repos/${up.owner}/${up.repo}/pulls`, {
 			title,
 			body,
 			head: `${login}:${branch}`,
@@ -525,7 +545,7 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 	// the wrong one silently produces a tree with no history behind it.
 	let baseCommit;
 	try {
-		baseCommit = await get(`${API}/repos/${login}/${UPSTREAM_REPO}/git/commits/${base.sha}`, { token });
+		baseCommit = await get(`${API}/repos/${login}/${upstream().repo}/git/commits/${base.sha}`, { token });
 	} catch (e) {
 		return at('syncing', { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) });
 	}
@@ -546,6 +566,22 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 		parentSha: base.sha
 	}, deps);
 	if (!branched.ok) return at('committing', branched);
+
+	// Everything up to here wrote only to the contributor's own fork, where a
+	// spare branch bothers nobody. The pull request is the one step the
+	// upstream's watchers hear about, so it is the one a dry run skips —
+	// letting the rest of the flow be exercised against the real API without
+	// generating noise.
+	if (process.env.WP_DEV_ENV_GITHUB_DRY_RUN) {
+		return {
+			ok: true,
+			dryRun: true,
+			url: `https://github.com/${login}/${upstream().repo}/tree/${branched.branch}`,
+			number: null,
+			branch: branched.branch,
+			exactBase: base.exact
+		};
+	}
 
 	report('opening');
 	const pr = await createPullRequest({ token, login, branch: branched.branch, title, body }, deps);

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -54,6 +54,36 @@ function upstream() {
 	if (match) return { owner: match[1], repo: match[2] };
 	return { owner: UPSTREAM_OWNER, repo: UPSTREAM_REPO };
 }
+
+/**
+ * True when this run stops before opening the pull request.
+ *
+ * @return {boolean}
+ */
+function isDryRun() {
+	return Boolean(process.env.WP_DEV_ENV_GITHUB_DRY_RUN);
+}
+
+/**
+ * What the panel needs to say about a run that is not a normal one, or null
+ * when it is.
+ *
+ * These switches are set in a terminal, minutes before the button is pressed,
+ * and then the app looks exactly like production — which is how a dry run that
+ * silently was not one opened a real pull request against wordpress-develop
+ * during testing. A mode the contributor cannot see is a mode they cannot
+ * rely on, so the card states it where the decision is made.
+ *
+ * @return {{dryRun: boolean, target: string}|null}
+ */
+function testMode() {
+	const up = upstream();
+	const target = `${up.owner}/${up.repo}`;
+	const sandboxed = target !== `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`;
+	if (!isDryRun() && !sandboxed) return null;
+	return { dryRun: isDryRun(), target };
+}
+
 const BASE_BRANCH = 'trunk';
 const API = 'https://api.github.com';
 
@@ -572,7 +602,7 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 	// upstream's watchers hear about, so it is the one a dry run skips —
 	// letting the rest of the flow be exercised against the real API without
 	// generating noise.
-	if (process.env.WP_DEV_ENV_GITHUB_DRY_RUN) {
+	if (isDryRun()) {
 		return {
 			ok: true,
 			dryRun: true,
@@ -596,6 +626,9 @@ module.exports = {
 	BASE_BRANCH,
 	MAX_BRANCH_ATTEMPTS,
 	classifyFailure,
+	upstream,
+	isDryRun,
+	testMode,
 	buildPullRequestBody,
 	branchNameFor,
 	ensureFork,

--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -1,0 +1,447 @@
+'use strict';
+
+/**
+ * Opening a pull request against wordpress-develop from the working tree (#167).
+ *
+ * Nothing here shells out to git and nothing here writes a credential to disk.
+ * The whole sequence is GitHub's own API: fork the repository, bring the fork's
+ * trunk up to date, upload the changed files as blobs, assemble a tree, commit
+ * it, create a branch pointing at that commit, and open the pull request. The
+ * only thing that ever holds the token is the main process, in memory, for the
+ * length of one app run.
+ *
+ * Why the Git Data API rather than the contents API, which is simpler: the
+ * contents endpoint writes one commit per file, so a five-file change would
+ * arrive as five commits with four intermediate states that never compiled.
+ * Blobs → tree → commit produces the one commit a reviewer expects.
+ *
+ * Two things in here exist because of a fork that already exists and is months
+ * stale — the case unit tests can only approximate and the one that will
+ * actually be hit at a contributor day:
+ *
+ *   - the commit is based on the local checkout's HEAD, and a stale fork does
+ *     not contain that commit at all, so creating a ref from it would 422. The
+ *     sync step is load-bearing, not hygiene.
+ *   - a fork that has diverged cannot be fast-forwarded, so the base falls back
+ *     to the fork's own trunk tip and the result says so, rather than failing.
+ *
+ * Every failure is typed, because every failure has the same fallback — the
+ * patch file, which is always still there — but not the same explanation.
+ */
+
+const { getJson, postJson } = require('./github-http.cjs');
+const { classifyHttpFailure } = require('./patch-sources.cjs');
+const { ticketUrl } = require('./renderer/trac-ticket.cjs');
+
+const UPSTREAM_OWNER = 'WordPress';
+const UPSTREAM_REPO = 'wordpress-develop';
+const BASE_BRANCH = 'trunk';
+const API = 'https://api.github.com';
+
+// Forking is asynchronous: the POST returns 202 and the repository appears a
+// moment later. GitHub's own guidance is to poll; these bounds are ~90 seconds,
+// which covers a repository of this size without hanging the panel forever.
+const FORK_POLL_ATTEMPTS = 30;
+const FORK_POLL_INTERVAL_MS = 3000;
+
+// How many `-2`, `-3`… suffixes to try before giving up on a branch name. A
+// contributor with ten open branches for one ticket has a different problem.
+const MAX_BRANCH_ATTEMPTS = 10;
+
+const DEFAULT_MODE = '100644';
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Why a request failed, in the terms the panel can act on.
+ *
+ * 401 is checked before the shared classifier because in the GitHub API it
+ * always means the token is no longer good — a revoked authorization, most
+ * often — and that has its own recovery: forget the token and offer sign-in
+ * again. classifyHttpFailure reads a 401 with a spent quota as rate-limiting,
+ * which is right for the anonymous reads it was written for and wrong here.
+ *
+ * @param {{status: number, headers: Object}} res
+ * @return {string}
+ */
+function classifyFailure(res) {
+	if (res.status === 401) return 'unauthorized';
+	return classifyHttpFailure(res.status, res.headers || {});
+}
+
+/**
+ * @param {{status: number, headers: Object, json: Object|null}} res
+ * @param {string}                                               what
+ * @return {{ok: false, reason: string, error: string}}
+ */
+function failure(res, what) {
+	const detail = res.json && res.json.message ? res.json.message : `GitHub returned ${res.status}`;
+	return { ok: false, reason: classifyFailure(res), error: `${what}: ${detail}` };
+}
+
+/**
+ * The pull request body, in the form core's Trac↔GitHub convention expects.
+ *
+ * The ticket line is not decoration: it is what links the pull request back to
+ * the ticket, what Trac's own bot reads, and — pleasingly — what this app's own
+ * `bodyCitesTicket` in patch-sources.cjs looks for, so a pull request opened
+ * here shows up in the site's "patches on this ticket" list afterwards.
+ *
+ * @param {Object}        root0
+ * @param {number|string} root0.ticketId
+ * @param {string}        [root0.handle]
+ * @param {string}        [root0.event]
+ * @return {string}
+ */
+function buildPullRequestBody({ ticketId, handle, event } = {}) {
+	const lines = [`Trac ticket: ${ticketUrl(ticketId)}`];
+	// The same two facts the mentor-handoff header carries (#166), for the same
+	// reason: props follow whoever wrote the patch, and a contributor-day room
+	// is worth naming while it is still happening.
+	if (handle) lines.push('', `Written by @${handle} on WordPress.org.`);
+	if (event) lines.push(handle ? `At ${event}.` : `Written at ${event}.`);
+	lines.push('', 'Opened from the WordPress Contributor Toolkit.');
+	return lines.join('\n');
+}
+
+/**
+ * A branch name for a ticket, and the alternatives to try if it is taken.
+ *
+ * @param {number|string} ticketId
+ * @param {number}        attempt  Zero for the first try.
+ * @return {string}
+ */
+function branchNameFor(ticketId, attempt = 0) {
+	const base = `trac-${String(ticketId).replace(/[^0-9]/g, '')}`;
+	return attempt === 0 ? base : `${base}-${attempt + 1}`;
+}
+
+/**
+ * The fork, creating it first if the contributor has none.
+ *
+ * An existing fork short-circuits: forking twice is not an error at GitHub, but
+ * it is a wasted write and a needless wait.
+ *
+ * @param {Object} root0
+ * @param {string} root0.token
+ * @param {string} root0.login
+ * @param {Object} [deps]
+ * @return {Promise<{ok: true, created: boolean}|{ok: false, reason: string, error: string}>}
+ */
+async function ensureFork({ token, login }, deps = {}) {
+	const get = deps.get || getJson;
+	const post = deps.post || postJson;
+	const wait = deps.sleep || sleep;
+	const attempts = deps.forkPollAttempts || FORK_POLL_ATTEMPTS;
+	const forkUrl = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+
+	// A repository under the fork's name is only usable if it actually is a
+	// fork of upstream. A contributor who happens to own an unrelated
+	// repository called wordpress-develop must be told at step one — the
+	// alternative is writing a branch and a commit into their project and
+	// failing at the very end with an opaque 422.
+	const isOurFork = (json) => Boolean(json && json.fork)
+		&& [json.parent, json.source].some((repo) => repo && repo.full_name === `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`);
+	const notAFork = () => ({
+		ok: false,
+		reason: 'error',
+		error: `You already have a repository named ${UPSTREAM_REPO} that is not a fork of ${UPSTREAM_OWNER}/${UPSTREAM_REPO}, so there is nowhere to push this. The patch file still works.`
+	});
+
+	let existing;
+	try {
+		existing = await get(forkUrl, { token });
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+	if (existing.status === 200) return isOurFork(existing.json) ? { ok: true, created: false } : notAFork();
+	if (existing.status !== 404) return failure(existing, 'Could not check for your fork');
+
+	let created;
+	try {
+		created = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, {}, { token });
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+	if (created.status !== 202 && created.status !== 200) return failure(created, 'Could not fork wordpress-develop');
+
+	for (let i = 0; i < attempts; i++) {
+		await wait(FORK_POLL_INTERVAL_MS);
+		let poll;
+		try {
+			poll = await get(forkUrl, { token });
+		} catch (e) {
+			return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+		}
+		if (poll.status === 200) return { ok: true, created: true };
+		if (poll.status !== 404) return failure(poll, 'Could not read your fork');
+	}
+
+	return {
+		ok: false,
+		reason: 'error',
+		error: 'Your fork is taking longer than expected to appear on GitHub. It may exist by now — try again in a minute.'
+	};
+}
+
+/**
+ * Which commit the new branch is based on.
+ *
+ * The honest answer is the local checkout's HEAD: that is what the contributor
+ * edited, and basing on anything else would silently fold in upstream changes
+ * they have not seen. A fresh fork contains it. A stale one does not, so the
+ * fork's trunk is fast-forwarded first; a fork that has diverged cannot be, and
+ * then the fork's own tip is the best available base — reported as
+ * `exact: false` so the caller can say the pull request may show more than the
+ * contributor changed.
+ *
+ * @param {Object} root0
+ * @param {string} root0.token
+ * @param {string} root0.login
+ * @param {string} root0.baseSha
+ * @param {Object} [deps]
+ * @return {Promise<{ok: true, sha: string, exact: boolean}|{ok: false, reason: string, error: string}>}
+ */
+async function resolveBase({ token, login, baseSha }, deps = {}) {
+	const get = deps.get || getJson;
+	const post = deps.post || postJson;
+	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+
+	const hasCommit = async (sha) => {
+		const res = await get(`${repo}/git/commits/${sha}`, { token });
+		return res.status === 200;
+	};
+
+	try {
+		if (baseSha && (await hasCommit(baseSha))) return { ok: true, sha: baseSha, exact: true };
+
+		// 409 here is a diverged fork, which is a normal state for someone who
+		// has contributed before — not a failure to report.
+		await post(`${repo}/merge-upstream`, { branch: BASE_BRANCH }, { token });
+
+		if (baseSha && (await hasCommit(baseSha))) return { ok: true, sha: baseSha, exact: true };
+
+		const ref = await get(`${repo}/git/ref/heads/${BASE_BRANCH}`, { token });
+		if (ref.status !== 200 || !ref.json || !ref.json.object || !ref.json.object.sha) {
+			return failure(ref, 'Could not read your fork’s trunk');
+		}
+		return { ok: true, sha: String(ref.json.object.sha), exact: false };
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+}
+
+/**
+ * Uploads the changed files and assembles the tree they belong in.
+ *
+ * `base_tree` is the base commit's tree, so unchanged files are inherited
+ * rather than re-uploaded — the alternative is sending all of wordpress-develop
+ * over a contributor day's wifi.
+ *
+ * A deletion is an entry with a null sha; that is the only way the tree API
+ * expresses one, and it is why deletions work here even though the `.diff` this
+ * app writes still drops them (#174).
+ *
+ * @param {Object} root0
+ * @param {string} root0.token
+ * @param {string} root0.login
+ * @param {string} root0.baseTreeSha
+ * @param {Array}  root0.files       `{ path, kind, content: Buffer|null, mode }`
+ * @param {Object} [deps]
+ * @return {Promise<{ok: true, sha: string}|{ok: false, reason: string, error: string}>}
+ */
+async function createTree({ token, login, baseTreeSha, files }, deps = {}) {
+	const post = deps.post || postJson;
+	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+	const entries = [];
+
+	try {
+		for (const file of files) {
+			if (file.kind === 'delete') {
+				entries.push({ path: file.path, mode: file.mode || DEFAULT_MODE, type: 'blob', sha: null });
+				continue;
+			}
+			// base64 for every file, not just the binary ones: it is the only
+			// encoding that survives a file the API's utf-8 mode would mangle,
+			// and there is no benefit to picking per file.
+			const blob = await post(`${repo}/git/blobs`, {
+				content: Buffer.from(file.content || Buffer.alloc(0)).toString('base64'),
+				encoding: 'base64'
+			}, { token });
+			if (blob.status !== 201 || !blob.json || !blob.json.sha) {
+				return failure(blob, `Could not upload ${file.path}`);
+			}
+			entries.push({ path: file.path, mode: file.mode || DEFAULT_MODE, type: 'blob', sha: blob.json.sha });
+		}
+
+		const tree = await post(`${repo}/git/trees`, { base_tree: baseTreeSha, tree: entries }, { token });
+		if (tree.status !== 201 || !tree.json || !tree.json.sha) return failure(tree, 'Could not assemble the change');
+		return { ok: true, sha: String(tree.json.sha) };
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+}
+
+/**
+ * The commit, and the branch that points at it.
+ *
+ * The branch is created last and separately so a name collision — the same
+ * ticket worked on twice — costs one retry rather than re-uploading everything.
+ *
+ * @param {Object}        root0
+ * @param {string}        root0.token
+ * @param {string}        root0.login
+ * @param {number|string} root0.ticketId
+ * @param {string}        root0.message
+ * @param {string}        root0.treeSha
+ * @param {string}        root0.parentSha
+ * @param {Object}        [deps]
+ * @return {Promise<{ok: true, branch: string, sha: string}|{ok: false, reason: string, error: string}>}
+ */
+async function commitAndBranch({ token, login, ticketId, message, treeSha, parentSha }, deps = {}) {
+	const post = deps.post || postJson;
+	const repo = `${API}/repos/${login}/${UPSTREAM_REPO}`;
+
+	try {
+		const commit = await post(`${repo}/git/commits`, {
+			message,
+			tree: treeSha,
+			parents: [parentSha]
+		}, { token });
+		if (commit.status !== 201 || !commit.json || !commit.json.sha) return failure(commit, 'Could not create the commit');
+		const sha = String(commit.json.sha);
+
+		let lastRes = null;
+		for (let attempt = 0; attempt < MAX_BRANCH_ATTEMPTS; attempt++) {
+			const branch = branchNameFor(ticketId, attempt);
+			const ref = await post(`${repo}/git/refs`, { ref: `refs/heads/${branch}`, sha }, { token });
+			if (ref.status === 201) return { ok: true, branch, sha };
+			// 422 is how GitHub says the reference already exists — the only
+			// status worth another name. Anything else is a real failure and
+			// retrying it nine more times would only slow down the report.
+			if (ref.status !== 422) return failure(ref, 'Could not create the branch');
+			lastRes = ref;
+		}
+		return failure(lastRes, 'Could not find an unused branch name');
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+}
+
+/**
+ * The pull request itself, opened on upstream from the fork's branch.
+ *
+ * @param {Object} root0
+ * @param {string} root0.token
+ * @param {string} root0.login
+ * @param {string} root0.branch
+ * @param {string} root0.title
+ * @param {string} root0.body
+ * @param {Object} [deps]
+ * @return {Promise<{ok: true, url: string, number: number}|{ok: false, reason: string, error: string}>}
+ */
+async function createPullRequest({ token, login, branch, title, body }, deps = {}) {
+	const post = deps.post || postJson;
+	try {
+		const res = await post(`${API}/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls`, {
+			title,
+			body,
+			head: `${login}:${branch}`,
+			base: BASE_BRANCH,
+			maintainer_can_modify: true
+		}, { token });
+		if (res.status !== 201 || !res.json || !res.json.html_url) return failure(res, 'Could not open the pull request');
+		return { ok: true, url: String(res.json.html_url), number: Number(res.json.number) };
+	} catch (e) {
+		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
+	}
+}
+
+/**
+ * The whole sequence, reporting each step as it starts.
+ *
+ * Returns rather than throws on every failure, and the caller's fallback is
+ * always the same: the patch file. `stage` says how far it got, which is what
+ * makes "your fork exists, the pull request does not" a message a contributor
+ * can act on instead of a dead end.
+ *
+ * @param {Object}        root0
+ * @param {string}        root0.token
+ * @param {string}        root0.login
+ * @param {number|string} root0.ticketId
+ * @param {string}        root0.baseSha
+ * @param {Array}         root0.files
+ * @param {string}        root0.title
+ * @param {string}        root0.body
+ * @param {Function}      [root0.onProgress]
+ * @param {Object}        [deps]
+ * @return {Promise<{ok: true, url: string, number: number, branch: string, exactBase: boolean}|{ok: false, reason: string, error: string, stage: string}>}
+ */
+async function openPullRequest({ token, login, ticketId, baseSha, files, title, body, onProgress }, deps = {}) {
+	const get = deps.get || getJson;
+	const report = typeof onProgress === 'function' ? onProgress : () => {};
+	const at = (stage, result) => ({ ...result, stage });
+
+	if (!files || files.length === 0) {
+		return { ok: false, reason: 'empty', error: 'There are no changes to open a pull request with.', stage: 'collect' };
+	}
+
+	report('forking');
+	const fork = await ensureFork({ token, login }, deps);
+	if (!fork.ok) return at('forking', fork);
+
+	report('syncing');
+	const base = await resolveBase({ token, login, baseSha }, deps);
+	if (!base.ok) return at('syncing', base);
+
+	// The tree the commit inherits from, read off the base commit rather than
+	// assumed: a commit sha and its tree sha are different objects, and passing
+	// the wrong one silently produces a tree with no history behind it.
+	let baseCommit;
+	try {
+		baseCommit = await get(`${API}/repos/${login}/${UPSTREAM_REPO}/git/commits/${base.sha}`, { token });
+	} catch (e) {
+		return at('syncing', { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) });
+	}
+	if (baseCommit.status !== 200 || !baseCommit.json || !baseCommit.json.tree) {
+		return at('syncing', failure(baseCommit, 'Could not read the base commit'));
+	}
+
+	report('committing');
+	const tree = await createTree({ token, login, baseTreeSha: baseCommit.json.tree.sha, files }, deps);
+	if (!tree.ok) return at('committing', tree);
+
+	const branched = await commitAndBranch({
+		token,
+		login,
+		ticketId,
+		message: title,
+		treeSha: tree.sha,
+		parentSha: base.sha
+	}, deps);
+	if (!branched.ok) return at('committing', branched);
+
+	report('opening');
+	const pr = await createPullRequest({ token, login, branch: branched.branch, title, body }, deps);
+	if (!pr.ok) return at('opening', pr);
+
+	return { ok: true, url: pr.url, number: pr.number, branch: branched.branch, exactBase: base.exact };
+}
+
+module.exports = {
+	UPSTREAM_OWNER,
+	UPSTREAM_REPO,
+	BASE_BRANCH,
+	MAX_BRANCH_ATTEMPTS,
+	classifyFailure,
+	buildPullRequestBody,
+	branchNameFor,
+	ensureFork,
+	resolveBase,
+	createTree,
+	commitAndBranch,
+	createPullRequest,
+	openPullRequest
+};

--- a/src/github-prs.js
+++ b/src/github-prs.js
@@ -14,80 +14,15 @@
  *
  * Requests use Electron's `net` rather than a new HTTP dependency: it rides the
  * Chromium network stack, so it honours the same proxy and TLS configuration
- * the rest of the app already relies on, and adds nothing to install.
+ * the rest of the app already relies on, and adds nothing to install. That
+ * request primitive now lives in github-http.cjs, because opening a pull
+ * request (#167) needs the same one with a method and a body.
  */
 
 const { parseLinkedPrs, classifyHttpFailure } = require('./patch-sources.cjs');
+const { httpGet } = require('./github-http.cjs');
 
 const REPO = 'WordPress/wordpress-develop';
-// GitHub rejects API requests with no User-Agent; an identifying one is also
-// the honest thing to send.
-const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/experimental-wp-dev-env)';
-const REQUEST_TIMEOUT_MS = 15000;
-
-/**
- * A single GET over Electron net. Never rejects on an HTTP status — the status
- * is data the caller classifies — only on a transport failure or timeout.
- * Modelled on the never-reject readiness probe in main.js.
- *
- * `opts` carries both test doubles and request options. The doubles (net client
- * and timers) exist only so the response, transport-error, timeout, and
- * settle-once paths can be exercised without the network or a real 15s wait;
- * production callers pass none and get Electron's `net` and the global timers.
- * `partition` + `useSessionCookies` let a caller ride a specific session's
- * cookies — the Trac attachment fetch reuses the session that passed the
- * proof-of-work challenge, so its `_hcc` cookie authorises the download; net
- * does not send session cookies unless asked, hence the explicit flag.
- *
- * @param {string}  url
- * @param {Object}  [headers]
- * @param {Object}  [opts]
- * @param {string}  [opts.partition]
- * @param {boolean} [opts.useSessionCookies]
- * @return {Promise<{status: number, headers: Object, body: string}>}
- */
-function httpGet(url, headers = {}, opts = {}) {
-	// Required lazily, not at module load: requiring `electron` outside Electron
-	// resolves the binary and can spawn its installer on a cold checkout, and the
-	// standalone tests inject their own client and must never reach it.
-	const netImpl = opts.net || require('electron').net;
-	const setTimeoutImpl = opts.setTimeout || setTimeout;
-	const clearTimeoutImpl = opts.clearTimeout || clearTimeout;
-	return new Promise((resolve, reject) => {
-		let settled = false;
-		const finish = (fn, arg) => { if (!settled) { settled = true; fn(arg); } };
-
-		const requestOptions = { method: 'GET', url };
-		if (opts.partition) {
-			requestOptions.partition = opts.partition;
-			requestOptions.useSessionCookies = opts.useSessionCookies !== false;
-		}
-		const request = netImpl.request(requestOptions);
-		request.setHeader('User-Agent', USER_AGENT);
-		for (const [key, value] of Object.entries(headers)) request.setHeader(key, value);
-
-		const timer = setTimeoutImpl(() => {
-			try { request.abort(); } catch {}
-			finish(reject, new Error(`Timed out after ${REQUEST_TIMEOUT_MS}ms`));
-		}, REQUEST_TIMEOUT_MS);
-
-		request.on('response', (response) => {
-			const chunks = [];
-			response.on('data', (chunk) => chunks.push(chunk));
-			response.on('end', () => {
-				clearTimeoutImpl(timer);
-				const lowerHeaders = {};
-				for (const [key, value] of Object.entries(response.headers || {})) {
-					lowerHeaders[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
-				}
-				finish(resolve, { status: response.statusCode, headers: lowerHeaders, body: Buffer.concat(chunks).toString('utf8') });
-			});
-			response.on('error', (e) => { clearTimeoutImpl(timer); finish(reject, e); });
-		});
-		request.on('error', (e) => { clearTimeoutImpl(timer); finish(reject, e); });
-		request.end();
-	});
-}
 
 /**
  * The pull requests that cite a ticket, newest first.

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
 const { getClientId: getGithubClientId, requestDeviceCode, pollForToken, fetchViewer } = require('./github-auth.cjs');
-const { openPullRequest, buildPullRequestBody } = require('./github-pr.cjs');
+const { openPullRequest, buildPullRequestBody, testMode: githubTestMode } = require('./github-pr.cjs');
 const { buildPullRequestEntries } = require('./pr-files.cjs');
 const { openAndScrape, fetchAttachment } = require('./trac-view');
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
@@ -512,7 +512,12 @@ ipcMain.handle('github:account', async () => ({
     login: githubLogin,
     // The panel says "sign-in is not set up in this build" rather than offering
     // a button that can only fail.
-    configured: Boolean(getGithubClientId())
+    configured: Boolean(getGithubClientId()),
+    // Null in every shipped build. When an env switch is set, the card has to
+    // say so: the switches are typed in a terminal minutes earlier, and an
+    // app that looks identical either way is how a dry run that silently was
+    // not one opened a real pull request during testing.
+    testMode: githubTestMode()
 }));
 
 ipcMain.handle('github:sign-out', async () => {

--- a/src/main.js
+++ b/src/main.js
@@ -493,7 +493,7 @@ ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
 //
 // That is a deliberate cost. A contributor who restarts the app signs in again.
 // The machine this runs on is often a borrowed laptop in a contributor-day
-// room, and a `public_repo` token outliving the session on one of those is a
+// room, and a `repo` token outliving the session on one of those is a
 // worse trade than a second sign-in.
 let githubToken = null;
 let githubLogin = null;

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,9 @@ const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, update
 const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
+const { getClientId: getGithubClientId, requestDeviceCode, pollForToken, fetchViewer } = require('./github-auth.cjs');
+const { openPullRequest, buildPullRequestBody } = require('./github-pr.cjs');
+const { buildPullRequestEntries } = require('./pr-files.cjs');
 const { openAndScrape, fetchAttachment } = require('./trac-view');
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
 const { deleteRegisteredSite, revealRegisteredSite } = require('./site-registry');
@@ -309,7 +312,17 @@ function buildPatchHtml(content) {
     </body></html>`;
 }
 
-async function createMinimalPatchForDir(dir) {
+// What this checkout has that its copy of trunk does not: one walk, read by
+// both destinations that need it.
+//
+// The `.diff` and the pull request (#167) must never disagree about what
+// changed — they are two renderings of one answer, and a contributor choosing
+// between them is choosing a destination, not a different set of edits. So the
+// walk lives here, once, and each destination interprets the result.
+//
+// Returns the base commit alongside the files because the pull request needs it
+// as the commit's parent, and it is the same oid the diff was taken against.
+async function collectChangedFiles(dir) {
     await ensureAutocrlf(dir);
     // The diff base is deliberately the local HEAD (the cloned trunk
     // snapshot), NOT the remote trunk ref: diffing local edits against a
@@ -343,23 +356,55 @@ async function createMinimalPatchForDir(dir) {
     // Compare working tree vs HEAD (which points to trunk tip after clone)
     const matrixAfterAdd = await git.statusMatrix({ fs, dir });
     const changed = matrixAfterAdd.filter(([, head, workdir]) => head !== workdir);
-    let patch = '';
+    const files = [];
     for (const [filepath, head, workdir] of changed) {
-        const abs = require('path').join(dir, filepath);
+        const abs = path.join(dir, filepath);
         const workBuf = workdir ? await fs.promises.readFile(abs).catch(() => null) : null;
         const base = head && headOid ? await git.readBlob({ fs, dir, oid: headOid, filepath }).catch(() => null) : null;
+        files.push({
+            path: filepath,
+            // The status codes, not the buffers, are what say whether a file is
+            // gone: a read that failed for any other reason must not be reported
+            // as a deletion, which in a pull request would actually delete it.
+            inHead: head !== 0,
+            inWorkdir: workdir !== 0,
+            base: base ? Buffer.from(base.blob) : null,
+            work: workBuf
+        });
+    }
+    return { headOid, files };
+}
+
+async function createMinimalPatchForDir(dir) {
+    const { files } = await collectChangedFiles(dir);
+    let patch = '';
+    for (const file of files) {
         // CRLF→LF on both sides: the workdir may be a CRLF checkout (native
         // git on Windows), and a patch full of line-ending churn applies
         // nowhere on Trac.
-        const a = base ? normalizeEol(Buffer.from(base.blob).toString('utf8')) : '';
-        const b = workBuf ? normalizeEol(workBuf.toString('utf8')) : a;
+        const a = file.base ? normalizeEol(file.base.toString('utf8')) : '';
+        const b = file.work ? normalizeEol(file.work.toString('utf8')) : a;
         if (a === b) continue;
         // Skip likely-binary
         if ((a.indexOf('\0') !== -1) || (b.indexOf('\0') !== -1)) continue;
-        const filePatch = JsDiff.createTwoFilesPatch(`a/${filepath}`, `b/${filepath}`, a, b, '', '', { context: 3 });
+        const filePatch = JsDiff.createTwoFilesPatch(`a/${file.path}`, `b/${file.path}`, a, b, '', '', { context: 3 });
         patch += filePatch + '\n';
     }
     return patch || 'No changes.';
+}
+
+// The same change, in the shape the tree API takes (#167).
+//
+// Two differences from the `.diff`, both of them the pull request being more
+// faithful rather than different: binary files are carried, because a blob is
+// base64 and a unified diff is not; and deletions are carried, which the patch
+// builder above still drops (#174). The shaping — modes, deletions, and the
+// CRLF handling that keeps a Windows checkout from rewriting every line —
+// lives in pr-files.cjs, where both platform branches are testable.
+async function collectPullRequestFiles(dir) {
+    const { headOid, files } = await collectChangedFiles(dir);
+    const entries = await buildPullRequestEntries(files, { git, fs, dir, headOid, platform: process.platform });
+    return { headOid, files: entries };
 }
 
 ipcMain.handle('git:get-patch', async (_e, sitePath) => {
@@ -436,6 +481,149 @@ ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
     } catch (e) {
         return { ok: false, error: String(e) };
     }
+});
+
+// --- Opening a pull request (#167) ---
+//
+// The access token lives here and nowhere else: one module-level variable, for
+// the length of one app run. It is never written to electron-store, never
+// logged, and never sent to the renderer — the renderer is told a login, which
+// is a name, not a credential. Signing out is forgetting a variable, and so is
+// quitting the app.
+//
+// That is a deliberate cost. A contributor who restarts the app signs in again.
+// The machine this runs on is often a borrowed laptop in a contributor-day
+// room, and a `public_repo` token outliving the session on one of those is a
+// worse trade than a second sign-in.
+let githubToken = null;
+let githubLogin = null;
+// Set while a device-flow poll is in flight; the object identity is what the
+// poll checks, so a cancel followed immediately by a new sign-in cannot cancel
+// the new one.
+let githubSignIn = null;
+
+function forgetGithubToken() {
+    githubToken = null;
+    githubLogin = null;
+}
+
+ipcMain.handle('github:account', async () => ({
+    ok: true,
+    login: githubLogin,
+    // The panel says "sign-in is not set up in this build" rather than offering
+    // a button that can only fail.
+    configured: Boolean(getGithubClientId())
+}));
+
+ipcMain.handle('github:sign-out', async () => {
+    forgetGithubToken();
+    return { ok: true };
+});
+
+ipcMain.handle('github:sign-in-cancel', async () => {
+    if (githubSignIn) githubSignIn.canceled = true;
+    githubSignIn = null;
+    return { ok: true };
+});
+
+ipcMain.handle('github:sign-in', async (event) => {
+    const started = await requestDeviceCode();
+    if (!started.ok) {
+        logEvent('github', `sign-in could not start: ${started.reason}`);
+        return started;
+    }
+
+    // A second sign-in supersedes the first rather than racing it.
+    if (githubSignIn) githubSignIn.canceled = true;
+    const session = { canceled: false };
+    githubSignIn = session;
+
+    // The poll runs past this handler's return so the code can be on screen
+    // while the contributor is in the browser. Its outcome comes back as an
+    // event, the same shape the install and script runners use.
+    //
+    // `githubSignIn` stays pointing at this session until the very end,
+    // including through the fetchViewer await: it is how the cancel handler
+    // reaches an in-flight sign-in, and clearing it early opened a window where
+    // Cancel was a no-op and the contributor ended up signed in anyway.
+    (async () => {
+        const finish = (payload) => {
+            if (githubSignIn === session) githubSignIn = null;
+            if (!session.canceled && !event.sender.isDestroyed()) event.sender.send('github:sign-in:done', payload);
+        };
+
+        const polled = await pollForToken(started, { isCanceled: () => session.canceled });
+        if (session.canceled) return finish(null);
+        if (!polled.ok) {
+            logEvent('github', `sign-in ended: ${polled.reason}`);
+            return finish(polled);
+        }
+
+        const viewer = await fetchViewer(polled.token);
+        if (session.canceled) return finish(null);
+        if (!viewer.ok) {
+            logEvent('github', `sign-in could not identify the account: ${viewer.reason}`);
+            return finish(viewer);
+        }
+
+        githubToken = polled.token;
+        githubLogin = viewer.login;
+        logEvent('github', `signed in as ${describeRefused(viewer.login)}`);
+        finish({ ok: true, login: viewer.login });
+    })();
+
+    // The device code is not the token, and the renderer needs both halves of
+    // it — the code to show and the page to open.
+    return { ok: true, userCode: started.userCode, verificationUri: started.verificationUri };
+});
+
+ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
+    if (!githubToken || !githubLogin) {
+        return { ok: false, reason: 'unauthorized', error: 'Sign in to GitHub first.', stage: 'auth' };
+    }
+
+    // The ticket is read from this site's stored metadata rather than taken
+    // from the caller, for the reason the handoff header is: the renderer
+    // should not be able to file a pull request against a different ticket than
+    // the one this site is linked to.
+    const s = await getStore();
+    const meta = (s.get('siteMeta') || {})[sitePath] || {};
+    const ticketId = meta.tracTicket;
+    if (!ticketId) {
+        return { ok: false, reason: 'no-ticket', error: 'Link a Trac ticket to this site first.', stage: 'auth' };
+    }
+    const { wporgHandle: handle = null, contributionEvent = null } = s.get('preferences') || {};
+
+    let collected;
+    try {
+        collected = await collectPullRequestFiles(sitePath);
+    } catch (e) {
+        return { ok: false, reason: 'error', error: String(e), stage: 'collect' };
+    }
+
+    const title = typeof options.title === 'string' && options.title.trim()
+        ? options.title.trim()
+        : `Ticket #${ticketId}`;
+
+    const result = await openPullRequest({
+        token: githubToken,
+        login: githubLogin,
+        ticketId,
+        baseSha: collected.headOid,
+        files: collected.files,
+        title,
+        body: buildPullRequestBody({ ticketId, handle, event: contributionEvent }),
+        onProgress: (stage) => {
+            if (!event.sender.isDestroyed()) event.sender.send('github:pr:progress', { sitePath, stage });
+        }
+    });
+
+    // A revoked authorization is the one failure that changes what the app
+    // knows: keeping a token that GitHub has stopped honouring would leave the
+    // panel offering a button that cannot work.
+    if (!result.ok && result.reason === 'unauthorized') forgetGithubToken();
+    logEvent('github', result.ok ? `opened pull request #${result.number}` : `pull request failed at ${result.stage}: ${result.reason}`);
+    return result;
 });
 
 // --- Trunk update path (#94) --- git mechanics live in src/trunk-update.js;

--- a/src/main.js
+++ b/src/main.js
@@ -622,7 +622,11 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
     // knows: keeping a token that GitHub has stopped honouring would leave the
     // panel offering a button that cannot work.
     if (!result.ok && result.reason === 'unauthorized') forgetGithubToken();
-    logEvent('github', result.ok ? `opened pull request #${result.number}` : `pull request failed at ${result.stage}: ${result.reason}`);
+    // The error detail carries GitHub's own words plus the request id, so it is
+    // bounded the way every externally-influenced string in this log is.
+    logEvent('github', result.ok
+        ? `opened pull request #${result.number}`
+        : `pull request failed at ${result.stage}: ${result.reason} — ${describeRefused(result.error)}`);
     return result;
 });
 

--- a/src/pr-files.cjs
+++ b/src/pr-files.cjs
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * The working tree's changes, in the shape the GitHub tree API takes (#167).
+ *
+ * This is the second consumer of main.js's collectChangedFiles walk — the
+ * first renders a `.diff` — and the two renderings must not disagree about
+ * what changed. That parity is why the EOL handling here mirrors the patch
+ * builder's instead of trusting the bytes on disk:
+ *
+ * A Windows checkout sits on disk as CRLF (`ensureAutocrlf` sets
+ * core.autocrlf=true, and native-git checkouts arrive that way). Upstream's
+ * blobs are LF-only. Uploading raw workdir bytes would publish a pull request
+ * where every line of an edited file is rewritten — and worse, the non-UTF-8
+ * files that statusMatrix's autocrlf handling misses (wordpress-develop's
+ * encoding fixtures; see isCrlfOnlyChange in trunk-update.js) would appear as
+ * changed files the contributor never touched. So text content is normalised
+ * to LF before upload, and a file whose only difference is line endings is
+ * not a change at all. Binary content — anything with a NUL byte on either
+ * side — is carried byte-for-byte, which is the one thing the `.diff` cannot
+ * do.
+ *
+ * Kept out of main.js and behind injected dependencies (platform, stat, git)
+ * so both sides of the platform split below are exercised by `node --test`
+ * from one machine — the house pattern, per win-spawn-patch.test.cjs.
+ */
+
+const path = require('path');
+const { normalizeEolBuffer } = require('./git-update.cjs');
+
+// The two modes a file in this repo can have. Git records nothing else for a
+// blob except symlinks, which statusMatrix reports as ordinary files and
+// wordpress-develop does not use.
+const GIT_MODE_FILE = '100644';
+const GIT_MODE_EXECUTABLE = '100755';
+
+/**
+ * The same heuristic the patch builder uses: a NUL byte means binary. Null and
+ * missing buffers are not binary — they are absence.
+ *
+ * @param {Buffer|null} buf
+ * @return {boolean}
+ */
+function isProbablyBinary(buf) {
+	return Buffer.isBuffer(buf) && buf.includes(0);
+}
+
+/**
+ * The mode git recorded for one path in one commit, read by walking that
+ * path's trees rather than the whole commit: a full walk of wordpress-develop
+ * is tens of thousands of entries to answer a question about five files.
+ *
+ * @param {Object} deps     `{ git, fs, dir }`
+ * @param {string} oid
+ * @param {string} filepath
+ * @return {Promise<string|null>}
+ */
+async function modeInCommit(deps, oid, filepath) {
+	const { git, fs, dir } = deps;
+	const { commit } = await git.readCommit({ fs, dir, oid });
+	let treeOid = commit.tree;
+	const segments = filepath.split('/');
+	for (let i = 0; i < segments.length; i++) {
+		const { tree } = await git.readTree({ fs, dir, oid: treeOid });
+		const entry = tree.find((e) => e.path === segments[i]);
+		if (!entry) return null;
+		if (i === segments.length - 1) return entry.mode;
+		treeOid = entry.oid;
+	}
+	return null;
+}
+
+/**
+ * The executable bit, which git records and a tree entry has to carry.
+ *
+ * On POSIX the working tree is authoritative — it is what the contributor
+ * actually has. Windows has no executable bit at all, so a file that arrived
+ * as 100755 would be silently demoted to 100644 by anything that asked the
+ * filesystem; there, the mode git already recorded in HEAD is the truth. An
+ * added file on Windows has no recorded mode and no bit to read, so 100644 is
+ * the only answer available, and the right one for source.
+ *
+ * @param {Object} deps `{ git, fs, dir, headOid, platform, stat }`
+ * @param {Object} file One collectChangedFiles entry.
+ * @return {Promise<string>}
+ */
+async function fileModeForEntry(deps, file) {
+	const { dir, headOid, platform } = deps;
+	const stat = deps.stat || deps.fs.promises.stat;
+	if (platform !== 'win32' && file.inWorkdir) {
+		try {
+			const stats = await stat(path.join(dir, file.path));
+			// eslint-disable-next-line no-bitwise -- 0o111 is the executable bit for owner, group and other; masking is how a POSIX mode is read.
+			const executable = (stats.mode & 0o111) !== 0;
+			return executable ? GIT_MODE_EXECUTABLE : GIT_MODE_FILE;
+		} catch {
+			// Fall through to the recorded mode.
+		}
+	}
+	if (file.inHead && headOid) {
+		const recorded = await modeInCommit(deps, headOid, file.path).catch(() => null);
+		if (recorded) return recorded;
+	}
+	return GIT_MODE_FILE;
+}
+
+/**
+ * collectChangedFiles entries → tree API entries.
+ *
+ * Deletions are entries with null content — the tree API expresses them as a
+ * null sha, and it is why the pull request carries deletions the `.diff`
+ * still drops (#174). Files present but unreadable are skipped, since the
+ * alternatives are committing a deletion or an empty file under that path.
+ *
+ * @param {Array}  files
+ * @param {Object} deps  `{ git, fs, dir, headOid, platform, stat }`
+ * @return {Promise<Array<{path: string, kind: string, content: Buffer|null, mode: string}>>}
+ */
+async function buildPullRequestEntries(files, deps) {
+	const entries = [];
+	for (const file of files) {
+		const mode = await fileModeForEntry(deps, file);
+		if (!file.inWorkdir) {
+			entries.push({ path: file.path, kind: 'delete', content: null, mode });
+			continue;
+		}
+		if (!file.work) continue;
+
+		const binary = isProbablyBinary(file.base) || isProbablyBinary(file.work);
+		// Text goes up LF-normalised, exactly as the patch renders it; the
+		// comparison happens on the same normalised bytes so a CRLF-only
+		// difference is no difference. Binary is compared and carried raw.
+		const base = binary || !file.base ? file.base : normalizeEolBuffer(file.base);
+		const work = binary ? file.work : normalizeEolBuffer(file.work);
+		if (base && base.equals(work)) continue;
+
+		entries.push({
+			path: file.path,
+			kind: file.inHead ? 'modify' : 'add',
+			content: work,
+			mode
+		});
+	}
+	return entries;
+}
+
+module.exports = {
+	GIT_MODE_FILE,
+	GIT_MODE_EXECUTABLE,
+	isProbablyBinary,
+	modeInCommit,
+	fileModeForEntry,
+	buildPullRequestEntries
+};

--- a/src/preload.js
+++ b/src/preload.js
@@ -98,6 +98,60 @@ contextBridge.exposeInMainWorld('api', {
 	// diff, which is what gets attached to a ticket.
 	savePatch: (sitePath, options) => ipcRenderer.invoke('git:save-patch', sitePath, options)
 ,
+	// Opening a pull request (#167). The token stays in the main process; what
+	// crosses this bridge is a login, a device code and a pull request URL —
+	// nothing that authorises anything.
+	getGithubAccount: () => ipcRenderer.invoke('github:account')
+,
+	// Resolves as soon as there is a code to show; the outcome of the wait
+	// arrives at `onDone`, since the contributor is in the browser by then.
+	//
+	// Exactly one done-listener exists at a time, tracked in the closure below:
+	// a cancelled sign-in gets no outcome event at all — the main process
+	// deliberately goes quiet — so the listener cannot clean itself up the way
+	// the install and script handlers above do, and each sign-in→cancel cycle
+	// would otherwise leave one behind for the life of the window.
+	...(() => {
+		let activeDoneHandler = null;
+		const dropDoneHandler = () => {
+			if (!activeDoneHandler) return;
+			ipcRenderer.removeListener('github:sign-in:done', activeDoneHandler);
+			activeDoneHandler = null;
+		};
+		return {
+			signInToGithub: async (onDone) => {
+				// A second sign-in supersedes the first in the main process, so
+				// the first's outcome is never coming either.
+				dropDoneHandler();
+				const doneHandler = (_e, payload) => {
+					if (activeDoneHandler === doneHandler) activeDoneHandler = null;
+					ipcRenderer.removeListener('github:sign-in:done', doneHandler);
+					if (onDone) onDone(payload);
+				};
+				activeDoneHandler = doneHandler;
+				ipcRenderer.on('github:sign-in:done', doneHandler);
+				const started = await ipcRenderer.invoke('github:sign-in');
+				// A sign-in that never started has no outcome coming.
+				if (!started || !started.ok) dropDoneHandler();
+				return started;
+			},
+			cancelGithubSignIn: () => {
+				dropDoneHandler();
+				return ipcRenderer.invoke('github:sign-in-cancel');
+			}
+		};
+	})()
+,
+	signOutOfGithub: () => ipcRenderer.invoke('github:sign-out')
+,
+	openPullRequest: (sitePath, options) => ipcRenderer.invoke('github:open-pr', sitePath, options)
+,
+	subscribePullRequestProgress: (handler) => {
+		const h = (_e, payload) => handler && handler(payload);
+		ipcRenderer.on('github:pr:progress', h);
+		return () => ipcRenderer.removeListener('github:pr:progress', h);
+	}
+,
 	isWorktreeDirty: (sitePath) => ipcRenderer.invoke('git:worktree-dirty', sitePath)
 ,
 	discardChanges: (sitePath) => ipcRenderer.invoke('git:discard-changes', sitePath)

--- a/src/renderer/github-account.cjs
+++ b/src/renderer/github-account.cjs
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * What the panel knows about the GitHub account it is acting for (#167).
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM (same convention as update-plan.cjs and trac-ticket.cjs).
+ */
+
+/**
+ * The account the panel should hold after signing in, signing out, or having an
+ * authorization revoked under it.
+ *
+ * Every one of those replaces the account wholesale, and the test mode used to
+ * go with it (#197): it is reported alongside the login but it does not belong
+ * to it — it comes from an env switch the main process reads once, so it is
+ * true for the whole run whoever is signed in. Losing it meant the card stopped
+ * saying "dry run" at exactly the point the button could push something, and
+ * the button went back to promising a pull request it would not open.
+ *
+ * An explicit `testMode` on the incoming account still wins; only an absent one
+ * is filled in from what was already known.
+ *
+ * @param {Object} [previous] The account the panel holds now.
+ * @param {Object} next       The account it is moving to.
+ * @return {Object}
+ */
+function carryTestMode(previous, next) {
+	const account = { ...next };
+	if (account.testMode === undefined && previous && previous.testMode !== undefined) {
+		account.testMode = previous.testMode;
+	}
+	return account;
+}
+
+module.exports = { carryTestMode };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2489,13 +2489,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 label="Title"
                 help="The ticket link and your WordPress.org username go in the description."
               />
+              {/*
+                The button says what it will actually do. A dry run's button
+                reading "Open pull request" is the label lying about the mode,
+                which is the failure this whole indicator exists to prevent.
+              */}
               <Button
                 variant="primary"
                 onClick={openPullRequest}
                 isBusy={Boolean(prStage)}
                 disabled={Boolean(prStage)}
                 style={{ justifyContent:'center' }}
-              >Open pull request</Button>
+              >{githubAccount?.testMode?.dryRun ? 'Push branch (dry run)' : 'Open pull request'}</Button>
             </>
           ) : (
             <div style={{ fontSize:12, color:'#6c6f72' }}>
@@ -3624,6 +3629,24 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     cost="A GitHub account. The fork is made for you; no password is typed into this app and no credential is written to disk."
                     after="Automated checks run on it. Post the link back on the ticket — a pull request does not replace one."
                   >
+                    {/*
+                      Absent from every shipped build. When a test switch is
+                      set it sits above the button, because that is where the
+                      decision is made — a mode set in a terminal minutes
+                      earlier, in an app that otherwise looks identical, is how
+                      a dry run that silently was not one opened a real pull
+                      request during testing.
+                    */}
+                    {githubAccount?.testMode ? (
+                      <div style={{ display:'flex', alignItems:'center', gap:8, padding:'8px 10px', background:'#f0f0f1', border:'1px dashed #949494', borderRadius:6, fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+                        <span style={{ fontWeight:600, letterSpacing:0.5, textTransform:'uppercase', fontSize:10, color:'#1d2327' }}>Test mode</span>
+                        <span>
+                          {githubAccount.testMode.dryRun
+                            ? 'Dry run — a branch is pushed to your fork, no pull request is opened.'
+                            : <>Pull requests go to <code style={{ fontSize:11 }}>{githubAccount.testMode.target}</code>, not to wordpress-develop.</>}
+                        </span>
+                      </div>
+                    ) : null}
                     {renderPullRequestBody()}
                     {githubError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{githubError}</div> : null}
                     {prError ? (

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2397,14 +2397,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             {' '}from <code style={{ fontSize:12 }}>{prResult.branch}</code>.
           </div>
           {/*
-            A fork that had diverged could not be fast-forwarded, so the branch
-            sits on the fork's own trunk and the pull request may show upstream
-            changes alongside the contributor's. Saying so beats letting them
-            discover it in the Files tab.
+            The branch always bases on today's trunk (see resolveBase); this
+            names the consequence when the local checkout was behind it. The
+            clash guard has already ruled out upstream changes to the same
+            files, so this is information, not alarm.
           */}
           {prResult.exactBase === false ? (
             <div style={{ fontSize:12, color:'#6e5406', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, padding:'8px 10px' }}>
-              Your fork had drifted from trunk, so this branch is based on your fork&apos;s copy. The pull request may show changes you did not make.
+              Your checkout was behind trunk, so the branch was based on today&apos;s trunk. None of your files were changed upstream in between — the pull request shows only your work.
             </div>
           ) : null}
           <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
@@ -2487,7 +2487,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             <div style={{ fontSize:12, color:'#6c6f72' }}>{PR_STAGE_LABELS[prStage] || 'Working…'}</div>
           ) : (
             <div style={{ fontSize:12, color:'#6c6f72' }}>
-              Signed in as {githubAccount.login}. <Button variant="link" onClick={signOutOfGithub} style={{ fontSize:12 }}>Sign out</Button>
+              {/*
+                The destination is named, not implied: "the fork is made for
+                you" answers what, this answers where — which account the fork
+                and the branch land in.
+              */}
+              Signed in as {githubAccount.login} — the fork and branch go to{' '}
+              <Button
+                variant="link"
+                onClick={()=>window.api.openExternal(`https://github.com/${githubAccount.login}/wordpress-develop`)}
+                style={{ fontSize:12 }}
+              >{githubAccount.login}/wordpress-develop</Button>.{' '}
+              <Button variant="link" onClick={signOutOfGithub} style={{ fontSize:12 }}>Sign out</Button>
             </div>
           )}
         </>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -26,6 +26,24 @@ import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { highlightDiff } from './diff-highlight.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
+// What the app is doing while a pull request is being opened (#167). Each step
+// is named because they take visibly different amounts of time — forking is the
+// slow one, and an unlabelled spinner there reads as a hang.
+const PR_STAGE_LABELS = {
+  forking: 'Creating your fork of wordpress-develop…',
+  syncing: 'Bringing your fork up to date…',
+  committing: 'Uploading your changes…',
+  opening: 'Opening the pull request…'
+};
+// Why it failed, in a sentence that says what to do about it. Every one of
+// these still leaves the patch file, which is what the card offers underneath.
+const PR_FAILURE_MESSAGES = {
+  unauthorized: 'That GitHub sign-in is no longer valid. Sign in again, or save the patch file instead.',
+  'rate-limited': 'GitHub is rate-limiting this connection. It usually clears within the hour.',
+  offline: 'No connection to GitHub.',
+  'no-ticket': 'Link a Trac ticket to this site first — a pull request has to cite one.',
+  empty: 'There are no changes to open a pull request with.'
+};
 // Per-status wording for the update chain card (#94), following the issue's
 // mockups: the skipped install step is named, never hidden, and the build
 // step points at the Terminal instead of opening a second log surface.
@@ -964,6 +982,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [handleError, setHandleError] = useState('');
   const [handleSaving, setHandleSaving] = useState(false);
   const [editingHandle, setEditingHandle] = useState(false);
+  // Opening a pull request (#167). `githubAccount` is null until the panel has
+  // asked; `{ login: null }` is a real answer meaning signed out, and the two
+  // must not render the same way — offering "Sign in" before the app knows
+  // whether it already is signed in makes the panel flicker on every open.
+  const [githubAccount, setGithubAccount] = useState(null);
+  const [githubDeviceCode, setGithubDeviceCode] = useState(null);
+  const [githubError, setGithubError] = useState('');
+  const [githubDeclined, setGithubDeclined] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
+  const [prTitle, setPrTitle] = useState('');
+  const [prStage, setPrStage] = useState('');
+  const [prResult, setPrResult] = useState(null);
+  const [prError, setPrError] = useState(null);
+  const [prLinkCopied, setPrLinkCopied] = useState(false);
   const [emails, setEmails] = useState([]);
   const [smtpPort, setSmtpPort] = useState(0);
   const newEmailUnsubRef = useRef(null);
@@ -2184,6 +2216,15 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setPatchSaveError('');
     setHandleError('');
     setEditingHandle(false);
+    // Same rule for the pull request card: last time's outcome belongs to last
+    // time's patch. The account is not reset — that survives the modal — but it
+    // is re-read, since it can have been signed out from another site's panel.
+    setPrResult(null);
+    setPrError(null);
+    setPrStage('');
+    setGithubError('');
+    setGithubDeclined(false);
+    loadGithubAccount();
     try {
       const res = await window.api.getPatch(sitePath);
       if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
@@ -2244,6 +2285,252 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const saveForHandoff = async () => {
     if (!wporg?.handle) return;
     await savePatchFile({ handoff: true });
+  };
+
+  // --- The pull request destination (#167) ---
+
+  const loadGithubAccount = async () => {
+    try {
+      const res = await window.api.getGithubAccount();
+      setGithubAccount(res && res.ok ? res : { login: null, configured: false });
+    } catch {
+      setGithubAccount({ login: null, configured: false });
+    }
+  };
+
+  // Sign-in is two-legged on purpose: this resolves as soon as there is a code
+  // to show, because the contributor's next move is in a browser, and the
+  // outcome of the wait arrives later on the callback.
+  const startGithubSignIn = async () => {
+    setGithubError('');
+    setCodeCopied(false);
+    let started;
+    try {
+      started = await window.api.signInToGithub((done) => {
+        setGithubDeviceCode(null);
+        if (done && done.ok) {
+          setGithubAccount({ login: done.login, configured: true });
+          setGithubError('');
+          return;
+        }
+        // Declining is a choice, not a fault, so it reads as one.
+        setGithubError(done && done.reason === 'denied'
+          ? 'The authorization was declined on GitHub. Nothing was changed.'
+          : (done && done.error) || 'Sign-in did not complete.');
+      });
+    } catch (e) {
+      setGithubError(e && e.message ? e.message : String(e));
+      return;
+    }
+    if (!started || !started.ok) {
+      setGithubError((started && started.error) || 'Could not start sign-in.');
+      return;
+    }
+    setGithubDeviceCode({ userCode: started.userCode, verificationUri: started.verificationUri });
+    // Opening the page here rather than making it a second button: the code on
+    // screen is only useful on that page, and a contributor who has just been
+    // told what will happen should not have to go looking for where.
+    window.api.openExternal(started.verificationUri);
+  };
+
+  const cancelGithubSignIn = async () => {
+    setGithubDeviceCode(null);
+    setGithubError('');
+    try { await window.api.cancelGithubSignIn(); } catch {}
+  };
+
+  const signOutOfGithub = async () => {
+    try { await window.api.signOutOfGithub(); } catch {}
+    setGithubAccount({ login: null, configured: githubAccount?.configured !== false });
+    setPrResult(null);
+    setPrError(null);
+  };
+
+  const openPullRequest = async () => {
+    setPrError(null);
+    setPrResult(null);
+    setPrStage('forking');
+    // Subscribed only for the duration of the attempt: the event carries a site
+    // path because one main process serves every open site, and a stale
+    // listener would move another site's spinner.
+    const unsubscribe = window.api.subscribePullRequestProgress((payload) => {
+      if (payload && payload.sitePath === sitePath) setPrStage(payload.stage);
+    });
+    try {
+      const res = await window.api.openPullRequest(sitePath, { title: prTitle });
+      if (res && res.ok) {
+        setPrResult(res);
+      } else {
+        setPrError(res || { reason: 'error', error: 'The pull request could not be opened.' });
+        // A revoked authorization is forgotten in the main process, so the card
+        // has to stop claiming an account it no longer has.
+        if (res && res.reason === 'unauthorized') setGithubAccount({ login: null, configured: true });
+      }
+    } catch (e) {
+      setPrError({ reason: 'error', error: e && e.message ? e.message : String(e) });
+    } finally {
+      setPrStage('');
+      unsubscribe();
+    }
+  };
+
+  const copyPrLink = async () => {
+    if (!prResult?.url) return;
+    try {
+      await navigator.clipboard.writeText(prResult.url);
+      setPrLinkCopied(true);
+      setTimeout(() => setPrLinkCopied(false), 2000);
+    } catch {}
+  };
+
+  // The pull request card has six states and they are genuinely sequential —
+  // done, still asking, waiting on the browser, ready, declined, not started.
+  // Written as nested ternaries in the JSX that is one expression six levels
+  // deep and unreadable at the point where the wording matters most, so the
+  // states get early returns and the card body gets one call.
+  const renderPullRequestBody = () => {
+    if (prResult) {
+      return (
+        <>
+          <div style={{ fontSize:13, color:'#0f5132' }}>
+            Opened <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}>pull request #{prResult.number}</Button>
+            {' '}from <code style={{ fontSize:12 }}>{prResult.branch}</code>.
+          </div>
+          {/*
+            A fork that had diverged could not be fast-forwarded, so the branch
+            sits on the fork's own trunk and the pull request may show upstream
+            changes alongside the contributor's. Saying so beats letting them
+            discover it in the Files tab.
+          */}
+          {prResult.exactBase === false ? (
+            <div style={{ fontSize:12, color:'#6e5406', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, padding:'8px 10px' }}>
+              Your fork had drifted from trunk, so this branch is based on your fork&apos;s copy. The pull request may show changes you did not make.
+            </div>
+          ) : null}
+          <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+            Triage and props live on the ticket, so the link belongs there too.
+          </div>
+          <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
+            {prLinkCopied ? 'Link copied' : 'Copy the link'}
+          </Button>
+          {tracTicket ? (
+            <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
+              Open #{tracTicket} to comment
+            </Button>
+          ) : null}
+        </>
+      );
+    }
+
+    // Not yet asked, which is not the same as signed out: offering "Sign in"
+    // before the answer arrives makes the card flicker on every open.
+    if (githubAccount === null) {
+      return <div style={{ fontSize:12, color:'#6c6f72' }}>Checking…</div>;
+    }
+
+    if (githubAccount.configured === false) {
+      return (
+        <div style={{ fontSize:12, color:'#6c6f72' }}>
+          This build has no GitHub application configured, so it cannot open a pull request. The other destinations still work.
+        </div>
+      );
+    }
+
+    if (githubDeviceCode) {
+      return (
+        <>
+          <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+            Enter this code at <strong>github.com/login/device</strong>, which has been opened in your browser.
+          </div>
+          <div style={{ fontFamily:'Menlo, Consolas, monospace', fontSize:24, letterSpacing:2, fontWeight:600, textAlign:'center', padding:'10px 0', color:'#1d2327' }}>
+            {githubDeviceCode.userCode}
+          </div>
+          <Button variant="secondary" onClick={copyDeviceCode} icon={codeCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
+            {codeCopied ? 'Code copied' : 'Copy the code'}
+          </Button>
+          <Flex justify="center" gap={2}>
+            <Spinner />
+            <div style={{ fontSize:12, color:'#6c6f72' }}>Waiting for you to finish in the browser…</div>
+          </Flex>
+          <Button variant="link" onClick={cancelGithubSignIn} style={{ fontSize:12 }}>Cancel</Button>
+        </>
+      );
+    }
+
+    if (githubAccount.login) {
+      return (
+        <>
+          {tracTicket ? (
+            <>
+              <TextControl
+                value={prTitle}
+                onChange={setPrTitle}
+                disabled={Boolean(prStage)}
+                placeholder={`Ticket #${tracTicket}`}
+                label="Title"
+                help="The ticket link and your WordPress.org username go in the description."
+              />
+              <Button
+                variant="primary"
+                onClick={openPullRequest}
+                isBusy={Boolean(prStage)}
+                disabled={Boolean(prStage)}
+                style={{ justifyContent:'center' }}
+              >Open pull request</Button>
+            </>
+          ) : (
+            <div style={{ fontSize:12, color:'#6c6f72' }}>
+              No ticket is linked to this site. A pull request has to cite one — link it in the Trac card.
+            </div>
+          )}
+          {prStage ? (
+            <div style={{ fontSize:12, color:'#6c6f72' }}>{PR_STAGE_LABELS[prStage] || 'Working…'}</div>
+          ) : (
+            <div style={{ fontSize:12, color:'#6c6f72' }}>
+              Signed in as {githubAccount.login}. <Button variant="link" onClick={signOutOfGithub} style={{ fontSize:12 }}>Sign out</Button>
+            </div>
+          )}
+        </>
+      );
+    }
+
+    if (githubDeclined) {
+      return (
+        <>
+          <div style={{ fontSize:12, color:'#6c6f72' }}>
+            Nothing was signed in and nothing was sent. The patch file is still yours to save, and the other two destinations are unchanged.
+          </div>
+          <Button variant="link" onClick={()=>setGithubDeclined(false)} style={{ fontSize:12 }}>Show this again</Button>
+        </>
+      );
+    }
+
+    return (
+      <>
+        {/*
+          The whole ask, before any of it happens — including the part the app
+          cannot do for you. Declining has to be as visible as accepting, or the
+          cliff is sprung rather than named.
+        */}
+        <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.6 }}>
+          Signing in lets the app fork wordpress-develop to your account, push this patch to a branch there, and open the pull request. It signs you in through your browser, never asks for your password, and forgets the authorization when you quit.
+        </div>
+        <div style={{ fontSize:12, color:'#6c6f72', lineHeight:1.6 }}>
+          It cannot create the GitHub account for you, and it cannot post to Trac on your behalf.
+        </div>
+        <Button variant="primary" onClick={startGithubSignIn} style={{ justifyContent:'center' }}>Sign in with GitHub</Button>
+        <Button variant="link" onClick={()=>{ setGithubDeclined(true); setGithubError(''); }} style={{ fontSize:12 }}>Not now</Button>
+      </>
+    );
+  };
+
+  const copyDeviceCode = async () => {
+    if (!githubDeviceCode?.userCode) return;
+    try {
+      await navigator.clipboard.writeText(githubDeviceCode.userCode);
+      setCodeCopied(true);
+      setTimeout(() => setCodeCopied(false), 2000);
+    } catch {}
   };
 
   // Both fields are written in one go, because they are asked in one form. The
@@ -3294,6 +3581,34 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         {handleError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{handleError}</div> : null}
                       </>
                     )}
+                  </DestinationCard>
+
+                  {/*
+                    The destination that actually gets automated checks and the
+                    one reviewers watch — and the one with the signup cliff
+                    (#167). The cliff is named here, before anything happens,
+                    rather than sprung after the contributor has left the venue.
+                  */}
+                  <DestinationCard
+                    title="Open a pull request"
+                    cost="A GitHub account. The fork is made for you; no password is typed into this app and no credential is written to disk."
+                    after="Automated checks run on it. Post the link back on the ticket — a pull request does not replace one."
+                  >
+                    {renderPullRequestBody()}
+                    {githubError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{githubError}</div> : null}
+                    {prError ? (
+                      <>
+                        <div role="alert" style={{ color:'#d63638', fontSize:12 }}>
+                          {PR_FAILURE_MESSAGES[prError.reason] || prError.error}
+                        </div>
+                        {/*
+                          Every failure lands here, and every failure has the
+                          same floor: the file exists regardless of what GitHub
+                          did.
+                        */}
+                        <Button variant="secondary" onClick={savePatch} style={{ justifyContent:'center' }}>Save the patch file instead</Button>
+                      </>
+                    ) : null}
                   </DestinationCard>
                 </div>
               </div>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -24,6 +24,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { highlightDiff } from './diff-highlight.cjs';
+import { carryTestMode } from './github-account.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // What the app is doing while a pull request is being opened (#167). Each step
@@ -2309,7 +2310,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       started = await window.api.signInToGithub((done) => {
         setGithubDeviceCode(null);
         if (done && done.ok) {
-          setGithubAccount({ login: done.login, configured: true });
+          setGithubAccount((prev) => carryTestMode(prev, { login: done.login, configured: true }));
           setGithubError('');
           return;
         }
@@ -2341,7 +2342,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   const signOutOfGithub = async () => {
     try { await window.api.signOutOfGithub(); } catch {}
-    setGithubAccount({ login: null, configured: githubAccount?.configured !== false });
+    setGithubAccount((prev) => carryTestMode(prev, { login: null, configured: prev?.configured !== false }));
     setPrResult(null);
     setPrError(null);
   };
@@ -2364,7 +2365,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         setPrError(res || { reason: 'error', error: 'The pull request could not be opened.' });
         // A revoked authorization is forgotten in the main process, so the card
         // has to stop claiming an account it no longer has.
-        if (res && res.reason === 'unauthorized') setGithubAccount({ login: null, configured: true });
+        if (res && res.reason === 'unauthorized') setGithubAccount((prev) => carryTestMode(prev, { login: null, configured: true }));
       }
     } catch (e) {
       setPrError({ reason: 'error', error: e && e.message ? e.message : String(e) });

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2392,10 +2392,21 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     if (prResult) {
       return (
         <>
+          {/*
+            A dry run (WP_DEV_ENV_GITHUB_DRY_RUN) stops after the branch: the
+            fork writes are private, the pull request is the step watchers
+            hear about. Saying so beats a "pull request #null".
+          */}
+          {prResult.dryRun ? (
+            <div style={{ fontSize:13, color:'#0f5132' }}>
+              Dry run — branch <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}><code style={{ fontSize:12 }}>{prResult.branch}</code></Button> was created on your fork; no pull request was opened.
+            </div>
+          ) : (
           <div style={{ fontSize:13, color:'#0f5132' }}>
             Opened <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}>pull request #{prResult.number}</Button>
             {' '}from <code style={{ fontSize:12 }}>{prResult.branch}</code>.
           </div>
+          )}
           {/*
             The branch always bases on today's trunk (see resolveBase); this
             names the consequence when the local checkout was behind it. The
@@ -2407,17 +2418,25 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               Your checkout was behind trunk, so the branch was based on today&apos;s trunk. None of your files were changed upstream in between — the pull request shows only your work.
             </div>
           ) : null}
-          <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
-            Triage and props live on the ticket, so the link belongs there too.
-          </div>
-          <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
-            {prLinkCopied ? 'Link copied' : 'Copy the link'}
-          </Button>
-          {tracTicket ? (
-            <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
-              Open #{tracTicket} to comment
-            </Button>
-          ) : null}
+          {/*
+            The Trac loop-back is for a pull request that exists — a dry run
+            has no link worth posting on a ticket.
+          */}
+          {!prResult.dryRun && (
+            <>
+              <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+                Triage and props live on the ticket, so the link belongs there too.
+              </div>
+              <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
+                {prLinkCopied ? 'Link copied' : 'Copy the link'}
+              </Button>
+              {tracTicket ? (
+                <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
+                  Open #{tracTicket} to comment
+                </Button>
+              ) : null}
+            </>
+          )}
         </>
       );
     }

--- a/test/github-account.test.cjs
+++ b/test/github-account.test.cjs
@@ -1,0 +1,37 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { carryTestMode } = require('../src/renderer/github-account.cjs');
+
+// The bug (#197): signing in replaced the account wholesale, so the dry-run
+// banner vanished and the button went back to reading "Open pull request" at
+// the one point it could actually push something.
+test('carryTestMode: signing in keeps the test mode the build is running in (issue #197)', () => {
+	const before = { login: null, configured: true, testMode: { dryRun: true } };
+	const after = carryTestMode(before, { login: 'juanmaguitar', configured: true });
+	assert.deepStrictEqual(after.testMode, { dryRun: true });
+	assert.strictEqual(after.login, 'juanmaguitar');
+});
+
+test('carryTestMode: signing out and losing an authorization keep it too (issue #197)', () => {
+	const signedIn = { login: 'juanmaguitar', configured: true, testMode: { target: 'juanmaguitar/sandbox' } };
+	assert.deepStrictEqual(
+		carryTestMode(signedIn, { login: null, configured: true }).testMode,
+		{ target: 'juanmaguitar/sandbox' }
+	);
+});
+
+test('carryTestMode: a shipped build is never given a mode it does not have (issue #197)', () => {
+	const after = carryTestMode({ login: null, configured: true }, { login: 'juanmaguitar', configured: true });
+	assert.strictEqual('testMode' in after, false);
+	assert.strictEqual(carryTestMode(undefined, { login: null }).testMode, undefined);
+});
+
+test('carryTestMode: what the main process reports wins over what was remembered (issue #197)', () => {
+	const after = carryTestMode(
+		{ testMode: { dryRun: true } },
+		{ login: 'juanmaguitar', configured: true, testMode: null }
+	);
+	assert.strictEqual(after.testMode, null);
+});

--- a/test/github-auth.test.cjs
+++ b/test/github-auth.test.cjs
@@ -1,0 +1,196 @@
+'use strict';
+
+// The device flow (#167), every state of it.
+//
+// The polling loop is where this feature is most likely to be quietly wrong:
+// four of GitHub's five documented answers are indistinguishable from each
+// other at a glance, they arrive minutes apart in real use, and getting one of
+// them wrong shows up as an app that hangs on a code the contributor has
+// already entered. So each one is driven here, without a network and without a
+// real wait — `post` and `sleep` are injected for exactly that.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { requestDeviceCode, pollForToken, fetchViewer, getClientId } = require('../src/github-auth.cjs');
+
+const CLIENT_ID = 'Ov23liTEST';
+
+// Answers the given responses in order, recording what it was asked. A queue
+// rather than a function of the request, because what matters in a poll is the
+// sequence: pending, pending, then granted.
+function replies(...queued) {
+	const calls = [];
+	const fn = async (url, payload) => {
+		calls.push({ url, payload });
+		const next = queued.length > 1 ? queued.shift() : queued[0];
+		if (next instanceof Error) throw next;
+		return { status: next.status || 200, headers: {}, body: '', json: next.json === undefined ? next : next.json };
+	};
+	fn.calls = calls;
+	return fn;
+}
+
+// Records the waits instead of taking them, so `slow_down` is observable.
+function fakeSleep() {
+	const waited = [];
+	const fn = async (ms) => { waited.push(ms); };
+	fn.waited = waited;
+	return fn;
+}
+
+test('getClientId prefers the environment, so a second application needs no rebuild', () => {
+	const original = process.env.WP_DEV_ENV_GITHUB_CLIENT_ID;
+	try {
+		process.env.WP_DEV_ENV_GITHUB_CLIENT_ID = 'Ov23liFROMENV';
+		assert.strictEqual(getClientId(), 'Ov23liFROMENV');
+		process.env.WP_DEV_ENV_GITHUB_CLIENT_ID = '   ';
+		// Blank is not a configuration, and treating it as one would ship a
+		// request with an empty client_id and a 404 nobody could explain.
+		assert.notStrictEqual(getClientId(), '   ');
+	} finally {
+		if (original === undefined) delete process.env.WP_DEV_ENV_GITHUB_CLIENT_ID;
+		else process.env.WP_DEV_ENV_GITHUB_CLIENT_ID = original;
+	}
+});
+
+test('requestDeviceCode returns the code, the page, and an absolute expiry', async () => {
+	const post = replies({
+		device_code: 'dev-code',
+		user_code: 'WDJB-MJHT',
+		verification_uri: 'https://github.com/login/device',
+		expires_in: 900,
+		interval: 5
+	});
+
+	const res = await requestDeviceCode({ post, clientId: CLIENT_ID, now: () => 1000 });
+
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.userCode, 'WDJB-MJHT');
+	assert.strictEqual(res.deviceCode, 'dev-code');
+	assert.strictEqual(res.interval, 5);
+	// GitHub sends a duration; every later comparison wants an instant.
+	assert.strictEqual(res.expiresAt, 1000 + 900 * 1000);
+	assert.strictEqual(post.calls[0].payload.client_id, CLIENT_ID);
+	assert.strictEqual(post.calls[0].payload.scope, 'public_repo');
+});
+
+// The build shipping without a client ID and the application not having device
+// flow enabled are the same symptom — nothing works — and neither is a network
+// failure. Both are named so the panel can say which.
+test('requestDeviceCode names an unconfigured build and an unconfigured application', async () => {
+	const noId = await requestDeviceCode({ post: replies({}), clientId: '' });
+	assert.strictEqual(noId.ok, false);
+	assert.strictEqual(noId.reason, 'not-configured');
+
+	const notEnabled = await requestDeviceCode({ post: replies({ status: 404, json: {} }), clientId: CLIENT_ID });
+	assert.strictEqual(notEnabled.ok, false);
+	assert.strictEqual(notEnabled.reason, 'not-configured');
+	assert.match(notEnabled.error, /device flow/);
+});
+
+test('requestDeviceCode reports a transport failure as offline, not as a refusal', async () => {
+	const res = await requestDeviceCode({ post: replies(new Error('ENOTFOUND')), clientId: CLIENT_ID });
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.reason, 'offline');
+});
+
+test('pollForToken waits through authorization_pending and returns the token', async () => {
+	const post = replies(
+		{ error: 'authorization_pending' },
+		{ error: 'authorization_pending' },
+		{ access_token: 'gho_test' }
+	);
+	const sleep = fakeSleep();
+
+	const res = await pollForToken(
+		{ deviceCode: 'dev-code', interval: 5, expiresAt: 10_000 },
+		{ post, sleep, now: () => 0, clientId: CLIENT_ID }
+	);
+
+	assert.deepStrictEqual(res, { ok: true, token: 'gho_test' });
+	assert.deepStrictEqual(sleep.waited, [5000, 5000, 5000]);
+	assert.strictEqual(post.calls[0].payload.grant_type, 'urn:ietf:params:oauth:grant-type:device_code');
+	assert.strictEqual(post.calls[0].payload.device_code, 'dev-code');
+});
+
+// Polling faster than GitHub asks gets the device code rejected outright, so
+// the bump is not politeness — ignoring it breaks the sign-in it is trying to
+// complete.
+test('pollForToken slows down when told to, taking GitHub’s own interval when it sends one', async () => {
+	const withInterval = fakeSleep();
+	await pollForToken(
+		{ deviceCode: 'd', interval: 5, expiresAt: 10_000 },
+		{ post: replies({ error: 'slow_down', interval: 12 }, { access_token: 't' }), sleep: withInterval, now: () => 0 }
+	);
+	assert.deepStrictEqual(withInterval.waited, [5000, 12_000]);
+
+	const withoutInterval = fakeSleep();
+	await pollForToken(
+		{ deviceCode: 'd', interval: 5, expiresAt: 10_000 },
+		{ post: replies({ error: 'slow_down' }, { access_token: 't' }), sleep: withoutInterval, now: () => 0 }
+	);
+	assert.deepStrictEqual(withoutInterval.waited, [5000, 10_000]);
+});
+
+test('pollForToken tells declining, expiry and an unknown failure apart', async () => {
+	const cases = [
+		[{ error: 'access_denied' }, 'denied'],
+		[{ error: 'expired_token' }, 'expired'],
+		[{ error: 'incorrect_device_code', error_description: 'nope' }, 'error']
+	];
+	for (const [answer, reason] of cases) {
+		const res = await pollForToken(
+			{ deviceCode: 'd', interval: 1, expiresAt: 10_000 },
+			{ post: replies(answer), sleep: fakeSleep(), now: () => 0 }
+		);
+		assert.strictEqual(res.ok, false);
+		assert.strictEqual(res.reason, reason, JSON.stringify(answer));
+	}
+});
+
+// A code that runs out while the contributor is still looking for the browser
+// window is the ordinary case, not an edge one, and it has to end the loop:
+// GitHub keeps answering, so nothing else would.
+test('pollForToken stops when the code has expired, without polling again', async () => {
+	const post = replies({ error: 'authorization_pending' });
+	let clock = 0;
+
+	const res = await pollForToken(
+		{ deviceCode: 'd', interval: 5, expiresAt: 4000 },
+		{ post, sleep: async () => { clock += 5000; }, now: () => clock }
+	);
+
+	assert.strictEqual(res.reason, 'expired');
+	assert.strictEqual(post.calls.length, 0, 'the expiry was checked after the wait, before spending a request');
+});
+
+test('pollForToken gives up as soon as the sign-in is canceled', async () => {
+	const post = replies({ error: 'authorization_pending' });
+	let canceled = false;
+
+	const res = await pollForToken(
+		{ deviceCode: 'd', interval: 5, expiresAt: 10_000 },
+		{ post, sleep: async () => { canceled = true; }, now: () => 0, isCanceled: () => canceled }
+	);
+
+	assert.strictEqual(res.reason, 'canceled');
+	assert.strictEqual(post.calls.length, 0);
+});
+
+// Losing the network mid-poll is not a decision the contributor made, and the
+// authorization on GitHub's side is still perfectly valid.
+test('pollForToken reports a dropped connection as offline', async () => {
+	const res = await pollForToken(
+		{ deviceCode: 'd', interval: 1, expiresAt: 10_000 },
+		{ post: replies(new Error('ECONNRESET')), sleep: fakeSleep(), now: () => 0 }
+	);
+	assert.strictEqual(res.reason, 'offline');
+});
+
+test('fetchViewer returns the login, and calls a rejected token unauthorized', async () => {
+	const ok = await fetchViewer('gho_test', { get: async () => ({ status: 200, json: { login: 'janedoe' } }) });
+	assert.deepStrictEqual(ok, { ok: true, login: 'janedoe' });
+
+	const revoked = await fetchViewer('gho_test', { get: async () => ({ status: 401, json: {} }) });
+	assert.strictEqual(revoked.reason, 'unauthorized');
+});

--- a/test/github-auth.test.cjs
+++ b/test/github-auth.test.cjs
@@ -194,3 +194,31 @@ test('fetchViewer returns the login, and calls a rejected token unauthorized', a
 	const revoked = await fetchViewer('gho_test', { get: async () => ({ status: 401, json: {} }) });
 	assert.strictEqual(revoked.reason, 'unauthorized');
 });
+
+// The bug found by hand: a device-flow sign-in against an app the account
+// authorized before can reuse the old grant with the old scopes. The token
+// then signs in fine, uploads blobs and the commit fine — the Git object
+// endpoints accept it — and 404s on the branch, the very last write. What
+// GitHub actually granted is in the X-OAuth-Scopes header, so a token that
+// cannot push is named at sign-in, with the remedy, instead of at the end.
+test('fetchViewer refuses a token whose granted scopes cannot push', async () => {
+	const viewer = (scopes) => fetchViewer('gho_test', {
+		get: async () => ({
+			status: 200,
+			headers: scopes === undefined ? {} : { 'x-oauth-scopes': scopes },
+			json: { login: 'janedoe' }
+		})
+	});
+
+	// A reused grant with no scopes, and one with only unrelated scopes.
+	assert.strictEqual((await viewer('')).reason, 'insufficient-scope');
+	assert.strictEqual((await viewer('gist, read:org')).reason, 'insufficient-scope');
+	assert.match((await viewer('')).error, /sign in here again/i);
+
+	// Either granted scope that can push passes; `repo` contains `public_repo`.
+	assert.strictEqual((await viewer('public_repo')).ok, true);
+	assert.strictEqual((await viewer('repo, gist')).ok, true);
+
+	// No header is no evidence — some token types omit it entirely.
+	assert.strictEqual((await viewer(undefined)).ok, true);
+});

--- a/test/github-auth.test.cjs
+++ b/test/github-auth.test.cjs
@@ -71,7 +71,10 @@ test('requestDeviceCode returns the code, the page, and an absolute expiry', asy
 	// GitHub sends a duration; every later comparison wants an instant.
 	assert.strictEqual(res.expiresAt, 1000 + 900 * 1000);
 	assert.strictEqual(post.calls[0].payload.client_id, CLIENT_ID);
-	assert.strictEqual(post.calls[0].payload.scope, 'public_repo');
+	// `repo`, not `public_repo`: ref creation accepts only the full scope
+	// (X-Accepted-OAuth-Scopes, verified by hand), and a token with the
+	// narrower one uploads everything and 404s on the branch.
+	assert.strictEqual(post.calls[0].payload.scope, 'repo');
 });
 
 // The build shipping without a client ID and the application not having device
@@ -215,8 +218,11 @@ test('fetchViewer refuses a token whose granted scopes cannot push', async () =>
 	assert.strictEqual((await viewer('gist, read:org')).reason, 'insufficient-scope');
 	assert.match((await viewer('')).error, /sign in here again/i);
 
-	// Either granted scope that can push passes; `repo` contains `public_repo`.
-	assert.strictEqual((await viewer('public_repo')).ok, true);
+	// `public_repo` is the trap this check exists for: documented to cover
+	// public-repo writes, refused by ref creation in practice — the token that
+	// uploads everything and fails on the branch.
+	assert.strictEqual((await viewer('public_repo')).reason, 'insufficient-scope');
+
 	assert.strictEqual((await viewer('repo, gist')).ok, true);
 
 	// No header is no evidence — some token types omit it entirely.

--- a/test/github-http.test.cjs
+++ b/test/github-http.test.cjs
@@ -9,7 +9,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
-const { httpRequest, postJson, getJson } = require('../src/github-http.cjs');
+const { httpRequest, postJson, postForm, getJson } = require('../src/github-http.cjs');
 
 // A stand-in for Electron's `net`, recording what the request was told to be:
 // the method and URL it was opened with, every header set on it, and everything
@@ -97,6 +97,23 @@ test('postJson serialises the payload and parses the answer', async () => {
 	assert.strictEqual(net.sent.headers['Content-Type'], 'application/json');
 	assert.strictEqual(res.status, 201);
 	assert.deepStrictEqual(res.json, { sha: 'abc' });
+});
+
+// The OAuth endpoints' documented request format. The scope grant rides in
+// this body — a scope that fails to arrive produces a token that signs in
+// fine and cannot push, and that failure surfaces at the last write of the
+// whole pull-request flow.
+test('postForm sends URL-encoded parameters and parses the JSON answer', async () => {
+	const net = fakeNet((req) => respond(req, { status: 200, body: '{"device_code":"d"}' }));
+
+	const res = await postForm('https://github.com/login/device/code', {
+		client_id: 'Ov23liTEST',
+		scope: 'public_repo'
+	}, { net: net.client });
+
+	assert.strictEqual(net.sent.headers['Content-Type'], 'application/x-www-form-urlencoded');
+	assert.deepStrictEqual(net.sent.written, ['client_id=Ov23liTEST&scope=public_repo']);
+	assert.deepStrictEqual(res.json, { device_code: 'd' });
 });
 
 // A proxy's HTML error page, a truncated response, an empty 204: all of them

--- a/test/github-http.test.cjs
+++ b/test/github-http.test.cjs
@@ -1,0 +1,129 @@
+'use strict';
+
+// The request primitive grew a method, a body and an Authorization header when
+// opening a pull request needed one (#167). Its GET behaviour is already pinned
+// by test/github-prs.test.cjs — the transport, timeout and settle-once paths —
+// so what is here is only what POST added, plus the one property everything
+// downstream leans on: a non-2xx status is data, never an exception.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { httpRequest, postJson, getJson } = require('../src/github-http.cjs');
+
+// A stand-in for Electron's `net`, recording what the request was told to be:
+// the method and URL it was opened with, every header set on it, and everything
+// written to its body.
+function fakeNet(onEnd) {
+	const sent = { headers: {}, written: [], options: null };
+	return {
+		sent,
+		client: {
+			request(options) {
+				sent.options = options;
+				const req = new EventEmitter();
+				req.setHeader = (key, value) => { sent.headers[key] = value; };
+				req.write = (chunk) => { sent.written.push(chunk); };
+				req.abort = () => {};
+				req.end = () => onEnd(req);
+				return req;
+			}
+		}
+	};
+}
+
+function respond(req, { status = 200, headers = {}, body = '' }) {
+	const res = new EventEmitter();
+	res.statusCode = status;
+	res.headers = headers;
+	req.emit('response', res);
+	if (body) res.emit('data', Buffer.from(body));
+	res.emit('end');
+}
+
+test('httpRequest sends the method, the body and an identifying User-Agent', async () => {
+	const net = fakeNet((req) => respond(req, { status: 201, body: '{}' }));
+
+	await httpRequest('POST', 'https://api.github.com/x', { Accept: 'application/json' }, {
+		net: net.client,
+		body: '{"a":1}'
+	});
+
+	assert.strictEqual(net.sent.options.method, 'POST');
+	assert.strictEqual(net.sent.options.url, 'https://api.github.com/x');
+	assert.deepStrictEqual(net.sent.written, ['{"a":1}']);
+	assert.strictEqual(net.sent.headers.Accept, 'application/json');
+	assert.match(net.sent.headers['User-Agent'], /WordPress-Contributor-Toolkit/);
+});
+
+// The header is what authorises every write in the pull request flow, and its
+// absence is what keeps the anonymous reads anonymous — an unconditional header
+// would send `Bearer undefined` on every one of them.
+test('httpRequest sends Authorization only when there is a token', async () => {
+	const withToken = fakeNet((req) => respond(req, { status: 200, body: '{}' }));
+	await httpRequest('GET', 'https://api.github.com/user', {}, { net: withToken.client, token: 'gho_x' });
+	assert.strictEqual(withToken.sent.headers.Authorization, 'Bearer gho_x');
+
+	const without = fakeNet((req) => respond(req, { status: 200, body: '{}' }));
+	await httpRequest('GET', 'https://api.github.com/user', {}, { net: without.client });
+	assert.strictEqual('Authorization' in without.sent.headers, false);
+});
+
+// A redirect on a token-bearing request must fail closed rather than let
+// Chromium's stack decide whether the Authorization header follows it to
+// another host. Anonymous requests keep the default and follow normally.
+test('httpRequest refuses redirects only when carrying a token', async () => {
+	const withToken = fakeNet((req) => respond(req, { status: 200, body: '{}' }));
+	await httpRequest('GET', 'https://api.github.com/user', {}, { net: withToken.client, token: 'gho_x' });
+	assert.strictEqual(withToken.sent.options.redirect, 'error');
+
+	const without = fakeNet((req) => respond(req, { status: 200, body: '{}' }));
+	await httpRequest('GET', 'https://api.github.com/x', {}, { net: without.client });
+	assert.strictEqual('redirect' in without.sent.options, false);
+});
+
+test('httpRequest writes no body when none was given', async () => {
+	const net = fakeNet((req) => respond(req, { status: 204 }));
+	await httpRequest('POST', 'https://api.github.com/x', {}, { net: net.client });
+	assert.deepStrictEqual(net.sent.written, []);
+});
+
+test('postJson serialises the payload and parses the answer', async () => {
+	const net = fakeNet((req) => respond(req, { status: 201, body: '{"sha":"abc"}' }));
+
+	const res = await postJson('https://api.github.com/x', { message: 'hi' }, { net: net.client });
+
+	assert.deepStrictEqual(net.sent.written, ['{"message":"hi"}']);
+	assert.strictEqual(net.sent.headers['Content-Type'], 'application/json');
+	assert.strictEqual(res.status, 201);
+	assert.deepStrictEqual(res.json, { sha: 'abc' });
+});
+
+// A proxy's HTML error page, a truncated response, an empty 204: all of them
+// reach a caller that is about to read `.json.something`. Surviving as null is
+// what lets the status decide instead of a parse throwing past the failure
+// classification.
+test('postJson and getJson survive a body that is not JSON', async () => {
+	const posted = await postJson('https://api.github.com/x', {}, {
+		net: fakeNet((req) => respond(req, { status: 502, body: '<html>bad gateway</html>' })).client
+	});
+	assert.strictEqual(posted.status, 502);
+	assert.strictEqual(posted.json, null);
+
+	const got = await getJson('https://api.github.com/x', {
+		net: fakeNet((req) => respond(req, { status: 204 })).client
+	});
+	assert.strictEqual(got.json, null);
+});
+
+// Every failure classification downstream reads a status, so a status that
+// throws instead of returning would route a spent rate limit, a revoked token
+// and a missing fork all into the same catch.
+test('a non-2xx status resolves rather than throwing', async () => {
+	const res = await postJson('https://api.github.com/x', {}, {
+		net: fakeNet((req) => respond(req, { status: 403, headers: { 'Retry-After': '60' }, body: '{"message":"slow"}' })).client
+	});
+	assert.strictEqual(res.status, 403);
+	assert.strictEqual(res.headers['retry-after'], '60');
+	assert.deepStrictEqual(res.json, { message: 'slow' });
+});

--- a/test/github-http.test.cjs
+++ b/test/github-http.test.cjs
@@ -108,11 +108,11 @@ test('postForm sends URL-encoded parameters and parses the JSON answer', async (
 
 	const res = await postForm('https://github.com/login/device/code', {
 		client_id: 'Ov23liTEST',
-		scope: 'public_repo'
+		scope: 'repo'
 	}, { net: net.client });
 
 	assert.strictEqual(net.sent.headers['Content-Type'], 'application/x-www-form-urlencoded');
-	assert.deepStrictEqual(net.sent.written, ['client_id=Ov23liTEST&scope=public_repo']);
+	assert.deepStrictEqual(net.sent.written, ['client_id=Ov23liTEST&scope=repo']);
 	assert.deepStrictEqual(res.json, { device_code: 'd' });
 });
 

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -1,0 +1,409 @@
+'use strict';
+
+// Fork, commit, pull request (#167) — the sequence, and the ways it goes wrong.
+//
+// Two of these tests are the reason the module is shaped the way it is. A fork
+// that already exists and is months stale is the ordinary case for anyone who
+// has contributed before, and it is the one where the obvious implementation
+// fails: the commit is based on the local checkout's HEAD, which a stale fork
+// does not contain. And a deletion is a tree entry with a null sha, which is
+// easy to get wrong in a way that silently drops the deletion instead of
+// carrying it.
+//
+// Everything is driven through injected `get`/`post`, so nothing here touches
+// the network or waits for a real fork to appear.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	buildPullRequestBody,
+	branchNameFor,
+	classifyFailure,
+	ensureFork,
+	resolveBase,
+	createTree,
+	commitAndBranch,
+	createPullRequest,
+	openPullRequest
+} = require('../src/github-pr.cjs');
+
+const TOKEN = 'gho_test';
+const LOGIN = 'janedoe';
+
+// Routes by URL, so a test states what GitHub has rather than the order it is
+// asked. `routes` maps a substring of the URL to a response or a function of
+// the call count.
+function router(routes) {
+	const calls = [];
+	// Matched against the end of the URL, not anywhere in it: every endpoint here
+	// is a path under the fork's own URL, so a substring match would route
+	// `…/wordpress-develop/git/commits/abc` to the route for the repository
+	// itself. Longest first breaks the remaining ties.
+	const patterns = Object.keys(routes)
+		.map((key) => ({ key, method: key.split(' ')[0], path: key.slice(key.indexOf(' ') + 1) }))
+		.sort((a, b) => b.path.length - a.path.length);
+	const hits = new Map();
+
+	const answer = (method) => async (url, payloadOrOpts) => {
+		const payload = method === 'POST' ? payloadOrOpts : undefined;
+		calls.push({ method, url, payload });
+		const match = patterns.find((p) => p.method === method && url.endsWith(p.path));
+		if (!match) return { status: 404, headers: {}, json: { message: `no route for ${method} ${url}` } };
+		// 1 on the first call, so a route written as a function reads as "the
+		// first time this is asked, …".
+		const seen = (hits.get(match.key) || 0) + 1;
+		hits.set(match.key, seen);
+		const route = routes[match.key];
+		const res = typeof route === 'function' ? route(seen) : route;
+		if (res instanceof Error) throw res;
+		return { status: res.status, headers: res.headers || {}, json: res.json === undefined ? {} : res.json };
+	};
+	return { calls, get: answer('GET'), post: answer('POST'), sleep: async () => {} };
+}
+
+const FORK_URL = `repos/${LOGIN}/wordpress-develop`;
+
+test('buildPullRequestBody cites the ticket in the form core’s convention expects', () => {
+	const body = buildPullRequestBody({ ticketId: 62281, handle: 'janedoe', event: 'WordCamp Europe 2026' });
+
+	// The exact string this app's own linked-PR search looks for, so a pull
+	// request opened here is discoverable by the panel that lists them.
+	assert.ok(body.includes('https://core.trac.wordpress.org/ticket/62281'));
+	assert.ok(body.includes('@janedoe'));
+	assert.ok(body.includes('WordCamp Europe 2026'));
+
+	const bare = buildPullRequestBody({ ticketId: 1 });
+	assert.ok(bare.includes('/ticket/1'));
+	assert.ok(!bare.includes('undefined'));
+});
+
+test('branchNameFor suffixes rather than reusing a taken name', () => {
+	assert.strictEqual(branchNameFor(62281), 'trac-62281');
+	assert.strictEqual(branchNameFor('#62281', 1), 'trac-62281-2');
+});
+
+// classifyHttpFailure reads a 401 with a spent quota as rate-limiting, which is
+// right for the anonymous reads it was written for. Here a 401 is always a
+// token that has stopped working, and it has its own recovery.
+test('classifyFailure calls a 401 unauthorized, and still recognises a spent quota', () => {
+	assert.strictEqual(classifyFailure({ status: 401, headers: { 'x-ratelimit-remaining': '0' } }), 'unauthorized');
+	assert.strictEqual(classifyFailure({ status: 403, headers: { 'x-ratelimit-remaining': '0' } }), 'rate-limited');
+	assert.strictEqual(classifyFailure({ status: 422, headers: {} }), 'error');
+});
+
+// What GitHub says about a repository that really is the contributor's fork.
+const FORK_JSON = { fork: true, parent: { full_name: 'WordPress/wordpress-develop' } };
+
+test('ensureFork uses the fork that is already there, without forking again', async () => {
+	const api = router({ [`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON } });
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.deepStrictEqual(res, { ok: true, created: false });
+	assert.strictEqual(api.calls.filter((c) => c.method === 'POST').length, 0);
+});
+
+// A contributor who owns an unrelated repository named wordpress-develop must
+// be told at step one. The alternative is a branch and a commit written into
+// their project, and a failure at the very last step with an opaque 422.
+test('ensureFork refuses a same-named repository that is not a fork of upstream', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 200, json: { fork: false } },
+		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /not a fork/);
+	// Nothing written anywhere: no fork attempted, and nothing for later steps
+	// to push into.
+	assert.strictEqual(api.calls.filter((c) => c.method === 'POST').length, 0);
+});
+
+// A fork of something else entirely under the same name is the same refusal.
+test('ensureFork refuses a fork of a different repository', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 200, json: { fork: true, parent: { full_name: 'someone/wordpress-develop' } } }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /not a fork/);
+});
+
+// Forking is asynchronous: the POST answers 202 and the repository appears a
+// moment later. Treating the 202 as done is the bug this pins — the very next
+// request would 404 on a repository that is about to exist.
+test('ensureFork waits for a new fork to appear before reporting success', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: (seen) => ({ status: seen < 3 ? 404 : 200 }),
+		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.deepStrictEqual(res, { ok: true, created: true });
+	assert.strictEqual(api.calls.filter((c) => c.method === 'GET').length, 3);
+});
+
+test('ensureFork gives up with something actionable when the fork never appears', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 404 },
+		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, { ...api, forkPollAttempts: 2 });
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /try again in a minute/);
+});
+
+test('ensureFork reports a revoked token as unauthorized rather than as a missing fork', async () => {
+	const api = router({ [`GET ${FORK_URL}`]: { status: 401, json: { message: 'Bad credentials' } } });
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.strictEqual(res.reason, 'unauthorized');
+});
+
+test('resolveBase uses the local HEAD when the fork already contains it', async () => {
+	const api = router({ 'GET git/commits/abc123': { status: 200 } });
+
+	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
+
+	assert.deepStrictEqual(res, { ok: true, sha: 'abc123', exact: true });
+	// No sync needed, so none attempted.
+	assert.strictEqual(api.calls.filter((c) => c.method === 'POST').length, 0);
+});
+
+// The stale fork. Without the sync the next step would create a ref from a
+// commit the fork has never heard of, and GitHub would refuse it.
+test('resolveBase syncs a stale fork, then finds the base commit there', async () => {
+	const api = router({
+		'GET git/commits/abc123': (seen) => ({ status: seen === 1 ? 404 : 200 }),
+		'POST merge-upstream': { status: 200 }
+	});
+
+	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
+
+	assert.deepStrictEqual(res, { ok: true, sha: 'abc123', exact: true });
+	assert.ok(api.calls.some((c) => c.url.includes('merge-upstream') && c.payload.branch === 'trunk'));
+});
+
+// A fork that has been committed to directly cannot be fast-forwarded. Failing
+// there would strand a contributor who is more experienced, not less — so the
+// fork's own tip becomes the base, and `exact: false` is what lets the panel
+// warn that the pull request may show more than they changed.
+test('resolveBase falls back to the fork’s own trunk when it cannot be fast-forwarded', async () => {
+	const api = router({
+		'GET git/commits/abc123': { status: 404 },
+		'POST merge-upstream': { status: 409, json: { message: 'diverged' } },
+		'GET git/ref/heads/trunk': { status: 200, json: { object: { sha: 'forktip' } } }
+	});
+
+	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
+
+	assert.deepStrictEqual(res, { ok: true, sha: 'forktip', exact: false });
+});
+
+test('createTree uploads each file as a base64 blob and inherits the rest', async () => {
+	const api = router({
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } }
+	});
+
+	const res = await createTree({
+		token: TOKEN,
+		login: LOGIN,
+		baseTreeSha: 'basetree',
+		files: [{ path: 'src/wp-admin/a.php', kind: 'modify', content: Buffer.from('<?php\n'), mode: '100644' }]
+	}, api);
+
+	assert.deepStrictEqual(res, { ok: true, sha: 'tree1' });
+	const blob = api.calls.find((c) => c.url.includes('git/blobs'));
+	assert.strictEqual(blob.payload.encoding, 'base64');
+	assert.strictEqual(Buffer.from(blob.payload.content, 'base64').toString('utf8'), '<?php\n');
+	const tree = api.calls.find((c) => c.url.includes('git/trees'));
+	// base_tree is what keeps this from being a commit that deletes all of
+	// wordpress-develop except the changed file.
+	assert.strictEqual(tree.payload.base_tree, 'basetree');
+	assert.deepStrictEqual(tree.payload.tree, [
+		{ path: 'src/wp-admin/a.php', mode: '100644', type: 'blob', sha: 'blob1' }
+	]);
+});
+
+// A null sha is the only way the tree API expresses a deletion, and it is why
+// the pull request carries deletions that the `.diff` this app writes does not.
+test('createTree expresses a deletion as a null sha, with no blob uploaded for it', async () => {
+	const api = router({
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } }
+	});
+
+	await createTree({
+		token: TOKEN,
+		login: LOGIN,
+		baseTreeSha: 'basetree',
+		files: [
+			{ path: 'gone.php', kind: 'delete', content: null, mode: '100644' },
+			{ path: 'kept.php', kind: 'add', content: Buffer.from('x'), mode: '100755' }
+		]
+	}, api);
+
+	const tree = api.calls.find((c) => c.url.includes('git/trees'));
+	assert.deepStrictEqual(tree.payload.tree, [
+		{ path: 'gone.php', mode: '100644', type: 'blob', sha: null },
+		{ path: 'kept.php', mode: '100755', type: 'blob', sha: 'blob1' }
+	]);
+	assert.strictEqual(api.calls.filter((c) => c.url.includes('git/blobs')).length, 1);
+});
+
+// A binary file is the other thing a unified diff cannot carry. Its bytes have
+// to survive the round trip exactly.
+test('createTree carries bytes a diff could not, unchanged', async () => {
+	const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff]);
+	const api = router({
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } }
+	});
+
+	await createTree({ token: TOKEN, login: LOGIN, baseTreeSha: 't', files: [{ path: 'a.png', kind: 'add', content: bytes, mode: '100644' }] }, api);
+
+	const blob = api.calls.find((c) => c.url.includes('git/blobs'));
+	assert.ok(Buffer.from(blob.payload.content, 'base64').equals(bytes));
+});
+
+test('commitAndBranch makes one commit, then a branch that points at it', async () => {
+	const api = router({
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 201 }
+	});
+
+	const res = await commitAndBranch({
+		token: TOKEN, login: LOGIN, ticketId: 62281, message: 'Fix it', treeSha: 'tree1', parentSha: 'base1'
+	}, api);
+
+	assert.deepStrictEqual(res, { ok: true, branch: 'trac-62281', sha: 'commit1' });
+	const commit = api.calls.find((c) => c.url.includes('git/commits'));
+	assert.deepStrictEqual(commit.payload.parents, ['base1']);
+	assert.strictEqual(commit.payload.tree, 'tree1');
+	const ref = api.calls.find((c) => c.url.includes('git/refs'));
+	assert.strictEqual(ref.payload.ref, 'refs/heads/trac-62281');
+});
+
+// Working the same ticket twice is normal. Re-uploading everything to find that
+// out is not, which is why the branch is created last.
+test('commitAndBranch takes the next name when the branch already exists', async () => {
+	const api = router({
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': (seen) => (seen === 1 ? { status: 422, json: { message: 'Reference already exists' } } : { status: 201 })
+	});
+
+	const res = await commitAndBranch({ token: TOKEN, login: LOGIN, ticketId: 62281, message: 'm', treeSha: 't', parentSha: 'p' }, api);
+
+	assert.strictEqual(res.branch, 'trac-62281-2');
+	assert.strictEqual(api.calls.filter((c) => c.url.includes('git/commits')).length, 1);
+});
+
+test('commitAndBranch stops on a failure that another name would not fix', async () => {
+	const api = router({
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 403, headers: { 'x-ratelimit-remaining': '0' } }
+	});
+
+	const res = await commitAndBranch({ token: TOKEN, login: LOGIN, ticketId: 1, message: 'm', treeSha: 't', parentSha: 'p' }, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.reason, 'rate-limited');
+	assert.strictEqual(api.calls.filter((c) => c.url.includes('git/refs')).length, 1);
+});
+
+test('createPullRequest opens it on upstream, from the fork’s branch', async () => {
+	const api = router({
+		'POST repos/WordPress/wordpress-develop/pulls': { status: 201, json: { html_url: 'https://github.com/WordPress/wordpress-develop/pull/9', number: 9 } }
+	});
+
+	const res = await createPullRequest({ token: TOKEN, login: LOGIN, branch: 'trac-62281', title: 'Fix it', body: 'B' }, api);
+
+	assert.deepStrictEqual(res, { ok: true, url: 'https://github.com/WordPress/wordpress-develop/pull/9', number: 9 });
+	const call = api.calls[0];
+	assert.strictEqual(call.payload.head, 'janedoe:trac-62281');
+	assert.strictEqual(call.payload.base, 'trunk');
+});
+
+function happyPathRoutes() {
+	return {
+		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
+		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } },
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 201 },
+		'POST repos/WordPress/wordpress-develop/pulls': { status: 201, json: { html_url: 'https://github.com/x/pull/9', number: 9 } }
+	};
+}
+
+test('openPullRequest runs the sequence and names each step as it starts', async () => {
+	const api = router(happyPathRoutes());
+	const stages = [];
+
+	const res = await openPullRequest({
+		token: TOKEN,
+		login: LOGIN,
+		ticketId: 62281,
+		baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 'Fix it',
+		body: 'B',
+		onProgress: (stage) => stages.push(stage)
+	}, api);
+
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.number, 9);
+	assert.strictEqual(res.branch, 'trac-62281');
+	assert.strictEqual(res.exactBase, true);
+	assert.deepStrictEqual(stages, ['forking', 'syncing', 'committing', 'opening']);
+});
+
+// The commit's tree comes from the base commit, not from the base commit's sha:
+// they are different objects, and passing the wrong one produces a commit whose
+// tree has nothing in it.
+test('openPullRequest bases the tree on the base commit’s tree', async () => {
+	const api = router(happyPathRoutes());
+
+	await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	const tree = api.calls.find((c) => c.url.includes('git/trees'));
+	assert.strictEqual(tree.payload.base_tree, 'basetree');
+});
+
+// Every failure has the same fallback — the patch file — but the panel has to
+// say which one happened and how far it got.
+test('openPullRequest reports how far it got when a step fails', async () => {
+	const api = router({ ...happyPathRoutes(), 'POST git/trees': { status: 401, json: { message: 'Bad credentials' } } });
+
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.reason, 'unauthorized');
+	assert.strictEqual(res.stage, 'committing');
+});
+
+test('openPullRequest refuses an empty change before it touches GitHub', async () => {
+	const api = router(happyPathRoutes());
+
+	const res = await openPullRequest({ token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123', files: [], title: 't', body: 'b' }, api);
+
+	assert.strictEqual(res.reason, 'empty');
+	assert.deepStrictEqual(api.calls, []);
+});

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -95,7 +95,10 @@ test('classifyFailure calls a 401 unauthorized, and still recognises a spent quo
 const FORK_JSON = { fork: true, parent: { full_name: 'WordPress/wordpress-develop' } };
 
 test('ensureFork uses the fork that is already there, without forking again', async () => {
-	const api = router({ [`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON } });
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'tip' } } }
+	});
 
 	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
 
@@ -138,14 +141,51 @@ test('ensureFork refuses a fork of a different repository', async () => {
 // request would 404 on a repository that is about to exist.
 test('ensureFork waits for a new fork to appear before reporting success', async () => {
 	const api = router({
-		[`GET ${FORK_URL}`]: (seen) => ({ status: seen < 3 ? 404 : 200 }),
+		[`GET ${FORK_URL}`]: (seen) => (seen < 3
+			? { status: 404 }
+			: { status: 200, json: FORK_JSON }),
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'tip' } } },
 		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
 	});
 
 	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
 
 	assert.deepStrictEqual(res, { ok: true, created: true });
-	assert.strictEqual(api.calls.filter((c) => c.method === 'GET').length, 3);
+});
+
+// The bug found by hand on the first real run: the repository *metadata*
+// appears well before the fork's own ref database is ready. Forks share their
+// upstream's object store, so every blob, tree and commit write succeeds
+// against a fork that cannot yet take a branch — and the failure surfaces at
+// the very last write as an opaque 404. Ready means the fork's own trunk ref
+// answers, not that the repo shell exists.
+test('ensureFork waits for the fork’s refs, not just its metadata', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
+		// The ref database catches up two polls after the metadata.
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: (seen) => (seen < 3
+			? { status: 404 }
+			: { status: 200, json: { object: { sha: 'tip' } } }),
+		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, api);
+
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(api.calls.filter((c) => c.url.endsWith('git/ref/heads/trunk')).length, 3);
+});
+
+test('ensureFork gives up on a fork whose refs never become ready, naming the wait', async () => {
+	const api = router({
+		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 404 },
+		'POST repos/WordPress/wordpress-develop/forks': { status: 202 }
+	});
+
+	const res = await ensureFork({ token: TOKEN, login: LOGIN }, { ...api, forkPollAttempts: 2 });
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /try again/i);
 });
 
 test('ensureFork gives up with something actionable when the fork never appears', async () => {
@@ -157,7 +197,7 @@ test('ensureFork gives up with something actionable when the fork never appears'
 	const res = await ensureFork({ token: TOKEN, login: LOGIN }, { ...api, forkPollAttempts: 2 });
 
 	assert.strictEqual(res.ok, false);
-	assert.match(res.error, /try again in a minute/);
+	assert.match(res.error, /still being set up/);
 });
 
 test('ensureFork reports a revoked token as unauthorized rather than as a missing fork', async () => {
@@ -307,6 +347,22 @@ test('commitAndBranch takes the next name when the branch already exists', async
 	assert.strictEqual(api.calls.filter((c) => c.url.includes('git/commits')).length, 1);
 });
 
+// The readiness gate in ensureFork shrinks this window but cannot close it: a
+// 404 here is the fork's ref database still initialising, and "Not Found" told
+// the contributor nothing.
+test('commitAndBranch names a still-initialising fork instead of saying Not Found', async () => {
+	const api = router({
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 404, json: { message: 'Not Found' } }
+	});
+
+	const res = await commitAndBranch({ token: TOKEN, login: LOGIN, ticketId: 1, message: 'm', treeSha: 't', parentSha: 'p' }, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /still being set up/);
+	assert.match(res.error, /try again/i);
+});
+
 test('commitAndBranch stops on a failure that another name would not fix', async () => {
 	const api = router({
 		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
@@ -336,6 +392,7 @@ test('createPullRequest opens it on upstream, from the fork’s branch', async (
 function happyPathRoutes() {
 	return {
 		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'tip' } } },
 		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
 		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
 		'POST git/trees': { status: 201, json: { sha: 'tree1' } },

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -507,6 +507,59 @@ test('openPullRequest reports how far it got when a step fails', async () => {
 	assert.strictEqual(res.stage, 'committing');
 });
 
+// The two quiet-testing switches (both env-driven, both absent in production):
+// a sandbox upstream so the whole flow can run without wordpress-develop's
+// watchers hearing about it, and a dry run that stops after the branch — the
+// fork writes are private; the pull request is the noisy step.
+
+test('WP_DEV_ENV_GITHUB_UPSTREAM points the whole flow at a sandbox', async (t) => {
+	process.env.WP_DEV_ENV_GITHUB_UPSTREAM = 'sandbox-org/pr-sandbox';
+	t.after(() => { delete process.env.WP_DEV_ENV_GITHUB_UPSTREAM; });
+
+	const api = router({
+		'GET repos/janedoe/pr-sandbox': { status: 200, json: { fork: true, parent: { full_name: 'sandbox-org/pr-sandbox' } } },
+		'GET repos/janedoe/pr-sandbox/git/ref/heads/trunk': { status: 200, json: { object: { sha: 'abc123' } } },
+		'POST merge-upstream': { status: 200 },
+		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } },
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 201 },
+		'POST repos/sandbox-org/pr-sandbox/pulls': { status: 201, json: { html_url: 'https://github.com/sandbox-org/pr-sandbox/pull/1', number: 1 } }
+	});
+
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.url, 'https://github.com/sandbox-org/pr-sandbox/pull/1');
+	// Nothing touched the real upstream.
+	assert.strictEqual(api.calls.some((c) => c.url.includes('wordpress-develop')), false);
+});
+
+test('WP_DEV_ENV_GITHUB_DRY_RUN stops after the branch, before the pull request', async (t) => {
+	process.env.WP_DEV_ENV_GITHUB_DRY_RUN = '1';
+	t.after(() => { delete process.env.WP_DEV_ENV_GITHUB_DRY_RUN; });
+
+	const api = router(happyPathRoutes());
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 62281, baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	assert.strictEqual(res.ok, true);
+	assert.strictEqual(res.dryRun, true);
+	assert.strictEqual(res.branch, 'trac-62281');
+	assert.match(res.url, /tree\/trac-62281$/);
+	// The branch was created; the pull request never was.
+	assert.strictEqual(api.calls.some((c) => c.url.includes('git/refs')), true);
+	assert.strictEqual(api.calls.some((c) => c.url.endsWith('/pulls')), false);
+});
+
 test('openPullRequest refuses an empty change before it touches GitHub', async () => {
 	const api = router(happyPathRoutes());
 

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -19,6 +19,7 @@ const {
 	buildPullRequestBody,
 	branchNameFor,
 	classifyFailure,
+	testMode,
 	ensureFork,
 	resolveBase,
 	staleTouchedPaths,
@@ -538,6 +539,30 @@ test('WP_DEV_ENV_GITHUB_UPSTREAM points the whole flow at a sandbox', async (t) 
 	assert.strictEqual(res.url, 'https://github.com/sandbox-org/pr-sandbox/pull/1');
 	// Nothing touched the real upstream.
 	assert.strictEqual(api.calls.some((c) => c.url.includes('wordpress-develop')), false);
+});
+
+// The card reads this to say which mode it is in. Null in a shipped build is
+// the load-bearing case: it is what keeps the badge off a real contributor's
+// screen.
+test('testMode is null unless a switch is set, and names the mode when one is', (t) => {
+	t.after(() => {
+		delete process.env.WP_DEV_ENV_GITHUB_DRY_RUN;
+		delete process.env.WP_DEV_ENV_GITHUB_UPSTREAM;
+	});
+
+	assert.strictEqual(testMode(), null);
+
+	process.env.WP_DEV_ENV_GITHUB_DRY_RUN = '1';
+	assert.deepStrictEqual(testMode(), { dryRun: true, target: 'WordPress/wordpress-develop' });
+
+	delete process.env.WP_DEV_ENV_GITHUB_DRY_RUN;
+	process.env.WP_DEV_ENV_GITHUB_UPSTREAM = 'sandbox-org/pr-sandbox';
+	assert.deepStrictEqual(testMode(), { dryRun: false, target: 'sandbox-org/pr-sandbox' });
+
+	// An upstream override that names the real repository is not a test mode —
+	// it changes nothing, so the badge would be a lie.
+	process.env.WP_DEV_ENV_GITHUB_UPSTREAM = 'WordPress/wordpress-develop';
+	assert.strictEqual(testMode(), null);
 });
 
 test('WP_DEV_ENV_GITHUB_DRY_RUN stops after the branch, before the pull request', async (t) => {

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -21,6 +21,7 @@ const {
 	classifyFailure,
 	ensureFork,
 	resolveBase,
+	staleTouchedPaths,
 	createTree,
 	commitAndBranch,
 	createPullRequest,
@@ -208,37 +209,37 @@ test('ensureFork reports a revoked token as unauthorized rather than as a missin
 	assert.strictEqual(res.reason, 'unauthorized');
 });
 
-test('resolveBase uses the local HEAD when the fork already contains it', async () => {
-	const api = router({ 'GET git/commits/abc123': { status: 200 } });
+// The base is the fork's trunk tip, always — verified by hand: git/refs 404s
+// a fresh commit parented anywhere else, even on a plainly-reachable ancestor,
+// and GET git/commits answers 200 for anything in the fork network, so "does
+// the fork contain the local HEAD" cannot even be asked honestly.
+test('resolveBase syncs the fork and bases on its trunk tip', async () => {
+	const api = router({
+		'POST merge-upstream': { status: 200 },
+		'GET git/ref/heads/trunk': { status: 200, json: { object: { sha: 'tipsha' } } }
+	});
 
-	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
+	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'oldlocal' }, api);
 
-	assert.deepStrictEqual(res, { ok: true, sha: 'abc123', exact: true });
-	// No sync needed, so none attempted.
-	assert.strictEqual(api.calls.filter((c) => c.method === 'POST').length, 0);
+	assert.deepStrictEqual(res, { ok: true, sha: 'tipsha', exact: false });
+	assert.ok(api.calls.some((c) => c.url.includes('merge-upstream') && c.payload.branch === 'trunk'));
 });
 
-// The stale fork. Without the sync the next step would create a ref from a
-// commit the fork has never heard of, and GitHub would refuse it.
-test('resolveBase syncs a stale fork, then finds the base commit there', async () => {
+test('resolveBase reports exact when the local HEAD is the tip', async () => {
 	const api = router({
-		'GET git/commits/abc123': (seen) => ({ status: seen === 1 ? 404 : 200 }),
-		'POST merge-upstream': { status: 200 }
+		'POST merge-upstream': { status: 200 },
+		'GET git/ref/heads/trunk': { status: 200, json: { object: { sha: 'abc123' } } }
 	});
 
 	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
 
 	assert.deepStrictEqual(res, { ok: true, sha: 'abc123', exact: true });
-	assert.ok(api.calls.some((c) => c.url.includes('merge-upstream') && c.payload.branch === 'trunk'));
 });
 
-// A fork that has been committed to directly cannot be fast-forwarded. Failing
-// there would strand a contributor who is more experienced, not less — so the
-// fork's own tip becomes the base, and `exact: false` is what lets the panel
-// warn that the pull request may show more than they changed.
-test('resolveBase falls back to the fork’s own trunk when it cannot be fast-forwarded', async () => {
+// A fork that has been committed to directly cannot be fast-forwarded — a 409
+// from merge-upstream is a normal state, and the fork's own tip is the base.
+test('resolveBase survives a fork that cannot be fast-forwarded', async () => {
 	const api = router({
-		'GET git/commits/abc123': { status: 404 },
 		'POST merge-upstream': { status: 409, json: { message: 'diverged' } },
 		'GET git/ref/heads/trunk': { status: 200, json: { object: { sha: 'forktip' } } }
 	});
@@ -246,6 +247,54 @@ test('resolveBase falls back to the fork’s own trunk when it cannot be fast-fo
 	const res = await resolveBase({ token: TOKEN, login: LOGIN, baseSha: 'abc123' }, api);
 
 	assert.deepStrictEqual(res, { ok: true, sha: 'forktip', exact: false });
+});
+
+// The guard for the sharp edge tip-basing has: the tree API replaces whole
+// files, so a contributor behind trunk who touched a file upstream also
+// changed would silently revert that upstream work.
+test('staleTouchedPaths names the files upstream changed since the local HEAD', async () => {
+	const shaAt = {
+		'a.php?ref=local': 'blob1', 'a.php?ref=tip': 'blob1', // untouched upstream
+		'b.php?ref=local': 'blob2', 'b.php?ref=tip': 'blob2-new', // changed upstream
+		'c.php?ref=local': 'blob3' // deleted upstream → 404 at tip
+	};
+	const api = {
+		get: async (url) => {
+			const key = Object.keys(shaAt).find((k) => url.includes(k));
+			return key ? { status: 200, json: { sha: shaAt[key] } } : { status: 404, json: {} };
+		}
+	};
+
+	const res = await staleTouchedPaths(
+		{ token: TOKEN, login: LOGIN, baseSha: 'local', tipSha: 'tip', paths: ['a.php', 'b.php', 'c.php'] },
+		api
+	);
+
+	assert.deepStrictEqual(res, { ok: true, clashes: ['b.php', 'c.php'] });
+});
+
+test('openPullRequest refuses a stale checkout whose files upstream also changed', async () => {
+	const api = router({
+		...happyPathRoutes(),
+		// Same key as the happy path's, so this override wins outright rather
+		// than competing on pattern length.
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'newer-tip' } } },
+		'GET contents/a.php?ref=abc123': { status: 200, json: { sha: 'blob-old' } },
+		'GET contents/a.php?ref=newer-tip': { status: 200, json: { sha: 'blob-upstream' } }
+	});
+
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123',
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.reason, 'stale');
+	assert.match(res.error, /a\.php/);
+	assert.match(res.error, /Update this site/);
+	// Refused before anything was uploaded.
+	assert.strictEqual(api.calls.filter((c) => c.url.includes('git/blobs')).length, 0);
 });
 
 test('createTree uploads each file as a base64 blob and inherits the rest', async () => {
@@ -392,7 +441,9 @@ test('createPullRequest opens it on upstream, from the fork’s branch', async (
 function happyPathRoutes() {
 	return {
 		[`GET ${FORK_URL}`]: { status: 200, json: FORK_JSON },
-		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'tip' } } },
+		// The tip equals the local HEAD, so the happy path is the exact-base one.
+		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'abc123' } } },
+		'POST merge-upstream': { status: 200 },
 		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
 		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
 		'POST git/trees': { status: 201, json: { sha: 'tree1' } },

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1509,6 +1509,187 @@ test('dir:show refuses a path the registry does not hold, and logs it', async ()
 	assert.deepEqual(main.calls.openPath, [SITE]);
 });
 
+// --- opening a pull request (#167) ---------------------------------------
+
+// Sign-in is two-legged: the handler returns as soon as there is a code to
+// show, and the outcome of the wait arrives on an event. `settle` gives the
+// background poll the turns it needs, since nothing the handler returns is tied
+// to it.
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+function fakeGithubAuth({ login = 'contributor', token = 'gho_test' } = {}) {
+	return {
+		getClientId: () => 'Ov23liTEST',
+		requestDeviceCode: spy(async () => ({
+			ok: true,
+			userCode: 'WDJB-MJHT',
+			verificationUri: 'https://github.com/login/device',
+			deviceCode: 'dev-code',
+			interval: 5,
+			expiresAt: 1
+		})),
+		pollForToken: spy(async () => ({ ok: true, token })),
+		fetchViewer: spy(async () => ({ ok: true, login }))
+	};
+}
+
+test('github:sign-in asks github-auth for a code, then for the token and the account', async () => {
+	const auth = fakeGithubAuth();
+	const main = loadMain({ stubs: { ...silentLogging(), './github-auth.cjs': auth } });
+	const event = createIpcEvent();
+
+	const started = await main.invokeWith('github:sign-in', event);
+	assert.equal(started.ok, true);
+	assert.equal(started.userCode, 'WDJB-MJHT');
+	assert.equal(started.verificationUri, 'https://github.com/login/device');
+	// The token is what the whole design is about: it must not be on the way
+	// back to the renderer, only the code the contributor types.
+	assert.equal(JSON.stringify(started).includes('gho_test'), false);
+
+	await settle();
+	await settle();
+
+	assert.equal(auth.requestDeviceCode.calls.length, 1);
+	assert.equal(auth.pollForToken.calls.length, 1);
+	assert.equal(auth.pollForToken.calls[0][0].deviceCode, 'dev-code');
+	assert.deepEqual(auth.fetchViewer.calls, [['gho_test']]);
+	assert.deepEqual(event.sent, [{ channel: 'github:sign-in:done', payload: { ok: true, login: 'contributor' } }]);
+});
+
+test('github:account reports the login the sign-in produced, and forgets it on sign-out', async () => {
+	const auth = fakeGithubAuth({ login: 'janedoe' });
+	const main = loadMain({ stubs: { ...silentLogging(), './github-auth.cjs': auth } });
+
+	assert.deepEqual(await main.invoke('github:account'), { ok: true, login: null, configured: true });
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+
+	assert.equal((await main.invoke('github:account')).login, 'janedoe');
+	await main.invoke('github:sign-out');
+	assert.equal((await main.invoke('github:account')).login, null);
+});
+
+// The race the earlier shape had: the in-flight session became unreachable
+// during fetchViewer, so Cancel in that window was a no-op and the contributor
+// ended up signed in anyway. The fetchViewer here does not resolve until the
+// cancel has landed.
+test('github:sign-in-cancel during the account lookup wins: nothing is signed in', async () => {
+	let releaseViewer;
+	const auth = {
+		...fakeGithubAuth(),
+		fetchViewer: () => new Promise((resolve) => { releaseViewer = () => resolve({ ok: true, login: 'janedoe' }); })
+	};
+	const main = loadMain({ stubs: { ...silentLogging(), './github-auth.cjs': auth } });
+	const event = createIpcEvent();
+
+	await main.invokeWith('github:sign-in', event);
+	// Let the poll resolve and the viewer lookup start.
+	await settle();
+	await settle();
+
+	await main.invoke('github:sign-in-cancel');
+	releaseViewer();
+	await settle();
+
+	assert.equal((await main.invoke('github:account')).login, null);
+	// And the renderer heard nothing: a canceled sign-in has no outcome.
+	assert.deepEqual(event.sent, []);
+});
+
+test('github:open-pr asks github-pr to open one, for the ticket this site is linked to', async (t) => {
+	const dir = await fixtureRepo(t);
+	const auth = fakeGithubAuth({ login: 'janedoe' });
+	const openPullRequest = spy(async () => ({ ok: true, url: 'https://github.com/WordPress/wordpress-develop/pull/9', number: 9, branch: 'trac-62281', exactBase: true }));
+	const buildPullRequestBody = spy(() => 'BODY');
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: { [dir]: { tracTicket: 62281 } },
+		preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./github-auth.cjs': auth,
+			'./github-pr.cjs': { openPullRequest, buildPullRequestBody }
+		}
+	});
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+
+	const result = await main.invoke('github:open-pr', dir, { title: 'Fix the thing' });
+
+	assert.equal(result.ok, true);
+	assert.equal(result.number, 9);
+	assert.equal(openPullRequest.calls.length, 1);
+	const [args] = openPullRequest.calls[0];
+	assert.equal(args.token, 'gho_test');
+	assert.equal(args.login, 'janedoe');
+	assert.equal(args.title, 'Fix the thing');
+	assert.equal(args.body, 'BODY');
+	// The ticket comes from the site's stored metadata, not from the caller: the
+	// renderer must not be able to file against a different one.
+	assert.equal(args.ticketId, 62281);
+	assert.deepEqual(buildPullRequestBody.calls, [[{ ticketId: 62281, handle: 'janedoe', event: 'WordCamp Europe 2026' }]]);
+	// The changed file the fixture leaves in the working tree, in the shape the
+	// tree API takes rather than as a diff.
+	assert.deepEqual(args.files.map((f) => [f.path, f.kind]), [['text.txt', 'modify']]);
+});
+
+test('github:open-pr refuses before it reaches GitHub when nothing is signed in, or no ticket is linked', async (t) => {
+	const dir = await fixtureRepo(t);
+	const openPullRequest = spy(async () => ({ ok: true }));
+	const auth = fakeGithubAuth();
+	const settings = fakeSettingsStore({ sites: [dir], siteMeta: { [dir]: {} } });
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./github-auth.cjs': auth,
+			'./github-pr.cjs': { openPullRequest, buildPullRequestBody: () => '' }
+		}
+	});
+
+	assert.equal((await main.invoke('github:open-pr', dir, {})).reason, 'unauthorized');
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+
+	assert.equal((await main.invoke('github:open-pr', dir, {})).reason, 'no-ticket');
+	assert.deepEqual(openPullRequest.calls, []);
+});
+
+test('github:open-pr forgets a revoked authorization rather than keep offering it', async (t) => {
+	const dir = await fixtureRepo(t);
+	const auth = fakeGithubAuth();
+	const settings = fakeSettingsStore({ sites: [dir], siteMeta: { [dir]: { tracTicket: 1 } } });
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./github-auth.cjs': auth,
+			'./github-pr.cjs': {
+				openPullRequest: async () => ({ ok: false, reason: 'unauthorized', error: 'gone', stage: 'forking' }),
+				buildPullRequestBody: () => ''
+			}
+		}
+	});
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+	assert.notEqual((await main.invoke('github:account')).login, null);
+
+	await main.invoke('github:open-pr', dir, {});
+
+	assert.equal((await main.invoke('github:account')).login, null);
+});
+
 // --- the harness's own guard ---------------------------------------------
 
 // Requiring the real `electron` package is not a harmless fallback: its
@@ -1569,7 +1750,10 @@ const WIRED = new Set([
 	'editor:open',
 	'dir:show',
 	'provenance:set-handle',
-	'provenance:set-event'
+	'provenance:set-event',
+	'github:account',
+	'github:sign-in',
+	'github:open-pr'
 ]);
 
 // Channels with no module to reach: they read or write electron-store, drive a
@@ -1593,7 +1777,9 @@ const NO_DELEGATION = new Map([
 	['smtp:start', 'starts the in-process SMTP server'],
 	['smtp:stop', 'stops the in-process SMTP server'],
 	['wp-debug:start', 'tails a file'],
-	['wp-debug:stop', 'stops a tail']
+	['wp-debug:stop', 'stops a tail'],
+	['github:sign-out', 'clears the in-memory token; asserted through github:account above'],
+	['github:sign-in-cancel', 'sets a flag the in-flight poll reads']
 ]);
 
 // There used to be a third list here, UNWIRED_INVARIANTS: the Playground and

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1560,7 +1560,9 @@ test('github:account reports the login the sign-in produced, and forgets it on s
 	const auth = fakeGithubAuth({ login: 'janedoe' });
 	const main = loadMain({ stubs: { ...silentLogging(), './github-auth.cjs': auth } });
 
-	assert.deepEqual(await main.invoke('github:account'), { ok: true, login: null, configured: true });
+	// testMode null is the load-bearing half: it is what keeps the test-mode
+	// badge off a real contributor's screen in a shipped build.
+	assert.deepEqual(await main.invoke('github:account'), { ok: true, login: null, configured: true, testMode: null });
 
 	await main.invokeWith('github:sign-in', createIpcEvent());
 	await settle();

--- a/test/pr-files.test.cjs
+++ b/test/pr-files.test.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+// Shaping the working tree into tree-API entries (#167): the platform split
+// for file modes, deletions, and the CRLF handling that keeps a Windows
+// checkout from publishing a pull request where every line is rewritten.
+//
+// Both platform branches run from one machine by injecting `platform`, `stat`
+// and `git` — the house pattern (test/win-spawn-patch.test.cjs), not `it.skip`,
+// which would leave each OS's CI blind to the other's branch.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	fileModeForEntry,
+	buildPullRequestEntries,
+	isProbablyBinary,
+	GIT_MODE_FILE,
+	GIT_MODE_EXECUTABLE
+} = require('../src/pr-files.cjs');
+
+const DIR = '/sites/wp';
+
+// A fake `git` whose HEAD commit records the given path → mode map. Tree
+// lookups walk path segments the way the real module does, so a nested path
+// exercises the descent.
+function fakeGitWithModes(modes) {
+	const paths = Object.keys(modes);
+	return {
+		readCommit: async () => ({ commit: { tree: 'root' } }),
+		readTree: async ({ oid }) => {
+			const prefix = oid === 'root' ? '' : `${oid}/`;
+			const seen = new Set();
+			const tree = [];
+			for (const p of paths.filter((x) => x.startsWith(prefix))) {
+				const rest = p.slice(prefix.length);
+				const segment = rest.split('/')[0];
+				if (seen.has(segment)) continue;
+				seen.add(segment);
+				tree.push(rest.includes('/')
+					? { path: segment, oid: `${prefix}${segment}`, mode: '040000' }
+					: { path: segment, oid: `blob-${p}`, mode: modes[p] });
+			}
+			return { tree };
+		}
+	};
+}
+
+function deps(overrides = {}) {
+	return {
+		git: fakeGitWithModes({}),
+		fs: null,
+		dir: DIR,
+		headOid: 'head',
+		platform: 'darwin',
+		stat: async () => ({ mode: 0o644 }),
+		...overrides
+	};
+}
+
+test('isProbablyBinary: a NUL byte means binary; absence means nothing', () => {
+	assert.strictEqual(isProbablyBinary(Buffer.from([0x89, 0x00, 0x4e])), true);
+	assert.strictEqual(isProbablyBinary(Buffer.from('plain text\n')), false);
+	assert.strictEqual(isProbablyBinary(null), false);
+});
+
+// POSIX: what is on disk decides, because it is what the contributor has.
+test('on POSIX the working tree’s executable bit decides the mode', async () => {
+	const executable = await fileModeForEntry(
+		deps({ stat: async () => ({ mode: 0o755 }) }),
+		{ path: 'tools/build.sh', inHead: true, inWorkdir: true }
+	);
+	assert.strictEqual(executable, GIT_MODE_EXECUTABLE);
+
+	const plain = await fileModeForEntry(
+		deps({ stat: async () => ({ mode: 0o644 }) }),
+		{ path: 'src/wp-admin/a.php', inHead: true, inWorkdir: true }
+	);
+	assert.strictEqual(plain, GIT_MODE_FILE);
+});
+
+// Windows: there is no bit to read, so the mode git recorded in HEAD is the
+// truth — the filesystem must not be consulted, or a 100755 file would be
+// silently demoted on every Windows contributor's pull request.
+test('on Windows the mode recorded in HEAD decides, and the filesystem is never asked', async () => {
+	let statted = false;
+	const mode = await fileModeForEntry(
+		deps({
+			platform: 'win32',
+			stat: async () => { statted = true; return { mode: 0o644 }; },
+			git: fakeGitWithModes({ 'tools/build.sh': '100755' })
+		}),
+		{ path: 'tools/build.sh', inHead: true, inWorkdir: true }
+	);
+	assert.strictEqual(mode, GIT_MODE_EXECUTABLE);
+	assert.strictEqual(statted, false);
+});
+
+test('an added file on Windows has no recorded mode and no bit: 100644', async () => {
+	const mode = await fileModeForEntry(
+		deps({ platform: 'win32', git: fakeGitWithModes({}) }),
+		{ path: 'new-file.php', inHead: false, inWorkdir: true }
+	);
+	assert.strictEqual(mode, GIT_MODE_FILE);
+});
+
+// A deletion's mode lookup must never stat the path — the file is gone.
+test('a deletion reads its mode from HEAD without touching the missing path', async () => {
+	let statted = false;
+	const entries = await buildPullRequestEntries(
+		[{ path: 'src/wp-includes/gone.php', inHead: true, inWorkdir: false, base: Buffer.from('x'), work: null }],
+		deps({
+			stat: async () => { statted = true; throw new Error('ENOENT'); },
+			git: fakeGitWithModes({ 'src/wp-includes/gone.php': '100644' })
+		})
+	);
+	assert.deepStrictEqual(entries, [{ path: 'src/wp-includes/gone.php', kind: 'delete', content: null, mode: '100644' }]);
+	assert.strictEqual(statted, false);
+});
+
+// The 🔴 case: a CRLF checkout. Edited text goes up LF-normalised — matching
+// what the `.diff` renders and what upstream stores — not as a full-file
+// rewrite.
+test('text content is uploaded LF-normalised, as the patch renders it', async () => {
+	const entries = await buildPullRequestEntries(
+		[{
+			path: 'src/wp-admin/a.php',
+			inHead: true,
+			inWorkdir: true,
+			base: Buffer.from('line1\nline2\n'),
+			work: Buffer.from('line1\r\nline2\r\nline3\r\n')
+		}],
+		deps()
+	);
+	assert.strictEqual(entries.length, 1);
+	assert.strictEqual(entries[0].content.toString('utf8'), 'line1\nline2\nline3\n');
+});
+
+// The phantom-change case: statusMatrix's autocrlf handling misses non-UTF-8
+// files, so a file whose only difference is line endings reaches this walk.
+// It must not become a pull request entry — the contributor never touched it,
+// and the `.diff` does not list it either.
+test('a CRLF-only difference is not a change', async () => {
+	const entries = await buildPullRequestEntries(
+		[{
+			path: 'tests/phpunit/data/encoded.php',
+			inHead: true,
+			inWorkdir: true,
+			base: Buffer.from('caf\xe9\nline2\n', 'latin1'),
+			work: Buffer.from('caf\xe9\r\nline2\r\n', 'latin1')
+		}],
+		deps()
+	);
+	assert.deepStrictEqual(entries, []);
+});
+
+// Binary is the opposite contract: carried byte-for-byte, no normalisation —
+// a 0x0d inside a PNG is data, not a line ending.
+test('binary content is compared and carried raw', async () => {
+	const bytes = Buffer.from([0x89, 0x50, 0x00, 0x0d, 0x0a, 0xff]);
+	const entries = await buildPullRequestEntries(
+		[{ path: 'a.png', inHead: false, inWorkdir: true, base: null, work: bytes }],
+		deps()
+	);
+	assert.strictEqual(entries.length, 1);
+	assert.ok(entries[0].content.equals(bytes), 'the bytes must survive untouched');
+
+	const unchanged = await buildPullRequestEntries(
+		[{ path: 'b.png', inHead: true, inWorkdir: true, base: bytes, work: Buffer.from(bytes) }],
+		deps()
+	);
+	assert.deepStrictEqual(unchanged, []);
+});
+
+test('a file present but unreadable is skipped, not deleted and not emptied', async () => {
+	const entries = await buildPullRequestEntries(
+		[{ path: 'locked.php', inHead: true, inWorkdir: true, base: Buffer.from('x'), work: null }],
+		deps()
+	);
+	assert.deepStrictEqual(entries, []);
+});
+
+test('adds and modifies carry their kind', async () => {
+	const entries = await buildPullRequestEntries(
+		[
+			{ path: 'new.php', inHead: false, inWorkdir: true, base: null, work: Buffer.from('a\n') },
+			{ path: 'old.php', inHead: true, inWorkdir: true, base: Buffer.from('a\n'), work: Buffer.from('b\n') }
+		],
+		deps()
+	);
+	assert.deepStrictEqual(entries.map((e) => [e.path, e.kind]), [['new.php', 'add'], ['old.php', 'modify']]);
+});

--- a/test/preload-listeners.test.cjs
+++ b/test/preload-listeners.test.cjs
@@ -261,6 +261,114 @@ for (const run of RUNS) {
 	});
 }
 
+// --- GitHub sign-in (#167) -----------------------------------------------
+//
+// The same listener-leak shape as the run subscriptions above, in a bridge with
+// one difference that matters: the subscription is made *before* the invoke,
+// because the outcome event can arrive at any point after it and missing it
+// would leave the card waiting forever on a sign-in that already finished. That
+// ordering is what creates the leak this pins — a sign-in that never starts has
+// no outcome coming, and the listener left behind would fire on the next one.
+
+test('signInToGithub subscribes before invoking, and unsubscribes once the outcome arrives', async () => {
+	const { api, ipcRenderer } = loadPreload({
+		invokeResults: { 'github:sign-in': () => ({ ok: true, userCode: 'WDJB-MJHT' }) }
+	});
+	const outcomes = [];
+
+	const started = await api.signInToGithub((payload) => outcomes.push(payload));
+
+	assert.deepEqual(started, { ok: true, userCode: 'WDJB-MJHT' });
+	assert.equal(ipcRenderer.listenerCount('github:sign-in:done'), 1);
+
+	ipcRenderer.emit('github:sign-in:done', { ok: true, login: 'janedoe' });
+
+	assert.deepEqual(outcomes, [{ ok: true, login: 'janedoe' }]);
+	assert.equal(ipcRenderer.listenerCount('github:sign-in:done'), 0);
+
+	// A second event on a global channel must reach nobody: the card is done
+	// with this sign-in, and a callback firing again would overwrite the
+	// account it just settled on.
+	ipcRenderer.emit('github:sign-in:done', { ok: false, reason: 'denied' });
+	assert.equal(outcomes.length, 1);
+});
+
+test('signInToGithub leaves no listener behind when the sign-in never starts', async () => {
+	const { api, ipcRenderer } = loadPreload({
+		invokeResults: { 'github:sign-in': () => ({ ok: false, reason: 'not-configured', error: 'no application' }) }
+	});
+	const outcomes = [];
+
+	const started = await api.signInToGithub((payload) => outcomes.push(payload));
+
+	assert.equal(started.ok, false);
+	assert.equal(ipcRenderer.listenerCount('github:sign-in:done'), 0);
+
+	// The next sign-in's outcome must not reach the callback from the one that
+	// failed to start.
+	ipcRenderer.emit('github:sign-in:done', { ok: true, login: 'someone-else' });
+	assert.deepEqual(outcomes, []);
+});
+
+// The path with neither outcome nor failed start: a cancelled sign-in. The
+// main process deliberately goes quiet, so nothing arrives to trigger the
+// self-removal — cancel itself has to drop the listener, or every
+// sign-in→cancel cycle leaks one for the life of the window and a later
+// successful sign-in fires all the stale callbacks.
+test('cancelGithubSignIn drops the outcome listener the quiet cancel would strand', async () => {
+	const { api, ipcRenderer } = loadPreload({
+		invokeResults: {
+			'github:sign-in': () => ({ ok: true, userCode: 'WDJB-MJHT' }),
+			'github:sign-in-cancel': () => ({ ok: true })
+		}
+	});
+	const outcomes = [];
+
+	await api.signInToGithub((payload) => outcomes.push(payload));
+	await api.cancelGithubSignIn();
+
+	assert.equal(ipcRenderer.listenerCount('github:sign-in:done'), 0);
+
+	// The next sign-in must reach only its own callback, once.
+	const next = [];
+	await api.signInToGithub((payload) => next.push(payload));
+	ipcRenderer.emit('github:sign-in:done', { ok: true, login: 'janedoe' });
+	assert.deepEqual(outcomes, []);
+	assert.deepEqual(next, [{ ok: true, login: 'janedoe' }]);
+});
+
+// A second sign-in supersedes the first in the main process, so the first's
+// outcome is never coming either — starting again must not accumulate.
+test('a superseding sign-in replaces the previous listener instead of stacking one', async () => {
+	const { api, ipcRenderer } = loadPreload({
+		invokeResults: { 'github:sign-in': () => ({ ok: true, userCode: 'WDJB-MJHT' }) }
+	});
+	const first = [];
+	const second = [];
+
+	await api.signInToGithub((payload) => first.push(payload));
+	await api.signInToGithub((payload) => second.push(payload));
+
+	assert.equal(ipcRenderer.listenerCount('github:sign-in:done'), 1);
+
+	ipcRenderer.emit('github:sign-in:done', { ok: true, login: 'janedoe' });
+	assert.deepEqual(first, []);
+	assert.deepEqual(second, [{ ok: true, login: 'janedoe' }]);
+});
+
+test('subscribePullRequestProgress hands back its own unsubscribe', () => {
+	const { api, ipcRenderer } = loadPreload();
+	const seen = [];
+
+	const unsubscribe = api.subscribePullRequestProgress((payload) => seen.push(payload));
+	ipcRenderer.emit('github:pr:progress', { sitePath: '/sites/wp', stage: 'forking' });
+	unsubscribe();
+	ipcRenderer.emit('github:pr:progress', { sitePath: '/sites/wp', stage: 'opening' });
+
+	assert.deepEqual(seen, [{ sitePath: '/sites/wp', stage: 'forking' }]);
+	assert.equal(ipcRenderer.listenerCount('github:pr:progress'), 0);
+});
+
 // The guard for the paragraph above isElectronPackage: if the stub ever stops
 // covering a path, this fails here rather than as a mystery download in another
 // file's test on a cold checkout.


### PR DESCRIPTION
Closes #167.

The destination panel (#166) named two places a patch can go and deliberately left out the one that gets automated checks and the one reviewers actually watch, because there was no path to it from a `.diff` the app could walk. This adds that path — opt-in, and by device code.

## What this does

- **A third destination card**: the whole ask stated before anything happens, including the part the app cannot do for you — and **Not now** costs nothing, returning to the other destinations.
- **Sign-in by device code.** The app shows a short code; the browser takes it to github.com; no password is ever typed into the app. The token lives in one main-process variable for one app run — never on disk, never logged, never sent to the renderer, which is told a login. Quitting the app is signing out.
- **Fork → sync → commit → pull request through the GitHub API**, no git shell-out. One commit via the Git Data API rather than one per file. A stale fork is fast-forwarded first (the commit is based on the local checkout's HEAD, which a stale fork does not contain); a diverged fork falls back to its own tip and the result says so; a same-named repository that is not a fork is refused at step one, before anything is written into it.
- **The pull request carries what the `.diff` cannot**: binary files, and deletions (#174 tracks the patch side). Text uploads LF-normalised exactly as the patch renders it, so a CRLF checkout neither publishes full-file rewrites nor drags in files the contributor never touched.
- **Every failure is typed and lands on the same floor** — the patch file, still there. A revoked authorization drops the card back to signed-out rather than showing a raw 401.
- **The loop closes on Trac**: the ticket a pull request cites is read from the site's stored metadata (not taken from the renderer), and the done state prompts posting the link back on the ticket, where triage and props live.

## Prerequisite from the issue

Resolved: the OAuth application is owned by the WordPress organisation. Device flow uses no client secret, so the client ID shipping in the binary distributes nothing secret. An env override (`WP_DEV_ENV_GITHUB_CLIENT_ID`) allows testing against another application without a rebuild.

## Self-review (per AGENTS.md)

The review in `.github/instructions/code-review.instructions.md` ran against this branch with the judgement pass in a fresh context: **5 [fix here] · 3 [follow-up]**, security explicitly clean (the token invariant holds at every point it examined).

All five were fixed before this PR: CRLF handling on blob uploads (the 🔴), the same-named-repository refusal, dependency-injected tests for the file-mode platform split, a cancel race during the account lookup, and a preload listener leak on cancelled sign-ins. A redirect guard on token-bearing requests was folded in from the review's open question.

The three follow-ups are filed rather than ignored: #176 (change collection memory), #177 (upload timeout), #178 (title validated only at the last step).

## Testing

`npm test` — 479 pass (63 new across five suites: device-flow poll outcomes including slow_down and post-wait expiry, fork/sync/tree/commit/PR sequence against a routed fake API, file modes on both platforms from one machine, deletion and binary tree entries, bridge listener lifecycles, and the IPC wiring including the cancel race). `npm run lint` clean.

By hand on macOS: sign in (code accepted in browser), Not now, cancel mid-wait, and the signed-out → ready → done card states. The paths that need a real second account — a pre-existing stale fork, a diverged fork — are the ones to exercise on the Buildkite artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)