### PR TITLE
Say which files need a rebuild, and why

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2835,7 +2835,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       key: 'build',
       label: 'Run full build',
       description: hasBuilt
-        ? 'Built. Changed files since? Run npm run build in the Terminal below — updates and applied patches rebuild on their own.'
+        ? 'Built. Edited files in src/ since? Run npm run build in the Terminal below so the site picks them up — updates and applied patches rebuild on their own.'
         : 'Compile WordPress Core to generate the dist files. Later updates rebuild automatically.',
       ...stepState.build,
       action: (
@@ -3511,7 +3511,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           <div style={{ marginTop: 8, fontSize: 12, color: '#3c434a' }}>
             {showTerminalHints ? (
               <>
-                <div>Changed files in your checkout? Run <TerminalCommandLink command="npm run build" onPrefill={prefillTerminalCommand} disabled={terminalBusy} />.</div>
+                <div>Edited files in <code>src/</code>? Run <TerminalCommandLink command="npm run build" onPrefill={prefillTerminalCommand} disabled={terminalBusy} /> so the site picks them up.</div>
                 <div style={{ marginTop: 2, marginBottom: 6 }}>Added a dependency to <code>package.json</code>? Run <TerminalCommandLink command="npm install" onPrefill={prefillTerminalCommand} disabled={terminalBusy} />.</div>
               </>
             ) : null}

--- a/test/terminal-hints.test.cjs
+++ b/test/terminal-hints.test.cjs
@@ -7,8 +7,8 @@ const { shouldShowTerminalHints, computeTerminalBusy } = require('../src/rendere
 
 test('the hints stay hidden until a build has completed (issue #182)', () => {
 	// They were showing from the moment a site existed, so a contributor watched
-	// "Changed files in your checkout? Run npm run build" scroll past while the
-	// clone was still writing the checkout that would contain those files.
+	// "Edited files in src/? Run npm run build" scroll past while the clone was
+	// still writing the checkout that would contain those files.
 	assert.strictEqual(shouldShowTerminalHints({ hasBuilt: false }), false);
 	assert.strictEqual(shouldShowTerminalHints({}), false, 'a site mid-clone must not show them');
 	assert.strictEqual(shouldShowTerminalHints(), false, 'no flags at all must not show them');


### PR DESCRIPTION
## Why

The hint under the Terminal asked "Changed files in your checkout? Run `npm run build`." Three
things are wrong with that sentence for the person it is written for. "Your checkout" is Git
jargon for a directory the app created and owns, so it does not read as the contributor's. "Changed
files" is broader than the truth — updates and applied patches rebuild on their own, as the
checklist line right above it already admits, so the hint asks for work that is often not needed.
And it never says why a build is needed at all: the site is served from `build/`, not `src/`
(`src/main.js:1577`), which is the one fact that makes the whole hint make sense.

## What changes

Name what was actually edited, and state the payoff:

> Edited files in `src/`? Run `npm run build` so the site picks them up.

The trailing clause carries the `src/` → `build/` model without turning the hint into a lecture, and
the sentence keeps the parallel with the `npm install` line directly below it ("Added a dependency
to `package.json`? Run `npm install`.").

The checklist's post-build description said the same thing the same vague way, so it moves with the
hint rather than leaving the app phrasing one idea two ways.

## How to test this

Platforms: any — this is renderer copy with no platform-specific path.

**Starting state:** a site that has finished "Run full build". The hints below the Terminal are
hidden until then by design (#182), so a freshly cloned site will not show them.

1. Open the site and scroll to the **Terminal** panel.
   Expected: the first hint line reads "Edited files in `src/`? Run `npm run build` so the site
   picks them up." — with `npm run build` still rendered as the clickable command link.
2. Click that `npm run build` link.
   Expected: the command is prefilled at the Terminal prompt, exactly as before. Nothing runs until
   you press Enter.
3. Scroll up to the setup checklist and read the **Run full build** step, which is now in its
   already-built state.
   Expected: "Built. Edited files in src/ since? Run npm run build in the Terminal below so the site
   picks them up — updates and applied patches rebuild on their own."
4. Start a command in the Terminal, then look at the hint again.
   Expected: the command link is disabled while the terminal is busy, unchanged from before.

**What must not have happened:** the command link must not have degraded into plain text — the
string around it changed, and the `<TerminalCommandLink>` element sits mid-sentence. The `npm
install` hint on the next line must be untouched. And the hints must still be hidden on a site that
has not been built.

## Risks and limitations

No behaviour changes — this is three strings. The `src/` framing is now load-bearing copy: if the
app ever serves the checkout directly instead of `build/`, both strings go stale together.

No screenshot: reaching the state where the hints render means a real clone, `npm install` and a
full Core build, which the copy change does not justify. The before/after strings are quoted in
full above instead.

## Related

Follows the hint visibility work in #182, which is what puts these strings on screen.

---

<details>
<summary>Design decisions and alternatives considered</summary>

Two other shapes were on the table:

- *Leading with the model* — "Your site runs from `build/`, not `src/`. After editing, run `npm run
  build`." Clearer the first time, wordier on every read after, and it breaks the "Did X? Run Y."
  parallel with the `npm install` line below.
- *Shortest* — "Edited WordPress source? Run `npm run build`." Fixes the jargon but keeps the hint
  silent about why, which was the main complaint.

The chosen wording keeps the question/answer parallel and pays for the extra clause with the one
fact a newcomer is missing.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up] — no findings across the five dimensions.

`npm run lint` is clean and `npm test` is 511 passing / 0 failing. The judgement pass ran in a
subagent with only the diff and the instructions file, per `.claude/skills/self-review/SKILL.md`. It
confirmed no spawn, IPC, persistence, path-handling or listener surface is touched, and that no new
test is warranted: `test/terminal-hints.test.cjs` asserts `shouldShowTerminalHints` behaviour rather
than the string, which is the correct side of the "do not assert exact log strings" rule. Only the
comment quoting the old wording moved.

</details>

<details>
<summary>Implementation notes</summary>

The three sites, all of which had to move together:

- `src/renderer/index.jsx:3514` — the Terminal hint.
- `src/renderer/index.jsx:2838` — the checklist's `hasBuilt` description.
- `test/terminal-hints.test.cjs:10` — a comment quoting the old string to explain why the hints are
  hidden pre-build. No assertion touches the wording.

`src/renderer/index.js` is the generated bundle and is not committed, so its copy of these strings
needs no separate handling.

</details>
