### PR TITLE
Tell the truth when there is no patch left to revert

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -504,8 +504,18 @@ ipcMain.handle('git:update-trunk', async (event, sitePath) => {
             // A failure during checkout leaves the ref moved over a partial
             // worktree — that is the "code is new, assets are old" state, so
             // persist it; a fetch failure moved nothing and stays plain.
+            //
+            // The applied-patch record needs the narrower question, which is why
+            // it reads worktreeReset rather than the stage: once the forced
+            // checkout has started it has taken the patch off disk, so keeping
+            // the record would offer a revert the app cannot honour (#184). The
+            // stage covers index and ref work that can fail with every file
+            // untouched, and dropping the only copy of the patch text there
+            // would strand a patch that is still applied.
             if (stage === 'checkout') {
-                try { await mergeSiteMeta(sitePath, { updateIncomplete: true }); } catch {}
+                const patch = { updateIncomplete: true };
+                if (e && e.worktreeReset) patch.appliedPatch = null;
+                try { await mergeSiteMeta(sitePath, patch); } catch {}
             }
             sendLog(`\nUpdate failed during ${stage}: ${String(e && e.message ? e.message : e)}\n`);
             sendDone({ ok: false, upToDate: false, error: String(e), stage });
@@ -673,7 +683,23 @@ ipcMain.handle('git:apply-patch', async (event, sitePath, options = {}) => {
 
             const result = await applyPatchToDir({ dir: sitePath, patchText, reverse, onLog: sendLog });
             if (!result.ok) {
-                sendDone({ ok: false, ...result });
+                // Nothing to revert means the record is describing a patch the
+                // checkout no longer has. Keeping it would leave the site stuck:
+                // the revert can never succeed, and the one-patch-at-a-time guard
+                // above would refuse every other patch on its behalf.
+                let recordCleared = false;
+                if (reverse && result.notApplied) {
+                    // Reported rather than assumed: if the store write fails the
+                    // site is still stuck, and telling the contributor it is
+                    // sorted would send them back to a button that still refuses.
+                    try {
+                        await mergeSiteMeta(sitePath, { appliedPatch: null });
+                        recordCleared = true;
+                    } catch (e) {
+                        logError('git:apply-patch', `clearing stale applied-patch record failed: ${String(e && e.stack ? e.stack : e)}`);
+                    }
+                }
+                sendDone({ ok: false, ...result, recordCleared });
                 return;
             }
 

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -185,6 +185,41 @@ function resolveFile(dir, file) {
 }
 
 /**
+ * Whether the checkout looks like the patch was never applied — every file it
+ * names sits at its pre-patch state.
+ *
+ * Only asked when a reverse has already failed, and only to tell two failures
+ * apart: a file that drifted since the patch was written, and a file that is
+ * pristine because something reset the tree (a trunk update, a discard) and
+ * took the patch with it. The second one is not a conflict, it is a stale
+ * record, and saying "the file has moved on" about an untouched file sends the
+ * contributor looking for a change that is not there.
+ *
+ * The question is answered by resolving the patch *forwards*: resolveFile
+ * already encodes what each kind needs — a modify whose hunks still match, an
+ * add whose target is absent, a delete whose target is present — so there is no
+ * second matching implementation to keep in step. Nothing is written; this only
+ * ever runs on the failure path, where the checkout is already being left
+ * alone. It has to be unanimous: a patch that is half in the tree is a real
+ * conflict, and dropping its record would strand the applied half.
+ *
+ * Unanimity here is necessary but not sufficient, which is why the caller also
+ * requires that nothing reversed. `JsDiff.applyPatch` searches by offset for a
+ * place the context fits, so a hunk whose context repeats in the file can
+ * "apply forwards" to a file that already has it — patching the other copy.
+ * The caller's guard is what keeps that from reading as an absent patch.
+ *
+ * @param {string} dir
+ * @param {Array}  files Forward (un-reversed) parsed files.
+ * @return {boolean}
+ */
+function patchIsAbsent(dir, files) {
+	const text = files.filter((f) => f.kind !== 'binary');
+	if (!text.length) return false;
+	return text.every((f) => !resolveFile(dir, f).error);
+}
+
+/**
  * Puts back everything a failed run had already written.
  *
  * Returns the paths it could not restore. The same full-disk, lock, or
@@ -265,6 +300,21 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	}
 
 	if (failures.length) {
+		// A reverse that fails on a checkout still holding the pre-patch content
+		// is not a conflict: the patch is gone and only the record of it is left.
+		// Naming that is what lets the caller drop the record instead of leaving
+		// the contributor with a patch they can neither revert nor replace.
+		//
+		// `!actions.length` — not a single file reversed — is the load-bearing
+		// half. A file that is still patched can nonetheless resolve forwards
+		// when its hunk context repeats, because applyPatch finds the other
+		// copy; requiring that nothing at all reversed means a half-present
+		// patch keeps its record and its conflict.
+		if (reverse && !actions.length && patchIsAbsent(dir, parsed.files)) {
+			const error = 'That patch is not in this checkout any more — something reset it, probably a trunk update or a discard. Nothing was reverted.';
+			onLog(`\n${error}\n`);
+			return { ok: false, notApplied: true, error, applied: [], skipped };
+		}
 		onLog(`\nThe patch was not applied — the checkout is unchanged.\n${failures.map((f) => `  • ${f}\n`).join('')}`);
 		return { ok: false, error: failures[0], failures, applied: [], skipped };
 	}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1003,6 +1003,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // chain starts, and the step list still has to know whether install runs.
   const [applyNeedsInstall, setApplyNeedsInstall] = useState(false);
   const [applyError, setApplyError] = useState('');
+  // Not every unhappy ending is a failure: a revert can find that the patch is
+  // already gone, which resolves the situation rather than blocking it. Red
+  // would read as "you broke something" when nothing is left to do.
+  const [applyNotice, setApplyNotice] = useState('');
   const [appliedPatch, setAppliedPatch] = useState(null);
   const [prUrlInput, setPrUrlInput] = useState('');
   const [dirtyModalOpen, setDirtyModalOpen] = useState(false);
@@ -1892,6 +1896,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // checkout — the contributor decides after seeing the file list.
   const choosePatchFile = async () => {
     setApplyError('');
+    setApplyNotice('');
     try {
       const chosen = await window.api.choosePatchFile();
       if (!chosen) return;
@@ -1967,6 +1972,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // so applying a PR and applying a downloaded patch are one path from here on.
   const previewPr = async (pr) => {
     setApplyError('');
+    setApplyNotice('');
     setFetchingPr(pr.number);
     try {
       const diff = await window.api.fetchPrDiff(pr.number);
@@ -2011,6 +2017,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // to the same preview the PR and file paths use.
   const previewAttachment = async (att) => {
     setApplyError('');
+    setApplyNotice('');
     setFetchingAttachment(att.url);
     try {
       const res = await window.api.fetchTracAttachment(att.url);
@@ -2035,7 +2042,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // linked to the ticket — same fetch → preview flow as the linked-PR list.
   const previewPrFromInput = () => {
     const parsed = parsePrRef(prUrlInput);
-    if (!parsed.ok) { setApplyError(parsed.error); return; }
+    if (!parsed.ok) { setApplyError(parsed.error); setApplyNotice(''); return; }
     setPrUrlInput('');
     previewPr({ number: parsed.number, url: `https://github.com/WordPress/wordpress-develop/pull/${parsed.number}` });
   };
@@ -2051,6 +2058,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       ? Boolean(appliedPatch?.files?.includes('package-lock.json'))
       : Boolean(preview.needsInstall);
     setApplyError('');
+    setApplyNotice('');
     setApplyNeedsInstall(needsInstall);
     setApplyState('applying');
     state.running = true;
@@ -2063,6 +2071,21 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       ({ data }) => writeToTerminal(data),
       (res) => {
         if (!res || !res.ok) {
+          // The main process has already dropped the stale record, so reloading
+          // the status is what takes the "is applied" banner down and frees the
+          // panel to accept another patch. Nothing was written, so there is
+          // nothing to install or build.
+          if (res?.notApplied) {
+            if (res.recordCleared) {
+              setApplyNotice(`${res.error} The applied-patch record has been cleared.`);
+            } else {
+              setApplyError(`${res.error} The record of it could not be cleared, so this site still thinks it is applied.`);
+            }
+            // finishApply reloads the status, which is what takes the banner
+            // down now that the main process has dropped the record.
+            finishApply();
+            return;
+          }
           setApplyError(res?.error || 'The patch could not be applied.');
           finishApply();
           return;
@@ -2923,7 +2946,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
               <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
                 <Button variant="primary" onClick={() => runApply()} disabled={isUpdating || installing || building}>Apply and rebuild</Button>
-                <Button variant="tertiary" onClick={() => { setApplyPreview(null); setApplyError(''); }}>Cancel</Button>
+                <Button variant="tertiary" onClick={() => { setApplyPreview(null); setApplyError(''); setApplyNotice(''); }}>Cancel</Button>
               </div>
             </div>
           ) : null}
@@ -2945,8 +2968,32 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
 
           {applyError ? (
-            <div role="alert" style={{ marginTop: 12, padding: '8px 10px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 12, color: '#8a1f21' }}>
-              {/[.!?]$/.test(applyError.trim()) ? applyError : `${applyError.trim()}.`} The checkout was not changed.
+            <div role="alert" style={{ marginTop: 12, padding: '8px 10px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 12, color: '#8a1f21', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+              <span style={{ flex: '1 1 auto' }}>{/[.!?]$/.test(applyError.trim()) ? applyError : `${applyError.trim()}.`} The checkout was not changed.</span>
+              <Button
+                variant="tertiary"
+                isSmall
+                aria-label="Dismiss"
+                onClick={() => setApplyError('')}
+                style={{ color: '#8a1f21' }}
+              >✕</Button>
+            </div>
+          ) : null}
+
+          {applyNotice ? (
+            // Dismissible, like the update summary above: the notice reports
+            // something already resolved, so it outlives its usefulness the
+            // moment it has been read, and nothing else in this panel takes it
+            // down until the next patch.
+            <div role="status" style={{ marginTop: 12, padding: '8px 10px', background: '#f0f6fc', border: '1px solid #3582c4', borderRadius: 6, fontSize: 12, color: '#1d3a5f', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+              <span style={{ flex: '1 1 auto' }}>{applyNotice}</span>
+              <Button
+                variant="tertiary"
+                isSmall
+                aria-label="Dismiss"
+                onClick={() => setApplyNotice('')}
+                style={{ color: '#1d3a5f' }}
+              >✕</Button>
             </div>
           ) : null}
 
@@ -2956,7 +3003,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ minWidth: 280, flex: '1 1 280px' }}>
                   <TextControl
                     value={prUrlInput}
-                    onChange={(value) => { setPrUrlInput(value); setApplyError(''); }}
+                    onChange={(value) => { setPrUrlInput(value); setApplyError(''); setApplyNotice(''); }}
                     onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); previewPrFromInput(); } }}
                     disabled={isUpdating || installing || building}
                     placeholder="Paste a pull request URL or number"

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -126,6 +126,12 @@ async function discardChanges(dir) {
  * plain failure) or 'checkout' (HEAD moved over a partial tree — the caller
  * must persist the incomplete state).
  *
+ * A thrown error also carries `error.worktreeReset`, true only once the forced
+ * checkout has actually begun. `stage` is deliberately coarser: it covers the
+ * index and ref work that precedes the checkout, and a caller that treats it as
+ * "the working tree was reset" would discard state — an applied patch's record
+ * — over a failure that touched no file.
+ *
  * Shallow-clone safe: a depth-1 re-fetch negotiates a new shallow tip, and
  * the forced checkout resets tracked files while untracked ones survive.
  *
@@ -137,6 +143,7 @@ async function discardChanges(dir) {
 async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 	await ensureAutocrlf(dir);
 	let stage = 'fetch';
+	let worktreeReset = false;
 	try {
 		const oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
 		onLog('Fetching latest trunk…\n');
@@ -174,6 +181,11 @@ async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 		}
 		onLog(`\nResetting to latest trunk (${newOid.slice(0, 7)})…\n`);
 		await git.writeRef({ fs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
+		// Everything above this line can fail with the working tree untouched —
+		// statusMatrix walks a 5k-file checkout and writeRef only moves a ref.
+		// From here on, files are being overwritten, so anything the tree used to
+		// hold (an applied patch) has to be assumed gone even if the call throws.
+		worktreeReset = true;
 		await git.checkout({
 			fs, dir, ref: 'trunk', force: true,
 			onProgress: (evt) => onLog(`${evt.phase || 'checkout'} ${evt.loaded || 0}/${evt.total || 0}\r`)
@@ -183,7 +195,10 @@ async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 		onLog(`\nNow on trunk as of ${trunkDate}.\n`);
 		return { upToDate: false, oldOid, newOid, lockfileChanged, trunkDate };
 	} catch (e) {
-		if (e && typeof e === 'object') e.stage = stage;
+		if (e && typeof e === 'object') {
+			e.stage = stage;
+			e.worktreeReset = worktreeReset;
+		}
 		throw e;
 	}
 }

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -479,6 +479,81 @@ test('git:update-trunk hands the update to trunk-update and streams its log back
 	]);
 });
 
+// An update that dies after the forced checkout has already reset the tree
+// (#184): the "incomplete" flag is still true, but the patch went with the
+// reset, so its record cannot be allowed to outlive it — that is precisely the
+// phantom the revert then cannot find.
+test('git:update-trunk drops the applied-patch record when it fails after the checkout', async () => {
+	const updateToLatestTrunk = spy(async () => {
+		const e = new Error('worktree write failed');
+		e.stage = 'checkout';
+		e.worktreeReset = true;
+		throw e;
+	});
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { appliedPatch: { label: 'PR #8913', text: 'STORED' } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './trunk-update': { updateToLatestTrunk } } });
+
+	const event = createIpcEvent();
+	const { updateId } = await main.invokeWith('git:update-trunk', event, '/sites/wp');
+	for (let i = 0; i < 50 && !event.sent.some((m) => m.channel === 'git:update-trunk:done'); i++) {
+		await new Promise((r) => setImmediate(r));
+	}
+
+	const done = event.sent.find((m) => m.channel === 'git:update-trunk:done');
+	assert.deepEqual(done.payload.updateId, updateId);
+	assert.equal(done.payload.stage, 'checkout');
+	assert.equal(settings.values.siteMeta['/sites/wp'].updateIncomplete, true);
+	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch, null);
+});
+
+// The stage is coarser than the reset: it is set before the index walk and the
+// ref write, either of which can fail with every file still in place. Reading
+// it as "the tree was reset" would discard the only copy of a patch that is
+// still applied, which is the failure #184 describes, inverted.
+test('git:update-trunk keeps the applied-patch record when the checkout never started', async () => {
+	const updateToLatestTrunk = spy(async () => {
+		const e = new Error('could not read the index');
+		e.stage = 'checkout';
+		e.worktreeReset = false;
+		throw e;
+	});
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { appliedPatch: { label: 'PR #8913', text: 'STORED' } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './trunk-update': { updateToLatestTrunk } } });
+
+	const event = createIpcEvent();
+	await main.invokeWith('git:update-trunk', event, '/sites/wp');
+	for (let i = 0; i < 50 && !event.sent.some((m) => m.channel === 'git:update-trunk:done'); i++) {
+		await new Promise((r) => setImmediate(r));
+	}
+
+	assert.equal(settings.values.siteMeta['/sites/wp'].updateIncomplete, true, 'the rebuild hint still applies');
+	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch.text, 'STORED');
+});
+
+// A fetch failure moved nothing, so a patch still in the tree keeps its record.
+test('git:update-trunk keeps the applied-patch record when the fetch fails', async () => {
+	const updateToLatestTrunk = spy(async () => { throw new Error('offline'); });
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { appliedPatch: { label: 'PR #8913', text: 'STORED' } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './trunk-update': { updateToLatestTrunk } } });
+
+	const event = createIpcEvent();
+	await main.invokeWith('git:update-trunk', event, '/sites/wp');
+	for (let i = 0; i < 50 && !event.sent.some((m) => m.channel === 'git:update-trunk:done'); i++) {
+		await new Promise((r) => setImmediate(r));
+	}
+
+	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch.text, 'STORED');
+});
+
 test('sites:add normalizes line endings before adopting a directory', async () => {
 	// Throwing ends the handler at its first delegation, which is the only thing
 	// under test — and it has to end there. The next line is a store write, and
@@ -1247,6 +1322,44 @@ test('git:apply-patch reverts using the stored patch text and clears the record'
 	assert.equal(args.reverse, true);
 	assert.equal(args.patchText, 'STORED', 'a revert applies the patch the app stored, not the renderer');
 	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch, null);
+});
+
+// The patch is gone from the tree but its record survived (#183/#184). Keeping
+// the record would be a dead end: the revert can never succeed, and the
+// one-patch-at-a-time guard would refuse every other patch on its behalf.
+test('git:apply-patch clears the record when the revert finds no patch to undo', async () => {
+	const applyPatchToDir = spy(async () => ({ ok: false, notApplied: true, error: 'That patch is not in this checkout any more.', applied: [], skipped: [] }));
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { appliedPatch: { label: 'L', text: 'STORED' } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './patch-apply': { applyPatchToDir } } });
+
+	const event = createIpcEvent();
+	const { applyId } = await main.invokeWith('git:apply-patch', event, '/sites/wp', { reverse: true });
+	const done = await applyDone(event, applyId);
+
+	assert.equal(done.ok, false);
+	assert.equal(done.notApplied, true, 'the renderer needs this to tell a resolution from a failure');
+	assert.equal(done.recordCleared, true, 'claimed only when the store write actually landed');
+	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch, null);
+});
+
+// The mirror of the above: a real failure must leave the record alone, or the
+// patch stays in the tree with nothing offering to undo it.
+test('git:apply-patch keeps the record when a revert fails for any other reason', async () => {
+	const applyPatchToDir = spy(async () => ({ ok: false, error: 'src/a.php has moved on since the patch was written', applied: [], skipped: [] }));
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { appliedPatch: { label: 'L', text: 'STORED' } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './patch-apply': { applyPatchToDir } } });
+
+	const event = createIpcEvent();
+	const { applyId } = await main.invokeWith('git:apply-patch', event, '/sites/wp', { reverse: true });
+	await applyDone(event, applyId);
+
+	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch.text, 'STORED');
 });
 
 // A store whose siteMeta write throws: the patch lands on disk but its revert

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -113,6 +113,118 @@ test('applyPatchToDir: reverting keeps unrelated local work (issue #11)', async 
 	assert.strictEqual(fs.readFileSync(path.join(dir, BAR), 'utf8'), 'my own work\n');
 });
 
+// A trunk update or a discard resets the worktree and takes the patch with it,
+// but the record of it can outlive the reset (#183/#184). Reverting then finds
+// a pristine file: not a conflict, nothing left to undo. Saying "the file has
+// moved on" sends the contributor looking for a change that is not there, and
+// leaves them unable to revert or to apply anything else.
+test('applyPatchToDir: reverting a patch that is no longer in the tree reports it as gone (issue #183)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY); // the reset
+	const before = snapshot(dir);
+
+	const res = await applyPatchToDir({ dir, patchText: FOO_PATCH, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.notApplied, true);
+	assert.doesNotMatch(res.error, /moved on/);
+	assert.match(res.error, /not in this checkout/);
+	assert.deepStrictEqual(snapshot(dir), before, 'reverting nothing must write nothing');
+});
+
+// The other half of the same judgement: a file that genuinely drifted is a
+// conflict, and clearing the record for it would strand a patch that is still
+// in the tree.
+test('applyPatchToDir: a file edited since the patch is still a conflict, not a missing patch (issue #183)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'ONE\nTWO\nTHREE\n');
+
+	const res = await applyPatchToDir({ dir, patchText: FOO_PATCH, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.ok(!res.notApplied, 'a drifted file must not be mistaken for an absent patch');
+	assert.match(res.error, /moved on/);
+});
+
+// Unanimity matters: with one file reverted by hand and one still patched, the
+// patch is half present. Dropping the record would leave the applied half in
+// the tree with nothing offering to undo it.
+test('applyPatchToDir: a half-present patch stays a conflict (issue #183)', async (t) => {
+	const twoFilePatch = `${FOO_PATCH}diff --git a/${BAR} b/${BAR}
+--- a/${BAR}
++++ b/${BAR}
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETA
+ gamma
+`;
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	const applied = await applyPatchToDir({ dir, patchText: twoFilePatch });
+	assert.strictEqual(applied.ok, true);
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY); // only one file reset
+	const before = snapshot(dir);
+
+	const res = await applyPatchToDir({ dir, patchText: twoFilePatch, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.ok(!res.notApplied, 'half a patch is not an absent patch');
+	assert.deepStrictEqual(snapshot(dir), before, 'nothing may change on a half-present patch');
+});
+
+// applyPatch searches by offset for somewhere the context fits, so a hunk whose
+// context repeats can succeed against a file that already carries it — patching
+// the other copy. A forward resolve is therefore not on its own proof that the
+// patch is gone, and treating it as one would drop the record for a patch still
+// sitting in the tree.
+test('applyPatchToDir: repeated context does not make a still-applied patch look absent (issue #183)', async (t) => {
+	const AMBIGUOUS = 'src/wp-includes/dup.php';
+	const body = 'x\ntwo\ny\nx\ntwo\ny\n';
+	const patch = `diff --git a/${AMBIGUOUS} b/${AMBIGUOUS}
+--- a/${AMBIGUOUS}
++++ b/${AMBIGUOUS}
+@@ -4,3 +4,3 @@
+ x
+-two
++TWO
+ y
+`;
+	const dir = await makeRepo(t, { [AMBIGUOUS]: body, [FOO]: FOO_BODY });
+	const twoFilePatch = `${patch}${FOO_PATCH}`;
+	assert.strictEqual((await applyPatchToDir({ dir, patchText: twoFilePatch })).ok, true);
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY); // only the unambiguous file is reset
+	const before = snapshot(dir);
+
+	const res = await applyPatchToDir({ dir, patchText: twoFilePatch, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.ok(!res.notApplied, 'one file still carries the patch, so the record must stand');
+	assert.deepStrictEqual(snapshot(dir), before);
+});
+
+// Added files survive a forced checkout, so an add is the kind most likely to
+// still be there when the modify beside it has been reset.
+test('applyPatchToDir: an added file still present keeps the patch from reading as absent (issue #183)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	const addAndModify = `${FOO_PATCH}diff --git a/src/added.php b/src/added.php
+new file mode 100644
+--- /dev/null
++++ b/src/added.php
+@@ -0,0 +1,1 @@
++added
+`;
+	assert.strictEqual((await applyPatchToDir({ dir, patchText: addAndModify })).ok, true);
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY); // the modify is reset, the untracked add survives
+
+	const res = await applyPatchToDir({ dir, patchText: addAndModify, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.ok(!res.notApplied, 'the added file is still in the tree, so the patch is not absent');
+	assert.strictEqual(fs.existsSync(path.join(dir, 'src/added.php')), true);
+});
+
 test('applyPatchToDir: a patch creates and removes files (issue #11)', async (t) => {
 	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
 	const addPatch = `diff --git a/src/new.php b/src/new.php

--- a/test/trunk-update-fetch.integration.test.cjs
+++ b/test/trunk-update-fetch.integration.test.cjs
@@ -260,8 +260,24 @@ test("updateToLatestTrunk: a failure after HEAD moves is tagged stage 'checkout'
 
 	await assert.rejects(
 		() => updateToLatestTrunk({ dir, url }),
-		(e) => e.stage === 'checkout'
+		(e) => e.stage === 'checkout' && e.worktreeReset === true
 	);
 	// HEAD moved over a partial tree — this is why the caller has to persist.
 	assert.strictEqual(await git.resolveRef({ fs, dir, ref: 'HEAD' }), newOid);
+});
+
+// A fetch failure is the other end of the same contract: nothing moved, so
+// nothing the caller holds about the worktree may be discarded. The
+// pre-checkout half of `stage: 'checkout'` — statusMatrix and writeRef, which
+// can fail with every file untouched — cannot be provoked portably from here
+// (it needs a filesystem permission trick Windows ignores), so the decision
+// that hangs off the flag is tested at the caller instead, in
+// test/ipc-wiring.test.cjs.
+test("updateToLatestTrunk: a fetch failure reports the worktree untouched (issue #183)", async (t) => {
+	const { dir, url } = await makeSiteAndOrigin(t);
+
+	await assert.rejects(
+		() => updateToLatestTrunk({ dir, url: `${url}/does-not-exist` }),
+		(e) => e.worktreeReset === false
+	);
 });


### PR DESCRIPTION
Closes #183. Closes #184.

A site can hold a record of an applied patch that the checkout no longer has: something reset the working tree — a trunk update, a discard — and the record outlived it. Reverting then failed with *"src/wp-admin/includes/class-plugin-upgrader.php has moved on since the patch was written"* about a file sitting at exactly its pre-patch state, and there was no way forward: the banner stayed up, the revert could never succeed, and the one-patch-at-a-time guard refused every other patch on its behalf.

Two changes, plus a dismiss button on the panel's two message boxes.

**Reverting tells the two failures apart.** When a reverse fails *and nothing at all reversed*, the patch is resolved forwards; if every file resolves, the patch is not in the tree, and the record is dropped so the panel works again. Both halves of that test carry weight — `applyPatch` searches by offset for somewhere the context fits, so a hunk whose context repeats can "apply forwards" to a file that already carries it, and only "nothing reversed" rules that out. A drifted file, or a patch half in the tree, is still a conflict and still says so.

**The reset path stops producing the stale record.** `updateToLatestTrunk` now reports whether the forced checkout actually began, separately from the stage. The stage is set before an index walk and a ref write that can both fail with every file untouched; clearing the record there would throw away the only copy of a patch that is still applied — the same bug inverted.

## How to test this

**Starting state:** an initialised site (Sites → one with a green checkmark, `node_modules` present). Any platform; nothing here touches paths, spawning or line endings.

### 1. The bug: reverting a patch that is no longer there

1. In **Apply a patch or PR**, paste `8913` and click **Apply PR**. Wait for the rebuild.
   - The green banner reads **PR #8913 is applied — 2 files**.
2. Click **Update to latest trunk** and let it finish. (This is what removes the patch in real life.)
   - The banner is gone — the update clears the record on its way past.
3. To reach the broken state deliberately, put the record back without the patch: quit the app, open `~/Library/Application Support/electron-setup-wordpress-core/settings.json` (`%APPDATA%\electron-setup-wordpress-core\settings.json` on Windows), and paste back the `appliedPatch` object for that site from before step 2. Reopen the app.
   - The green banner is back, claiming PR #8913 is applied. It is not — `grep environment src/wp-admin/includes/class-plugin-upgrader.php` in the checkout finds nothing.
4. Click **Revert this patch**.
   - **Expected:** a blue notice — *"That patch is not in this checkout any more — something reset it, probably a trunk update or a discard. Nothing was reverted. The applied-patch record has been cleared."*
   - The green banner is gone and the **Apply PR** field accepts a patch again.
   - **On `trunk` this instead says** *"…has moved on since the patch was written"*, the banner stays, and the site is stuck.
5. Click the ✕ on the notice.
   - It closes and stays closed.

**Must NOT have happened:** no file in the checkout changed at step 4 — `git status` in the site folder is exactly what it was before the click. Nothing was installed or rebuilt; the terminal shows one line, not an npm run.

### 2. A real revert still works

1. Apply PR `8913` again, wait for the rebuild.
2. Click **Revert this patch**.
   - It reverts for real: the two files go back, the rebuild runs, the banner clears.

**Must NOT have happened:** the revert did not silently no-op and clear the record — after step 2, `grep environment src/wp-admin/includes/class-plugin-upgrader.php` finds nothing *and* the terminal reported `Reverted 2 files`, not the blue notice.

### 3. A genuine conflict is still a conflict

1. Apply PR `8913`.
2. In the checkout, edit `src/wp-admin/includes/class-theme-upgrader.php` — change a line inside the patched region.
3. Click **Revert this patch**.
   - **Expected:** the red error, still naming the file as having moved on, and the banner **stays**. That is correct: the patch is still partly in the tree, and dropping the record would strand it.

### What I could not test by hand

The `git:update-trunk` half — a checkout that fails after it has started overwriting files, versus one that fails in the index walk before it. Staging either reliably needs a filesystem failure I could not provoke on demand, so both branches are covered by injection in `test/ipc-wiring.test.cjs` instead, and `test/trunk-update-fetch.integration.test.cjs` pins the flag on the two failures a real repo can produce.

## Tests

`npm test` — 428 pass. New: five in `test/patch-apply.integration.test.cjs` (absent patch, drifted file, half-present patch, repeated-context ambiguity, add-that-survives-a-checkout) and four in `test/ipc-wiring.test.cjs` (the record cleared and reported, kept on any other failure, and both sides of the update-trunk decision). Each fails on the old code. `npm run lint` clean.

Spotted while fixing this, filed rather than widened: #188 — an add-only patch survives a forced checkout, but the reset paths clear its record anyway. The mirror image of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
