### PR TITLE
Say when windowsHide is the wrong flag, and hold main.js to it

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -199,10 +199,18 @@ not assume a path has no spaces; contributors pick their own directories.
 `src/kill-tree.js`. A new spawn that does not set `detached` correctly, or that is terminated with
 a bare `child.kill()`, will leave orphaned processes on one platform or the other.
 
-**Windows specifics.** Executables need their extension (`.cmd`, `.bat`, `.exe`) resolved;
-`windowsHide: true` keeps console windows from flashing; `EPERM` and `EINVAL` have
-Windows-specific causes. `src/win-spawn-patch.js` documents the traps that have already bitten —
-consult it rather than re-deriving them.
+**Windows specifics.** Executables need their extension (`.cmd`, `.bat`, `.exe`) resolved; `EPERM`
+and `EINVAL` have Windows-specific causes. `src/win-spawn-patch.js` documents the traps that have
+already bitten — consult it rather than re-deriving them.
+
+**`windowsHide: true` turns on the child's subsystem, not on whether anyone reads its output.**
+Node sets `CREATE_NO_WINDOW` and STARTUPINFO's "start hidden" together; which of the two the child
+honors is what differs. A console application takes the first and gets a console that is never
+displayed — the flashing fix, and why `src/kill-tree.js` sets it on `taskkill` even though nothing
+reads that output. A GUI application takes the second, and one that passes it through to its first
+window — Chromium does, so VS Code and Cursor both — launches invisible while the spawn still
+reports success (#181). So: set it on a console child; leave it off a child whose window is the
+point. `src/editor-launch.js` is the only case of the second kind.
 
 **Line endings** matter when generating patches, which are destined for Trac.
 

--- a/src/hide-child-windows.js
+++ b/src/hide-child-windows.js
@@ -11,6 +11,20 @@
 // requiring that CLI — reaches those spawns. `windowsHide: true` maps to
 // CREATE_NO_WINDOW, which gives cmd.exe a console that is never displayed and
 // which its own descendants inherit, so one patch covers the whole subtree.
+//
+// Who must NOT call this: the main process. The patch is deliberately blunt. It
+// forces the flag on every child_process entry point of the process, overriding
+// even an explicit `windowsHide: false`, and main.js is the process that spawns
+// the contributor's editor — a GUI application, which the flag starts with no
+// window while the spawn still reports success (#181; the comment above
+// openSiteInEditor in src/editor-launch.js has the mechanism). Whether a given
+// call site escapes depends on whether it captured its `spawn` binding before
+// the patch ran, which is exactly the kind of thing nobody should have to
+// reason about. "Hide the console flashes everywhere, once at startup" is the
+// plausible-looking change that reinstates that bug; the ipc-wiring suite
+// asserts main.js does not make it. Only the four runners — install, script,
+// server, playground-web — take this patch, and only because they load npm's or
+// Playground's CLI in-process.
 
 const PATCHED = Symbol.for('wp-dev-env.windowsHidePatched');
 

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -826,6 +826,48 @@ test('provenance:get reads the remembered handle and event', async () => {
 	});
 });
 
+// --- main must not take the windowsHide patch (#181) ---------------------
+//
+// The inverse of test/runner-wiring.test.cjs, which pins that the four runners
+// DO call hideChildWindows(). Main must not: that patch forces `windowsHide` on
+// every child_process entry point of the process, overriding even an explicit
+// `false`, and main.js is what spawns the contributor's editor — a GUI
+// application, which the flag starts with no window while the spawn still
+// reports success.
+//
+// Until now that was a convention nobody had written down. "Hide the console
+// flashes everywhere, do it once at startup" is the plausible-looking change
+// that reinstates the bug, and nothing else here would fail:
+// test/editor-launch.test.cjs injects its own spawn, so it never sees the real
+// module at all.
+//
+// Asserted as a call that does not happen rather than by reading the flag off
+// the real child_process, because patchChildProcess is a no-op off Windows —
+// that version would be green on macOS whatever main.js did.
+//
+// Scoped to module evaluation, which is where "once at startup" lands. A call
+// made lazily inside a handler would slip past this; it is also a much less
+// likely shape, and the module header says what the rule is.
+test('main.js does not apply the windowsHide patch when it loads', () => {
+	const calls = [];
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			'./hide-child-windows': {
+				hideChildWindows: () => { calls.push('hideChildWindows'); },
+				patchChildProcess: (cp) => { calls.push('patchChildProcess'); return cp; }
+			}
+		}
+	});
+
+	assert.ok(main.channels().length > 0, 'main.js registered no handlers, so it did not really load');
+	assert.deepEqual(
+		calls,
+		[],
+		'main.js patched its own child_process with windowsHide — every spawn in the process now carries the flag, including the editor launch (#181)'
+	);
+});
+
 // --- npm:* -> src/npm-runner.js + src/kill-tree.js -----------------------
 
 // The npm handlers run the real runNpmWithEngineRetry, which calls


### PR DESCRIPTION
Closes #202. Closes #203.

Two halves of the same question, so one PR.

## The rule was written for one kind of child

The Windows section of the review standard said the flag flatly:

> `windowsHide: true` keeps console windows from flashing

True for a console child, misleading for a GUI one — and that gap is what produced #181. The editor spawn carried the flag, the editor honored the "start hidden" it puts in STARTUPINFO, and it launched with no window while the spawn still reported success. Left as it was, the rule hands the same advice to the next GUI process someone spawns.

It now turns on the child's subsystem rather than on whether anyone reads the child's output. That distinction matters for more than the editor: `src/kill-tree.js` sets the flag on `taskkill`, whose output nobody reads, and an "only if you read its output" rule would have made that line look wrong.

## Nothing stopped main from applying the patch

`patchChildProcess` is deliberately blunt — every `child_process` entry point, overriding even an explicit `windowsHide: false`. That is safe today only because the four runners call it and `main.js` does not, which nothing said and nothing checked.

"Hide the console flashes everywhere, do it once at startup" is the plausible-looking change that reinstates #181 in silence. `test/editor-launch.test.cjs` injects its own `spawn`, so it never sees the real module; `test/runner-wiring.test.cjs` only asserts that the runners *do* call it.

So the module header now names who must not call it, and `test/ipc-wiring.test.cjs` asserts `main.js` does not.

## On the test

It watches for a call that does not happen rather than reading the flag off the real `child_process`. `patchChildProcess` is a no-op off Windows, so the flag-reading version would be green on macOS whatever `main.js` did — the "green while proving nothing" shape the standard already names.

Scoped to module evaluation, which is where "once at startup" lands. A call made lazily inside a handler would slip past it; that is a less likely shape, and the module header carries the rule for it.

## Testing

- `npm test` — 610 pass, 0 fail.
- `npm run lint` — clean.
- Mutation-checked: prepending `require('./hide-child-windows').hideChildWindows();` to `src/main.js` fails the new test, and only that test.
- No runtime behaviour changes — the diff is one document, one comment, one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)