### PR TITLE
Put the diff first and the destinations beside it

### DIFF
--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -344,45 +344,52 @@ async function resolveBase({ token, login, baseSha }, deps = {}) {
 }
 
 /**
- * Which of the contributor's files upstream has also changed since the local
- * checkout's HEAD. Non-empty means opening the pull request would replace
- * those files wholesale and silently revert the upstream work.
+ * Which of the contributor's files upstream has changed since the commit their
+ * checkout started from. Non-empty means opening the pull request would
+ * replace those files wholesale and silently revert the upstream work.
  *
- * Asked per file through the contents API rather than once through compare:
- * compare caps its file list at 300, and a checkout a few weeks old is behind
- * by more than that repo-wide — a cap that silently hides exactly the clash
- * being looked for. The contributor's own file count is small.
+ * Only the tip side is asked of GitHub. The base side is `baseBlobSha`,
+ * computed from the blob already in the checkout — an earlier version asked
+ * the fork for the base commit too, and that was wrong twice over: it spent a
+ * request per file to learn something local git already knew, and it made the
+ * answer depend on the fork resolving a commit that a fork need not have.
+ * A 404 on that lookup is indistinguishable from "the file was not there",
+ * so an unrecognised base commit read as *every touched file having changed*
+ * — the guard firing on a file upstream had not touched since 2021.
  *
- * A path answers with its blob sha at each of the two commits; any difference
- * — content, or existing on one side only — is a clash. An error reading
- * either side counts as a clash too: the check exists to prevent silent
- * damage, so it fails closed.
+ * Asked per file rather than through compare, whose file list caps at 300: a
+ * checkout a few weeks old is behind by more than that repo-wide, and the cap
+ * would silently hide the clash being looked for.
  *
- * @param {Object}   root0
- * @param {string}   root0.token
- * @param {string}   root0.login
- * @param {string}   root0.baseSha Local checkout's HEAD.
- * @param {string}   root0.tipSha  The fork's trunk tip.
- * @param {string[]} root0.paths   Repo-relative paths the contributor changed.
- * @param {Object}   [deps]
+ * An error reading the tip counts as a clash. The check exists to prevent
+ * silent damage, so it fails closed.
+ *
+ * @param {Object} root0
+ * @param {string} root0.token
+ * @param {string} root0.login
+ * @param {string} root0.tipSha The fork's trunk tip.
+ * @param {Array}  root0.files  `{ path, baseBlobSha }` per changed file.
+ * @param {Object} [deps]
  * @return {Promise<{ok: true, clashes: string[]}|{ok: false, reason: string, error: string}>}
  */
-async function staleTouchedPaths({ token, login, baseSha, tipSha, paths }, deps = {}) {
+async function staleTouchedPaths({ token, login, tipSha, files }, deps = {}) {
 	const get = deps.get || getJson;
 	const repo = `${API}/repos/${login}/${upstream().repo}`;
 
-	const blobShaAt = async (path, ref) => {
-		const res = await get(`${repo}/contents/${encodeURI(path)}?ref=${ref}`, { token });
-		if (res.status === 404) return null;
-		if (res.status !== 200 || !res.json || !res.json.sha) throw new Error(`GitHub returned ${res.status} for ${path}`);
-		return String(res.json.sha);
-	};
-
 	const clashes = [];
 	try {
-		for (const path of paths) {
-			const [atBase, atTip] = await Promise.all([blobShaAt(path, baseSha), blobShaAt(path, tipSha)]);
-			if (atBase !== atTip) clashes.push(path);
+		for (const file of files) {
+			const res = await get(`${repo}/contents/${encodeURI(file.path)}?ref=${tipSha}`, { token });
+			// Absent at the tip: a clash only if it was present at the base,
+			// which means upstream deleted a file this change would restore.
+			if (res.status === 404) {
+				if (file.baseBlobSha) clashes.push(file.path);
+				continue;
+			}
+			if (res.status !== 200 || !res.json || !res.json.sha) {
+				throw new Error(`GitHub returned ${res.status} for ${file.path}`);
+			}
+			if (String(res.json.sha) !== file.baseBlobSha) clashes.push(file.path);
 		}
 	} catch (e) {
 		return { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) };
@@ -572,13 +579,7 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 	// the app's own update flow rather than at a pull request that undoes
 	// commits its author never saw.
 	if (!base.exact) {
-		const stale = await staleTouchedPaths({
-			token,
-			login,
-			baseSha,
-			tipSha: base.sha,
-			paths: files.map((f) => f.path)
-		}, deps);
+		const stale = await staleTouchedPaths({ token, login, tipSha: base.sha, files }, deps);
 		if (!stale.ok) return at('syncing', stale);
 		if (stale.clashes.length > 0) {
 			return {

--- a/src/pr-files.cjs
+++ b/src/pr-files.cjs
@@ -26,6 +26,7 @@
  */
 
 const path = require('path');
+const crypto = require('crypto');
 const { normalizeEolBuffer } = require('./git-update.cjs');
 
 // The two modes a file in this repo can have. Git records nothing else for a
@@ -33,6 +34,30 @@ const { normalizeEolBuffer } = require('./git-update.cjs');
 // wordpress-develop does not use.
 const GIT_MODE_FILE = '100644';
 const GIT_MODE_EXECUTABLE = '100755';
+
+/**
+ * Git's own object id for a blob: sha1 over `blob <length>\0` and the bytes.
+ *
+ * Computed here rather than asked of GitHub, because the answer is already on
+ * disk. The staleness check needs to know what upstream had at the commit the
+ * contributor started from, and that is exactly the blob their checkout holds
+ * — asking a fork about a commit it may not have heard of, to learn something
+ * local git already knows, is a network round trip that can also be wrong.
+ *
+ * Raw bytes, not the EOL-normalised ones sent as content: this has to equal
+ * the sha upstream recorded, and upstream recorded what it stored.
+ *
+ * @param {Buffer|null} content
+ * @return {string|null} Null when the file did not exist at that commit.
+ */
+function blobSha(content) {
+	if (!Buffer.isBuffer(content)) return null;
+	return crypto
+		.createHash('sha1')
+		.update(`blob ${content.length}\0`)
+		.update(content)
+		.digest('hex');
+}
 
 /**
  * The same heuristic the patch builder uses: a NUL byte means binary. Null and
@@ -121,7 +146,7 @@ async function buildPullRequestEntries(files, deps) {
 	for (const file of files) {
 		const mode = await fileModeForEntry(deps, file);
 		if (!file.inWorkdir) {
-			entries.push({ path: file.path, kind: 'delete', content: null, mode });
+			entries.push({ path: file.path, kind: 'delete', content: null, mode, baseBlobSha: blobSha(file.base) });
 			continue;
 		}
 		if (!file.work) continue;
@@ -138,7 +163,10 @@ async function buildPullRequestEntries(files, deps) {
 			path: file.path,
 			kind: file.inHead ? 'modify' : 'add',
 			content: work,
-			mode
+			mode,
+			// What upstream had at the commit this checkout started from, which
+			// is what the staleness check compares against.
+			baseBlobSha: blobSha(file.base)
 		});
 	}
 	return entries;
@@ -148,6 +176,7 @@ module.exports = {
 	GIT_MODE_FILE,
 	GIT_MODE_EXECUTABLE,
 	isProbablyBinary,
+	blobSha,
 	modeInCommit,
 	fileModeForEntry,
 	buildPullRequestEntries

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -18,6 +18,35 @@
     .path { font-family: Menlo, monospace; font-size: 12px; color: #333; word-break: break-all; }
     #log { white-space: pre-wrap; background: #111; color: #eee; padding: 12px; border-radius: 6px; height: 220px; overflow: auto; }
     .patch-modal-header .components-modal__header-heading { color: #1e1e1e !important; }
+    /*
+      The patch screen's two columns (#186): the diff takes the room and where
+      it can go stands beside it.
+
+      A media query rather than flex-wrap, which was tried first and cannot do
+      this. Wrapping keeps both columns on one flex line whose height is fixed
+      by the modal, so the wrapped sidebar had nowhere to go and the diff
+      overlapped it. Stacking has to change what scrolls as well as what sits
+      where: side by side the sidebar scrolls alone and the diff stays put;
+      stacked, the pair scrolls as one and the diff keeps a floor so it cannot
+      collapse to a sliver above the destinations.
+
+      The breakpoint is where a 300px sidebar starts squeezing the code rather
+      than sitting next to it, which is what the screen is for.
+    */
+    .patch-columns { display: flex; gap: 16px; flex: 1; min-height: 0; align-items: stretch; }
+    .patch-columns > .patch-diff { flex: 2 1 460px; min-width: 0; display: flex; flex-direction: column; min-height: 0; gap: 8px; }
+    .patch-columns > .patch-destinations { flex: 1 1 340px; min-width: 300px; max-width: 460px; display: flex; flex-direction: column; gap: 12px; min-height: 0; overflow-y: auto; }
+    @media (max-width: 900px) {
+      .patch-columns { flex-direction: column; overflow-y: auto; }
+      /*
+        A definite height, not a minimum: the diff pane fills its column with
+        `height: 100%`, and a percentage against a parent whose own height is
+        content-derived resolves to nothing — the pane then grew past the
+        column and sat on top of the destinations below it.
+      */
+      .patch-columns > .patch-diff { flex: none; height: 340px; }
+      .patch-columns > .patch-destinations { flex: none; max-width: none; overflow-y: visible; }
+    }
     .components-dropdown-menu__toggle { display: flex; flex-direction: row-reverse; gap: 4px; }
   </style>
   <link rel="stylesheet" href="index.css" />

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -28,6 +28,14 @@ import { highlightDiff } from './diff-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
+// What the Copy button says about the press just made. Keyed rather than
+// nested ternaries, so a fourth state is a line here instead of another branch
+// in the middle of the JSX.
+const COPY_BUTTON_LABELS = {
+  idle: 'Copy',
+  copied: 'Copied',
+  failed: 'Could not copy'
+};
 // What the app is doing while a pull request is being opened (#167). Each step
 // is named because they take visibly different amounts of time — forking is the
 // slow one, and an unlabelled spinner there reads as a hang.
@@ -1008,6 +1016,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // the destination panel is where the contributor is looking, and the path
   // matters — it is the file they are about to upload or hand over (#166).
   const [patchSaved, setPatchSaved] = useState(null);
+  // '' | 'copied' | 'failed', shown on the Copy button for two seconds.
+  const [patchCopied, setPatchCopied] = useState('');
+  // Held so a second press restarts the message rather than being cut short by
+  // the first press's timer, and so an unmount does not leave one running.
+  const copyFeedbackTimer = useRef(null);
   const [patchSaveError, setPatchSaveError] = useState('');
   const [handleInput, setHandleInput] = useState('');
   const [eventInput, setEventInput] = useState('');
@@ -2270,8 +2283,28 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     }
   };
 
-  const copyPatch = async ()=>{
-    try { await navigator.clipboard.writeText(patchText); } catch {}
+  // Copying is the one action here with no visible result: the clipboard is
+  // somewhere else, the diff does not move, and a button that answers nothing
+  // reads as a button that did nothing — so it gets pressed again, and the
+  // contributor is left unsure whether they have the patch at all.
+  //
+  // A failed copy says so rather than staying quiet. `writeText` rejects when
+  // the document is not focused, which is exactly the case where someone has
+  // clicked away mid-action and is least likely to notice nothing happened.
+  useEffect(() => () => { if (copyFeedbackTimer.current) clearTimeout(copyFeedbackTimer.current); }, []);
+
+  const copyPatch = async () => {
+    // Cleared first so a second press restarts the message instead of
+    // inheriting the timer of the one before it.
+    if (copyFeedbackTimer.current) clearTimeout(copyFeedbackTimer.current);
+    let state = 'copied';
+    try {
+      await navigator.clipboard.writeText(patchText);
+    } catch {
+      state = 'failed';
+    }
+    setPatchCopied(state);
+    copyFeedbackTimer.current = setTimeout(() => setPatchCopied(''), 2000);
   };
 
   // Naming destinations for a patch that does not exist would be noise, and
@@ -3618,7 +3651,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   */}
                   <div style={{ display:'flex', gap:8 }}>
                     <Button variant="secondary" icon={download} onClick={savePatch} disabled={patchLoading}>Save</Button>
-                    <Button variant="secondary" icon={copyIcon} onClick={copyPatch} disabled={patchLoading}>Copy</Button>
+                    <Button
+                      variant="secondary"
+                      icon={patchCopied === 'copied' ? checkIcon : copyIcon}
+                      onClick={copyPatch}
+                      disabled={patchLoading}
+                      // The label carries the outcome rather than a tooltip or
+                      // a toast: it is the thing that was just pressed, so it
+                      // is where the eye already is, and a screen reader
+                      // announces the change on the focused control.
+                    >{COPY_BUTTON_LABELS[patchCopied] || COPY_BUTTON_LABELS.idle}</Button>
                   </div>
                 </div>
                 {/*

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3580,29 +3580,100 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 There is nothing to send yet — this site has no changes against its copy of trunk.
               </div>
             )}
-            {/*
-              Where the patch goes, named at the moment it exists (#166), each
-              destination with what it costs — a tool that emits a file and stops
-              leaves the contributor to work that out alone.
+{/*
+              Diff on the left, destinations on the right (#186).
 
-              Grouped by who does the sending. The subtitle states that split
-              once, in the only place a reader passes before the cards; it used
-              to promise that nothing was uploaded and no account was asked for,
-              which stopped being true the moment #167 put a pull request on
-              this screen.
+              The patch used to sit under the destinations, which put the
+              choice above the thing being chosen for: a contributor scrolled
+              past three cards to read their own code, then scrolled back. The
+              code is what they came to look at and the largest thing on the
+              screen, so it takes the room, and where it can go stands beside
+              it — visible the whole time they are reading, rather than
+              something to scroll back to.
+
+              This is the shape of an earlier take on the same screen (#6),
+              revived here on top of the destinations this app has now.
             */}
-            {!patchLoading && patchHasChanges && (
-              <div>
-                <div style={{ display:'flex', alignItems:'baseline', gap:8, marginBottom:8, flexWrap:'wrap' }}>
-                  <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Where this patch goes</div>
-                  <div style={{ fontSize:12, color:'#6c6f72' }}>The pull request is the one the app sends for you. The other two save a file for you to send.</div>
+            <div className="patch-columns">
+
+              {/*
+                The column widths, the stacking breakpoint and what scrolls in
+                each case are in index.html — a media query can express them and
+                an inline style cannot. `min-width: 0` there is load-bearing on
+                a flex child holding a <pre>: without it the diff's longest line
+                sets the column's floor and pushes the destinations off the
+                modal instead of scrolling.
+              */}
+              <div className="patch-diff">
+                <div style={{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:12, flexWrap:'wrap' }}>
+                  <div>
+                    <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Your changes</div>
+                    <div style={{ fontSize:12, color:'#6c6f72' }}>Everything this site has that its copy of trunk does not.</div>
+                  </div>
+                  {/*
+                    Out of the diff and into the header: these used to float
+                    over the top-right of the code, which was survivable at
+                    full width and covers the first line of a hunk once the
+                    pane is a column.
+                  */}
+                  <div style={{ display:'flex', gap:8 }}>
+                    <Button variant="secondary" icon={download} onClick={savePatch} disabled={patchLoading}>Save</Button>
+                    <Button variant="secondary" icon={copyIcon} onClick={copyPatch} disabled={patchLoading}>Copy</Button>
+                  </div>
                 </div>
                 {/*
-                  `start`, not `stretch`: the groups hold different amounts, and
-                  stretching the shorter one to match leaves a tall empty box
-                  under its button that reads as something failing to load.
+                  Under the diff rather than beside the destinations that
+                  trigger it: this is the outcome for the file, the file is
+                  what this column is, and the header's own Save button needs
+                  somewhere to report even when there are no destinations to
+                  show.
                 */}
-                <div style={{ display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(300px, 1fr))', gap:12, alignItems:'start' }}>
+                {patchSaved ? (
+                  <div style={{ fontSize:13, color:'#0f5132' }}>Saved to {patchSaved}</div>
+                ) : null}
+                {patchSaveError ? (
+                  <div role="alert" style={{ fontSize:13, color:'#d63638' }}>Could not save the patch: {patchSaveError}</div>
+                ) : null}
+                <div style={{ position:'relative', flex:1, minHeight:0 }}>
+              {patchLoading ? (
+                <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:16 }}>
+                  <Spinner />
+                  <div style={{ color:'#666', fontSize:14 }}>Generating patch...</div>
+                </div>
+              ) : (
+                <>
+                  {/*
+                      `boxSizing: border-box` with `height: 100%` and a
+                      padding: without it the pane is its container plus
+                      24px of padding, and it overflows by exactly that.
+                      Invisible while the diff spanned the modal and the
+                      overflow fell off the bottom; beside a sidebar it
+                      sits on top of the destinations.
+                    */}
+                    <pre style={{ margin:0, whiteSpace:'pre-wrap', background:'#111', color:'#eee', padding:12, borderRadius:6, height:'100%', boxSizing:'border-box', overflowY:'auto' }}>
+                    {patchText && patchText.trim().length ? <DiffText text={patchText} /> : 'No changes.'}
+                  </pre>
+                </>
+              )}
+                </div>
+              </div>
+
+              {/*
+                Where the patch goes, named at the moment it exists (#166),
+                each destination with what it costs — a tool that emits a file
+                and stops leaves the contributor to work that out alone.
+
+                Grouped by who does the sending, and stacked rather than laid
+                side by side: in a column the grouping is what the shared card
+                says, and the sidebar can scroll on its own while the diff
+                stays put.
+              */}
+              {!patchLoading && patchHasChanges && (
+                <div className="patch-destinations">
+                  <div>
+                  <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Where this patch goes</div>
+                  <div style={{ fontSize:12, color:'#6c6f72', lineHeight:1.5 }}>The pull request is the one the app sends for you. The other two save a file for you to send.</div>
+                  </div>
 
                   {/*
                     Alone in its own group, because it is the one destination
@@ -3756,49 +3827,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     </Destination>
                   </DestinationGroup>
                   </div>
-                </div>
-            )}
-            {/*
-              Outside the destinations block on purpose: the plain Save button
-              over the diff is still there when there is nothing to send, and an
-              outcome that renders nowhere is the alert this replaced.
-            */}
-            {patchSaved ? (
-              <div style={{ fontSize:13, color:'#0f5132' }}>Saved to {patchSaved}</div>
-            ) : null}
-            {patchSaveError ? (
-              <div role="alert" style={{ fontSize:13, color:'#d63638' }}>Could not save the patch: {patchSaveError}</div>
-            ) : null}
-            <div style={{ position:'relative', flex:1, minHeight:0 }}>
-              {patchLoading ? (
-                <div style={{ display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', height:'100%', gap:16 }}>
-                  <Spinner />
-                  <div style={{ color:'#666', fontSize:14 }}>Generating patch...</div>
-                </div>
-              ) : (
-                <>
-                  <div style={{ position:'absolute', top:8, right:8, zIndex:2, display:'flex', gap:8 }}>
-                    <Button
-                      icon={download}
-                      label="Save"
-                      onClick={savePatch}
-                      style={{
-                        background:'#fff', border:'1px solid #ddd', color:'#111', boxShadow:'none'
-                      }}
-                    />
-                    <Button
-                      icon={copyIcon}
-                      label="Copy"
-                      onClick={copyPatch}
-                      style={{
-                        background:'#fff', border:'1px solid #ddd', color:'#111', boxShadow:'none'
-                      }}
-                    />
-                  </div>
-                  <pre style={{ margin:0, whiteSpace:'pre-wrap', background:'#111', color:'#eee', padding:12, borderRadius:6, height:'100%', overflowY:'auto' }}>
-                    {patchText && patchText.trim().length ? <DiffText text={patchText} /> : 'No changes.'}
-                  </pre>
-                </>
               )}
             </div>
           </div>

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -292,25 +292,81 @@ test('resolveBase survives a fork that cannot be fast-forwarded', async () => {
 // The guard for the sharp edge tip-basing has: the tree API replaces whole
 // files, so a contributor behind trunk who touched a file upstream also
 // changed would silently revert that upstream work.
-test('staleTouchedPaths names the files upstream changed since the local HEAD', async () => {
-	const shaAt = {
-		'a.php?ref=local': 'blob1', 'a.php?ref=tip': 'blob1', // untouched upstream
-		'b.php?ref=local': 'blob2', 'b.php?ref=tip': 'blob2-new', // changed upstream
-		'c.php?ref=local': 'blob3' // deleted upstream → 404 at tip
+//
+// The base side is the blob sha the checkout already holds, not a second
+// lookup — which is the bug this shape fixes, below.
+test('staleTouchedPaths names the files upstream changed since the local base', async () => {
+	const atTip = {
+		'a.php': 'blob1',        // unchanged upstream
+		'b.php': 'blob2-new',    // changed upstream
+		'd.php': 'blob4'         // added upstream, absent from the base
 	};
 	const api = {
 		get: async (url) => {
-			const key = Object.keys(shaAt).find((k) => url.includes(k));
-			return key ? { status: 200, json: { sha: shaAt[key] } } : { status: 404, json: {} };
+			const name = decodeURI(url).split('/contents/')[1].split('?')[0];
+			return name in atTip
+				? { status: 200, json: { sha: atTip[name] } }
+				: { status: 404, json: {} };
+		}
+	};
+
+	const res = await staleTouchedPaths({
+		token: TOKEN,
+		login: LOGIN,
+		tipSha: 'tip',
+		files: [
+			{ path: 'a.php', baseBlobSha: 'blob1' },
+			{ path: 'b.php', baseBlobSha: 'blob2' },
+			// Present at the base, gone at the tip: upstream deleted it, and
+			// uploading would bring it back.
+			{ path: 'c.php', baseBlobSha: 'blob3' },
+			// The contributor is adding it; upstream added one too.
+			{ path: 'd.php', baseBlobSha: null }
+		]
+	}, api);
+
+	assert.deepStrictEqual(res, { ok: true, clashes: ['b.php', 'c.php', 'd.php'] });
+});
+
+// A file the contributor is adding that upstream does not have is not a clash,
+// and must not be reported as one — it is the ordinary case for a new test
+// file.
+test('staleTouchedPaths does not call a genuinely new file a clash', async () => {
+	const api = { get: async () => ({ status: 404, json: {} }) };
+
+	const res = await staleTouchedPaths(
+		{ token: TOKEN, login: LOGIN, tipSha: 'tip', files: [{ path: 'tests/new-test.php', baseBlobSha: null }] },
+		api
+	);
+
+	assert.deepStrictEqual(res, { ok: true, clashes: [] });
+});
+
+// The false positive this shape exists to prevent, reported from a real run:
+// the guard fired on CONTRIBUTING.md, a file upstream had not touched since
+// 2021. The base side used to be a second lookup against the fork, and a fork
+// answers 404 for a commit it has not heard of — indistinguishable from "the
+// file was not there", so an unrecognised base read as every touched file
+// having changed. Now the base is the sha the checkout holds, and no request
+// can produce that answer.
+test('staleTouchedPaths cannot be misled about the base by the fork', async () => {
+	const asked = [];
+	const api = {
+		get: async (url) => {
+			asked.push(url);
+			return { status: 200, json: { sha: 'unchanged-since-2021' } };
 		}
 	};
 
 	const res = await staleTouchedPaths(
-		{ token: TOKEN, login: LOGIN, baseSha: 'local', tipSha: 'tip', paths: ['a.php', 'b.php', 'c.php'] },
+		{ token: TOKEN, login: LOGIN, tipSha: 'tip', files: [{ path: 'CONTRIBUTING.md', baseBlobSha: 'unchanged-since-2021' }] },
 		api
 	);
 
-	assert.deepStrictEqual(res, { ok: true, clashes: ['b.php', 'c.php'] });
+	assert.deepStrictEqual(res, { ok: true, clashes: [] });
+	// One request, for the tip. The base is never asked about.
+	assert.strictEqual(asked.length, 1);
+	assert.ok(asked[0].includes('ref=tip'));
 });
 
 test('openPullRequest refuses a stale checkout whose files upstream also changed', async () => {
@@ -319,13 +375,12 @@ test('openPullRequest refuses a stale checkout whose files upstream also changed
 		// Same key as the happy path's, so this override wins outright rather
 		// than competing on pattern length.
 		[`GET ${FORK_URL}/git/ref/heads/trunk`]: { status: 200, json: { object: { sha: 'newer-tip' } } },
-		'GET contents/a.php?ref=abc123': { status: 200, json: { sha: 'blob-old' } },
 		'GET contents/a.php?ref=newer-tip': { status: 200, json: { sha: 'blob-upstream' } }
 	});
 
 	const res = await openPullRequest({
 		token: TOKEN, login: LOGIN, ticketId: 1, baseSha: 'abc123',
-		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		files: [{ path: 'a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644', baseBlobSha: 'blob-old' }],
 		title: 't', body: 'b'
 	}, api);
 

--- a/test/pr-files.test.cjs
+++ b/test/pr-files.test.cjs
@@ -14,6 +14,7 @@ const {
 	fileModeForEntry,
 	buildPullRequestEntries,
 	isProbablyBinary,
+	blobSha,
 	GIT_MODE_FILE,
 	GIT_MODE_EXECUTABLE
 } = require('../src/pr-files.cjs');
@@ -113,7 +114,15 @@ test('a deletion reads its mode from HEAD without touching the missing path', as
 			git: fakeGitWithModes({ 'src/wp-includes/gone.php': '100644' })
 		})
 	);
-	assert.deepStrictEqual(entries, [{ path: 'src/wp-includes/gone.php', kind: 'delete', content: null, mode: '100644' }]);
+	assert.deepStrictEqual(entries, [{
+		path: 'src/wp-includes/gone.php',
+		kind: 'delete',
+		content: null,
+		mode: '100644',
+		// The blob the checkout held, so the staleness check can tell an
+		// upstream change to this file from the deletion being proposed.
+		baseBlobSha: blobSha(Buffer.from('x'))
+	}]);
 	assert.strictEqual(statted, false);
 });
 
@@ -188,4 +197,18 @@ test('adds and modifies carry their kind', async () => {
 		deps()
 	);
 	assert.deepStrictEqual(entries.map((e) => [e.path, e.kind]), [['new.php', 'add'], ['old.php', 'modify']]);
+	// A file the contributor is adding has no base blob; a modified one does.
+	assert.strictEqual(entries[0].baseBlobSha, null);
+	assert.strictEqual(entries[1].baseBlobSha, blobSha(Buffer.from('a\n')));
+});
+
+// The sha has to be git's, not any hash: it is compared against what GitHub
+// reports for the same file, and a different scheme would make every file look
+// changed. This is the value `git hash-object` prints for an empty blob and for
+// "hello\n" — both fixed by the format, not by this implementation.
+test('blobSha computes git’s own object id', () => {
+	assert.strictEqual(blobSha(Buffer.alloc(0)), 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391');
+	assert.strictEqual(blobSha(Buffer.from('hello\n')), 'ce013625030ba8dba906f756967f9e9ca394464a');
+	// No file at that commit is not a hash of nothing.
+	assert.strictEqual(blobSha(null), null);
 });


### PR DESCRIPTION
Stacked on #204 (→ #200 → #179). Continues #186, and revives the layout from **#6**.

## Prior art

The layout in the v0.1.1 release notes is not hypothetical — it is [#6](https://github.com/WordPress/contributor-toolkit/pull/6) by @adamziel, open since November and 72 commits behind trunk. It put the diff on the left and the destinations in a sidebar. This takes that shape and rebuilds it on the destinations this app has now.

Worth recording what the two takes did differently on the GitHub side, since #6 is still open and someone will ask:

| | #6 (Nov) | #167 (now) |
| --- | --- | --- |
| Sign-in | Device flow, scope `repo` | Same — arrived at independently, the hard way |
| Token | Persisted in `electron-store` | Main-process memory, forgotten on quit |
| The pull request | Pushes a branch, then opens GitHub's compare form in the browser | Created through the API; the app never leaves |

#6 also skipped `.github/workflows/` files, which needs the `workflow` scope. **This flow does not**, and a patch touching one will fail — filed separately.

## Why this layout

The patch sat *under* the destinations, which put the choice above the thing being chosen for: a contributor scrolled past three cards to read their own code, then scrolled back up to act on it. The code is what they opened the screen to look at and the largest thing on it, so it takes the room, and where it can go stands beside it — in view the whole time they are reading rather than something to scroll back to.

## What fell out of it

**Save and Copy move into the column header.** Floating over the diff was survivable at full width; over a column it covers the first line of a hunk.

**The columns are CSS with a media query, not inline styles.** Flex-wrap was tried first and cannot express this — wrapping keeps both columns on one flex line whose height the modal fixes, so the wrapped sidebar had nowhere to go and the diff overlapped it. Stacking has to change *what scrolls* as well as what sits where: side by side the sidebar scrolls alone and the diff stays put; stacked, the pair scrolls as one and the diff keeps a definite height so it cannot collapse to a sliver.

**A pre-existing bug the layout exposed.** The diff pane is `height: 100%` with `padding: 12px` and content-box sizing, so it has always been 24px taller than its container. Harmless while it spanned the modal and the overflow fell off the bottom; beside a sidebar it sat on top of the destinations.

## Testing

`npm test` — 496 pass, unchanged. `npm run lint` clean.

Checked at 1400px, 900px and 560px, and **measured rather than eyeballed** — after the box-sizing fix the pane ends exactly on its column bottom, and stacked there are the full 16px between it and what follows. That measurement is what caught the bug: it looked like a rendering artefact until the numbers said 24px, twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
