### PR TITLE
Ask what a reviewer needs, and say what core does with a pull request

### DIFF
--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -150,22 +150,42 @@ function describeResponse(res) {
 	return ` [${parts.join('; ')}]`;
 }
 
+// A pull request body is not a place to be terse, but it is a place to be
+// bounded: GitHub caps a body at 65,536 characters and rejects the whole
+// request past it, which would fail at the last step after every file was
+// uploaded. Nothing a contributor types into a notes box comes near this;
+// a paste of the wrong thing does.
+const MAX_NOTES_LENGTH = 20000;
+
 /**
  * The pull request body, in the form core's Trac↔GitHub convention expects.
  *
- * The ticket line is not decoration: it is what links the pull request back to
- * the ticket, what Trac's own bot reads, and — pleasingly — what this app's own
- * `bodyCitesTicket` in patch-sources.cjs looks for, so a pull request opened
- * here shows up in the site's "patches on this ticket" list afterwards.
+ * The ticket line is not decoration. The core handbook is blunt about why:
+ * pull requests on GitHub are not monitored, and one that is not attached to a
+ * Trac ticket is not considered for inclusion. It is also what Trac's own bot
+ * reads and — pleasingly — what this app's `bodyCitesTicket` in
+ * patch-sources.cjs looks for, so a pull request opened here shows up in the
+ * site's "patches on this ticket" list afterwards.
+ *
+ * The contributor's own notes go first, above the ticket line: a reviewer
+ * opening this wants to know what the change is before they want its
+ * paperwork. Everything the app adds sits underneath, in a fixed order, so the
+ * one part a human wrote is the part at the top.
  *
  * @param {Object}        root0
  * @param {number|string} root0.ticketId
  * @param {string}        [root0.handle]
  * @param {string}        [root0.event]
+ * @param {string}        [root0.notes]  Free text from the contributor.
  * @return {string}
  */
-function buildPullRequestBody({ ticketId, handle, event } = {}) {
-	const lines = [`Trac ticket: ${ticketUrl(ticketId)}`];
+function buildPullRequestBody({ ticketId, handle, event, notes } = {}) {
+	const lines = [];
+
+	const written = typeof notes === 'string' ? notes.trim().slice(0, MAX_NOTES_LENGTH) : '';
+	if (written) lines.push(written, '');
+
+	lines.push(`Trac ticket: ${ticketUrl(ticketId)}`);
 	// The same two facts the mentor-handoff header carries (#166), for the same
 	// reason: props follow whoever wrote the patch, and a contributor-day room
 	// is worth naming while it is still happening.
@@ -626,6 +646,7 @@ module.exports = {
 	BASE_BRANCH,
 	MAX_BRANCH_ATTEMPTS,
 	classifyFailure,
+	MAX_NOTES_LENGTH,
 	upstream,
 	isDryRun,
 	testMode,

--- a/src/main.js
+++ b/src/main.js
@@ -617,7 +617,7 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
         baseSha: collected.headOid,
         files: collected.files,
         title,
-        body: buildPullRequestBody({ ticketId, handle, event: contributionEvent }),
+        body: buildPullRequestBody({ ticketId, handle, event: contributionEvent, notes: options.notes }),
         onProgress: (stage) => {
             if (!event.sender.isDestroyed()) event.sender.send('github:pr:progress', { sitePath, stage });
         }

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -10,6 +10,7 @@ import {
   DropdownMenu,
   Modal,
   TextControl,
+  TextareaControl,
   Spinner
 } from '@wordpress/components';
 import { plus, chevronLeft, chevronRight, copy as copyIcon, check as checkIcon, edit, download, comment } from '@wordpress/icons';
@@ -1023,6 +1024,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [githubDeclined, setGithubDeclined] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
   const [prTitle, setPrTitle] = useState('');
+  const [prNotes, setPrNotes] = useState('');
   const [prStage, setPrStage] = useState('');
   const [prResult, setPrResult] = useState(null);
   const [prError, setPrError] = useState(null);
@@ -2253,6 +2255,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setPrResult(null);
     setPrError(null);
     setPrStage('');
+    setPrNotes('');
     setGithubError('');
     setGithubDeclined(false);
     loadGithubAccount();
@@ -2388,7 +2391,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       if (payload && payload.sitePath === sitePath) setPrStage(payload.stage);
     });
     try {
-      const res = await window.api.openPullRequest(sitePath, { title: prTitle });
+      const res = await window.api.openPullRequest(sitePath, { title: prTitle, notes: prNotes });
       if (res && res.ok) {
         setPrResult(res);
       } else {
@@ -2512,14 +2515,62 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         <>
           {tracTicket ? (
             <>
+              {/*
+                The placeholder used to be the fallback title, `Ticket #NNNNN`,
+                which taught the wrong thing by example: a reviewer scanning a
+                list of pull requests learns nothing from a ticket number they
+                can already see. It shows a good title instead, and the line
+                under the field says what an empty box will produce, so the
+                fallback stays honest without being the model.
+              */}
               <TextControl
                 value={prTitle}
                 onChange={setPrTitle}
                 disabled={Boolean(prStage)}
-                placeholder={`Ticket #${tracTicket}`}
+                placeholder="Reject a theme zip in the plugin installer"
                 label="Title"
-                help="The ticket link and your WordPress.org username go in the description."
+                help="What the change does, in one line. Reviewers scan these."
               />
+              {!prTitle.trim() ? (
+                <div style={{ fontSize:12, color:'#6c6f72', marginTop:-4 }}>
+                  Left empty, it will be titled <strong>Ticket #{tracTicket}</strong>.
+                </div>
+              ) : null}
+              {/*
+                The one part of the body a human writes, and the reason the
+                field exists: everything else — the ticket link, the handle,
+                the event — the app already knows and adds. It goes to the top
+                of the description, above the ticket line.
+              */}
+              <TextareaControl
+                value={prNotes}
+                onChange={setPrNotes}
+                disabled={Boolean(prStage)}
+                rows={4}
+                label="Notes for reviewers (optional)"
+                placeholder={'What the change does, and why.\nHow to see it working — the steps you used.\nAnything you are unsure about.'}
+                help="Goes at the top of the description. The ticket link and your WordPress.org username are added underneath."
+              />
+              {/*
+                Two facts from the core handbook that a first-timer has no way
+                to know and that change what they do next: nobody is watching
+                GitHub, and nothing is merged there. Both make the Trac step
+                this flow ends on the point rather than the postscript, so they
+                are stated before the button, not after the pull request
+                exists.
+              */}
+              <details style={{ fontSize:12, color:'#6c6f72' }}>
+                <summary style={{ cursor:'pointer', color:'#3858e9' }}>How pull requests work in core</summary>
+                <div style={{ padding:'8px 0 0', lineHeight:1.6, display:'flex', flexDirection:'column', gap:6 }}>
+                  <div>Nobody watches the pull request list. Yours is seen because its link is on the ticket — which is why this flow ends by sending you back there.</div>
+                  <div>Nothing is merged on GitHub either. A committer applies the change themselves, and the ticket is where they decide to.</div>
+                  <Button
+                    variant="link"
+                    onClick={()=>window.api.openExternal('https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/')}
+                    style={{ fontSize:12 }}
+                  >The handbook page on pull requests</Button>
+                </div>
+              </details>
               {/*
                 The button says what it will actually do. A dry run's button
                 reading "Open pull request" is the label lying about the mode,
@@ -3544,7 +3595,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div>
                 <div style={{ display:'flex', alignItems:'baseline', gap:8, marginBottom:8, flexWrap:'wrap' }}>
                   <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Where this patch goes</div>
-                  <div style={{ fontSize:12, color:'#6c6f72' }}>Two destinations save a file for you to send. The pull request is the one the app sends for you.</div>
+                  <div style={{ fontSize:12, color:'#6c6f72' }}>The pull request is the one the app sends for you. The other two save a file for you to send.</div>
                 </div>
                 {/*
                   `start`, not `stretch`: the groups hold different amounts, and
@@ -3552,6 +3603,56 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   under its button that reads as something failing to load.
                 */}
                 <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(300px, 1fr))', gap:12, alignItems:'start' }}>
+
+                  {/*
+                    Alone in its own group, because it is the one destination
+                    that acts for the contributor: it signs them in, forks, and
+                    pushes. That is also where the signup cliff is (#167), named
+                    here before anything happens rather than sprung after they
+                    have left the venue.
+                  */}
+                  <DestinationGroup>
+                    <Destination
+                      title="Open a pull request"
+                      cost="A GitHub account. The fork is made for you; no password is typed into this app and no credential is written to disk."
+                      after="Automated checks run on it. Nobody watches GitHub, though — posting the link on the ticket is what gets it seen."
+                    >
+                      {/*
+                        Absent from every shipped build. When a test switch is
+                        set it sits above the button, because that is where the
+                        decision is made — a mode set in a terminal minutes
+                        earlier, in an app that otherwise looks identical, is how
+                        a dry run that silently was not one opened a real pull
+                        request during testing.
+                      */}
+                      {githubAccount?.testMode ? (
+                        <div style={{ display:'flex', alignItems:'center', gap:8, padding:'8px 10px', background:'#f0f0f1', border:'1px dashed #949494', borderRadius:6, fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+                          <span style={{ fontWeight:600, letterSpacing:0.5, textTransform:'uppercase', fontSize:10, color:'#1d2327' }}>Test mode</span>
+                          <span>
+                            {githubAccount.testMode.dryRun
+                              ? 'Dry run — a branch is pushed to your fork, no pull request is opened.'
+                              : <>Pull requests go to <code style={{ fontSize:11 }}>{githubAccount.testMode.target}</code>, not to wordpress-develop.</>}
+                          </span>
+                        </div>
+                      ) : null}
+                      {renderPullRequestBody()}
+                      {githubError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{githubError}</div> : null}
+                      {prError ? (
+                        <>
+                          <div role="alert" style={{ color:'#d63638', fontSize:12 }}>
+                            {PR_FAILURE_MESSAGES[prError.reason] || prError.error}
+                          </div>
+                          {/*
+                            Every failure lands here, and every failure has the
+                            same floor: the file exists regardless of what GitHub
+                            did.
+                          */}
+                          <Button variant="secondary" onClick={savePatch} style={{ justifyContent:'center' }}>Save the patch file instead</Button>
+                        </>
+                      ) : null}
+                    </Destination>
+                  </DestinationGroup>
+
                   <DestinationGroup>
                     <Destination
                       title="Attach to Trac"
@@ -3652,55 +3753,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                           {handleError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{handleError}</div> : null}
                         </>
                       )}
-                    </Destination>
-                  </DestinationGroup>
-
-                  {/*
-                    Alone in its own group, because it is the one destination
-                    that acts for the contributor: it signs them in, forks, and
-                    pushes. That is also where the signup cliff is (#167), named
-                    here before anything happens rather than sprung after they
-                    have left the venue.
-                  */}
-                  <DestinationGroup>
-                    <Destination
-                      title="Open a pull request"
-                      cost="A GitHub account. The fork is made for you; no password is typed into this app and no credential is written to disk."
-                      after="Automated checks run on it. Post the link back on the ticket — a pull request does not replace one."
-                    >
-                      {/*
-                        Absent from every shipped build. When a test switch is
-                        set it sits above the button, because that is where the
-                        decision is made — a mode set in a terminal minutes
-                        earlier, in an app that otherwise looks identical, is how
-                        a dry run that silently was not one opened a real pull
-                        request during testing.
-                      */}
-                      {githubAccount?.testMode ? (
-                        <div style={{ display:'flex', alignItems:'center', gap:8, padding:'8px 10px', background:'#f0f0f1', border:'1px dashed #949494', borderRadius:6, fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
-                          <span style={{ fontWeight:600, letterSpacing:0.5, textTransform:'uppercase', fontSize:10, color:'#1d2327' }}>Test mode</span>
-                          <span>
-                            {githubAccount.testMode.dryRun
-                              ? 'Dry run — a branch is pushed to your fork, no pull request is opened.'
-                              : <>Pull requests go to <code style={{ fontSize:11 }}>{githubAccount.testMode.target}</code>, not to wordpress-develop.</>}
-                          </span>
-                        </div>
-                      ) : null}
-                      {renderPullRequestBody()}
-                      {githubError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{githubError}</div> : null}
-                      {prError ? (
-                        <>
-                          <div role="alert" style={{ color:'#d63638', fontSize:12 }}>
-                            {PR_FAILURE_MESSAGES[prError.reason] || prError.error}
-                          </div>
-                          {/*
-                            Every failure lands here, and every failure has the
-                            same floor: the file exists regardless of what GitHub
-                            did.
-                          */}
-                          <Button variant="secondary" onClick={savePatch} style={{ justifyContent:'center' }}>Save the patch file instead</Button>
-                        </>
-                      ) : null}
                     </Destination>
                   </DestinationGroup>
                   </div>

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -19,6 +19,7 @@ const {
 	buildPullRequestBody,
 	branchNameFor,
 	classifyFailure,
+	MAX_NOTES_LENGTH,
 	testMode,
 	ensureFork,
 	resolveBase,
@@ -77,6 +78,44 @@ test('buildPullRequestBody cites the ticket in the form core’s convention expe
 	const bare = buildPullRequestBody({ ticketId: 1 });
 	assert.ok(bare.includes('/ticket/1'));
 	assert.ok(!bare.includes('undefined'));
+});
+
+// The contributor's own words are the only part of the body a human writes,
+// so they lead — a reviewer wants to know what the change is before they want
+// its paperwork.
+test('buildPullRequestBody puts the contributor’s notes above the ticket line', () => {
+	const body = buildPullRequestBody({
+		ticketId: 62281,
+		handle: 'janedoe',
+		notes: '  Rejects a theme zip in the plugin installer.\n\nSteps: upload twentytwentyfour.zip under Plugins → Add New.  '
+	});
+
+	assert.ok(body.startsWith('Rejects a theme zip'), 'the notes lead, and are trimmed');
+	assert.ok(body.indexOf('Rejects a theme zip') < body.indexOf('Trac ticket:'));
+	// Blank lines inside the notes survive: they are the contributor's
+	// paragraphs, and flattening them would rewrite what they wrote.
+	assert.ok(body.includes('installer.\n\nSteps:'));
+	// The ticket line still has to be there and still has to be findable by
+	// bodyCitesTicket, whatever a contributor typed above it.
+	assert.ok(body.includes('Trac ticket: https://core.trac.wordpress.org/ticket/62281'));
+	assert.ok(body.includes('@janedoe'));
+});
+
+test('buildPullRequestBody without notes is what it always was', () => {
+	const body = buildPullRequestBody({ ticketId: 62281 });
+	assert.ok(body.startsWith('Trac ticket:'));
+	// Whitespace-only notes are no notes; they must not open the body with a
+	// blank line above the ticket.
+	assert.strictEqual(buildPullRequestBody({ ticketId: 62281, notes: '   \n  ' }), body);
+});
+
+// A body over GitHub's 65,536-character limit is rejected outright — at the
+// last step, after every file has been uploaded. Nothing typed reaches this;
+// a paste of the wrong thing does.
+test('buildPullRequestBody bounds the notes it was given', () => {
+	const body = buildPullRequestBody({ ticketId: 1, notes: 'x'.repeat(MAX_NOTES_LENGTH + 5000) });
+	assert.ok(body.length < MAX_NOTES_LENGTH + 500);
+	assert.ok(body.includes('Trac ticket:'), 'the ticket line survives the truncation');
 });
 
 test('branchNameFor suffixes rather than reusing a taken name', () => {

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1623,7 +1623,7 @@ test('github:open-pr asks github-pr to open one, for the ticket this site is lin
 	await settle();
 	await settle();
 
-	const result = await main.invoke('github:open-pr', dir, { title: 'Fix the thing' });
+	const result = await main.invoke('github:open-pr', dir, { title: 'Fix the thing', notes: 'What it does, and how to see it.' });
 
 	assert.equal(result.ok, true);
 	assert.equal(result.number, 9);
@@ -1636,7 +1636,10 @@ test('github:open-pr asks github-pr to open one, for the ticket this site is lin
 	// The ticket comes from the site's stored metadata, not from the caller: the
 	// renderer must not be able to file against a different one.
 	assert.equal(args.ticketId, 62281);
-	assert.deepEqual(buildPullRequestBody.calls, [[{ ticketId: 62281, handle: 'janedoe', event: 'WordCamp Europe 2026' }]]);
+	// The notes are the caller's to supply — unlike the ticket, the handle and
+	// the event, which are read from stored state so the renderer cannot claim
+	// a different contributor or a different ticket than this site's.
+	assert.deepEqual(buildPullRequestBody.calls, [[{ ticketId: 62281, handle: 'janedoe', event: 'WordCamp Europe 2026', notes: 'What it does, and how to see it.' }]]);
 	// The changed file the fixture leaves in the working tree, in the shape the
 	// tree API takes rather than as a diff.
 	assert.deepEqual(args.files.map((f) => [f.path, f.kind]), [['text.txt', 'modify']]);


### PR DESCRIPTION
Stacked on #200 (which is stacked on #179). Continues #186.

## Why

The card collected a title and sent a description the contributor never saw. Everything in that body was machine-written — ticket link, handle, event — and none of it says what the change does or how to check it. Meanwhile the title field's placeholder was the fallback, `Ticket #NNNNN`, teaching by example the one title that tells a reviewer nothing they cannot already see.

## What this adds

**A notes field.** Free text, optional, placed at the **top** of the pull request body — above the ticket line, because a reviewer wants the change before its paperwork. Bounded at 20k characters: GitHub rejects a body past 65,536 outright, and it would fail at the last step, after every file has been uploaded.

**Guidance on the title.** The placeholder now models a good one (`Reject a theme zip in the plugin installer`), the help says what it is for ("What the change does, in one line. Reviewers scan these."), and a line under the field states what an empty box will produce — so the fallback stays honest without being the example.

**Two facts from the [core handbook](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/)**, behind a disclosure, that a first-timer cannot guess and that change what they do next:

> Pull requests on GitHub are not monitored. […] Pull requests **must** be attached to a Trac ticket to be considered for inclusion in WordPress Core.

> Pull requests on GitHub will **not** be merged.

That is exactly why this flow ends by sending the contributor back to Trac — until now the app asserted the ticket mattered without saying why. The card's `after` line now carries the reason: *"Automated checks run on it. Nobody watches GitHub, though — posting the link on the ticket is what gets it seen."*

## Also

On request, the pull request group moves to the left of the grid and the subtitle follows the new order.

## Testing

`npm test` — 496 pass (3 new on body composition: notes lead and are trimmed, their paragraphs survive, whitespace-only notes change nothing, and the ticket line survives truncation; plus the IPC wiring test now pins that notes come from the caller while ticket, handle and event stay read from stored state). `npm run lint` clean.

Checked visually at 1100px with the disclosure open and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)