### PR TITLE
Let a contributor debug their WordPress code from the app

### DIFF
--- a/src/log-tail.js
+++ b/src/log-tail.js
@@ -1,0 +1,52 @@
+// What to read from a file that is being tailed, given how big it was last time
+// and how big it is now.
+//
+// Extracted from the fs.watch callback in main.js so the rule below can be
+// tested: inside the callback it was unreachable, and the rule it was missing —
+// a file that shrank — is not a corner case. The Clear button under the
+// debug.log panel truncates the file, and `grunt clean` removes it during a
+// rebuild.
+//
+// Deliberately free of Electron and fs imports, like log-lines.js.
+
+// The most of an existing file to replay when the tail first attaches. A
+// contributor opening a site that has been logging for a week does not want the
+// week; they want enough to see what the last run did.
+const MAX_INITIAL_READ = 256 * 1024;
+
+// The byte range to send when attaching to a file for the first time.
+function planInitialRead(size, max = MAX_INITIAL_READ) {
+	const total = Math.max(0, Number(size) || 0);
+	return {
+		// Null rather than a zero-length range: an empty file has no backlog, and
+		// the caller uses this to decide whether to open a stream at all.
+		read: total > 0 ? { start: total > max ? total - max : 0 } : null,
+		lastSize: total
+	};
+}
+
+// The byte range to send when a watched file changes, and the offset to
+// remember. `read` is null when there is nothing new.
+function planTailRead(lastSize, size) {
+	const previous = Math.max(0, Number(lastSize) || 0);
+	const current = Math.max(0, Number(size) || 0);
+
+	// Smaller than last time: the file was truncated or replaced, and the bytes
+	// that used to be at `previous` are gone. Reading from there would skip past
+	// everything written from now on — the whole file has to fit past the old
+	// offset before a single line reappears — so the panel goes quiet for the
+	// rest of the session. Start over from the beginning of what is there now.
+	if (current < previous) {
+		return { read: current > 0 ? { start: 0 } : null, lastSize: current };
+	}
+
+	if (current > previous) return { read: { start: previous }, lastSize: current };
+
+	// Unchanged size. fs.watch fires on metadata changes too, and a rewrite that
+	// happens to land on the same length is not something a size comparison can
+	// see; replaying from 0 on every such event would duplicate the file into the
+	// panel, which is worse than missing it.
+	return { read: null, lastSize: current };
+}
+
+module.exports = { MAX_INITIAL_READ, planInitialRead, planTailRead };

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,8 @@ const { openPullRequest, buildPullRequestBody, testMode: githubTestMode } = requ
 const { buildPullRequestEntries } = require('./pr-files.cjs');
 const { openAndScrape, fetchAttachment } = require('./trac-view');
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
-const { deleteRegisteredSite, revealRegisteredSite } = require('./site-registry');
+const { deleteRegisteredSite, revealRegisteredSite, clearRegisteredSiteLog } = require('./site-registry');
+const { planInitialRead, planTailRead } = require('./log-tail');
 const { getStore } = require('./settings-store');
 const { parseTicketRef } = require('./renderer/trac-ticket.cjs');
 const { parseHandle } = require('./wporg-handle.cjs');
@@ -1855,39 +1856,68 @@ ipcMain.handle('smtp:stop', async (_e, sitePath) => {
 });
 
 // --- WordPress debug.log tailing ---
+
+// Written into the stream between the backlog replayed on attach and the lines
+// this run produces. Distinguishable from a WordPress entry, which always opens
+// with a bracketed timestamp.
+const WP_DEBUG_SESSION_MARKER = '—— tail attached; everything above is from an earlier run ——';
+
+// Where WordPress writes it, for the three things that need to agree on it: the
+// tail, the Clear button and Show in folder. Composed here rather than in the
+// renderer, which would have to concatenate with '/' and be wrong on Windows.
+//
+// Under `build/`, not `src/`, because `build/` is what Playground serves — the
+// asymmetry worth naming, since a contributor editing src/wp-content/themes/…
+// will look for their log next to the file they just edited.
+function wpDebugLogPath(sitePath) {
+	return path.join(sitePath, 'build', 'wp-content', 'debug.log');
+}
+
 function startWpDebugTail(sitePath, webContents) {
 	if (wpDebugWatchers[sitePath]?.fileWatcher || wpDebugWatchers[sitePath]?.dirWatcher) {
 		return true;
 	}
-	const wpContentDir = path.join(sitePath, 'build', 'wp-content');
-	const filePath = path.join(wpContentDir, 'debug.log');
+	const filePath = wpDebugLogPath(sitePath);
+	const wpContentDir = path.dirname(filePath);
 	wpDebugWatchers[sitePath] = { filePath, lastSize: 0 };
 	const state = wpDebugWatchers[sitePath];
+
+	function send(data) {
+		webContents.send('wp:debug-log:data', { sitePath, data });
+	}
 
 	function attachFileWatcher() {
 		try {
 			const stat = fs.existsSync(filePath) ? fs.statSync(filePath) : null;
 			if (!stat) return false;
-			// Send initial tail (cap to last 256KB)
-			const maxInitial = 256 * 1024;
-			const start = stat.size > maxInitial ? stat.size - maxInitial : 0;
-			state.lastSize = stat.size;
-			if (stat.size > 0) {
-				const rs = fs.createReadStream(filePath, { start });
-				rs.on('data', (chunk) => {
-					webContents.send('wp:debug-log:data', { sitePath, data: chunk.toString() });
-				});
+			const initial = planInitialRead(stat.size);
+			state.lastSize = initial.lastSize;
+			if (initial.read) {
+				const rs = fs.createReadStream(filePath, initial.read);
+				rs.on('data', (chunk) => send(chunk.toString()));
+				// The file outlives the dev server, so what was just replayed is
+				// whatever previous runs left behind — with WordPress's own
+				// timestamps on it, which is exactly what makes it read as
+				// something that happened just now. The marker is the app saying
+				// where the backlog ends.
+				rs.on('end', () => send(`${WP_DEBUG_SESSION_MARKER}\n`));
 			}
 			state.fileWatcher = fs.watch(filePath, (evt) => {
+				// 'rename' is the file being replaced or removed under the
+				// watcher, which stays bound to the old inode and would never
+				// fire again. Re-attaching is what keeps the panel alive across a
+				// `grunt clean` or a manual delete.
+				if (evt === 'rename') { reattachAfterLoss(); return; }
 				if (evt !== 'change') return;
 				try {
-					const s = fs.statSync(filePath);
-					if (s.size > state.lastSize) {
-						const rs2 = fs.createReadStream(filePath, { start: state.lastSize });
-						rs2.on('data', (chunk) => {
-							webContents.send('wp:debug-log:data', { sitePath, data: chunk.toString() });
-						});
-						state.lastSize = s.size;
+					// Including the case the panel's Clear button creates: a file
+					// that shrank has to be re-read from the start, not from the
+					// old offset. See log-tail.js.
+					const next = planTailRead(state.lastSize, fs.statSync(filePath).size);
+					state.lastSize = next.lastSize;
+					if (next.read) {
+						const rs2 = fs.createReadStream(filePath, next.read);
+						rs2.on('data', (chunk) => send(chunk.toString()));
 					}
 				} catch {}
 			});
@@ -1897,8 +1927,11 @@ function startWpDebugTail(sitePath, webContents) {
 		}
 	}
 
-	// Watch directory for creation if the file doesn't exist yet
-	if (!attachFileWatcher()) {
+	// Watch the directory for the file appearing. Used both before it exists at
+	// all — the common case, since nothing writes it until WordPress logs
+	// something — and again if it is later removed.
+	function watchForFile() {
+		if (attachFileWatcher()) return;
 		try {
 			state.dirWatcher = fs.watch(wpContentDir, () => {
 				if (attachFileWatcher() && state.dirWatcher) {
@@ -1908,6 +1941,15 @@ function startWpDebugTail(sitePath, webContents) {
 			});
 		} catch {}
 	}
+
+	function reattachAfterLoss() {
+		try { state.fileWatcher?.close(); } catch {}
+		state.fileWatcher = undefined;
+		state.lastSize = 0;
+		watchForFile();
+	}
+
+	watchForFile();
 	return true;
 }
 
@@ -1919,12 +1961,72 @@ function stopWpDebugTail(sitePath) {
 	delete wpDebugWatchers[sitePath];
 }
 
+// Returns the path as well as starting the tail. The panel shows it, because a
+// contributor who wants to `tail -f` it in a terminal, open it in an editor or
+// attach it to a ticket cannot guess it: the log is under `build/`, while the
+// file they were editing when it appeared is under `src/`.
 ipcMain.handle('wp-debug:start', async (event, sitePath) => {
 	startWpDebugTail(sitePath, event.sender);
-	return true;
+	return { ok: true, filePath: wpDebugLogPath(sitePath) };
 });
 
 ipcMain.handle('wp-debug:stop', async (_event, sitePath) => {
 	stopWpDebugTail(sitePath);
 	return true;
+});
+
+// Clearing the panel alone would be a promise the app cannot keep: the file
+// outlives the dev server, and the tail replays it the next time it attaches, so
+// the same lines come straight back. This empties the file the panel is showing.
+ipcMain.handle('wp-debug:clear', async (_event, sitePath) => {
+	const s = await getStore();
+	return clearRegisteredSiteLog(sitePath, {
+		sites: s.get('sites'),
+		truncate: async (target) => {
+			const filePath = wpDebugLogPath(target);
+			try {
+				// Truncated rather than unlinked: WordPress opens the file per
+				// write, but the app's own fs.watch is bound to the inode, and
+				// removing it would leave the watcher listening to a file nothing
+				// writes to again. The watcher's own truncation branch handles
+				// this too — this keeps the two in step without waiting for it.
+				await fs.promises.truncate(filePath, 0);
+				const state = wpDebugWatchers[target];
+				if (state) state.lastSize = 0;
+				return { ok: true };
+			} catch (e) {
+				// Nothing has been logged yet, so there is nothing to clear and
+				// nothing went wrong.
+				if (e && e.code === 'ENOENT') return { ok: true };
+				logError('wp-debug', `could not clear the debug log: ${String(e && e.message ? e.message : e)}`);
+				return { ok: false, reason: 'truncate-failed', error: String(e && e.message ? e.message : e) };
+			}
+		},
+		onRefused: (description) => logEvent('sites', `refused to clear the debug log for ${description} — not a registered site`)
+	});
+});
+
+// Shows the log file in Finder/Explorer. Same boundary and same helper as
+// `dir:show` — this reveals a file inside the site rather than the site itself,
+// which is the only difference, so the gate is reused rather than reimplemented.
+ipcMain.handle('wp-debug:reveal', async (_event, sitePath) => {
+	const s = await getStore();
+	return revealRegisteredSite(sitePath, {
+		sites: s.get('sites'),
+		// Resolves to electron's convention: '' for success, a message otherwise.
+		// The existence check is the message that matters — showItemInFolder does
+		// nothing at all for a path that is not there, which from the contributor's
+		// chair is a button that did nothing.
+		reveal: async (target) => {
+			const filePath = wpDebugLogPath(target);
+			try {
+				await fs.promises.access(filePath);
+			} catch {
+				return 'WordPress has not written a debug.log for this site yet.';
+			}
+			shell.showItemInFolder(filePath);
+			return '';
+		},
+		onRefused: (description) => logEvent('sites', `refused to reveal the debug log for ${description} — not a registered site`)
+	});
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -201,17 +201,28 @@ contextBridge.exposeInMainWorld('api', {
 		return { updateId };
 	}
 ,
+	// Resolves to the log's path as well as its unsubscribe: the panel shows the
+	// path, and only the main process can compose it correctly on both platforms.
 	startWpDebug: async (sitePath, onData) => {
 		const handler = (_e, payload) => {
 			if (payload.sitePath === sitePath && onData) onData(payload.data);
 		};
 		ipcRenderer.on('wp:debug-log:data', handler);
-		await ipcRenderer.invoke('wp-debug:start', sitePath);
-		return () => ipcRenderer.removeListener('wp:debug-log:data', handler);
+		const started = await ipcRenderer.invoke('wp-debug:start', sitePath);
+		return {
+			filePath: started?.filePath || '',
+			unsubscribe: () => ipcRenderer.removeListener('wp:debug-log:data', handler)
+		};
 	},
 	stopWpDebug: async (sitePath) => {
 		await ipcRenderer.invoke('wp-debug:stop', sitePath);
-	}
+	},
+	// Empties the file, not just the panel: the tail replays what is on disk
+	// every time it attaches, so a pane cleared on its own fills straight back up
+	// on the next dev-server start.
+	clearWpDebug: (sitePath) => ipcRenderer.invoke('wp-debug:clear', sitePath)
+,
+	revealWpDebug: (sitePath) => ipcRenderer.invoke('wp-debug:reveal', sitePath)
 ,
 	startServer: async (sitePath, onLog, onUrl, onStopped) => {
 		const logHandler = (_e, payload) => {

--- a/src/renderer/debug-log.cjs
+++ b/src/renderer/debug-log.cjs
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * The two pieces of logic behind the debug.log panel.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly
+ * (same convention as dev-server-command.cjs and setup-steps.cjs).
+ */
+
+/**
+ * How much of the log the panel keeps in memory.
+ *
+ * The existing runtime log grows without any bound at all
+ * (`setRuntimeLogs((v) => v + chunk)`), which is survivable only because a dev
+ * server is comparatively quiet. This one is not: the tail opens by sending up
+ * to 256KB of backlog (startWpDebugTail in main.js), and a site looping a
+ * notice inside a template writes a line per request. Unbounded, a long session
+ * ends as a multi-megabyte string the renderer re-renders on every chunk.
+ *
+ * 512KB is far more scrollback than anyone reads and small enough that holding
+ * it costs nothing.
+ */
+const MAX_LOG_CHARACTERS = 512 * 1024;
+
+/**
+ * Appends a chunk, dropping the oldest content once the result exceeds `limit`.
+ *
+ * Drops at a line boundary rather than mid-character-count: the first thing
+ * anyone does with this panel is read a PHP error, and a half line at the top
+ * of a scrollback reads as corruption.
+ *
+ * Some lines have no boundary to drop to — a var_dump or a serialized object
+ * longer than the whole limit. There the tail is kept instead, because the end
+ * of such a line is where the file and line number are. Note that the boundary
+ * search can land on the line's own terminator and leave nothing behind, which
+ * is the same case reached by a different route: the result is checked for
+ * empty rather than the input for a trailing newline, since a log line that
+ * ends in one is the normal shape, not the exception.
+ *
+ * @param {string} previous Text already held by the panel.
+ * @param {string} chunk    Newly received text.
+ * @param {number} limit    Maximum characters to retain.
+ * @return {string} The text the panel should now hold.
+ */
+function appendBounded(previous, chunk, limit = MAX_LOG_CHARACTERS) {
+	const text = `${previous ?? ''}${chunk ?? ''}`;
+	if (text.length <= limit) return text;
+
+	// Everything up to this index has to go for the result to fit; the cut then
+	// moves forward to the next line boundary. Searching from one before it so a
+	// boundary that already lands exactly right does not cost an extra line.
+	const excess = text.length - limit;
+	const boundary = text.indexOf('\n', excess - 1);
+	const dropped = boundary === -1 ? '' : text.slice(boundary + 1);
+
+	// Dropping whole lines left nothing: there is one line here and it is longer
+	// than the buffer. Keep its end.
+	return dropped === '' ? text.slice(text.length - limit) : dropped;
+}
+
+/**
+ * How many complete lines a chunk carries, for the unread count on the tab.
+ *
+ * Counts terminators rather than split() parts, so a chunk that ends mid-line
+ * contributes that line only once — when the rest of it arrives. Every line
+ * WordPress writes through error_log() is terminated, so in practice nothing is
+ * missed; the alternative over-counts a line split across two reads.
+ *
+ * @param {string} chunk
+ * @return {number}
+ */
+function countLines(chunk) {
+	const text = String(chunk ?? '');
+	let count = 0;
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === '\n') count++;
+	}
+	return count;
+}
+
+module.exports = { MAX_LOG_CHARACTERS, appendBounded, countLines };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -23,6 +23,7 @@ import 'xterm/css/xterm.css';
 import { computeSetupStepState } from './setup-steps.cjs';
 import { shouldShowTerminalHints, computeTerminalBusy } from './terminal-hints.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
+import { appendBounded, countLines } from './debug-log.cjs';
 import { pathBasename } from './path-basename.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, APPLY_STATE_TO_STEP } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
@@ -32,6 +33,8 @@ import { highlightDiff } from './diff-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
+// Shared by both log panes so the tabs cannot drift apart visually.
+const LOG_PANE_STYLE = { whiteSpace: 'pre-wrap', background: '#111', color: '#eee', padding: 12, borderRadius: 6, height: 220, overflow: 'auto' };
 // What the Copy button says about the press just made. Keyed rather than
 // nested ternaries, so a fourth state is a line here instead of another branch
 // in the middle of the JSX.
@@ -1010,6 +1013,19 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [installing, setInstalling] = useState(false);
   const [npmLogs, setNpmLogs] = useState('');
   const [runtimeLogs, setRuntimeLogs] = useState('');
+  // WordPress's own debug.log, kept apart from the server's output: one is what
+  // Playground is doing, the other is what the contributor's code is doing, and
+  // interleaving them buries the second in the first.
+  const [debugLogs, setDebugLogs] = useState('');
+  const [debugUnread, setDebugUnread] = useState(0);
+  // Kept after the dev server stops: the file is still there, and so is the
+  // reason someone wants the path.
+  const [debugLogPath, setDebugLogPath] = useState('');
+  const [activeLogTab, setActiveLogTab] = useState('runtime');
+  const activeLogTabRef = useRef('runtime');
+  // '' | 'copied' | 'failed', on the debug.log Copy button for two seconds.
+  const [debugCopied, setDebugCopied] = useState('');
+  const debugCopyTimer = useRef(null);
   const [isPatchOpen, setIsPatchOpen] = useState(false);
   const [patchText, setPatchText] = useState('');
   const [patchLoading, setPatchLoading] = useState(false);
@@ -1047,6 +1063,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [smtpPort, setSmtpPort] = useState(0);
   const newEmailUnsubRef = useRef(null);
   const smtpStartedUnsubRef = useRef(null);
+  const wpDebugUnsubRef = useRef(null);
   const [isEmailOpen, setIsEmailOpen] = useState(false);
   const [activeEmail, setActiveEmail] = useState(null);
   const [, setEmailViewTab] = useState('rendered');
@@ -1098,9 +1115,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // sticky refs per log
   const npmRef = useRef(null);
   const runtimeRef = useRef(null);
+  const debugRef = useRef(null);
   const currentRunIdRef = useRef(null);
   const threshold = 8;
-  const [logStick, setLogStick] = useState({ npm: true, runtime: true });
+  const [logStick, setLogStick] = useState({ npm: true, runtime: true, debug: true });
   const updateStick = useCallback((key, value) => {
     setLogStick((prev) => (prev[key] === value ? prev : { ...prev, [key]: value }));
   }, []);
@@ -1108,7 +1126,19 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setLogStick((prev) => (prev[key] ? prev : { ...prev, [key]: true }));
   }, []);
   useEffect(() => { if (logStick.npm && npmRef.current) npmRef.current.scrollTop = npmRef.current.scrollHeight; }, [npmLogs, logStick.npm]);
-  useEffect(() => { if (logStick.runtime && runtimeRef.current) runtimeRef.current.scrollTop = runtimeRef.current.scrollHeight; }, [runtimeLogs, logStick.runtime]);
+  // Both log effects watch `activeLogTab` because TabPanel renders only the
+  // selected tab: the pane is a fresh element every time it is switched back to,
+  // scrolled to the top, and the arriving-text dependency alone would not fire
+  // to put it back at the bottom. The guard is not just for the dependency — the
+  // other tab's element is unmounted, so there is nothing to scroll.
+  useEffect(() => {
+    if (activeLogTab !== 'runtime') return;
+    if (logStick.runtime && runtimeRef.current) runtimeRef.current.scrollTop = runtimeRef.current.scrollHeight;
+  }, [runtimeLogs, logStick.runtime, activeLogTab]);
+  useEffect(() => {
+    if (activeLogTab !== 'debug') return;
+    if (logStick.debug && debugRef.current) debugRef.current.scrollTop = debugRef.current.scrollHeight;
+  }, [debugLogs, logStick.debug, activeLogTab]);
   const makeOnScroll = useCallback((key) => (e) => {
     const el = e.currentTarget;
     const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - threshold;
@@ -1281,6 +1311,69 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   const appendNpm = useCallback((s)=>setNpmLogs((v)=>v+s),[]);
   const appendRuntime = useCallback((s)=>setRuntimeLogs((v)=>v + String(s ?? '')),[]);
+  const appendDebug = useCallback((s) => {
+    const chunk = String(s ?? '');
+    if (!chunk) return;
+    setDebugLogs((v) => appendBounded(v, chunk));
+    // Counted only while the tab is not the one being read. Selecting it zeroes
+    // the badge, so incrementing there would flicker it straight back on.
+    if (activeLogTabRef.current !== 'debug') setDebugUnread((n) => n + countLines(chunk));
+  }, []);
+  const selectLogTab = useCallback((name) => {
+    activeLogTabRef.current = name;
+    setActiveLogTab(name);
+    if (name === 'debug') setDebugUnread(0);
+  }, []);
+  // The count is on the tab rather than beside it because the tab is what the
+  // contributor is not looking at: a notice landing while they read the server
+  // output is the case this panel exists for.
+  const logTabs = useMemo(() => ([
+    { name: 'runtime', title: 'Server' },
+    { name: 'debug', title: debugUnread ? `debug.log (${debugUnread})` : 'debug.log' }
+  ]), [debugUnread]);
+  const clearDebugLog = useCallback(async () => {
+    setDebugLogs('');
+    setDebugUnread(0);
+    // The file has to go with the pane. Clearing only the pane looks like it
+    // worked and then hands the same lines back on the next dev-server start,
+    // because the tail replays whatever is on disk when it attaches.
+    let cleared;
+    try {
+      cleared = await window.api.clearWpDebug(sitePath);
+    } catch (e) {
+      cleared = { ok: false, error: e && e.message ? e.message : String(e) };
+    }
+    if (!cleared?.ok) appendDebug(`Could not clear ${pathBasename(sitePath)}'s debug.log: ${cleared?.error || cleared?.reason || 'unknown error'}. The panel was cleared; the file was not.\n`);
+  }, [appendDebug, sitePath]);
+  // Same shape as copyPatch below, and for the same reason: a clipboard write
+  // has no visible result, so the button has to report one. This log goes
+  // straight into a Trac ticket or a pull request comment.
+  const copyDebugLog = useCallback(async () => {
+    if (debugCopyTimer.current) clearTimeout(debugCopyTimer.current);
+    let state = 'copied';
+    try {
+      await navigator.clipboard.writeText(debugLogs);
+    } catch {
+      state = 'failed';
+    }
+    setDebugCopied(state);
+    debugCopyTimer.current = setTimeout(() => setDebugCopied(''), 2000);
+  }, [debugLogs]);
+  useEffect(() => () => { if (debugCopyTimer.current) clearTimeout(debugCopyTimer.current); }, []);
+  // Switching to another site unmounts this panel without going through
+  // stopDevServer, so the listener has to come off here too.
+  useEffect(() => () => { try { if (wpDebugUnsubRef.current) { wpDebugUnsubRef.current(); wpDebugUnsubRef.current = null; } } catch {} }, []);
+  const revealDebugLog = useCallback(async () => {
+    let revealed;
+    try {
+      revealed = await window.api.revealWpDebug(sitePath);
+    } catch (e) {
+      revealed = { ok: false, error: e && e.message ? e.message : String(e) };
+    }
+    // Nothing on screen moves when a file manager opens behind the app, so a
+    // refusal that says nothing is a button that did nothing.
+    if (!revealed?.ok) appendDebug(`Could not show the log file: ${revealed?.error || revealed?.reason || 'unknown error'}\n`);
+  }, [appendDebug, sitePath]);
   const sortEmails = useCallback((list)=>[...list].sort((a,b)=>new Date(b.sentAt||b.date||0)-new Date(a.sentAt||a.date||0)),[]);
   const openEmail = useCallback((m)=>{ setActiveEmail(m); setEmailViewTab('rendered'); setIsEmailOpen(true); },[]);
   const clearEmails = useCallback(async ()=>{ await window.api.clearEmails(sitePath); setEmails([]); }, [sitePath]);
@@ -1697,6 +1790,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setStarting(false);
     try { await window.api.stopServer(sitePath); } catch {}
     try { window.api.stopWpDebug(sitePath); } catch {}
+    // stopWpDebug only tears down the watcher in the main process. The renderer
+    // keeps its own 'wp:debug-log:data' listener until this runs, and a second
+    // start would add another one on top of it — every line then appended once
+    // per dev-server run the session has had.
+    try { if (wpDebugUnsubRef.current) { wpDebugUnsubRef.current(); wpDebugUnsubRef.current = null; } } catch {}
     try { if (newEmailUnsubRef.current) { newEmailUnsubRef.current(); newEmailUnsubRef.current = null; } } catch {}
     try { if (smtpStartedUnsubRef.current) { smtpStartedUnsubRef.current(); smtpStartedUnsubRef.current = null; } } catch {}
     setRunning(false);
@@ -1767,9 +1865,21 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       runningRef.current = false;
       return;
     }
-    window.api.startWpDebug(sitePath,(d)=>appendRuntime(d || ''));
+    // Reset before subscribing: the tail replays the tail of the file when it
+    // attaches (up to 256KB, startWpDebugTail in main.js), so a restart would
+    // otherwise show the previous session's log a second time below itself.
+    // Stopping the server does not clear the pane — after a crash that log is
+    // the thing to read — but starting a new run does.
+    setDebugLogs('');
+    setDebugUnread(0);
+    try {
+      if (wpDebugUnsubRef.current) { wpDebugUnsubRef.current(); wpDebugUnsubRef.current = null; }
+      const tail = await window.api.startWpDebug(sitePath,(d)=>appendDebug(d || ''));
+      wpDebugUnsubRef.current = tail?.unsubscribe || null;
+      if (tail?.filePath) setDebugLogPath(tail.filePath);
+    } catch {}
     try { const { port, emails: fetchedEmails } = await window.api.getEmails(sitePath); if (port) setSmtpPort(port); setEmails(fetchedEmails||[]); } catch {}
-  }, [appendRuntime, ensureStick, killCurrent, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails, stopDevServer]);
+  }, [appendDebug, appendRuntime, ensureStick, killCurrent, newEmailUnsubRef, setEmails, setRunning, setServerUrl, setStarting, setSmtpPort, sitePath, smtpStartedUnsubRef, sortEmails, stopDevServer]);
 
   const toggleDevServer = async ()=>{
     if (!running) {
@@ -3521,8 +3631,36 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           </div>
         </div>
         <div>
-          <div style={{ fontWeight: 600, marginBottom: 8 }}>Server & WordPress logs</div>
-          <div ref={runtimeRef} onScroll={makeOnScroll('runtime')} style={{ whiteSpace:'pre-wrap', background:'#111', color:'#eee', padding:12, borderRadius:6, height:220, overflow:'auto' }}>{runtimeLogs}</div>
+          <div style={{ fontWeight: 600, marginBottom: 8 }}>Logs</div>
+          <TabPanel className="log-tabs" activeClass="is-active" onSelect={selectLogTab} tabs={logTabs}>
+            {(tab) => (tab.name === 'runtime' ? (
+              <div ref={runtimeRef} onScroll={makeOnScroll('runtime')} style={LOG_PANE_STYLE}>{runtimeLogs}</div>
+            ) : (
+              <>
+                <div ref={debugRef} onScroll={makeOnScroll('debug')} style={LOG_PANE_STYLE}>
+                  {debugLogs || (
+                    // An empty pane reads as broken, which is what this one was
+                    // for as long as WP_DEBUG_LOG was never set. Say what fills
+                    // it instead.
+                    <span style={{ color:'#888' }}>No PHP notices or errors yet. Anything WordPress or your code writes — <code>error_log()</code>, notices, deprecations, fatals — appears here while the dev server runs.</span>
+                  )}
+                </div>
+                <div style={{ display:'flex', gap:8, marginTop:8, alignItems:'center', justifyContent:'space-between', flexWrap:'wrap' }}>
+                  {/* The file is under build/, while the file being edited when
+                      it filled up is under src/ — so it cannot be guessed, and
+                      it is what someone needs to tail it in a terminal or attach
+                      it to a ticket. Selectable rather than truncated with an
+                      ellipsis: a path you cannot copy is decoration. */}
+                  <code style={{ fontSize:11, color:'#666', userSelect:'text', wordBreak:'break-all', flex:'1 1 240px' }}>{debugLogPath || 'The log file appears once the dev server has run.'}</code>
+                  <div style={{ display:'flex', gap:8 }}>
+                    <Button size="small" variant="secondary" onClick={revealDebugLog} disabled={!debugLogPath}>Show in folder</Button>
+                    <Button size="small" variant="secondary" onClick={copyDebugLog} disabled={!debugLogs}>{COPY_BUTTON_LABELS[debugCopied] || COPY_BUTTON_LABELS.idle}</Button>
+                    <Button size="small" variant="secondary" onClick={clearDebugLog} disabled={!debugLogs}>Clear</Button>
+                  </div>
+                </div>
+              </>
+            ))}
+          </TabPanel>
         </div>
         <div>
           <div style={{ fontWeight: 600, marginBottom: 8 }}>Mail</div>

--- a/src/server-runner.js
+++ b/src/server-runner.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const { hideChildWindows } = require('./hide-child-windows');
 const { bindLoopbackOnly } = require('./bind-loopback');
 const { formatErrorChain } = require('./error-chain');
+const { WP_DEBUG_CONSTANTS } = require('./wp-debug-constants');
 
 // Must run before the Playground CLI is required, so anything it spawns is
 // covered too.
@@ -50,6 +51,10 @@ async function main() {
 			verbosity: 'debug',
 			blueprint: {
 				constants: {
+					// Debug first, mail second. This is the only point at which
+					// constants can be set: Playground generates the wp-config.php
+					// itself, and these have to be defined before WordPress loads.
+					...WP_DEBUG_CONSTANTS,
 					'WP_MAIL_SMTP_HOST': process.env.WP_MAIL_SMTP_HOST || '127.0.0.1',
 					'WP_MAIL_SMTP_PORT': Number(process.env.WP_MAIL_SMTP_PORT || 25),
 					'WP_MAIL_SMTP_AUTH': String(process.env.WP_MAIL_SMTP_AUTH || 'false') === 'true',

--- a/src/site-registry.js
+++ b/src/site-registry.js
@@ -68,9 +68,28 @@ async function revealRegisteredSite(sitePath, { sites, reveal, onRefused } = {})
 	return error ? { ok: false, reason: 'open-failed', error } : { ok: true };
 }
 
+// The `wp-debug:clear` handler's body. Emptying a file is nowhere near as
+// severe as `fse.remove`, but the shape is the same one this module exists for:
+// the renderer names a path and the app then writes to a location derived from
+// it. A path outside the registry would have the app truncating a file in a
+// directory it never created.
+//
+// `truncate` is injected like `remove` and `reveal` above, and reports whether
+// it succeeded rather than throwing, so the renderer can say that the pane was
+// cleared and the file was not.
+async function clearRegisteredSiteLog(sitePath, { sites, truncate, onRefused } = {}) {
+	if (!isRegisteredSite(sitePath, sites)) {
+		if (typeof onRefused === 'function') onRefused(describeRefusedSite(sitePath));
+		return { ok: false, reason: 'unregistered-site' };
+	}
+
+	return truncate(sitePath);
+}
+
 module.exports = {
 	isRegisteredSite,
 	describeRefusedSite,
 	revealRegisteredSite,
-	deleteRegisteredSite
+	deleteRegisteredSite,
+	clearRegisteredSiteLog
 };

--- a/src/wp-debug-constants.js
+++ b/src/wp-debug-constants.js
@@ -1,0 +1,69 @@
+// The WordPress debug constants every site this app runs is booted with.
+//
+// The app already tails each site's build/wp-content/debug.log and streams it to
+// the renderer, but nothing ever turned WP_DEBUG_LOG on, so that file did not
+// exist and the panel reading it could never show a line. A contributor's
+// error_log() went nowhere, notices and deprecation warnings — the output core
+// work actually runs on — were invisible, and a fatal was replaced by
+// WordPress's recovery screen.
+//
+// Not configurable, and deliberately so. A wordpress-develop checkout is a
+// development environment by definition; nobody sets one up through this app to
+// observe production behaviour. A settings panel here would be one more thing to
+// find, get wrong, and support at a Contributor Day.
+//
+// Kept free of Electron and Playground imports so it can be unit-tested: the
+// values are the whole of the behaviour, so a test that reads them is a test of
+// the feature.
+
+// Booleans, never strings. These are written into the generated wp-config.php as
+// PHP literals, and the string "false" is truthy in PHP — the failure mode is a
+// constant that reads as disabled everywhere except where it counts.
+const WP_DEBUG_CONSTANTS = Object.freeze({
+	// Notices, warnings, deprecations and _doing_it_wrong(). Half of what core
+	// development is watching for.
+	WP_DEBUG: true,
+
+	// Writes them to wp-content/debug.log — the file startWpDebugTail in main.js
+	// has been watching all along. Left at WordPress's default path on purpose:
+	// the tailer resolves the same one.
+	WP_DEBUG_LOG: true,
+
+	// Errors are also printed in the browser. A fatal that shows the file and
+	// line on screen is what makes a newcomer understand what happened; the cost
+	// is that a notice fired mid-request corrupts REST and AJAX responses that
+	// expect clean JSON. Chosen knowingly — the panel alone leaves a blank page
+	// and no signal that anywhere is worth looking.
+	WP_DEBUG_DISPLAY: true,
+
+	// Serves core's unminified JS and CSS. Without it the scripts in the browser
+	// are .min.js and debugging core JavaScript is not possible at all.
+	SCRIPT_DEBUG: true,
+
+	// The non-obvious one. WordPress's fatal error handler intercepts a fatal and
+	// substitutes "There has been a critical error on this website", which is
+	// precisely the screen that hides the error being looked for. Off, a fatal
+	// surfaces as itself.
+	WP_DISABLE_FATAL_ERROR_HANDLER: true,
+
+	// The one constant here that changes behaviour rather than visibility, and it
+	// is here because WP_DEBUG is what made the problem appear: core's automatic
+	// updater logs "Automatic updates starting…" / "…complete." only when
+	// WP_DEBUG is on, so turning the log on filled the contributor's panel with
+	// core's own housekeeping in between their error_log() lines. wp-cron runs it
+	// on page loads, so it recurs.
+	//
+	// Disabled rather than filtered out of the panel, because an automatic
+	// updater has nothing to do in a wordpress-develop checkout in the first
+	// place: it reaches api.wordpress.org on a conference network, and anything
+	// it decided to install would be written over the build/ the contributor is
+	// editing and Playground has mounted. Narrower than DISABLE_WP_CRON, which
+	// would also stop the scheduled work a contributor may be working on.
+	AUTOMATIC_UPDATER_DISABLED: true
+
+	// SAVEQUERIES is left out. It records every query for the whole request and
+	// only pays for itself alongside a viewer like Query Monitor, which this app
+	// does not install yet.
+});
+
+module.exports = { WP_DEBUG_CONSTANTS };

--- a/test/debug-log.test.cjs
+++ b/test/debug-log.test.cjs
@@ -1,0 +1,90 @@
+'use strict';
+
+// The buffer behind the debug.log panel. What it has to get right is the drop:
+// the pane is read by someone looking for a PHP error, and a half line at the
+// top of the scrollback reads as corruption rather than as a trimmed log.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { appendBounded, countLines, MAX_LOG_CHARACTERS } = require('../src/renderer/debug-log.cjs');
+
+test('text under the limit is appended unchanged', () => {
+	assert.strictEqual(appendBounded('one\n', 'two\n', 100), 'one\ntwo\n');
+});
+
+test('an empty previous value and an empty chunk are both handled', () => {
+	assert.strictEqual(appendBounded('', 'first\n', 100), 'first\n');
+	assert.strictEqual(appendBounded('kept\n', '', 100), 'kept\n');
+	assert.strictEqual(appendBounded(undefined, undefined, 100), '');
+});
+
+test('the oldest lines are dropped once the limit is passed', () => {
+	// Four lines of five characters each, in a buffer that holds twelve. The cut
+	// moves forward to the next boundary, so the result comes in under the limit
+	// rather than over it — a whole line is dropped, never part of one.
+	const result = appendBounded('aaaa\nbbbb\ncccc\n', 'dddd\n', 12);
+
+	assert.strictEqual(result, 'cccc\ndddd\n');
+	assert.ok(result.length <= 12, 'the limit is a ceiling');
+});
+
+// The property the panel depends on. Cutting at the character count alone would
+// leave the pane starting mid-message.
+test('the drop lands on a line boundary, never mid-line', () => {
+	const result = appendBounded('PHP Warning: something long here\n', 'PHP Notice: short\n', 20);
+
+	assert.strictEqual(result, 'PHP Notice: short\n');
+	assert.ok(!result.startsWith('ing here'), 'a partial first line reads as corruption');
+});
+
+test('the newest content always survives', () => {
+	const result = appendBounded('old\n'.repeat(100), 'newest line\n', 20);
+
+	assert.ok(result.endsWith('newest line\n'));
+});
+
+// A var_dump or a serialized object is one line with no boundary to cut on. The
+// tail is what is kept, because the end of such a line is where the file and
+// line number are.
+//
+// Both terminations are asserted, and the terminated one is the case that
+// matters: everything error_log() writes ends in a newline, so a version of
+// this test using only an unterminated line exercises the one shape that cannot
+// occur. It passed while appendBounded returned '' for every real line of this
+// kind — the boundary search found the line's own terminator and dropped the
+// whole buffer, blanking the panel mid-incident.
+test('a single line longer than the whole limit keeps its tail', () => {
+	const unterminated = appendBounded('', `${'x'.repeat(50)}END`, 10);
+	assert.strictEqual(unterminated.length, 10);
+	assert.ok(unterminated.endsWith('END'));
+
+	const terminated = appendBounded('', `${'x'.repeat(50)}END\n`, 10);
+	assert.strictEqual(terminated.length, 10);
+	assert.ok(terminated.endsWith('END\n'));
+});
+
+test('an over-long terminated line does not wipe the buffer', () => {
+	const result = appendBounded('a\n'.repeat(20), `PHP Fatal ${'z'.repeat(60)}\n`, 20);
+
+	assert.notStrictEqual(result, '', 'a single long line must not blank the panel');
+	assert.strictEqual(result.length, 20);
+	assert.ok(result.endsWith('z\n'));
+});
+
+test('the default limit is generous but finite', () => {
+	assert.strictEqual(MAX_LOG_CHARACTERS, 512 * 1024);
+
+	const overflowing = appendBounded('a\n'.repeat(MAX_LOG_CHARACTERS), 'last\n');
+	assert.ok(overflowing.length <= MAX_LOG_CHARACTERS);
+	assert.ok(overflowing.endsWith('last\n'));
+});
+
+test('countLines counts terminators, so a split line is counted once', () => {
+	assert.strictEqual(countLines('one\ntwo\n'), 2);
+	// The two halves of a line that arrived across two reads.
+	assert.strictEqual(countLines('one\ntw'), 1);
+	assert.strictEqual(countLines('o\n'), 1);
+	assert.strictEqual(countLines(''), 0);
+	assert.strictEqual(countLines(undefined), 0);
+});

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1519,6 +1519,85 @@ test('dir:show refuses a path the registry does not hold, and logs it', async ()
 	assert.deepEqual(main.calls.openPath, [SITE]);
 });
 
+// --- wp-debug:clear -> src/site-registry.js -------------------------------
+//
+// The Clear button under the debug.log panel. It empties
+// build/wp-content/debug.log inside the named site, so it is behind the same
+// registry boundary as sites:delete and dir:show — without it the renderer
+// could name any path and have the app truncate a file under it.
+
+test('wp-debug:clear asks site-registry whether the log may be emptied', async () => {
+	const clearRegisteredSiteLog = spy(async () => ({ ok: true }));
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [SITE] }).stubs, './site-registry': { clearRegisteredSiteLog } }
+	});
+
+	await main.invoke('wp-debug:clear', SITE);
+
+	assert.equal(clearRegisteredSiteLog.calls.length, 1);
+	const [sitePath, options] = clearRegisteredSiteLog.calls[0];
+	assert.equal(sitePath, SITE);
+	assert.deepEqual(options.sites, [SITE]);
+	assert.equal(typeof options.truncate, 'function');
+	assert.equal(typeof options.onRefused, 'function');
+});
+
+test('wp-debug:clear refuses a path the registry does not hold, and logs it', async () => {
+	const logEvent = spy();
+	const main = loadMain({
+		stubs: { './logging': { ...silentLogging()['./logging'], logEvent }, ...fakeSettingsStore({ sites: [SITE] }).stubs }
+	});
+
+	const result = await main.invoke('wp-debug:clear', '/Users/dev/somewhere-else');
+
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, 'unregistered-site');
+	assert.equal(logEvent.calls.length, 1);
+	assert.match(logEvent.calls[0][1], /refused to clear the debug log for \/Users\/dev\/somewhere-else/);
+});
+
+test('wp-debug:reveal asks site-registry whether the log may be shown', async () => {
+	const revealRegisteredSite = spy(async () => ({ ok: true }));
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [SITE] }).stubs, './site-registry': { revealRegisteredSite } }
+	});
+
+	await main.invoke('wp-debug:reveal', SITE);
+
+	assert.equal(revealRegisteredSite.calls.length, 1);
+	const [sitePath, options] = revealRegisteredSite.calls[0];
+	assert.equal(sitePath, SITE);
+	assert.deepEqual(options.sites, [SITE]);
+	assert.equal(typeof options.reveal, 'function');
+	assert.equal(typeof options.onRefused, 'function');
+});
+
+test('wp-debug:reveal refuses a path the registry does not hold, and logs it', async () => {
+	const logEvent = spy();
+	const main = loadMain({
+		stubs: { './logging': { ...silentLogging()['./logging'], logEvent }, ...fakeSettingsStore({ sites: [SITE] }).stubs }
+	});
+
+	const result = await main.invoke('wp-debug:reveal', '/Users/dev/somewhere-else');
+
+	assert.equal(result.ok, false);
+	assert.deepEqual(main.calls.showItemInFolder, []);
+	assert.equal(logEvent.calls.length, 1);
+	assert.match(logEvent.calls[0][1], /refused to reveal the debug log for \/Users\/dev\/somewhere-else/);
+});
+
+// The path is what the panel displays, so a handler that started the tail but
+// answered with a bare `true` would leave the line blank and Show in folder
+// disabled, with nothing failing.
+test('wp-debug:start answers with the log path', async () => {
+	const main = loadMain({ stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [SITE] }).stubs } });
+
+	const started = await main.invoke('wp-debug:start', SITE);
+
+	assert.equal(started.ok, true);
+	assert.equal(started.filePath, path.join(SITE, 'build', 'wp-content', 'debug.log'));
+});
+
 // --- opening a pull request (#167) ---------------------------------------
 
 // Sign-in is two-legged: the handler returns as soon as there is a code to
@@ -1762,6 +1841,8 @@ const WIRED = new Set([
 	'editor:list',
 	'editor:open',
 	'dir:show',
+	'wp-debug:clear',
+	'wp-debug:reveal',
 	'provenance:set-handle',
 	'provenance:set-event',
 	'github:account',

--- a/test/log-tail.test.cjs
+++ b/test/log-tail.test.cjs
@@ -1,0 +1,70 @@
+'use strict';
+
+// The read policy behind the debug.log tail.
+//
+// The rule that matters is the shrinking file. Before it existed the tail only
+// ever moved forward, so emptying the file — which the panel's own Clear button
+// now does, and which `grunt clean` does as part of a rebuild — left the offset
+// pointing past the end. Nothing was ever read again: the file had to grow back
+// past its old length before a single byte reappeared, and until then the panel
+// looked exactly like a site that was not logging.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { planInitialRead, planTailRead, MAX_INITIAL_READ } = require('../src/log-tail.js');
+
+test('an empty file has no backlog to replay', () => {
+	assert.deepEqual(planInitialRead(0), { read: null, lastSize: 0 });
+});
+
+test('a small file is replayed whole', () => {
+	assert.deepEqual(planInitialRead(500), { read: { start: 0 }, lastSize: 500 });
+});
+
+test('a large file is replayed from its tail, not its start', () => {
+	const size = MAX_INITIAL_READ * 3;
+
+	assert.deepEqual(planInitialRead(size), { read: { start: size - MAX_INITIAL_READ }, lastSize: size });
+});
+
+test('growth is read from where the last read stopped', () => {
+	assert.deepEqual(planTailRead(100, 180), { read: { start: 100 }, lastSize: 180 });
+});
+
+test('an unchanged size reads nothing', () => {
+	assert.deepEqual(planTailRead(100, 100), { read: null, lastSize: 100 });
+});
+
+// The regression this module exists for.
+test('a truncated file is read again from the start, not from the stale offset', () => {
+	const next = planTailRead(4096, 120);
+
+	assert.deepEqual(next.read, { start: 0 }, 'reading from the old offset skips everything written next');
+	assert.equal(next.lastSize, 120);
+});
+
+test('a file emptied to nothing leaves nothing to read and forgets the offset', () => {
+	const next = planTailRead(4096, 0);
+
+	assert.equal(next.read, null);
+	assert.equal(next.lastSize, 0, 'a stale offset here silences every later write');
+});
+
+// The sequence the Clear button produces: a full file, truncated to nothing,
+// then written to again. The last step is what was broken — it has to arrive.
+test('writes after a clear still reach the panel', () => {
+	let lastSize = 4096;
+
+	lastSize = planTailRead(lastSize, 0).lastSize;
+	const afterClear = planTailRead(lastSize, 60);
+
+	assert.deepEqual(afterClear.read, { start: 0 });
+	assert.equal(afterClear.lastSize, 60);
+});
+
+test('junk sizes are floored rather than producing a negative range', () => {
+	assert.deepEqual(planTailRead(undefined, 50), { read: { start: 0 }, lastSize: 50 });
+	assert.deepEqual(planTailRead(-10, 50), { read: { start: 0 }, lastSize: 50 });
+	assert.deepEqual(planInitialRead(-1), { read: null, lastSize: 0 });
+});

--- a/test/preload-listeners.test.cjs
+++ b/test/preload-listeners.test.cjs
@@ -369,6 +369,61 @@ test('subscribePullRequestProgress hands back its own unsubscribe', () => {
 	assert.equal(ipcRenderer.listenerCount('github:pr:progress'), 0);
 });
 
+// startWpDebug's unsubscribe went unused for as long as nothing wrote a
+// debug.log to tail. Now that WordPress is booted with WP_DEBUG_LOG the renderer
+// depends on it: stopWpDebug only tears down the watcher in the main process, so
+// without this the listener survives every stop and a second dev-server run
+// appends each line twice.
+//
+// The renderer's half of that — actually holding the function and calling it —
+// is in index.jsx and out of this suite's reach. What is pinned here is the
+// contract it now relies on: that an unsubscribe comes back at all, and that it
+// removes only its own listener rather than clearing the channel for the other
+// sites subscribed to it.
+test('startWpDebug hands back an unsubscribe that drops only its own listener', async () => {
+	const { api, ipcRenderer } = loadPreload();
+	const mine = [];
+	const other = [];
+
+	const { unsubscribe } = await api.startWpDebug('/sites/wp', (data) => mine.push(data));
+	await api.startWpDebug('/sites/other', (data) => other.push(data));
+
+	ipcRenderer.emit('wp:debug-log:data', { sitePath: '/sites/wp', data: 'first\n' });
+	unsubscribe();
+	ipcRenderer.emit('wp:debug-log:data', { sitePath: '/sites/wp', data: 'after\n' });
+	ipcRenderer.emit('wp:debug-log:data', { sitePath: '/sites/other', data: 'theirs\n' });
+
+	assert.deepEqual(mine, ['first\n'], 'the unsubscribed callback kept receiving data');
+	assert.deepEqual(other, ['theirs\n'], 'unsubscribing one site removed another site listener');
+	assert.equal(ipcRenderer.listenerCount('wp:debug-log:data'), 1);
+});
+
+// The panel shows the path so it can be tailed in a terminal or attached to a
+// ticket. Composed in the main process — the renderer would have to join it with
+// '/' and be wrong on Windows — so the bridge has to carry it back out.
+test('startWpDebug carries the log path back to the renderer', async () => {
+	const { api } = loadPreload({
+		invokeResults: { 'wp-debug:start': () => ({ ok: true, filePath: '/sites/wp/build/wp-content/debug.log' }) }
+	});
+
+	const started = await api.startWpDebug('/sites/wp', () => {});
+
+	assert.equal(started.filePath, '/sites/wp/build/wp-content/debug.log');
+	assert.equal(typeof started.unsubscribe, 'function');
+});
+
+// A main process that answered with the old bare `true` — or with nothing —
+// must still leave a usable unsubscribe rather than throwing on `.filePath`.
+test('startWpDebug survives a reply carrying no path', async () => {
+	const { api, ipcRenderer } = loadPreload({ invokeResults: { 'wp-debug:start': () => undefined } });
+
+	const started = await api.startWpDebug('/sites/wp', () => {});
+
+	assert.equal(started.filePath, '');
+	started.unsubscribe();
+	assert.equal(ipcRenderer.listenerCount('wp:debug-log:data'), 0);
+});
+
 // The guard for the paragraph above isElectronPackage: if the stub ever stops
 // covering a path, this fails here rather than as a mystery download in another
 // file's test on a cold checkout.

--- a/test/runner-wiring.test.cjs
+++ b/test/runner-wiring.test.cjs
@@ -28,6 +28,8 @@ const assert = require('node:assert/strict');
 const Module = require('node:module');
 const path = require('node:path');
 
+const { WP_DEBUG_CONSTANTS } = require('../src/wp-debug-constants');
+
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const SERVER_RUNNER = path.join(SRC_DIR, 'server-runner.js');
 const WEB_RUNNER = path.join(SRC_DIR, 'playground-web-runner.js');
@@ -58,7 +60,7 @@ function realPackageLoaded() {
 }
 
 // Loads a runner with its side-effecting dependencies replaced, and returns the
-// ordered log of what it called and loaded.
+// ordered log of what it called and loaded, plus the options it handed runCLI.
 //
 // hideChildWindows/bindLoopbackOnly are recorded when the runner *calls* them;
 // the Playground CLI is recorded when the runner *requires* it. Comparing their
@@ -71,7 +73,10 @@ function realPackageLoaded() {
 // already recorded by the time require(runnerPath) returns.
 function loadRunner(runnerPath, extraArgv) {
 	const events = [];
-	const cliStub = { runCLI: () => new Promise(() => {}) };
+	// runCLI is called synchronously, before the `await` main() parks at, so its
+	// argument is already recorded by the time require(runnerPath) returns.
+	const cliCalls = [];
+	const cliStub = { runCLI: (options) => { cliCalls.push(options); return new Promise(() => {}); } };
 	const phpWasmStub = { writeFiles: async () => {} };
 	const hideStub = { hideChildWindows: () => { events.push('call:hideChildWindows'); } };
 	const bindStub = { bindLoopbackOnly: () => { events.push('call:bindLoopbackOnly'); } };
@@ -105,7 +110,7 @@ function loadRunner(runnerPath, extraArgv) {
 		clearSrcCache();
 	}
 
-	return events;
+	return { events, cliOptions: cliCalls[0] };
 }
 
 // The shared assertion: both patches were called, the CLI was loaded, and both
@@ -129,13 +134,44 @@ function assertPatchesPrecedeCli(events, runner) {
 }
 
 test('server-runner patches loopback and hides child windows before loading the Playground CLI', () => {
-	const events = loadRunner(SERVER_RUNNER, ['/tmp/does-not-need-to-exist']);
+	const { events } = loadRunner(SERVER_RUNNER, ['/tmp/does-not-need-to-exist']);
 	assertPatchesPrecedeCli(events, 'server-runner');
 	assert.equal(realPackageLoaded(), false, 'server-runner loaded a real electron/Playground package instead of the stub');
 });
 
 test('playground-web-runner patches loopback and hides child windows before loading the Playground CLI', () => {
-	const events = loadRunner(WEB_RUNNER, ['/tmp/does-not-need-to-exist']);
+	const { events } = loadRunner(WEB_RUNNER, ['/tmp/does-not-need-to-exist']);
 	assertPatchesPrecedeCli(events, 'playground-web-runner');
 	assert.equal(realPackageLoaded(), false, 'playground-web-runner loaded a real electron/Playground package instead of the stub');
+});
+
+// The blueprint's `constants` step is the only place these can be set: Playground
+// generates the wp-config.php itself, and a constant has to be defined before
+// WordPress loads to have any effect.
+//
+// test/wp-debug-constants.test.cjs asserts the values. This asserts the wiring,
+// which is where the bug actually lived — the app tailed build/wp-content/debug.log
+// for a file WordPress was never told to write, and the module exporting the
+// right constants would not have caught that on its own.
+test('server-runner passes the WordPress debug constants to Playground', () => {
+	const { cliOptions } = loadRunner(SERVER_RUNNER, ['/tmp/does-not-need-to-exist']);
+
+	assert.ok(cliOptions, 'runCLI was never called');
+	const constants = cliOptions.blueprint && cliOptions.blueprint.constants;
+	assert.ok(constants, 'the blueprint carries no constants at all');
+
+	for (const [name, value] of Object.entries(WP_DEBUG_CONSTANTS)) {
+		assert.strictEqual(constants[name], value, `${name} did not reach the blueprint`);
+	}
+});
+
+// Spreading the debug constants in ahead of the mail ones must not have taken
+// the mail ones out: this is how a site's outgoing mail reaches the app's SMTP
+// catcher, and losing it is silent — mail simply stops arriving.
+test('the SMTP constants survive alongside them', () => {
+	const { cliOptions } = loadRunner(SERVER_RUNNER, ['/tmp/does-not-need-to-exist']);
+	const constants = cliOptions.blueprint.constants;
+
+	assert.strictEqual(constants.WP_MAIL_SMTP_HOST, '127.0.0.1');
+	assert.strictEqual(typeof constants.WP_MAIL_SMTP_PORT, 'number');
 });

--- a/test/site-registry.test.cjs
+++ b/test/site-registry.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { isRegisteredSite, describeRefusedSite, deleteRegisteredSite, revealRegisteredSite } = require('../src/site-registry.js');
+const { isRegisteredSite, describeRefusedSite, deleteRegisteredSite, revealRegisteredSite, clearRegisteredSiteLog } = require('../src/site-registry.js');
 
 // A couple of paths the app might actually hold in its registry, one per platform
 // shape, so the tests aren't accidentally tied to POSIX separators.
@@ -160,4 +160,57 @@ test('a reveal the OS declines is reported rather than swallowed', async () => {
 	assert.equal(result.ok, false);
 	assert.equal(result.reason, 'open-failed');
 	assert.equal(result.error, 'Failed to open path');
+});
+
+// --- clearRegisteredSiteLog ---
+//
+// The Clear button under the debug.log panel empties build/wp-content/debug.log
+// inside the named site. Less severe than the two above, same shape: the
+// renderer names the path and the app writes at a location derived from it.
+
+function clearRecorder(sites = REGISTERED, result = { ok: true }) {
+	const truncated = [];
+	const refused = [];
+	return {
+		truncated,
+		refused,
+		options: {
+			sites,
+			truncate: async (p) => { truncated.push(p); return result; },
+			onRefused: (description) => { refused.push(description); }
+		}
+	};
+}
+
+test('a registered site has its log truncated', async () => {
+	const rec = clearRecorder();
+
+	assert.deepEqual(await clearRegisteredSiteLog('/Users/dev/sites/my-site', rec.options), { ok: true });
+
+	assert.deepEqual(rec.truncated, ['/Users/dev/sites/my-site']);
+	assert.deepEqual(rec.refused, []);
+});
+
+test('a path the registry does not hold has nothing truncated', async () => {
+	const rec = clearRecorder();
+
+	const result = await clearRegisteredSiteLog('/Users/dev/somewhere-else', rec.options);
+
+	assert.equal(result.ok, false);
+	assert.equal(result.reason, 'unregistered-site');
+	assert.deepEqual(rec.truncated, [], 'a file was emptied in a directory the app never registered');
+	assert.deepEqual(rec.refused, ['/Users/dev/somewhere-else']);
+});
+
+// A read-only or locked file is the case the panel has to report: it has already
+// cleared itself by the time this answers, so a swallowed failure leaves the
+// pane empty and the file full, and the lines reappear on the next start with
+// no explanation.
+test('a truncation the filesystem declines is passed back, not swallowed', async () => {
+	const rec = clearRecorder(REGISTERED, { ok: false, reason: 'truncate-failed', error: 'EACCES' });
+
+	const result = await clearRegisteredSiteLog('/Users/dev/sites/my-site', rec.options);
+
+	assert.equal(result.ok, false);
+	assert.equal(result.error, 'EACCES');
 });

--- a/test/wp-debug-constants.test.cjs
+++ b/test/wp-debug-constants.test.cjs
@@ -1,0 +1,85 @@
+'use strict';
+
+// The debug constants are the whole of the feature: there is no UI, no setting
+// and no branch, so a test that reads the values is a test of the behaviour.
+//
+// What these guard against is a silent regression. The app has always tailed
+// build/wp-content/debug.log and streamed it to the renderer, and for as long as
+// WP_DEBUG_LOG went unset that file did not exist and the panel could not show a
+// line — a whole feature wired end to end and structurally unable to produce
+// output, with nothing failing anywhere. Dropping a constant here puts it back
+// in exactly that state.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { WP_DEBUG_CONSTANTS } = require('../src/wp-debug-constants');
+
+test('the debug constants are exactly the six the app boots a site with', () => {
+	assert.deepStrictEqual(Object.keys(WP_DEBUG_CONSTANTS).sort(), [
+		'AUTOMATIC_UPDATER_DISABLED',
+		'SCRIPT_DEBUG',
+		'WP_DEBUG',
+		'WP_DEBUG_DISPLAY',
+		'WP_DEBUG_LOG',
+		'WP_DISABLE_FATAL_ERROR_HANDLER'
+	]);
+});
+
+test('WP_DEBUG_LOG is on, or the debug.log panel has nothing to read', () => {
+	assert.strictEqual(WP_DEBUG_CONSTANTS.WP_DEBUG, true);
+	assert.strictEqual(WP_DEBUG_CONSTANTS.WP_DEBUG_LOG, true);
+});
+
+test('SCRIPT_DEBUG is on, so core JS and CSS are served unminified', () => {
+	assert.strictEqual(WP_DEBUG_CONSTANTS.SCRIPT_DEBUG, true);
+});
+
+// The non-obvious one, and the easiest to remove as apparent noise. With
+// WordPress's fatal error handler in place a fatal is replaced by "There has
+// been a critical error on this website" — the screen that hides the error
+// being looked for.
+test('the fatal error handler is disabled, so a fatal surfaces as itself', () => {
+	assert.strictEqual(WP_DEBUG_CONSTANTS.WP_DISABLE_FATAL_ERROR_HANDLER, true);
+});
+
+// The only constant here that changes behaviour rather than visibility, and the
+// only one whose reason is a consequence of the others: core's updater logs
+// "Automatic updates starting…" only under WP_DEBUG, so turning the log on is
+// what put core's housekeeping in the contributor's panel. Verified against a
+// real site — those lines appeared between the contributor's own error_log()
+// output on every page load, because wp-cron runs the updater.
+test('the automatic updater is disabled', () => {
+	assert.strictEqual(WP_DEBUG_CONSTANTS.AUTOMATIC_UPDATER_DISABLED, true);
+});
+
+// The narrower constant on purpose. DISABLE_WP_CRON would also silence it, and
+// would stop the scheduled work a contributor may be there to debug.
+test('wp-cron itself is left alone', () => {
+	assert.strictEqual('DISABLE_WP_CRON' in WP_DEBUG_CONSTANTS, false);
+});
+
+// Left out deliberately: it records every query for the whole request and only
+// pays for itself alongside a viewer, which this app does not install. Asserted
+// so adding it is a decision rather than a drive-by.
+test('SAVEQUERIES is not set', () => {
+	assert.strictEqual('SAVEQUERIES' in WP_DEBUG_CONSTANTS, false);
+});
+
+// These are written into the generated wp-config.php as PHP literals, and the
+// string "false" is truthy in PHP — a constant defined as a string reads as
+// enabled everywhere except where it matters. The SMTP constants beside them in
+// the blueprint already go through Number() and === 'true' for the same reason.
+test('every value is a real boolean, not a string', () => {
+	for (const [name, value] of Object.entries(WP_DEBUG_CONSTANTS)) {
+		assert.strictEqual(typeof value, 'boolean', `${name} must be a boolean`);
+	}
+});
+
+// Shared, frozen, and spread into a blueprint object that Playground is free to
+// do what it likes with. A caller that mutated it would change the constants of
+// every server started afterwards in the same process.
+test('the exported object cannot be mutated by a caller', () => {
+	assert.throws(() => { WP_DEBUG_CONSTANTS.WP_DEBUG = false; }, TypeError);
+	assert.strictEqual(WP_DEBUG_CONSTANTS.WP_DEBUG, true);
+});


### PR DESCRIPTION
## Why

There is no way to debug WordPress code in this app today. A contributor adds an `error_log()` to the file they are working on, reloads, and nothing appears anywhere. Notices and deprecation warnings — the output core work actually runs on — are invisible, and a fatal is replaced by WordPress's "There has been a critical error on this website", which is the one page that hides the error being looked for.

The app already tails each site's `build/wp-content/debug.log`, streams it over IPC and renders it. But the Playground blueprint never set `WP_DEBUG` or `WP_DEBUG_LOG`, so WordPress wrote no such file: a feature wired end to end and structurally unable to produce a single line, with nothing failing anywhere to say so.

## What changes

**Six constants go into the blueprint**, ahead of the SMTP ones. That is the only place they can go — Playground generates the `wp-config.php` itself, and a constant has to be defined before WordPress loads.

| | |
|---|---|
| `WP_DEBUG`, `WP_DEBUG_LOG` | notices, deprecations, `_doing_it_wrong()`, written to the file the app already tails |
| `WP_DEBUG_DISPLAY` | the error on screen, with file and line |
| `SCRIPT_DEBUG` | core JS and CSS served unminified |
| `WP_DISABLE_FATAL_ERROR_HANDLER` | a fatal surfaces as itself instead of the recovery screen |
| `AUTOMATIC_UPDATER_DISABLED` | see below |

**Deliberately not configurable.** A `wordpress-develop` checkout is a development environment by definition; nobody sets one up through this app to observe production behaviour. A settings panel here would be one more thing to find, get wrong and support at a Contributor Day.

**`AUTOMATIC_UPDATER_DISABLED` is the one that changes behaviour rather than visibility**, and it is in this PR because `WP_DEBUG` is what made the problem appear: core's updater logs `Automatic updates starting…` only under `WP_DEBUG`, so turning the log on put core's own housekeeping in among the contributor's output on every page load. Narrower than `DISABLE_WP_CRON`, which would also stop scheduled work someone may be there to debug.

**The debug log gets its own tab**, out of the runtime pane it was interleaved with, with the file's path, Show in folder, Copy and Clear. The path is shown because it cannot be guessed: the log is under `build/`, while the file being edited when it filled up is under `src/`.

Three things surfaced while making that panel work against a real site, and are fixed here:

- **Clear emptied the pane and not the file**, so the tail replayed the same lines on the next dev-server start. It now truncates the file, behind the same registry gate as `sites:delete` and `dir:show`.
- **The tail only ever moved forward.** A file that shrank — which Clear now does, and which `grunt clean` does mid-session — left the offset past the end and the panel silent for the rest of the session. The read policy moved to `src/log-tail.js` where it can be tested, and the `rename` branch re-attaches instead of holding a dead inode.
- **`startWpDebug`'s unsubscribe was never called.** Harmless while nothing wrote the file; with it written, every dev-server restart added a listener and appended each line again.

**Not in this PR:** the deeper debugging view of #221 and the `SAVEQUERIES` that only pays for itself alongside it; and everything about diagnosing *the app itself* — log levels, IPC tracing, renderer error capture — which is a separate change.

## How to test this

Platforms: **any**. No paths, spawning or line endings are touched; the tail is the same code on all three.

**Starting state:** a site with a completed build and the dev server stopped.

1. Start the dev server. The log section now has two tabs, **Server** and **debug.log**. Server shows Playground's output exactly as before.
2. Open `http://127.0.0.1:9400/wp-admin/` and view source. Search `wp-includes/js/jquery` → `jquery.js`, **not** `jquery.min.js`. Search `wp-includes/js/dist/` → unminified. The strongest signal is `dist/development/react-refresh-runtime.js`: core enqueues it only under `SCRIPT_DEBUG`, so if the constant is not landing those lines are simply absent.
3. Add to the active theme's `functions.php`:
   ```php
   function log_message( $m ) { if ( WP_DEBUG === true ) { error_log( is_array( $m ) || is_object( $m ) ? print_r( $m, true ) : $m ); } }
   log_message( 'functions.php loaded' );
   ```
   Wait for the watcher to rebuild, reload the front page. The line appears in **debug.log**, and the tab shows an unread count if you were on Server.
4. Reload twice more. Each reload appends only its own lines — **no line repeats with the same timestamp**. (Two entries per reload is correct: the page request and the `wp-cron` loopback.)
5. Press **Clear**, then reload. The pane empties and new lines arrive. Before this branch the tail would have gone silent here for the rest of the session.
6. **Show in folder** opens Finder/Explorer with `debug.log` selected. **Copy** puts the pane on the clipboard. The path under the pane is selectable and ends in `build/wp-content/debug.log`.
7. Stop the dev server and start it again. The pane resets, replays what is on disk, then writes `—— tail attached; everything above is from an earlier run ——` before this run's output. Nothing is duplicated.
8. Append `$nope = null; $nope->boom();` to the same `functions.php`, wait for the rebuild, reload. The browser shows `Fatal error: Uncaught Error: Call to a member function boom() on null` with file and line — **not** the critical-error screen — and the same fatal, with its stack trace one frame per line, lands in the panel. Remove the two lines afterwards; a fatal in `functions.php` takes `/wp-admin/` down with the front end.
9. Confirm no `Automatic updates starting…` lines appear in a session started on this branch.

**What must not have happened:**

- `build/wp-content/debug.log` must not appear in a patch generated from the patch panel. `build/` is gitignored in `wordpress-develop` and `statusMatrix` honours it, but the patch is hand-rolled against `HEAD` rather than by `git diff`, so it is worth looking.
- The Server tab must still receive Playground's output — the debug log moved out of it, nothing else did.
- No line duplicated across a stop/start cycle. That is the subscription leak, and it is the failure this branch's `startWpDebug` change exists to prevent.
- Mail must still work: the debug constants are spread in ahead of the SMTP ones, and dropping those is silent — mail simply stops arriving. `test/runner-wiring.test.cjs` asserts both sets reach the blueprint.

Automated: `npm run lint` clean, `npm test` 551/551.

## Risks and limitations

- **`WP_DEBUG_DISPLAY = true` corrupts responses that expect clean JSON.** A notice printed mid-request lands in REST and AJAX output. Observed, not theoretical: a fatal in a theme's `functions.php` reaches `admin-ajax.php` and WordPress's heartbeat gets HTML back. Accepted knowingly — the alternative leaves a fatal as a blank page with no signal that anywhere is worth looking. If it proves annoying in practice the fix is to set it `false` and rely on the panel, not to add a setting.
- **There is no Xdebug.** The site runs on PHP-WASM and there is no step debugging or breakpoints; no trace of Xdebug in the installed Playground packages. This improves debugging by record and does not replace it. Worth an upstream question to Playground.
- **PHP error paths are Playground's, not the contributor's.** An error reads `/wordpress/wp-content/themes/…`, the VFS mount, so it cannot be pasted into an editor. Pre-existing, surfaced by this change, filed as #220.
- **PHPUnit is still out of reach** — it needs native PHP and a database.
- The renderer half of the unsubscribe fix (that `index.jsx` actually holds and calls the function) is outside the suite's reach; it is step 7 above. What is pinned automatically is the contract it depends on, in `test/preload-listeners.test.cjs`.
- Review outcome: **2 [fix here] · 1 [follow-up] — both fixed, and the follow-up was pulled in too.** Detail below.

## Related

Follow-up to #221 — the debugging view a plugin already provides, opt-in per site, which is also what would make `SAVEQUERIES` worth its cost.
Follow-up to #220 — a PHP error now names a file and line, but the path it names is Playground's mount under `build/`, not the `src/` file the contributor was editing.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**A settings panel per constant, or a single "Debug mode" toggle, versus always on.** Considered both and rejected them. The constants apply at boot, so a toggle means "restart the dev server to apply" — a state that can be wrong, in an app whose thesis is that it works without configuration. Always-on has no such state, and there is no plausible reason to run a `wordpress-develop` checkout with debugging off.

**`WP_DEBUG_DISPLAY` on or off.** Off keeps every HTTP response clean and pushes everything through the panel, at the cost of a fatal being a blank page. On was chosen because the blank page is what a newcomer cannot get past. The cost is real and is named in Risks.

**Clearing the pane only, versus truncating the file.** The first was what this branch shipped internally, and it was wrong: the tail replays the file when it attaches, so the lines came straight back on the next start. A Clear button that does not clear is worse than no button.

**`DISABLE_WP_CRON` instead of `AUTOMATIC_UPDATER_DISABLED`.** It would silence the updater too, and a great deal else — including scheduled work a contributor may be debugging. The narrow constant is the one that matches the reason.

**Writing the read policy inline in the `fs.watch` callback.** It was already there and untestable, which is why the shrinking-file case had never been handled. `src/log-tail.js` follows `log-lines.js`: no Electron imports, so the rule is a unit test.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**2 [fix here] · 1 [follow-up] — both `[fix here]` fixed, and the `[follow-up]` fixed as well.**

`[fix here]` 🔴 **`appendBounded` returned an empty string for a real log line.** The boundary search could land on the line's own terminator, so any single line at or over the buffer limit and ending in `\n` — every line `error_log()` writes — discarded the whole scrollback and blanked the panel mid-incident. Two of my own tests were green while proving nothing: they exercised the one form of that line that cannot occur, an unterminated one. Fixed by checking the result rather than the input, and both tests now cover both terminations.

`[fix here]` 🟡 **`startWpDebug`'s unsubscribe was never captured.** Pre-existing line, made observable by this change. Fixed with the same ref-and-teardown shape the SMTP subscriptions beside it already use, plus an unmount cleanup for the switching-sites path they do not cover.

`[follow-up]` 🔵 **The tail did not survive the file being truncated or replaced.** Raised as a follow-up because it is pre-existing; pulled into this PR after it bit during manual testing, since the Clear button added here is exactly what triggers it.

Also checked and cleared, recorded so they are not re-raised: `WP_DEBUG_DISPLAY` does not reach the bundled Adminer (it never loads `wp-config.php`) and does not disturb the server's readiness parse, which reads the runner's stdout; debug.log content cannot forge entries in the app's own `electron-log` file, since it goes straight to `webContents.send` and never through `logChildOutput`; it is rendered as a React text child and therefore escaped; `TabPanel` selects by `name`, so rebuilding the tabs array on each unread-count change does not bounce the selection.

The judgement pass ran in a subagent with the diff and the instructions file and nothing else from the authoring session, as `.claude/skills/self-review/SKILL.md` requires.

</details>

<details>
<summary>Implementation notes</summary>

- `src/wp-debug-constants.js` — the constants, frozen, with the reasoning per entry. Booleans, never strings: these become PHP literals and `"false"` is truthy in PHP.
- `src/log-tail.js` — `planInitialRead` / `planTailRead`. The 256KB initial replay cap lives here too, so the whole read policy is in one testable place.
- `src/renderer/debug-log.cjs` — `appendBounded` (512KB, dropped at a line boundary) and `countLines`. The bound matters: the runtime log grows unbounded today and the tail opens with up to 256KB.
- `src/site-registry.js` — `clearRegisteredSiteLog`, the third handler body behind the registry boundary, same injected-effect shape as the two beside it. `wp-debug:reveal` reuses `revealRegisteredSite` rather than adding a fourth.
- `wp-debug:start` now answers `{ ok, filePath }` instead of `true`. No new channel for the path: the main process has to compose it anyway, since joining with `/` in the renderer would be wrong on Windows.
- Truncate rather than unlink on Clear: WordPress opens the file per write, but the app's own `fs.watch` is bound to the inode.
- `test/ipc-wiring.test.cjs`'s completeness guard caught both new channels before they could ship untested — it failed red on `wp-debug:clear` until a wiring test existed.

</details>

<details>
<summary>Screenshots or recording</summary>

All four are from a real `wordpress-develop` checkout driven through the app. There is no "before" for the panel: before this branch it existed but could never receive a line.

**1 — The debug.log tab.** The contributor's own `error_log()` output, the session marker separating it from an earlier run, the file's path, and Show in folder / Copy / Clear.

<img width="2238" height="702" alt="1-debug-log-panel" src="https://github.com/user-attachments/assets/962dadd1-0f27-46e9-9651-d3daadd3765f" />

**2 — `SCRIPT_DEBUG`, the conclusive signal.** Core enqueues `dist/development/react-refresh-runtime.js` only when the constant is set, so these two lines cannot appear otherwise.

<img width="2632" height="100" alt="2-script-debug-react-refresh" src="https://github.com/user-attachments/assets/922fbc19-9448-47d7-a7dd-2cd5977e5bba" />

**3 — `SCRIPT_DEBUG` across the board.** Everything under `wp-includes/js/dist/` unminified, `vendor/react.js` rather than the production build.

<img width="2336" height="840" alt="3-script-debug-unminified-dist" src="https://github.com/user-attachments/assets/7a95f88e-7591-4fab-bd53-d8b47a538f9f" />

**4 — A fatal, as itself.** File and line and stack trace in the browser, instead of "There has been a critical error on this website". The same fatal reaches the panel, one frame per line.

<img width="3388" height="436" alt="4-fatal-in-browser" src="https://github.com/user-attachments/assets/0089915f-ea27-4455-9c9a-87385dd89343" />


</details>
