### PR TITLE
Open a site's folder from one menu instead of a remembered editor

### DIFF
--- a/src/editor-launch.js
+++ b/src/editor-launch.js
@@ -170,6 +170,32 @@ async function detectEditors({ platform, env = {}, exists } = {}) {
 	return found.filter(Boolean);
 }
 
+// The detected application at this path, or null for a path detection did not
+// return — the answer to "may this app be asked to launch that?".
+//
+// It exists because the window now names the application: the folder-opening
+// menu lists what detection found and sends back one of those paths, where the
+// choice used to be read from the store on this side of the wire. So the set of
+// launchable applications has to be re-established here rather than trusted, and
+// this is where that lives — a pure check with its effects injected, like every
+// other guard in this file, so both the case-sensitive and case-insensitive
+// branches are testable from one machine.
+//
+// It returns the *detected* path rather than true. A caller that checked one
+// string and then launched the caller's own string would not have checked
+// anything (see the note on the parsed URL in external-url.js); handing back the
+// path detection vouches for makes that mistake impossible to write.
+async function matchDetectedEditor(editorPath, { platform, env = {}, exists } = {}) {
+	if (typeof editorPath !== 'string' || editorPath === '') return null;
+
+	const insensitive = platform === 'win32' || platform === 'darwin';
+	const normalize = (p) => (insensitive ? p.toLowerCase() : p);
+	const wanted = normalize(editorPath);
+
+	const detected = await detectEditors({ platform, env, exists });
+	return detected.find((candidate) => normalize(candidate.path) === wanted) || null;
+}
+
 // The name the table has for an application at this path, or null for one it
 // does not know.
 //
@@ -250,7 +276,8 @@ function resolveLaunch(editorPath, sitePath, { platform } = {}) {
 
 const REFUSAL_REASONS = {
 	UNREGISTERED_SITE: 'unregistered-site',
-	UNLAUNCHABLE_EDITOR: 'unlaunchable-editor'
+	UNLAUNCHABLE_EDITOR: 'unlaunchable-editor',
+	UNKNOWN_EDITOR: 'unknown-editor'
 };
 
 // The `editor:open` handler's body.
@@ -358,6 +385,7 @@ module.exports = {
 	REFUSAL_REASONS,
 	editorCandidates,
 	detectEditors,
+	matchDetectedEditor,
 	knownEditorName,
 	isLaunchableEditorPath,
 	resolveLaunch,

--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ const { parseTicketRef } = require('./renderer/trac-ticket.cjs');
 const { parseHandle } = require('./wporg-handle.cjs');
 const { parseEventName, buildProvenanceHeader, handoffFilename } = require('./patch-provenance.cjs');
 const { describeRefused } = require('./safe-log');
-const { detectEditors, knownEditorName, isLaunchableEditorPath, openSiteInEditor } = require('./editor-launch');
+const { detectEditors, matchDetectedEditor, openSiteInEditor, REFUSAL_REASONS } = require('./editor-launch');
 
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
@@ -995,9 +995,10 @@ ipcMain.handle('url:open', async (_e, url) => openExternalUrl(url, {
 // --- opening a site's code -----------------------------------------------
 //
 // See editor-launch.js for why none of this consults PATH. What is here is the
-// wiring: the store holds one app-wide editor choice, and every path — detected,
-// picked, or remembered from a previous run — goes through the same check before
-// anything is spawned.
+// wiring, and it holds no state: the application is an argument to "open this
+// folder", not a setting configured beforehand. The window lists what is
+// installed, the contributor names one, and that name is checked against the
+// same detection before anything is spawned.
 
 // Asynchronous on purpose: this runs on the process that draws the window, and
 // probing a dozen locations that mostly do not exist is exactly what a slow
@@ -1026,41 +1027,44 @@ async function statPath(targetPath) {
 
 const editorLaunchDeps = () => ({ platform: process.platform, statPath });
 
-async function getChosenEditor() {
-	const s = await getStore();
-	const chosen = (s.get('preferences') || {}).editor;
-	return chosen && typeof chosen.path === 'string' ? chosen : null;
-}
-
-// The remembered choice, and nothing else. This is what the window asks for on
-// load — just enough to name the button "Open in Cursor" — so it touches no
-// filesystem at all. Whether that editor is still installed is answered by
-// trying to open it, which is a question the contributor has just asked anyway.
-ipcMain.handle('editor:get', async () => getChosenEditor());
+const detectionDeps = () => ({
+	platform: process.platform,
+	env: process.env,
+	exists: async (p) => (await statPath(p)) !== null
+});
 
 // The editors on this machine. Detection stats a dozen or so absolute locations,
-// so it runs when the contributor opens the picker rather than on every load —
-// `editor:get` is the cheap one.
-ipcMain.handle('editor:list', async () => ({
-	detected: await detectEditors({
-		platform: process.platform,
-		env: process.env,
-		exists: async (p) => (await statPath(p)) !== null
-	}),
-	chosen: await getChosenEditor()
-}));
+// so it runs when the contributor opens the menu rather than on every load.
+ipcMain.handle('editor:list', async () => ({ detected: await detectEditors(detectionDeps()) }));
 
-// Remembers an editor. With a path it is the one the contributor picked from the
-// detected list; without one it opens the file dialog, which is the answer for
-// every editor the detection table does not know about — the reason no editor is
-// ever shown as unavailable with nothing to do about it.
+// The application the contributor just named, or null for "one this list does
+// not have" — which opens the file dialog, and is the reason no editor is ever
+// shown as unavailable with nothing to do about it.
 //
-// The dialog's result is validated exactly like a detected path. A dialog is
-// still input.
-ipcMain.handle('editor:choose', async (_e, editorPath) => {
-	let target = typeof editorPath === 'string' ? editorPath : null;
+// A named path is checked against a fresh detection before it is used. Nothing
+// downstream needs that check to be safe — `openSiteInEditor` refuses anything
+// that is not an absolute application of the platform's shape, and the folder
+// must be one the registry holds — but this handler is now the one place where
+// the *window* names an executable, and the window is where injected content
+// ends up. So the answer to "which applications may this app be asked to
+// launch?" stays what it always was: the ones detection found on this machine,
+// plus the one a human picked in a native dialog.
+//
+// Everything after that is unchanged from when the path came out of the store.
+ipcMain.handle('editor:open', async (_e, sitePath, editorPath) => {
+	let target = typeof editorPath === 'string' && editorPath !== '' ? editorPath : null;
 
-	if (!target) {
+	if (target) {
+		const detected = await matchDetectedEditor(target, detectionDeps());
+		if (!detected) {
+			logEvent('editor', `refused to open ${describeRefused(target)} — not an application detection found`);
+			return { ok: false, reason: REFUSAL_REASONS.UNKNOWN_EDITOR };
+		}
+		// The detected path, not the one that arrived: checking one string and
+		// launching another is not a check. See external-url.js, which hands the
+		// OS its parsed URL for the same reason.
+		target = detected.path;
+	} else {
 		const filtersByPlatform = {
 			darwin: [{ name: 'Applications', extensions: ['app'] }],
 			win32: [{ name: 'Programs', extensions: ['exe'] }]
@@ -1069,42 +1073,19 @@ ipcMain.handle('editor:choose', async (_e, editorPath) => {
 		// narrow what can be picked.
 		const filters = filtersByPlatform[process.platform] || [];
 		const result = await dialog.showOpenDialog({
-			title: 'Choose the editor to open sites in',
+			title: 'Choose the application to open this folder in',
 			properties: ['openFile'],
 			defaultPath: process.platform === 'darwin' ? '/Applications' : undefined,
 			filters
 		});
+		// Closing the dialog is an answer, not a failure: the caller says nothing
+		// rather than showing an error for something the contributor just decided.
 		if (result.canceled || result.filePaths.length === 0) return { ok: false, reason: 'cancelled' };
 		target = result.filePaths[0];
 	}
 
-	if (!await isLaunchableEditorPath(target, editorLaunchDeps())) {
-		logEvent('editor', `refused to remember ${describeRefused(target)} — not an application this app can launch`);
-		return { ok: false, reason: 'unlaunchable-editor' };
-	}
-
 	const s = await getStore();
-	const editor = {
-		path: target,
-		// The table's name for a known application; a filename only for one the
-		// contributor pointed at that the table has never heard of.
-		name: knownEditorName(target, { platform: process.platform, env: process.env })
-			|| path.basename(target, path.extname(target))
-	};
-	s.set('preferences', { ...(s.get('preferences') || {}), editor });
-	return { ok: true, editor };
-});
-
-// Only a path the app has on record is opened, and only in an application that
-// is still where it was — see editor-launch.js. A refusal is logged rather than
-// dropped so a caller that trips the guard shows up in the log file instead of
-// just doing nothing.
-ipcMain.handle('editor:open', async (_e, sitePath) => {
-	const chosen = await getChosenEditor();
-	if (!chosen) return { ok: false, reason: 'no-editor' };
-
-	const s = await getStore();
-	return openSiteInEditor(sitePath, chosen.path, {
+	return openSiteInEditor(sitePath, target, {
 		...editorLaunchDeps(),
 		sites: s.get('sites'),
 		spawn,
@@ -1114,9 +1095,9 @@ ipcMain.handle('editor:open', async (_e, sitePath) => {
 
 // --- Who the patch came from, and where (#166) ---
 //
-// Both fields are stored beside the editor choice and for the same reason: they
-// are facts about the contributor and their afternoon, asked once, not
-// properties of a checkout. They exist so a handed-off patch can say who wrote
+// Both fields are asked once and kept, because they are facts about the
+// contributor and their afternoon rather than properties of a checkout — unlike
+// the application a folder is opened in, which is now named per open. They exist so a handed-off patch can say who wrote
 // it and at which event; nothing here contacts wordpress.org, and the handle is
 // never checked against a real account — an unverified name is what a props
 // line is anyway.

--- a/src/preload.js
+++ b/src/preload.js
@@ -47,14 +47,11 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	openExternal: (url) => ipcRenderer.invoke('url:open', url)
 ,
-	getEditor: () => ipcRenderer.invoke('editor:get')
-,
 	listEditors: () => ipcRenderer.invoke('editor:list')
 ,
-	// With a path, remembers that editor; without one, opens the file dialog.
-	chooseEditor: (editorPath) => ipcRenderer.invoke('editor:choose', editorPath)
-,
-	openInEditor: (sitePath) => ipcRenderer.invoke('editor:open', sitePath)
+	// With a path, opens the folder in that application — one of the detected
+	// ones, which main checks. Without one, the file dialog answers instead.
+	openInEditor: (sitePath, editorPath = null) => ipcRenderer.invoke('editor:open', sitePath, editorPath)
 ,
 	// Who the patch came from and where, app-wide (#166). An empty ref forgets
 	// the field it is passed to.

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -8,11 +8,14 @@ import {
   Dropdown,
   Flex,
   DropdownMenu,
+  Icon,
+  MenuGroup,
+  MenuItem,
   Modal,
   TextControl,
   Spinner
 } from '@wordpress/components';
-import { plus, chevronLeft, chevronRight, copy as copyIcon, check as checkIcon, edit, download, comment } from '@wordpress/icons';
+import { plus, chevronLeft, chevronRight, chevronDown, copy as copyIcon, check as checkIcon, edit, download, comment } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
@@ -42,7 +45,12 @@ const UPDATE_STEP_MARKS = {
 };
 // The file manager has a name on the two platforms that have one; everywhere
 // else it is whatever the desktop provides, so it is called what it is.
+//
+// Two forms, because it appears in two places: an instruction in a list of
+// commands ("Show in Finder"), and an application named alongside the editors in
+// the "Open directory in" menu, where every other row is a bare name.
 const FILE_MANAGER_LABELS = { darwin: 'Show in Finder', win32: 'Show in Explorer' };
+const FILE_MANAGER_NAMES = { darwin: 'Finder', win32: 'File Explorer' };
 const TERMINAL_INSTALL_ALIASES = ['npm install', 'npm i', 'install'];
 const RENAME_INPUT_ID = 'rename-site-name-input';
 const CREATE_SITE_NAME_INPUT_ID = 'create-site-name-input';
@@ -64,69 +72,44 @@ function formatEmailDate(email) {
 }
 const FEEDBACK_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLScnMxicyDxZO2OoaS5ela8FArYWjCyLfC3hxRBBRSF7XLPzKg/viewform';
 
-// The editor is one app-wide choice, so it is held once for the window rather
-// than once per site. Every site is mounted at all times (the inactive ones are
-// hidden), so per-row state here would mean N copies of the same answer: N loads
-// on startup, and a choice made in one row leaving every other row's button
-// still saying "Open in editor".
+// Which applications this machine has is a fact about the machine, not about a
+// site, so it is held once for the window rather than once per site. Every site
+// is mounted at all times (the inactive ones are hidden), so per-row state here
+// would mean N copies of the same answer and N filesystem sweeps.
 //
-// Detection is deliberately not part of the load: `editor:get` is a store read,
-// and the filesystem probe behind `editor:list` waits until the picker is
-// actually opened.
-function useEditorChoice() {
-  const [chosen, setChosen] = useState(null);
+// Detection is deliberately not part of the load: the probe behind `editor:list`
+// waits until a menu is actually opened. It is re-run on every open rather than
+// cached for the session, because an editor installed while this app is running
+// is one the next menu should offer. The previous answer is kept on screen in the
+// meantime, so reopening the menu does not blink through an empty list.
+function useDetectedEditors() {
   const [detected, setDetected] = useState([]);
-
-  useEffect(() => {
-    let cancelled = false;
-    window.api.getEditor()
-      .then((editor) => { if (!cancelled) setChosen(editor || null); })
-      // The window carries on with no remembered editor, which is a state it
-      // handles — but "the store could not be read" and "nothing chosen yet"
-      // must not be the same event to whoever reads the log afterwards.
-      // eslint-disable-next-line no-console -- reaches the log file: logging.js initializes electron-log with spyRendererConsole, so this is how the renderer records a diagnostic.
-      .catch((err) => console.error('Could not read the remembered editor:', err));
-    return () => { cancelled = true; };
-  }, []);
+  const [loading, setLoading] = useState(false);
 
   const loadDetected = useCallback(async () => {
+    setLoading(true);
     try {
       const result = await window.api.listEditors();
       setDetected(result?.detected || []);
-      setChosen(result?.chosen || null);
     } catch (err) {
-      // eslint-disable-next-line no-console -- see the note on the first console.error above.
+      // The menu still offers the file manager and "Other application…", which
+      // is enough to finish the job — but "detection failed" and "nothing is
+      // installed" must not be the same event to whoever reads the log.
+      // eslint-disable-next-line no-console -- reaches the log file: logging.js initializes electron-log with spyRendererConsole, so this is how the renderer records a diagnostic.
       console.error('Could not list the editors on this machine:', err);
       setDetected([]);
+    } finally {
+      setLoading(false);
     }
   }, []);
 
-  // `editorPath` is one of the detected editors; without one the main process
-  // opens the file dialog, which is what covers every editor detection misses.
-  //
-  // A rejected invoke is reported as a refusal rather than raised: the caller
-  // draws a notice from it, and an unhandled rejection here would be a button
-  // that silently did nothing.
-  const remember = useCallback(async (editorPath) => {
-    let result;
-    try {
-      result = await window.api.chooseEditor(editorPath);
-    } catch (err) {
-      // eslint-disable-next-line no-console -- see the note on the first console.error above.
-      console.error('Could not remember that editor:', err);
-      return { ok: false, reason: 'unavailable', error: String(err?.message ?? err) };
-    }
-    if (result?.ok) setChosen(result.editor);
-    return result;
-  }, []);
-
-  return { chosen, detected, loadDetected, remember };
+  return { detected, loading, loadDetected };
 }
 
 // Who this contributor is and where they are contributing from (#166), held
-// once for the same reason the editor choice is: both are facts about the
-// person, not about a checkout, so answering them in one site's patch modal
-// must not leave every other site still asking.
+// once for the same reason the detected editors are: both are facts about the
+// person or their machine, not about a checkout, so answering them in one site's
+// patch modal must not leave every other site still asking.
 function useContributorProvenance() {
   const [handle, setHandle] = useState(null);
   const [event, setEvent] = useState(null);
@@ -141,8 +124,8 @@ function useContributorProvenance() {
       })
       // "nothing answered yet" is an ordinary state; "the store could not be
       // read" is not, and the two must not look the same in the log. Same
-      // argument as useEditorChoice above.
-      // eslint-disable-next-line no-console -- reaches the log file, see the note in useEditorChoice.
+      // argument as useDetectedEditors above.
+      // eslint-disable-next-line no-console -- reaches the log file, see the note in useDetectedEditors.
       .catch((err) => console.error('Could not read the remembered contributor details:', err));
     return () => { cancelled = true; };
   }, []);
@@ -192,8 +175,9 @@ function useSites() {
 
 function App() {
   const { sites, siteMeta, refresh, setSiteMeta, setSites } = useSites();
-  // One choice for the window, shared by every site row.
-  const editorChoice = useEditorChoice();
+  // One answer for the window, shared by every site row: which applications this
+  // machine has is a fact about the machine, not about a site.
+  const detectedApplications = useDetectedEditors();
   const wporg = useContributorProvenance();
   const [downloadPhase, setDownloadPhase] = useState('');
   // Directories whose clone is still running. An array rather than a single
@@ -798,7 +782,7 @@ function App() {
                       onForget={onForget}
                       onDelete={onDelete}
                       onRename={onRename}
-                      editor={editorChoice}
+                      editor={detectedApplications}
                       wporg={wporg}
                       isPending={pendingSites.includes(s)}
                       setupLogs={setupLogsBySite[s] || ''}
@@ -1116,25 +1100,39 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     }
   }, [sitePath]);
 
-  // --- opening the code ---------------------------------------------------
+  // --- opening the directory ------------------------------------------------
   //
-  // The editor itself is chosen once for the whole window (see useEditorChoice);
-  // what is per-site here is only the UI around it. Every path out of this ends
-  // somewhere the contributor can act: a launch that fails opens the picker, the
-  // picker always offers "Choose application…", and the copy button above is the
-  // floor under all of it.
-  const { chosen: chosenEditor, detected: detectedEditors, loadDetected, remember } = editor;
-  const [editorPickerOpen, setEditorPickerOpen] = useState(false);
+  // One menu, one intention: open this folder, in that. The application is the
+  // argument to the action rather than a setting configured first, so there is
+  // nothing remembered, nothing to change later, and no first-run picker.
+  //
+  // What the menu offers is what detection found (see editor-launch.js — a
+  // convenience, not a claim about what is installed) plus the file manager and
+  // "Other application…", which is what covers everything the table misses. No
+  // entry is ever drawn disabled: an application this app cannot find is not one
+  // it refuses to use, and the copy button above is the floor under all of it.
+  const { detected: detectedEditors, loading: detectingEditors, loadDetected } = editor;
   const [editorNotice, setEditorNotice] = useState('');
 
   const fileManagerLabel = FILE_MANAGER_LABELS[window.api?.platform] || 'Show in file manager';
+  const fileManagerName = FILE_MANAGER_NAMES[window.api?.platform] || 'File manager';
 
-  const describeOpenFailure = useCallback((result) => {
+  // `picked` says which of the two failures 'unlaunchable-editor' is: an
+  // application detection offered that has since moved, or one the contributor
+  // just pointed at that is not an application at all. Main cannot tell them
+  // apart — the guard is the same — but the caller knows which it asked for, and
+  // the two need different next steps.
+  const describeOpenFailure = useCallback((result, { picked = false } = {}) => {
     if (result?.reason === 'unlaunchable-editor') {
-      return 'That editor is no longer where it was. Choose it again.';
+      return picked
+        ? 'That is not an application this app can open a folder in.'
+        : 'That application is no longer where it was. Choose another.';
+    }
+    if (result?.reason === 'unknown-editor') {
+      return 'That application is no longer where it was. Choose another.';
     }
     if (result?.reason === 'spawn-failed') {
-      return `The editor would not start: ${result.error || 'unknown error'}`;
+      return `The application would not start: ${result.error || 'unknown error'}`;
     }
     if (result?.reason === 'unregistered-site') {
       return 'This app has no record of that folder, so it will not open it.';
@@ -1142,57 +1140,37 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     if (result?.reason === 'unavailable') {
       return `Could not reach the app's main process: ${result.error || 'unknown error'}`;
     }
-    return 'Could not open the folder in an editor.';
+    return 'Could not open the folder in an application.';
   }, []);
 
+  // `editorPath` is one of the detected applications; null asks the main process
+  // for the file dialog instead.
+  //
   // The invoke itself can reject — a handler that throws, a window being torn
-  // down — and a rejection here would leave the notice unset and the picker
-  // unopened: the button would appear to do nothing, which is the one outcome
-  // this feature is not allowed to produce.
-  const askToOpen = useCallback(async () => {
+  // down — and a rejection here would leave the notice unset: the menu item
+  // would appear to do nothing, which is the one outcome this feature is not
+  // allowed to produce.
+  const openIn = useCallback(async (editorPath = null) => {
+    let result;
     try {
-      return await window.api.openInEditor(sitePath);
+      result = await window.api.openInEditor(sitePath, editorPath);
     } catch (err) {
       // eslint-disable-next-line no-console -- see the note on the first console.error above.
-      console.error('Could not open the site in an editor:', err);
-      return { ok: false, reason: 'unavailable', error: String(err?.message ?? err) };
+      console.error('Could not open the site directory:', err);
+      result = { ok: false, reason: 'unavailable', error: String(err?.message ?? err) };
     }
-  }, [sitePath]);
-
-  const openInEditor = useCallback(async () => {
-    const result = await askToOpen();
-    if (result?.ok) {
+    // Closing the dialog is an answer, not a failure — saying something about it
+    // would be the app arguing with a decision the contributor just made.
+    if (result?.ok || result?.reason === 'cancelled') {
       setEditorNotice('');
       return;
     }
-    // Nothing chosen yet is not an error, it is the first use. Anything else is
-    // worth saying out loud — but both end at the same place: the picker.
-    setEditorNotice(result?.reason === 'no-editor' ? '' : describeOpenFailure(result));
-    await loadDetected();
-    setEditorPickerOpen(true);
-  }, [askToOpen, describeOpenFailure, loadDetected]);
-
-  const rememberEditor = useCallback(async (editorPath) => {
-    const result = await remember(editorPath);
-    if (!result?.ok) {
-      if (result?.reason === 'unlaunchable-editor') {
-        setEditorNotice('That is not an application this app can open a folder in.');
-      } else if (result?.reason === 'unavailable') {
-        setEditorNotice(describeOpenFailure(result));
-      }
-      // 'cancelled' is the contributor closing the dialog, which is an answer,
-      // not a failure. The picker stays open either way: it is where the next
-      // attempt starts from.
-      return;
-    }
-    const opened = await askToOpen();
-    setEditorNotice(opened?.ok ? '' : describeOpenFailure(opened));
-    // Only a launch that actually worked closes the picker. Closing it on the
-    // choice alone would leave a contributor whose editor failed looking at a
-    // notice with no picker, one step further from a working editor than before
-    // they clicked.
-    if (opened?.ok) setEditorPickerOpen(false);
-  }, [askToOpen, describeOpenFailure, remember]);
+    setEditorNotice(describeOpenFailure(result, { picked: editorPath === null }));
+    // An application that was detected and then failed is one detection should be
+    // asked about again, so the next menu does not offer it as if nothing had
+    // happened.
+    if (editorPath !== null) await loadDetected();
+  }, [describeOpenFailure, loadDetected, sitePath]);
 
   const showInFileManager = useCallback(async () => {
     let result;
@@ -2464,23 +2442,62 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               isSmall
             />
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8, flexWrap: 'wrap' }}>
-            <Button variant="secondary" onClick={openInEditor}>
-              {chosenEditor ? `Open in ${chosenEditor.name}` : 'Open in editor'}
-            </Button>
-            <Button variant="tertiary" onClick={showInFileManager}>{fileManagerLabel}</Button>
-            {chosenEditor ? (
-              <Button
-                variant="tertiary"
-                isSmall
-                onClick={async () => { await loadDetected(); setEditorPickerOpen(true); }}
-              >Change editor</Button>
-            ) : null}
+          {/* One control for one intention, directly under the path it acts on.
+              Detection runs when the menu is opened rather than on load: it is a
+              filesystem sweep, and the answer is only needed once someone asks.
+              It is re-read on every open, so an application installed while this
+              app is running shows up the next time the menu is used. */}
+          <div style={{ marginTop: 4 }}>
+            <Dropdown
+              popoverProps={{ placement: 'bottom-start', offset: 4 }}
+              renderToggle={({ isOpen, onToggle }) => (
+                <Button
+                  variant="link"
+                  aria-expanded={isOpen}
+                  aria-haspopup="menu"
+                  onClick={() => {
+                    if (!isOpen) void loadDetected();
+                    onToggle();
+                  }}
+                  style={{ display: 'inline-flex', alignItems: 'center', gap: 2, fontSize: 12 }}
+                >
+                  Open directory in
+                  <Icon icon={chevronDown} size={18} />
+                </Button>
+              )}
+              renderContent={({ onClose }) => (
+                <MenuGroup>
+                  <MenuItem onClick={() => { onClose(); void showInFileManager(); }}>
+                    {fileManagerName}
+                  </MenuItem>
+                  {detectedEditors.map((candidate) => (
+                    <MenuItem key={candidate.path} onClick={() => { onClose(); void openIn(candidate.path); }}>
+                      {candidate.name}
+                    </MenuItem>
+                  ))}
+                  {/* A menu that is still counting is not an empty menu, and the
+                      difference has to be visible: without this, a slow sweep
+                      looks exactly like a machine with no editors on it. */}
+                  {detectingEditors ? (
+                    <MenuItem disabled>Looking for applications…</MenuItem>
+                  ) : null}
+                  {/* Always offered, never only as a fallback: detection is a
+                      shortcut, and an application it misses is not one this app
+                      refuses to use. */}
+                  <MenuItem onClick={() => { onClose(); void openIn(null); }}>
+                    Other application…
+                  </MenuItem>
+                </MenuGroup>
+              )}
+            />
           </div>
+          {/* With no modal in the way, this is the only place a failed open can
+              speak — and it carries the way out with it, rather than leaving the
+              contributor to find the menu again. */}
           {editorNotice ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginTop: 8, padding: '8px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
+            <div role="alert" style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginTop: 8, padding: '8px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
               <span style={{ flex: '1 1 240px' }}>{editorNotice}</span>
-              <Button variant="tertiary" isSmall onClick={() => rememberEditor()}>Choose application…</Button>
+              <Button variant="tertiary" isSmall onClick={() => void openIn(null)}>Choose application…</Button>
             </div>
           ) : null}
         </div>
@@ -2490,7 +2507,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             text=""
             controls={[
               { title: 'Copy path', onClick: copyPath },
-              { title: chosenEditor ? `Open in ${chosenEditor.name}` : 'Open in editor', onClick: openInEditor },
+              // Opening the folder lives in the header's "Open directory in"
+              // menu, next to the path it acts on. Repeating it here would be two
+              // menus answering the same question a few pixels apart.
               { title: fileManagerLabel, onClick: showInFileManager },
               // Also reachable when the site is not yet stale (the staleness
               // notice is the primary entry point) — a fresh site just gets
@@ -3028,42 +3047,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           </div>
         </div>
       </div>
-      {editorPickerOpen ? (
-        <Modal
-          title="Open sites in"
-          onRequestClose={() => setEditorPickerOpen(false)}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 420 }}>
-            {/* Why the picker is open, inside the picker. The notice below the
-                path row says the same thing, but the modal takes focus, so a
-                contributor using the keyboard or a screen reader would otherwise
-                be reading generic copy with the reason left behind them. */}
-            {editorNotice ? (
-              <div
-                role="alert"
-                style={{ padding: '8px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}
-              >{editorNotice}</div>
-            ) : null}
-            <p style={{ margin: 0, fontSize: 13, lineHeight: 1.5 }}>
-              {detectedEditors.length
-                ? 'Choose the editor to open this site in. This app will remember it.'
-                : 'This app could not find an editor in the usual place. Point at yours and it will remember it.'}
-            </p>
-            {detectedEditors.map((candidate) => (
-              <Button
-                key={candidate.path}
-                variant="secondary"
-                onClick={() => rememberEditor(candidate.path)}
-                style={{ justifyContent: 'flex-start' }}
-              >{candidate.name}</Button>
-            ))}
-            {/* Always offered, never only as a fallback: the detection list is a
-                shortcut, and an editor missing from it is not an editor this app
-                refuses to use. */}
-            <Button variant="tertiary" onClick={() => rememberEditor()}>Choose application…</Button>
-          </div>
-        </Modal>
-      ) : null}
       {dirtyModalOpen ? (
         <Modal
           title="Update to latest trunk?"

--- a/src/settings-store.js
+++ b/src/settings-store.js
@@ -24,9 +24,9 @@ async function getStore() {
 				const Store = m.default || m;
 				store = new Store({
 					name: 'settings',
-					// `preferences` is app-wide rather than per-site: the editor a
-					// contributor uses is a fact about them, asked once, not a
-					// property of each checkout.
+					// `preferences` is app-wide rather than per-site: who the
+					// contributor is and where they are contributing from are facts
+					// about them, asked once, not properties of each checkout.
 					defaults: { sites: [], siteMeta: {}, preferences: {} }
 				});
 			});

--- a/test/editor-launch.test.cjs
+++ b/test/editor-launch.test.cjs
@@ -19,6 +19,7 @@ const {
 	REFUSAL_REASONS,
 	editorCandidates,
 	detectEditors,
+	matchDetectedEditor,
 	knownEditorName,
 	isLaunchableEditorPath,
 	resolveLaunch,
@@ -207,6 +208,52 @@ test('on Linux a file the OS will not execute is not an application', async () =
 
 	assert.equal(await isLaunchableEditorPath('/home/dev/notes.txt', { platform: 'linux', statPath: fs.statPath }), false);
 	assert.equal(await isLaunchableEditorPath('/usr/bin/code', { platform: 'linux', statPath: fs.statPath }), true);
+});
+
+// --- which applications may be launched at all ----------------------------
+//
+// The window names the application now, so this is the set the main process
+// re-establishes rather than trusts. Every case below is written from one
+// machine by injecting `platform` and `exists`: a check that only holds on
+// Windows is a check CI never runs.
+
+test('an application detection found is matched, and answered with the path detection vouches for', async () => {
+	const fs = fakeFs({ '/Applications/Cursor.app': 'dir' });
+
+	const match = await matchDetectedEditor('/Applications/Cursor.app', { platform: 'darwin', env: MAC_ENV, exists: fs.exists });
+
+	assert.equal(match.path, '/Applications/Cursor.app');
+	assert.equal(match.name, 'Cursor');
+});
+
+test('an application detection did not find is not matched, however plausible it looks', async () => {
+	const fs = fakeFs({ '/Applications/Cursor.app': 'dir' });
+	const onMac = { platform: 'darwin', env: MAC_ENV, exists: fs.exists };
+
+	// Installed, but not where the table looks, so this app has never seen it.
+	assert.equal(await matchDetectedEditor('/Applications/Some Editor.app', onMac), null);
+	// In the table, but not on this machine.
+	assert.equal(await matchDetectedEditor('/Applications/Zed.app', onMac), null);
+	for (const value of [null, undefined, 42, '', {}]) {
+		assert.equal(await matchDetectedEditor(value, onMac), null);
+	}
+});
+
+// The same three-way split as knownEditorName, and for the same reason: the
+// platform decides whether two differently-cased paths are one file.
+test('the match is case-insensitive exactly where the filesystem is', async () => {
+	const mac = fakeFs({ '/Applications/Cursor.app': 'dir' });
+	const matched = await matchDetectedEditor('/applications/cursor.app', { platform: 'darwin', env: MAC_ENV, exists: mac.exists });
+	// Answered with the detected casing, which is the path that will be spawned.
+	assert.equal(matched.path, '/Applications/Cursor.app');
+
+	const win = fakeFs({ 'C:\\Users\\dev\\AppData\\Local\\Programs\\cursor\\Cursor.exe': 'file' });
+	const onWin = await matchDetectedEditor('c:\\users\\dev\\appdata\\local\\programs\\cursor\\cursor.exe', { platform: 'win32', env: WIN_ENV, exists: win.exists });
+	assert.equal(onWin.path, 'C:\\Users\\dev\\AppData\\Local\\Programs\\cursor\\Cursor.exe');
+
+	// Linux is case-sensitive, so this is a different file and must not match.
+	const linux = fakeFs({ '/usr/bin/code': 'exe' });
+	assert.equal(await matchDetectedEditor('/USR/BIN/CODE', { platform: 'linux', env: {}, exists: linux.exists }), null);
 });
 
 // --- what the editor is called -------------------------------------------

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1373,17 +1373,21 @@ test('trac:fetch-attachment goes through trac-view', async () => {
 const SITE = '/Users/dev/sites/wp';
 const EDITOR = '/Applications/Cursor.app';
 
+// `editor:open` now asks editor-launch which detected application a path is; a
+// stub that answers with one stands in for a machine that has it installed.
+const matching = (candidate) => spy((wanted) => (wanted === candidate.path ? candidate : null));
+
 test('editor:open asks editor-launch to open the site, with the registry as its boundary', async () => {
 	const openSiteInEditor = spy(async () => ({ ok: true }));
 	const main = loadMain({
 		stubs: {
 			...silentLogging(),
-			...fakeSettingsStore({ sites: [SITE], preferences: { editor: { path: EDITOR, name: 'Cursor' } } }).stubs,
-			'./editor-launch': { openSiteInEditor }
+			...fakeSettingsStore({ sites: [SITE] }).stubs,
+			'./editor-launch': { openSiteInEditor, matchDetectedEditor: matching({ id: 'cursor', name: 'Cursor', path: EDITOR }) }
 		}
 	});
 
-	assert.deepEqual(await main.invoke('editor:open', SITE), { ok: true });
+	assert.deepEqual(await main.invoke('editor:open', SITE, EDITOR), { ok: true });
 
 	assert.equal(openSiteInEditor.calls.length, 1);
 	const [sitePath, editorPath, options] = openSiteInEditor.calls[0];
@@ -1398,66 +1402,72 @@ test('editor:open asks editor-launch to open the site, with the registry as its 
 	assert.equal(options.platform, process.platform);
 });
 
+// The renderer names the application now, where it used to come out of the store
+// — so "which applications may this app be asked to launch?" is answered here,
+// and this is the test that says so. A path detection did not return is refused
+// before the module that would spawn it is even reached.
+test('editor:open refuses an application detection did not find', async () => {
+	const openSiteInEditor = spy(async () => ({ ok: true }));
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({ sites: [SITE] }).stubs,
+			'./editor-launch': { openSiteInEditor, matchDetectedEditor: matching({ id: 'cursor', name: 'Cursor', path: EDITOR }), REFUSAL_REASONS: { UNKNOWN_EDITOR: 'unknown-editor' } }
+		}
+	});
+
+	const result = await main.invoke('editor:open', SITE, '/Applications/Something Else.app');
+
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, 'unknown-editor');
+	assert.deepEqual(openSiteInEditor.calls, []);
+});
+
 // The end of the wire, with the real module in place. This is the assertion that
-// fails if the handler ever spawns an editor itself.
+// fails if the handler ever spawns an editor itself. Detection is the one thing
+// stubbed, because the alternative is a test whose answer depends on which
+// editors the machine running it happens to have installed.
 test('editor:open does not spawn for a path the registry does not hold', async () => {
 	const cp = { spawn: spy(() => { throw new Error('a refused open must not reach spawn'); }) };
 	const main = loadMain({
 		stubs: {
 			...silentLogging(),
-			...fakeSettingsStore({ sites: [SITE], preferences: { editor: { path: EDITOR, name: 'Cursor' } } }).stubs,
+			...fakeSettingsStore({ sites: [SITE] }).stubs,
+			'./editor-launch': {
+				...require(path.join(SRC_DIR, 'editor-launch.js')),
+				matchDetectedEditor: matching({ id: 'cursor', name: 'Cursor', path: EDITOR })
+			},
 			child_process: cp
 		}
 	});
 
-	const result = await main.invoke('editor:open', '/Users/dev/somewhere-else');
+	const result = await main.invoke('editor:open', '/Users/dev/somewhere-else', EDITOR);
 
 	assert.equal(result.ok, false);
 	assert.equal(result.reason, 'unregistered-site');
 	assert.deepEqual(cp.spawn.calls, []);
 });
 
-test('editor:open with nothing chosen asks for a choice rather than guessing', async () => {
+// No path is not a failure: it is "the one you are looking for is not in that
+// list", which is the file dialog. Nothing is opened when it is dismissed.
+test('editor:open with no application named goes to the file dialog', async () => {
 	const openSiteInEditor = spy(async () => ({ ok: true }));
+	const matchDetectedEditor = matching({ id: 'cursor', name: 'Cursor', path: EDITOR });
 	const main = loadMain({
-		stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [SITE] }).stubs, './editor-launch': { openSiteInEditor } }
+		stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [SITE] }).stubs, './editor-launch': { openSiteInEditor, matchDetectedEditor } }
 	});
 
-	assert.deepEqual(await main.invoke('editor:open', SITE), { ok: false, reason: 'no-editor' });
+	assert.deepEqual(await main.invoke('editor:open', SITE, null), { ok: false, reason: 'cancelled' });
+	assert.equal(main.calls.showOpenDialog.length, 1);
 	assert.deepEqual(openSiteInEditor.calls, []);
-});
+	// The dialog's answer is the contributor's own; checking it against the
+	// detection table would refuse exactly the editors that table misses.
+	assert.deepEqual(matchDetectedEditor.calls, []);
 
-test('editor:choose validates what the dialog returned before remembering it', async () => {
-	const isLaunchableEditorPath = spy(() => false);
-	const main = loadMain({
-		stubs: { ...silentLogging(), ...fakeSettingsStore().stubs, './editor-launch': { isLaunchableEditorPath } }
-	});
-
-	const result = await main.invoke('editor:choose', '/Users/dev/not-an-app');
-
-	assert.equal(result.ok, false);
-	assert.equal(result.reason, 'unlaunchable-editor');
-	assert.equal(isLaunchableEditorPath.calls.length, 1);
-	assert.equal(isLaunchableEditorPath.calls[0][0], '/Users/dev/not-an-app');
-});
-
-// The window asks this on load, for every site it has. It must not turn into a
-// filesystem sweep: detection belongs to `editor:list`, which runs when the
-// picker opens.
-test('editor:get reads the remembered choice and touches nothing else', async () => {
-	const detectEditors = spy(() => []);
-	const isLaunchableEditorPath = spy(() => true);
-	const main = loadMain({
-		stubs: {
-			...silentLogging(),
-			...fakeSettingsStore({ preferences: { editor: { path: EDITOR, name: 'Cursor' } } }).stubs,
-			'./editor-launch': { detectEditors, isLaunchableEditorPath }
-		}
-	});
-
-	assert.deepEqual(await main.invoke('editor:get'), { path: EDITOR, name: 'Cursor' });
-	assert.deepEqual(detectEditors.calls, []);
-	assert.deepEqual(isLaunchableEditorPath.calls, []);
+	main.dialogResults.showOpenDialog = { canceled: false, filePaths: ['/Applications/Something Else.app'] };
+	assert.deepEqual(await main.invoke('editor:open', SITE, null), { ok: true });
+	assert.equal(openSiteInEditor.calls.length, 1);
+	assert.equal(openSiteInEditor.calls[0][1], '/Applications/Something Else.app');
 });
 
 test('editor:list asks editor-launch what is installed, without a shell', async () => {
@@ -1563,9 +1573,7 @@ const WIRED = new Set([
 	'git:fetch-pr-diff',
 	'git:list-ticket-patches',
 	'trac:fetch-attachment',
-	'editor:get',
 	'editor:list',
-	'editor:choose',
 	'editor:open',
 	'dir:show',
 	'provenance:set-handle',


### PR DESCRIPTION
## Why

Opening a site's folder shipped in #158 as a *remembered choice*: an **Open in editor** button, a
**Show in Finder** button, a **Change editor** button, and a modal picker on first use — four
controls and a modal for one intention. This explores the alternative shape sketched in the issue
thread: one menu that says what it does, listing the applications the folder can be opened in.

The application is what the contributor is actually choosing, and it changes — Finder to look at the
files, an editor to change them. Making it a setting configured once puts the wrong thing in front
of them and then makes them go back to change it.

## What changes

**One control, on the row under the path it acts on.** `Open directory in ⌄` opens a menu of the
file manager, every editor detection found, and **Other application…**. Nothing is remembered: the
application is an argument to `editor:open`, not a stored preference. That deletes `editor:get`,
`editor:choose`, the `preferences.editor` store entry, the first-run picker modal, and the
stale-remembered-editor failure path — three of the four old buttons go with them.

**Deliberately not in it: the "(not installed)" rows** from the sketch. Detection in
`src/editor-launch.js` is a fixed table of absolute install locations, and its own header calls it
"a convenience, not the contract" — it misses JetBrains' versioned install directories and most
Linux packaging. A greyed-out **VS Code (not installed)** would be a confident lie to anyone whose
install the table does not probe, and #158's standing rule is that nothing here ends at a disabled
button. The menu shows what was found; **Other application…** is always there, never only as a
fallback.

**The security shape changed, and that is the part to review hardest.** The renderer now names an
executable, where the path used to come out of the main-side store. So `editor:open` re-establishes
what it is allowed to launch: `matchDetectedEditor` re-runs detection and answers with the
*detected* path, which is what gets spawned — checking one string and launching the caller's string
would not be a check (same reason `external-url.js` hands the OS its parsed URL). A path detection
did not return is refused as `unknown-editor` before `openSiteInEditor` is reached. `null` still
means the native file dialog, whose result is validated exactly as it was under `editor:choose`.

The path chip and its copy button are untouched — still the floor under all of it.

## How to test this

Platforms: **any**, but the case-insensitivity of the new check is what differs across them and is
covered by tests that run both branches from one machine (`test/editor-launch.test.cjs`).

**Starting state:** the app open on any site, with at least one of VS Code / Cursor / PhpStorm /
Sublime Text / Zed installed in its normal location, and ideally one editor installed somewhere
unusual (a JetBrains Toolbox PhpStorm, or any `.app` outside `/Applications`).

1. Look at the site header. Under the path row there is a single **Open directory in ⌄** link. The
   old **Open in editor** / **Show in Finder** / **Change editor** buttons are gone, and the path
   chip and its copy button are unchanged.
2. Click it. The menu lists **Finder** (or **File Explorer**), then each editor found on this
   machine by name, then **Other application…**. No row is greyed out, and no row claims something
   is "not installed".
3. Choose **Finder**. The folder opens in the file manager.
4. Reopen the menu and choose an editor. That editor opens on the folder. Reopen the menu: it looks
   exactly as it did — nothing was remembered, no "Change editor" appeared, the chosen one is not
   marked.
5. Choose **Other application…** and press Escape / Cancel in the dialog. Nothing opens and **no
   error appears** — dismissing a dialog is an answer, not a failure.
6. Choose **Other application…** again and point it at the editor installed somewhere the menu did
   not list. It opens, and it is still not remembered.
7. Choose **Other application…** and point it at something that is not an application (a `.txt`, or
   any document). A yellow notice appears under the path saying it is not an application this app
   can open a folder in, with a **Choose application…** button that reopens the dialog.
8. Open the **⋯ More** menu at the top right. **Copy path** and **Show in Finder** are still there;
   **Open in editor** is not — that lives in the new menu now.

**What must not have happened:**

- No remembered editor anywhere: no button that says "Open in Cursor", no "Change editor", no picker
  on first use. If any of those appear, a code path from #158 survived.
- No dead end. Every menu row does something, and every failure leaves a visible notice with a way
  forward. A row that opens nothing and says nothing is the one outcome this feature may not
  produce.
- Nothing writes to `preferences.editor` any more. An existing user's stored editor is left inert in
  `settings.json` — it must not be read, and their sites and contributor details must be untouched.

Not testable by hand here: the Windows and Linux branches of the launchable-path and
case-sensitivity checks. Those are exercised by injection in `test/editor-launch.test.cjs` rather
than skipped, and I verified both new checks fail the suite when the logic is removed.

## Risks and limitations

- **One extra click per open, forever.** The remembered-editor button was one click; this is two.
  That is the trade this shape makes, and it is the main thing to decide before merging.
- Self-review found **3 [fix here] · 1 [follow-up]** — all 3 fixed, 1 deferred. Detail in the
  collapsed block below.
- The menu re-runs detection on each open rather than caching it, so an editor installed while the
  app is running appears next time. That is ~10–20 `stat`s per open, all async, off the main
  thread's critical path.
- Not done: keyboard-driven verification of the popover on Windows. The menu is
  `Dropdown` + `MenuGroup`/`MenuItem` from `@wordpress/components`, the same primitives the sidebar's
  feedback dropdown and the ⋯ menu already use.

## Related

Follow-up to #158. Explores the alternative UI proposed for it.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Greyed-out "not installed" rows — rejected.** The sketch showed all five known editors always
listed, disabled when absent. Two problems: it turns the detection table from a shortcut into a
claim about the machine, and the table is knowingly incomplete (its own comment says the picker
covers versioned JetBrains installs "exactly as well"). Someone with PhpStorm installed via the
JetBrains installer would read **PHPStorm (not installed)** and believe the app. A third option —
dimmed but clickable, opening the dialog prefilled — was also dropped: it makes a row mean two
different things depending on a state the contributor cannot see, and **Other application…** already
covers it honestly.

**Dropping the memory entirely — chosen over "remember, last used on top".** Keeping the memory
would have kept `editor:get`, `editor:choose` and the stored preference alive to save one click.
Since the menu has to exist anyway, the remembered copy is a second source of truth for the same
answer, plus a failure path (the remembered editor moved) that only exists because something was
remembered. The one click is the price.

**Where the menu goes.** First on the metadata line beside the created date, then beside the copy
button, and finally on its own row under the path — the folder is what it acts on, so it reads
directly beneath the folder, above everything that acts on the site itself.

**`matchDetectedEditor` returns the candidate, not a boolean.** A boolean would let a caller check
one string and spawn another; returning the path detection vouches for makes that mistake
unwritable. It lives in `editor-launch.js` rather than the handler so the case-sensitivity split has
an injected `platform` and both branches are testable from one machine — the house pattern.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**3 [fix here] · 1 [follow-up] — all 3 fixed, the follow-up deferred.**

Fixed:

1. **Tests 🟡** — the new allow-list check read `process.platform` inline, so neither branch of the
   case-sensitivity comparison could be exercised from one machine, and no test passed a
   case-differing path at all: the suite would have stayed green with `normalize` deleted. Moved the
   check into `editor-launch.js` as `matchDetectedEditor` with an injected `platform`, and added
   three tests covering the macOS, Windows and Linux branches. Verified both new tests fail when the
   logic is removed.
2. **Security 🔵** — the handler compared `normalize(candidate.path)` but then passed `target`, the
   renderer's own string, to `openSiteInEditor`. On a case-sensitive volume `/applications/Cursor.app`
   would pass the comparison while being a different filesystem entry. Now the detected path is what
   is spawned.
3. **Architecture 🔵** — the comparison duplicated `knownEditorName`'s normalisation while leaving
   that function without a production caller. Both now live in `editor-launch.js`; the duplication is
   gone.

Deferred:

4. **Architecture 🔵 [follow-up]** — the **Other application…** branch opens the file dialog before
   `sitePath` is checked against the registry, so a site forgotten in another window would show a
   file browser and only then refuse. The ordering predates this PR (`editor:choose` had the same
   dialog with no site in hand at all), and fixing it belongs with the registry-staleness handling
   rather than here.

Verified and explicitly not findings: `preferences.editor` needs no migration (nothing reads it on
either side of the upgrade, and the surviving writer spreads the existing object, so contributor
provenance is preserved); the second detection sweep per open is not a user-visible cost.

Style notes from the same pass, all applied: comments in `settings-store.js`, `main.js` and
`index.jsx` that still described the remembered editor, the `editorChoice` variable name for a hook
that no longer holds a choice, and `'unknown-editor'` as a bare literal rather than a
`REFUSAL_REASONS` entry.

</details>

<details>
<summary>Implementation notes</summary>

- `src/editor-launch.js` — adds `matchDetectedEditor(editorPath, { platform, env, exists })` and
  `REFUSAL_REASONS.UNKNOWN_EDITOR`. Detection, launchability and the spawn are unchanged; nothing
  here consults `PATH`, at either end, for the reason the file's header gives.
- `src/main.js` — `editor:get` and `editor:choose` are gone; `editor:list` drops `chosen`;
  `editor:open` takes `(sitePath, editorPath | null)`.
- `src/preload.js` — `getEditor` and `chooseEditor` removed; `openInEditor` takes the second
  argument.
- `src/renderer/index.jsx` — `useEditorChoice` becomes `useDetectedEditors` (detected + loading, no
  chosen, no remember); the picker modal and the three-button row are deleted; the inline notice
  stays and is now the only place a failure speaks, so it carries **Choose application…** with it.
- Tests: `test/editor-launch.test.cjs` gains the three `matchDetectedEditor` cases;
  `test/ipc-wiring.test.cjs` swaps the `editor:get`/`editor:choose` wiring tests for the refusal and
  file-dialog paths. 419 pass, lint clean.

</details>

<details>
<summary>Screenshots or recording</summary>

**The menu, open**, on a site with four applications found. Everything the folder can be opened in,
in one list, with `Other application…` always at the end — no row disabled, nothing claiming to know
what is not installed:

<img width="2000" height="1336" alt="1-menu-open" src="https://github.com/user-attachments/assets/f183a31f-2dd5-499e-8117-f5b4e3cf3a67" />

**Closed**, the resting state: one link directly under the path it acts on, where three buttons and
a "Change editor" used to be:

<img width="2000" height="1336" alt="2-menu-closed" src="https://github.com/user-attachments/assets/565aebc2-ab12-4df9-ba2d-268063032949" />

Both captured from the running app on macOS through `webContents.capturePage()`, with the menu
opened by a real click rather than a mock.

</details>
