### PR TITLE
Give the patch screen one moment at a time

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3575,10 +3575,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             */}
             {!patchLoading && patchHasChanges && (
               <div>
-                <div style={{ display:'flex', alignItems:'baseline', gap:8, marginBottom:8 }}>
-                  <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Where this patch goes</div>
-                  <div style={{ fontSize:12, color:'#6c6f72' }}>Nothing is uploaded and no account is asked for here.</div>
-                </div>
+                {/*
+                  The heading this block used to carry is the screen's own now
+                  (#190) — the chooser is a state of the modal, not a section
+                  inside it, and saying it twice three lines apart read as two
+                  different questions.
+                */}
                 <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(260px, 1fr))', gap:12, alignItems:'stretch' }}>
                   <DestinationCard
                     title="Attach to Trac"

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -24,6 +24,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { highlightDiff } from './diff-highlight.cjs';
+import { patchScreenStep, patchScreenCopy, prFailureMessage } from './patch-screen.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // What the app is doing while a pull request is being opened (#167). Each step
@@ -34,15 +35,6 @@ const PR_STAGE_LABELS = {
   syncing: 'Bringing your fork up to date…',
   committing: 'Uploading your changes…',
   opening: 'Opening the pull request…'
-};
-// Why it failed, in a sentence that says what to do about it. Every one of
-// these still leaves the patch file, which is what the card offers underneath.
-const PR_FAILURE_MESSAGES = {
-  unauthorized: 'That GitHub sign-in is no longer valid. Sign in again, or save the patch file instead.',
-  'rate-limited': 'GitHub is rate-limiting this connection. It usually clears within the hour.',
-  offline: 'No connection to GitHub.',
-  'no-ticket': 'Link a Trac ticket to this site first — a pull request has to cite one.',
-  empty: 'There are no changes to open a pull request with.'
 };
 // Per-status wording for the update chain card (#94), following the issue's
 // mockups: the skipped install step is named, never hidden, and the build
@@ -2248,6 +2240,29 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     && patchText.trim() !== 'No changes.'
     && !patchText.startsWith('Error');
 
+  // Which moment the patch screen is in, and what it says there (#190). Derived
+  // from the flow's own state rather than tracked beside it, so the screen and
+  // the pull request can never disagree about where the contributor is.
+  const patchStep = patchScreenStep({
+    prResult,
+    prError,
+    prStage,
+    deviceCode: githubDeviceCode
+  });
+  const patchCopy = patchScreenCopy({
+    step: patchStep,
+    dryRun: Boolean(prResult && prResult.dryRun),
+    failureReason: prError ? prError.reason : ''
+  });
+  // Leaving a finished moment means clearing what put the screen there. The
+  // sign-in is the one that has to reach the main process too: a poll left
+  // running would resolve into a screen nobody is on.
+  const leavePatchStep = () => {
+    if (patchStep === 'signin') { cancelGithubSignIn(); return; }
+    setPrResult(null);
+    setPrError(null);
+  };
+
   // Saving the file, for every destination that needs one (#166). `handoff`
   // asks the main process for the provenance header and the name that carries
   // the handle; without it this is the plain diff the Save button has always
@@ -2383,64 +2398,15 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     } catch {}
   };
 
-  // The pull request card has six states and they are genuinely sequential —
-  // done, still asking, waiting on the browser, ready, declined, not started.
-  // Written as nested ternaries in the JSX that is one expression six levels
-  // deep and unreadable at the point where the wording matters most, so the
-  // states get early returns and the card body gets one call.
-  const renderPullRequestBody = () => {
-    if (prResult) {
-      return (
-        <>
-          {/*
-            A dry run (WP_DEV_ENV_GITHUB_DRY_RUN) stops after the branch: the
-            fork writes are private, the pull request is the step watchers
-            hear about. Saying so beats a "pull request #null".
-          */}
-          {prResult.dryRun ? (
-            <div style={{ fontSize:13, color:'#0f5132' }}>
-              Dry run — branch <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}><code style={{ fontSize:12 }}>{prResult.branch}</code></Button> was created on your fork; no pull request was opened.
-            </div>
-          ) : (
-          <div style={{ fontSize:13, color:'#0f5132' }}>
-            Opened <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}>pull request #{prResult.number}</Button>
-            {' '}from <code style={{ fontSize:12 }}>{prResult.branch}</code>.
-          </div>
-          )}
-          {/*
-            The branch always bases on today's trunk (see resolveBase); this
-            names the consequence when the local checkout was behind it. The
-            clash guard has already ruled out upstream changes to the same
-            files, so this is information, not alarm.
-          */}
-          {prResult.exactBase === false ? (
-            <div style={{ fontSize:12, color:'#6e5406', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, padding:'8px 10px' }}>
-              Your checkout was behind trunk, so the branch was based on today&apos;s trunk. None of your files were changed upstream in between — the pull request shows only your work.
-            </div>
-          ) : null}
-          {/*
-            The Trac loop-back is for a pull request that exists — a dry run
-            has no link worth posting on a ticket.
-          */}
-          {!prResult.dryRun && (
-            <>
-              <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
-                Triage and props live on the ticket, so the link belongs there too.
-              </div>
-              <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
-                {prLinkCopied ? 'Link copied' : 'Copy the link'}
-              </Button>
-              {tracTicket ? (
-                <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
-                  Open #{tracTicket} to comment
-                </Button>
-              ) : null}
-            </>
-          )}
-        </>
-      );
-    }
-
+  // What the chooser asks about the pull request destination: whether there is
+  // an account, and the button that starts everything. The states that used to
+  // sit in this same card — the code, the wait, the outcome — own the screen
+  // now (#190) and render from the four functions below it.
+  //
+  // Still early returns rather than nested ternaries: written inline that is
+  // one expression several levels deep, unreadable exactly where the wording
+  // matters most.
+  const renderPullRequestChoice = () => {
     // Not yet asked, which is not the same as signed out: offering "Sign in"
     // before the answer arrives makes the card flicker on every open.
     if (githubAccount === null) {
@@ -2455,27 +2421,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       );
     }
 
-    if (githubDeviceCode) {
-      return (
-        <>
-          <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
-            Enter this code at <strong>github.com/login/device</strong>, which has been opened in your browser.
-          </div>
-          <div style={{ fontFamily:'Menlo, Consolas, monospace', fontSize:24, letterSpacing:2, fontWeight:600, textAlign:'center', padding:'10px 0', color:'#1d2327' }}>
-            {githubDeviceCode.userCode}
-          </div>
-          <Button variant="secondary" onClick={copyDeviceCode} icon={codeCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
-            {codeCopied ? 'Code copied' : 'Copy the code'}
-          </Button>
-          <Flex justify="center" gap={2}>
-            <Spinner />
-            <div style={{ fontSize:12, color:'#6c6f72' }}>Waiting for you to finish in the browser…</div>
-          </Flex>
-          <Button variant="link" onClick={cancelGithubSignIn} style={{ fontSize:12 }}>Cancel</Button>
-        </>
-      );
-    }
-
     if (githubAccount.login) {
       return (
         <>
@@ -2484,7 +2429,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <TextControl
                 value={prTitle}
                 onChange={setPrTitle}
-                disabled={Boolean(prStage)}
                 placeholder={`Ticket #${tracTicket}`}
                 label="Title"
                 help="The ticket link and your WordPress.org username go in the description."
@@ -2497,8 +2441,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <Button
                 variant="primary"
                 onClick={openPullRequest}
-                isBusy={Boolean(prStage)}
-                disabled={Boolean(prStage)}
                 style={{ justifyContent:'center' }}
               >{githubAccount?.testMode?.dryRun ? 'Push branch (dry run)' : 'Open pull request'}</Button>
             </>
@@ -2507,24 +2449,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               No ticket is linked to this site. A pull request has to cite one — link it in the Trac card.
             </div>
           )}
-          {prStage ? (
-            <div style={{ fontSize:12, color:'#6c6f72' }}>{PR_STAGE_LABELS[prStage] || 'Working…'}</div>
-          ) : (
-            <div style={{ fontSize:12, color:'#6c6f72' }}>
-              {/*
-                The destination is named, not implied: "the fork is made for
-                you" answers what, this answers where — which account the fork
-                and the branch land in.
-              */}
-              Signed in as {githubAccount.login} — the fork and branch go to{' '}
-              <Button
-                variant="link"
-                onClick={()=>window.api.openExternal(`https://github.com/${githubAccount.login}/wordpress-develop`)}
-                style={{ fontSize:12 }}
-              >{githubAccount.login}/wordpress-develop</Button>.{' '}
-              <Button variant="link" onClick={signOutOfGithub} style={{ fontSize:12 }}>Sign out</Button>
-            </div>
-          )}
+          <div style={{ fontSize:12, color:'#6c6f72' }}>
+            {/*
+              The destination is named, not implied: "the fork is made for
+              you" answers what, this answers where — which account the fork
+              and the branch land in.
+            */}
+            Signed in as {githubAccount.login} — the fork and branch go to{' '}
+            <Button
+              variant="link"
+              onClick={()=>window.api.openExternal(`https://github.com/${githubAccount.login}/wordpress-develop`)}
+              style={{ fontSize:12 }}
+            >{githubAccount.login}/wordpress-develop</Button>.{' '}
+            <Button variant="link" onClick={signOutOfGithub} style={{ fontSize:12 }}>Sign out</Button>
+          </div>
         </>
       );
     }
@@ -2556,6 +2494,118 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         <Button variant="primary" onClick={startGithubSignIn} style={{ justifyContent:'center' }}>Sign in with GitHub</Button>
         <Button variant="link" onClick={()=>{ setGithubDeclined(true); setGithubError(''); }} style={{ fontSize:12 }}>Not now</Button>
       </>
+    );
+  };
+
+  const renderSignInStep = () => (
+    <div style={{ display:'flex', flexDirection:'column', gap:12, maxWidth:520 }}>
+      <div style={{ fontSize:13, color:'#3c434a', lineHeight:1.5 }}>
+        Enter this code at <strong>github.com/login/device</strong>, which has been opened in your browser.
+      </div>
+      <div style={{ fontFamily:'Menlo, Consolas, monospace', fontSize:32, letterSpacing:4, fontWeight:600, color:'#1d2327' }}>
+        {githubDeviceCode?.userCode}
+      </div>
+      <div>
+        <Button variant="secondary" onClick={copyDeviceCode} icon={codeCopied ? checkIcon : copyIcon}>
+          {codeCopied ? 'Code copied' : 'Copy the code'}
+        </Button>
+      </div>
+      <Flex justify="flex-start" gap={2}>
+        <Spinner />
+        <div style={{ fontSize:12, color:'#6c6f72' }}>Waiting for you to finish in the browser…</div>
+      </Flex>
+      <div style={{ fontSize:12, color:'#6c6f72', lineHeight:1.6 }}>
+        You are asked for one thing: permission to fork wordpress-develop and push a branch. No credential is written to disk, and the authorization is forgotten when you quit.
+      </div>
+    </div>
+  );
+
+  const renderWorkingStep = () => (
+    <Flex justify="flex-start" gap={2}>
+      <Spinner />
+      <div style={{ fontSize:13, color:'#3c434a' }}>{PR_STAGE_LABELS[prStage] || 'Working…'}</div>
+    </Flex>
+  );
+
+  // What the last save did. Rendered wherever a save can be started from — the
+  // chooser and the failed attempt — because a save that reports nowhere is
+  // "the button did nothing", and the path matters: it is the file the
+  // contributor is about to upload or hand over.
+  const renderSaveOutcome = () => (
+    <>
+      {patchSaved ? (
+        <div style={{ fontSize:13, color:'#0f5132' }}>Saved to {patchSaved}</div>
+      ) : null}
+      {patchSaveError ? (
+        <div role="alert" style={{ fontSize:13, color:'#d63638' }}>Could not save the patch: {patchSaveError}</div>
+      ) : null}
+    </>
+  );
+
+  const renderFailedStep = () => (
+    <div style={{ display:'flex', flexDirection:'column', gap:12, alignItems:'flex-start', maxWidth:520 }}>
+      <div role="alert" style={{ fontSize:13, color:'#d63638', lineHeight:1.5 }}>
+        {prFailureMessage(prError)}
+      </div>
+      {/*
+        Every failure lands here, and every failure has the same floor: the file
+        exists regardless of what GitHub did.
+      */}
+      <Button variant="secondary" onClick={savePatch}>Save the patch file instead</Button>
+      {renderSaveOutcome()}
+    </div>
+  );
+
+  const renderDoneStep = () => {
+    if (!prResult) return null;
+    return (
+      <div style={{ display:'flex', flexDirection:'column', gap:12, alignItems:'flex-start', maxWidth:640 }}>
+        {/*
+          A dry run (WP_DEV_ENV_GITHUB_DRY_RUN) stops after the branch: the
+          fork writes are private, the pull request is the step watchers
+          hear about. Saying so beats a "pull request #null".
+        */}
+        {prResult.dryRun ? (
+          <div style={{ fontSize:13, color:'#0f5132' }}>
+            Dry run — branch <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}><code style={{ fontSize:12 }}>{prResult.branch}</code></Button> was created on your fork; no pull request was opened.
+          </div>
+        ) : (
+        <div style={{ fontSize:13, color:'#0f5132' }}>
+          Opened <Button variant="link" onClick={()=>window.api.openExternal(prResult.url)} style={{ fontSize:13 }}>pull request #{prResult.number}</Button>
+          {' '}from <code style={{ fontSize:12 }}>{prResult.branch}</code>.
+        </div>
+        )}
+        {/*
+          The branch always bases on today's trunk (see resolveBase); this
+          names the consequence when the local checkout was behind it. The
+          clash guard has already ruled out upstream changes to the same
+          files, so this is information, not alarm.
+        */}
+        {prResult.exactBase === false ? (
+          <div style={{ fontSize:12, color:'#6e5406', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, padding:'8px 10px' }}>
+            Your checkout was behind trunk, so the branch was based on today&apos;s trunk. None of your files were changed upstream in between — the pull request shows only your work.
+          </div>
+        ) : null}
+        {/*
+          The Trac loop-back is for a pull request that exists — a dry run
+          has no link worth posting on a ticket.
+        */}
+        {!prResult.dryRun && (
+          <>
+            <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+              Triage and props live on the ticket, so the link belongs there too.
+            </div>
+            <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
+              {prLinkCopied ? 'Link copied' : 'Copy the link'}
+            </Button>
+            {tracTicket ? (
+              <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
+                Open #{tracTicket} to comment
+              </Button>
+            ) : null}
+          </>
+        )}
+      </div>
     );
   };
 
@@ -3481,13 +3531,26 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       ) : null}
       {isPatchOpen && (
         <Modal
-          title="Patch"
+          title={patchCopy.heading}
           onRequestClose={()=>setIsPatchOpen(false)}
           shouldCloseOnClickOutside
           isFullScreen
           headerClassName="patch-modal-header"
         >
           <div style={{ display:'flex', flexDirection:'column', height:'80vh', gap:12 }}>
+            {/*
+              Said in every moment, not once at the top (#190). The state where
+              a contributor most needs to hear that the patch file is untouched
+              is the one where they are least able to go looking for it.
+            */}
+            <div style={{ fontSize:13, color:'#6c6f72', lineHeight:1.5 }}>{patchCopy.subheading}</div>
+            {/*
+              One moment owns the screen at a time. Everything from here to the
+              diff is the chooser's; the four states of the pull request flow
+              render on their own below it.
+            */}
+            {patchStep === 'choose' ? (
+            <>
             {!patchLoading && age.stale && (
               <div style={{ padding:'12px 16px', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, fontSize:13, lineHeight:1.5, color:'#6e5406' }}>
                 This site&apos;s WordPress code is {age.ageDays} days old — this patch may not apply on Trac. Consider updating to the latest trunk first.
@@ -3647,21 +3710,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </span>
                       </div>
                     ) : null}
-                    {renderPullRequestBody()}
+                    {renderPullRequestChoice()}
+                    {/*
+                      A sign-in that failed is not given the screen the way a
+                      failed pull request is: it leaves nothing behind, and the
+                      contributor is still standing in front of the destination
+                      they were about to choose.
+                    */}
                     {githubError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{githubError}</div> : null}
-                    {prError ? (
-                      <>
-                        <div role="alert" style={{ color:'#d63638', fontSize:12 }}>
-                          {PR_FAILURE_MESSAGES[prError.reason] || prError.error}
-                        </div>
-                        {/*
-                          Every failure lands here, and every failure has the
-                          same floor: the file exists regardless of what GitHub
-                          did.
-                        */}
-                        <Button variant="secondary" onClick={savePatch} style={{ justifyContent:'center' }}>Save the patch file instead</Button>
-                      </>
-                    ) : null}
                   </DestinationCard>
                 </div>
               </div>
@@ -3671,12 +3727,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               over the diff is still there when there is nothing to send, and an
               outcome that renders nowhere is the alert this replaced.
             */}
-            {patchSaved ? (
-              <div style={{ fontSize:13, color:'#0f5132' }}>Saved to {patchSaved}</div>
-            ) : null}
-            {patchSaveError ? (
-              <div role="alert" style={{ fontSize:13, color:'#d63638' }}>Could not save the patch: {patchSaveError}</div>
-            ) : null}
+            {renderSaveOutcome()}
             <div style={{ position:'relative', flex:1, minHeight:0 }}>
               {patchLoading ? (
                 <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:16 }}>
@@ -3709,6 +3760,37 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 </>
               )}
             </div>
+            </>
+            ) : (
+              // The other four moments each get the room the diff was taking:
+              // a live authorization and a wall of green and red are not two
+              // things anyone reads at once.
+              <div style={{ flex:1, minHeight:0, overflowY:'auto', paddingTop:4 }}>
+                {patchStep === 'signin' ? renderSignInStep() : null}
+                {patchStep === 'working' ? renderWorkingStep() : null}
+                {patchStep === 'done' ? renderDoneStep() : null}
+                {patchStep === 'failed' ? renderFailedStep() : null}
+              </div>
+            )}
+            {/*
+              The footer belongs to the moment too: what this step costs on the
+              left, the way out of it on the right. The chooser has neither —
+              it is already the way out, and its destinations carry their own
+              buttons.
+            */}
+            {patchStep !== 'choose' ? (
+              <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:16, borderTop:'1px solid #dcdcde', paddingTop:12 }}>
+                <span style={{ fontSize:12, color:'#6c6f72' }}>{patchCopy.footerNote}</span>
+                <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+                  {patchCopy.backLabel ? (
+                    <Button variant="tertiary" onClick={leavePatchStep}>{patchCopy.backLabel}</Button>
+                  ) : null}
+                  {patchStep === 'done' ? (
+                    <Button variant="primary" onClick={()=>setIsPatchOpen(false)}>Done</Button>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
         </Modal>
       )}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -24,7 +24,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { highlightDiff } from './diff-highlight.cjs';
-import { patchScreenStep, patchScreenCopy, prFailureMessage } from './patch-screen.cjs';
+import { patchScreenStep, patchScreenCopy, carryTestMode, prFailureMessage } from './patch-screen.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // What the app is doing while a pull request is being opened (#167). Each step
@@ -2324,7 +2324,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       started = await window.api.signInToGithub((done) => {
         setGithubDeviceCode(null);
         if (done && done.ok) {
-          setGithubAccount({ login: done.login, configured: true });
+          setGithubAccount((prev) => carryTestMode(prev, { login: done.login, configured: true }));
           setGithubError('');
           return;
         }
@@ -2356,7 +2356,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   const signOutOfGithub = async () => {
     try { await window.api.signOutOfGithub(); } catch {}
-    setGithubAccount({ login: null, configured: githubAccount?.configured !== false });
+    setGithubAccount((prev) => carryTestMode(prev, { login: null, configured: prev?.configured !== false }));
     setPrResult(null);
     setPrError(null);
   };
@@ -2379,7 +2379,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         setPrError(res || { reason: 'error', error: 'The pull request could not be opened.' });
         // A revoked authorization is forgotten in the main process, so the card
         // has to stop claiming an account it no longer has.
-        if (res && res.reason === 'unauthorized') setGithubAccount({ login: null, configured: true });
+        if (res && res.reason === 'unauthorized') setGithubAccount((prev) => carryTestMode(prev, { login: null, configured: true }));
       }
     } catch (e) {
       setPrError({ reason: 'error', error: e && e.message ? e.message : String(e) });

--- a/src/renderer/patch-screen.cjs
+++ b/src/renderer/patch-screen.cjs
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * Which moment the patch screen is in, and what it says while it lasts
+ * (issue #190, part of #186).
+ *
+ * Choosing a destination, signing in, watching the pull request happen and
+ * reading its outcome are four different moments, and the screen used to show
+ * all of them at once. Deriving the moment from the flow's own state — rather
+ * than tracking a separate "screen" variable alongside it — means the two can
+ * never disagree about where the contributor is.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM (same convention as update-plan.cjs and trac-ticket.cjs).
+ */
+
+/**
+ * The moment the screen is in, from the pull request flow's state.
+ *
+ * The order the checks run in is the order the contributor experiences: an
+ * outcome outranks a stage, a stage outranks a code, a code outranks the
+ * chooser. It has to be, because the flow leaves state briefly overlapping —
+ * a failure is recorded before the stage is cleared, and reading the stage
+ * first would flash "opening the pull request" over a request that already
+ * failed.
+ *
+ * A sign-in that fails is deliberately not a moment of its own: it clears the
+ * code and returns to the chooser, where the error sits on the destination it
+ * belongs to. Only the pull request itself gets a failure screen, because only
+ * it can fail after the contributor has stopped watching.
+ *
+ * @param {Object} root0
+ * @param {Object} [root0.prResult]   The opened pull request, once there is one.
+ * @param {Object} [root0.prError]    Why the attempt failed.
+ * @param {string} [root0.prStage]    The stage the attempt is in, while it runs.
+ * @param {Object} [root0.deviceCode] The one-time code, while GitHub waits for it.
+ * @return {string} 'choose' | 'signin' | 'working' | 'done' | 'failed'
+ */
+function patchScreenStep({ prResult, prError, prStage, deviceCode } = {}) {
+	if (prResult) return 'done';
+	if (prError) return 'failed';
+	if (prStage) return 'working';
+	if (deviceCode) return 'signin';
+	return 'choose';
+}
+
+// Why it failed, in a sentence that says what to do about it, and the heading
+// that moment is given. Title and message live together so they cannot drift
+// into contradicting each other — the heading names the cause, the message
+// names the way out, and every one of them still leaves the patch file.
+const PR_FAILURES = {
+	unauthorized: {
+		title: 'That sign-in is no longer valid',
+		message: 'That GitHub sign-in is no longer valid. Sign in again, or save the patch file instead.'
+	},
+	'rate-limited': {
+		title: 'GitHub is rate limiting',
+		message: 'GitHub is rate-limiting this connection. It usually clears within the hour.'
+	},
+	offline: {
+		title: 'No connection to GitHub',
+		message: 'No connection to GitHub.'
+	},
+	'no-ticket': {
+		title: 'No ticket is linked',
+		message: 'Link a Trac ticket to this site first — a pull request has to cite one.'
+	},
+	empty: {
+		title: 'There is nothing to send',
+		message: 'There are no changes to open a pull request with.'
+	}
+};
+
+const DEFAULT_FAILURE_TITLE = 'The pull request was not opened';
+
+/**
+ * What the screen says in this moment: the heading naming it, the line under
+ * the heading saying what is still safe, the footer note, and the way back out.
+ *
+ * The reassurance is repeated in every state rather than stated once at the
+ * top, because the state where a contributor most needs to hear that the patch
+ * file is untouched is the one where they are least able to go looking for it.
+ *
+ * `backLabel` is empty where there is nothing to go back to: the chooser is
+ * already the way out, and an attempt in flight cannot be called off — the
+ * fork and the branch are already being written.
+ *
+ * @param {Object}  root0
+ * @param {string}  root0.step
+ * @param {boolean} [root0.dryRun]        The attempt stopped before opening a pull request.
+ * @param {string}  [root0.failureReason] `reason` from the failed attempt.
+ * @return {{heading: string, subheading: string, footerNote: string, backLabel: string}}
+ */
+function patchScreenCopy({ step, dryRun = false, failureReason = '' } = {}) {
+	if (step === 'signin') {
+		return {
+			heading: 'Sign in to GitHub',
+			subheading: 'In your browser, with a one-time code. No password is typed into this app.',
+			footerNote: 'Declining costs nothing — the patch file stays exactly where it is.',
+			backLabel: 'Not now'
+		};
+	}
+	if (step === 'working') {
+		return {
+			heading: 'Opening the pull request',
+			subheading: 'The patch file is already saved. Nothing here can lose it.',
+			footerNote: 'This runs through the GitHub API. No push credential is written to disk.',
+			backLabel: ''
+		};
+	}
+	if (step === 'done') {
+		// A dry run stops after the branch, so the heading that names the pull
+		// request would be the screen lying about what happened — the exact
+		// failure the test-mode indicator exists to prevent.
+		return {
+			heading: dryRun ? 'Branch pushed — dry run' : 'Pull request opened',
+			subheading: dryRun
+				? 'No pull request was opened. The branch is on your fork.'
+				: 'One step left: the ticket does not know about it yet.',
+			footerNote: 'Props are recorded on the ticket, not on the pull request.',
+			backLabel: 'Back to destinations'
+		};
+	}
+	if (step === 'failed') {
+		return {
+			heading: (PR_FAILURES[failureReason] || {}).title || DEFAULT_FAILURE_TITLE,
+			subheading: 'Your patch is untouched. Every other destination is still open.',
+			footerNote: 'You can try the pull request again at any time.',
+			backLabel: 'Pick another destination'
+		};
+	}
+	return {
+		heading: 'Where this patch goes',
+		subheading: 'Nothing is uploaded and no account is asked for until you continue.',
+		footerNote: '',
+		backLabel: ''
+	};
+}
+
+/**
+ * The sentence explaining a failed attempt. Falls back to whatever the flow
+ * reported: an unrecognised reason is still worth showing, because the
+ * alternative is a heading with nothing under it.
+ *
+ * @param {Object} [prError]
+ * @return {string}
+ */
+function prFailureMessage(prError) {
+	if (!prError) return '';
+	return (PR_FAILURES[prError.reason] || {}).message || prError.error || '';
+}
+
+module.exports = {
+	PR_FAILURES,
+	DEFAULT_FAILURE_TITLE,
+	patchScreenStep,
+	patchScreenCopy,
+	prFailureMessage
+};

--- a/src/renderer/patch-screen.cjs
+++ b/src/renderer/patch-screen.cjs
@@ -138,6 +138,32 @@ function patchScreenCopy({ step, dryRun = false, failureReason = '' } = {}) {
 }
 
 /**
+ * The account the panel should hold after signing in, signing out, or having an
+ * authorization revoked under it.
+ *
+ * Every one of those replaces the account wholesale, and the test mode used to
+ * go with it (#197): it is reported alongside the login but it does not belong
+ * to it — it comes from an env switch the main process reads once, so it is
+ * true for the whole run whoever is signed in. Losing it meant the card stopped
+ * saying "dry run" at exactly the point the button could push something, and
+ * the button went back to promising a pull request it would not open.
+ *
+ * An explicit `testMode` on the incoming account still wins; only an absent one
+ * is filled in from what was already known.
+ *
+ * @param {Object} [previous] The account the panel holds now.
+ * @param {Object} next       The account it is moving to.
+ * @return {Object}
+ */
+function carryTestMode(previous, next) {
+	const account = { ...next };
+	if (account.testMode === undefined && previous && previous.testMode !== undefined) {
+		account.testMode = previous.testMode;
+	}
+	return account;
+}
+
+/**
  * The sentence explaining a failed attempt. Falls back to whatever the flow
  * reported: an unrecognised reason is still worth showing, because the
  * alternative is a heading with nothing under it.
@@ -155,5 +181,6 @@ module.exports = {
 	DEFAULT_FAILURE_TITLE,
 	patchScreenStep,
 	patchScreenCopy,
+	carryTestMode,
 	prFailureMessage
 };

--- a/test/patch-screen.test.cjs
+++ b/test/patch-screen.test.cjs
@@ -1,0 +1,122 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	PR_FAILURES,
+	DEFAULT_FAILURE_TITLE,
+	patchScreenStep,
+	patchScreenCopy,
+	prFailureMessage
+} = require('../src/renderer/patch-screen.cjs');
+
+test('patchScreenStep: nothing in flight is the chooser (issue #190)', () => {
+	assert.strictEqual(patchScreenStep(), 'choose');
+	assert.strictEqual(patchScreenStep({}), 'choose');
+	assert.strictEqual(patchScreenStep({ prStage: '', prError: null, prResult: null }), 'choose');
+});
+
+test('patchScreenStep: a code on screen is the sign-in moment (issue #190)', () => {
+	assert.strictEqual(
+		patchScreenStep({ deviceCode: { userCode: 'WDF4-9CQX' } }),
+		'signin'
+	);
+});
+
+test('patchScreenStep: a stage in flight is the working moment (issue #190)', () => {
+	assert.strictEqual(patchScreenStep({ prStage: 'forking' }), 'working');
+});
+
+test('patchScreenStep: an opened pull request is the outcome (issue #190)', () => {
+	assert.strictEqual(patchScreenStep({ prResult: { number: 6091 } }), 'done');
+});
+
+test('patchScreenStep: a failure is its own moment (issue #190)', () => {
+	assert.strictEqual(patchScreenStep({ prError: { reason: 'offline' } }), 'failed');
+});
+
+// The flow leaves these overlapping for a render or two, which is exactly when
+// the wrong precedence is visible: a failure flashing as progress, or a stale
+// code covering the pull request it produced.
+test('patchScreenStep: a failure recorded before the stage clears reads as failed (issue #190)', () => {
+	assert.strictEqual(
+		patchScreenStep({ prStage: 'committing', prError: { reason: 'rate-limited' } }),
+		'failed'
+	);
+});
+
+test('patchScreenStep: an outcome outranks a stage still set (issue #190)', () => {
+	assert.strictEqual(
+		patchScreenStep({ prStage: 'opening', prResult: { number: 6091 } }),
+		'done'
+	);
+});
+
+test('patchScreenStep: the pull request outranks the code that authorized it (issue #190)', () => {
+	assert.strictEqual(
+		patchScreenStep({ deviceCode: { userCode: 'WDF4-9CQX' }, prResult: { number: 6091 } }),
+		'done'
+	);
+	assert.strictEqual(
+		patchScreenStep({ deviceCode: { userCode: 'WDF4-9CQX' }, prStage: 'forking' }),
+		'working'
+	);
+});
+
+test('patchScreenCopy: every moment names itself and what is still safe (issue #190)', () => {
+	for (const step of ['choose', 'signin', 'working', 'done', 'failed']) {
+		const copy = patchScreenCopy({ step });
+		assert.ok(copy.heading.length > 0, `${step} has a heading`);
+		assert.ok(copy.subheading.length > 0, `${step} says what is still safe`);
+	}
+});
+
+test('patchScreenCopy: an attempt in flight offers no way back (issue #190)', () => {
+	assert.strictEqual(patchScreenCopy({ step: 'working' }).backLabel, '');
+});
+
+test('patchScreenCopy: the chooser is already the way out (issue #190)', () => {
+	const copy = patchScreenCopy({ step: 'choose' });
+	assert.strictEqual(copy.backLabel, '');
+	assert.strictEqual(copy.footerNote, '');
+});
+
+test('patchScreenCopy: a dry run never claims a pull request (issue #190)', () => {
+	const dry = patchScreenCopy({ step: 'done', dryRun: true });
+	assert.ok(!/pull request opened/i.test(dry.heading));
+	assert.match(dry.subheading, /No pull request was opened/);
+
+	const real = patchScreenCopy({ step: 'done' });
+	assert.strictEqual(real.heading, 'Pull request opened');
+});
+
+test('patchScreenCopy: the failure heading names the cause it was given (issue #190)', () => {
+	assert.strictEqual(
+		patchScreenCopy({ step: 'failed', failureReason: 'rate-limited' }).heading,
+		PR_FAILURES['rate-limited'].title
+	);
+	assert.strictEqual(
+		patchScreenCopy({ step: 'failed', failureReason: 'something-new' }).heading,
+		DEFAULT_FAILURE_TITLE
+	);
+	assert.strictEqual(
+		patchScreenCopy({ step: 'failed' }).heading,
+		DEFAULT_FAILURE_TITLE
+	);
+});
+
+test('prFailureMessage: a known reason is explained in the app\'s own words (issue #190)', () => {
+	assert.strictEqual(
+		prFailureMessage({ reason: 'unauthorized', error: 'HTTP 401' }),
+		PR_FAILURES.unauthorized.message
+	);
+});
+
+test('prFailureMessage: an unknown reason still shows what the flow reported (issue #190)', () => {
+	assert.strictEqual(
+		prFailureMessage({ reason: 'teapot', error: 'GitHub returned 418.' }),
+		'GitHub returned 418.'
+	);
+	assert.strictEqual(prFailureMessage({ reason: 'teapot' }), '');
+	assert.strictEqual(prFailureMessage(null), '');
+});

--- a/test/patch-screen.test.cjs
+++ b/test/patch-screen.test.cjs
@@ -7,6 +7,7 @@ const {
 	DEFAULT_FAILURE_TITLE,
 	patchScreenStep,
 	patchScreenCopy,
+	carryTestMode,
 	prFailureMessage
 } = require('../src/renderer/patch-screen.cjs');
 
@@ -103,6 +104,38 @@ test('patchScreenCopy: the failure heading names the cause it was given (issue #
 		patchScreenCopy({ step: 'failed' }).heading,
 		DEFAULT_FAILURE_TITLE
 	);
+});
+
+// The bug (#197): signing in replaced the account wholesale, so the dry-run
+// banner vanished and the button went back to reading "Open pull request" at
+// the one point it could actually push something.
+test('carryTestMode: signing in keeps the test mode the build is running in (issue #197)', () => {
+	const before = { login: null, configured: true, testMode: { dryRun: true } };
+	const after = carryTestMode(before, { login: 'juanmaguitar', configured: true });
+	assert.deepStrictEqual(after.testMode, { dryRun: true });
+	assert.strictEqual(after.login, 'juanmaguitar');
+});
+
+test('carryTestMode: signing out and losing an authorization keep it too (issue #197)', () => {
+	const signedIn = { login: 'juanmaguitar', configured: true, testMode: { target: 'juanmaguitar/sandbox' } };
+	assert.deepStrictEqual(
+		carryTestMode(signedIn, { login: null, configured: true }).testMode,
+		{ target: 'juanmaguitar/sandbox' }
+	);
+});
+
+test('carryTestMode: a shipped build is never given a mode it does not have (issue #197)', () => {
+	const after = carryTestMode({ login: null, configured: true }, { login: 'juanmaguitar', configured: true });
+	assert.strictEqual('testMode' in after, false);
+	assert.strictEqual(carryTestMode(undefined, { login: null }).testMode, undefined);
+});
+
+test('carryTestMode: what the main process reports wins over what was remembered (issue #197)', () => {
+	const after = carryTestMode(
+		{ testMode: { dryRun: true } },
+		{ login: 'juanmaguitar', configured: true, testMode: null }
+	);
+	assert.strictEqual(after.testMode, null);
 });
 
 test('prFailureMessage: a known reason is explained in the app\'s own words (issue #190)', () => {


### PR DESCRIPTION
Closes #190, fixes #197. Part of #186.

Stacked on #179 — the base is `juanmaguitar/open-a-pull-request-from-the-app-without-a-push`, and GitHub reparents this to `trunk` once that merges.

## What changes

The patch modal showed the three destinations, every state of the sign-in and pull request flow, and the full diff at the same time, in a screen that never changed shape. A contributor halfway through a sign-in saw the same thing as one who had not chosen yet, plus a code, plus a wall of green and red.

Each moment now owns the screen: **choose**, **sign in**, **working**, **done**, **failed**. Each carries a heading naming it, a line under the heading saying what is still safe, and a footer with the note for that step and the way back out of it.

Which moment it is comes from the flow's own state — `prResult` / `prError` / `prStage` / the device code — rather than a screen variable tracked alongside them, so the two cannot disagree about where the contributor is. The precedence is the order the contributor experiences: an outcome outranks a stage, a stage outranks a code, a code outranks the chooser. That matters because the flow leaves those briefly overlapping, and reading the stage first would flash "opening the pull request" over one that had already failed.

This is the frame the rest of #186 hangs on. **The content of each state is the wording it had today** — the sign-in moment (#192), the destination comparison (#191), the diff summary (#193) and the progress/outcome/failure states (#194) each get their own pull request.

## Files

- `src/renderer/patch-screen.cjs` — new, pure: `patchScreenStep`, `patchScreenCopy`, `prFailureMessage`. Same convention as `update-plan.cjs` and `trac-ticket.cjs`, so it is testable without a DOM. `PR_FAILURE_MESSAGES` moved here and gained the matching headings, so a cause and its way out cannot drift apart.
- `src/renderer/index.jsx` — `renderPullRequestBody`'s six inline branches split into the four state renderers plus the chooser's own `renderPullRequestChoice`; per-state header and footer on the modal.
- `test/patch-screen.test.cjs` — new, 19 cases: one per transition, the precedence pairs, the dry run that must not claim a pull request, unknown failure reasons.

## Also fixes #197

Found while testing this screen: the test-mode indicator was visible only while signed **out**. Signing in, signing out and losing an authorization each replaced the account object wholesale and dropped `testMode` with it — so with a dry run set, the card offered a button reading **Open pull request** rather than **Push branch (dry run)**, which is the exact failure that indicator was added to prevent. The mode is reported alongside the login but does not belong to it: it comes from an env switch the main process reads once per run.

`carryTestMode` in `patch-screen.cjs` now fills it in across all three transitions, and what the main process reports still wins. Four tests cover it; with the old pass-through semantics two of them fail.

## Behaviour

No change to the pull request flow itself — same IPC, same handlers, same test-mode indicator. Two things a reviewer should look at deliberately:

- **The diff is hidden outside the chooser.** A live authorization and a wall of green and red are not two things anyone reads at once. The failed state still offers Save; `done` is terminal and its next action is on Trac.
- **A failed pull request is now its own screen** rather than a red line inside the card, and it is left by "Pick another destination", which clears the error.

## Self-review

Run per AGENTS.md, judgement pass dispatched to a subagent. `eslint .` clean; 504/504 tests pass.

**2 [fix here] · 2 [follow-up]**

- **[fix here] 🟡 architecture** — the failed state's "Save the patch file instead" reported nothing: `patchSaved` / `patchSaveError` rendered only inside the chooser, so a save that failed there was "the button did nothing". Fixed — the outcome is now a shared `renderSaveOutcome()` rendered wherever a save can be started.
- **[fix here] 🔵** — the chooser said "Where this patch goes" twice, once as the modal heading and once as the destinations block's own header. Filed as a follow-up initially; fixed here instead, since the duplication is one this PR introduced.
- **[follow-up] 🔵** — the chooser's heading is unconditional, so it also sits over "Generating patch…" and over the "nothing to send" notice. `patchScreenStep` has no input that expresses either today; belongs with #191.
- **[follow-up] 🔵 tests** — `leavePatchStep`'s split (cancel the sign-in vs. clear the outcome) is the one piece of new logic outside the tested module. The repo has no renderer/JSX harness, so this PR cannot reasonably add it.

## Testing

`npm test`, `npm run lint`, `npm run build:once`, and the app launched and rendered. The states themselves were not exercised end to end from this machine — that needs a site with changes and a GitHub sign-in, and `WP_DEV_ENV_GITHUB_DRY_RUN` is the switch that walks working → done without opening a real pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


