### PR TITLE
Stop promising dark mode the window does not have

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -31,7 +31,20 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
   <meta http-equiv="Permissions-Policy" content="clipboard-read=(self), clipboard-write=(self)" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="color-scheme" content="light dark" />
+  <!--
+    `light`, not `light dark`: this window has no dark theme. Every surface in
+    it is painted light by hand — white cards, #1e1e1e text — and
+    @wordpress/components ships light styles only. Declaring support for both
+    let the browser paint the parts it owns, the native form controls, to match
+    the OS instead. On a machine in dark mode that produced charcoal inputs on
+    white cards, with placeholder text at dark-on-dark contrast: unreadable,
+    and the guidance this app puts in placeholders is exactly what a first-timer
+    needs to read.
+
+    This was a promise the app could not keep, so it stops making it. The day a
+    real dark theme exists, this goes back to `light dark` along with it.
+  -->
+  <meta name="color-scheme" content="light" />
   <meta name="robots" content="noindex, nofollow" />
   <meta name="referrer" content="no-referrer" />
 </head>

--- a/test/color-scheme.test.cjs
+++ b/test/color-scheme.test.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+// The window declares which colour schemes it supports, and the browser paints
+// the parts it owns — native form controls — to match. Declaring `light dark`
+// on a machine in dark mode gave charcoal inputs on hand-painted white cards,
+// with placeholder text at dark-on-dark contrast. That is not cosmetic here:
+// this app puts guidance in placeholders ("Ticket number or URL, e.g. 62281",
+// "WordPress.org username, e.g. janedoe"), so the unreadable text is the text
+// a first-timer most needs.
+//
+// A string assertion looks trivial, and the regression it guards is not: the
+// declaration is one word in a file nobody opens, the app looks perfect to
+// anyone whose OS is in light mode, and CI machines are in light mode too. The
+// only thing that would catch it is a reviewer on a dark laptop, which is how
+// it was found.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INDEX_HTML = path.join(__dirname, '..', 'src', 'renderer', 'index.html');
+
+test('the window declares only the colour scheme it actually implements', () => {
+	const html = fs.readFileSync(INDEX_HTML, 'utf8');
+	const declaration = /<meta\s+name="color-scheme"\s+content="([^"]*)"/i.exec(html);
+
+	assert.ok(declaration, 'index.html no longer declares a color-scheme at all');
+
+	const schemes = declaration[1].trim().toLowerCase().split(/\s+/);
+	assert.ok(
+		!schemes.includes('dark'),
+		'index.html promises dark mode. Every surface in this window is painted light by hand and ' +
+		'@wordpress/components ships light styles only, so the promise reaches the browser and ' +
+		'nothing else: form controls turn dark against white cards. Remove it, or land a real dark ' +
+		'theme in the same change.'
+	);
+	assert.deepEqual(schemes, ['light']);
+});


### PR DESCRIPTION
Not stacked — this is independent of the pull-request work and fixes every text field in the app, so it goes straight to trunk.

## The bug

On an OS in dark mode, every text field renders charcoal against the white cards around it, with placeholder text at dark-on-dark contrast. Reported while testing #204; it affects the ticket field, the WordPress.org username and event fields, and everything else.

## The cause

One word. `index.html` declared:

```html
<meta name="color-scheme" content="light dark" />
```

That tells the browser the page supports both, so it paints the parts it owns — native form controls — to match the OS. Every surface the app paints itself is light by hand (white cards, `#1e1e1e` text), and `@wordpress/components` ships light styles only. There is no dark theme here to meet it halfway; the declaration was a promise nothing kept.

The patch window is unaffected: it never declares a scheme, and a page that does not opt in is painted light regardless of the OS.

## Why it is not cosmetic

This app puts guidance in placeholders — the ticket format, the username example, what to write for reviewers. The unreadable text was the text a first-timer most needs.

## Testing

`npm test` — 418 pass, one new. `npm run lint` clean.

Reproduced and verified in a browser with the OS colour scheme forced to dark, rendering the real components: charcoal inputs before, readable after. The new test asserts the declaration names no scheme the app has not implemented — it fails on the old value and passes on the new one. It looks trivial and guards something that is not: the word sits in a file nobody opens, and the app looks perfect to anyone whose OS is in light mode, CI included. It took a reviewer on a dark laptop to see it.

## Note for the stacked branches

#179, #200 and #204 do not have this fix. Once this merges, merging trunk into #179 carries it to the whole stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)