### PR TITLE
Settle #216 by keeping renderer decisions in modules, and extract the first one

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -125,6 +125,20 @@ spawn failure, and `runNpmWithEngineRetry` in `src/main.js` shows the expected s
 chair. And a setup that dies halfway must leave the site registry consistent — no phantom site
 in `electron-store` for a directory that was never finished.
 
+**Renderer decisions live in modules, not in `index.jsx`.** `src/renderer/index.jsx` mounts itself
+at module scope and cannot be loaded without a DOM, so nothing in the suite can reach it: a
+decision made there is untestable by construction. Anything with more than one branch — a string
+the user reads, a path joined, a status derived, a command parsed — belongs in a
+`src/renderer/*.cjs` module with its own test, leaving the component holding JSX, state
+assignments and the call. `site-folder.cjs` and `open-failure.cjs` are the shape.
+
+This is the direction chosen in #216 over building a DOM harness, which was judged too much setup
+for the coverage it buys against a 4000-line component. The consequence is that it is enforced
+here, by review, and nowhere else — `no-unused-vars` catches a module whose last call site is
+deleted, but nothing catches a second code path that answers the same question inline. That is
+exactly what #180 was. Reopen the harness question if a bug ever lands in the assignments the
+modules cannot absorb.
+
 **New dependencies are findings by default.** Native compilation or a host binary breaks the
 zero-prerequisite promise on user machines. A dependency with lifecycle scripts also needs an
 `allowScripts` entry in `package.json` — the mechanism already exists, and a missing entry means
@@ -243,6 +257,10 @@ is dependency injection, not skipping: `test/win-spawn-patch.test.cjs` exercises
 paths from macOS by injecting `platform`, lookup and env rather than reading `process.platform`.
 A new platform split tested with `it.skip` on the other OS is a coverage hole CI will never
 close, since the suite runs on both platforms but each skips the other's branch.
+
+**Renderer logic is tested through its module, so check it has one.** A PR that puts a branch
+inside `src/renderer/index.jsx` has written code the suite cannot reach — see the invariant in §1.
+The finding is the missing module, not the missing test.
 
 **Scope stays proportional.** Missing tests on a touched line of legacy code is `[follow-up]`,
 not `[fix here]` — the strong rule applies to what the PR introduces, not to everything it

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -25,6 +25,7 @@ import { shouldShowTerminalHints, computeTerminalBusy } from './terminal-hints.c
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
 import { appendBounded, countLines } from './debug-log.cjs';
 import { pathBasename } from './path-basename.cjs';
+import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, APPLY_STATE_TO_STEP } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
@@ -395,21 +396,6 @@ function App() {
     setCreateModalOpen(true);
   }, [createSubmitting]);
 
-  const sanitizeSiteFolder = useCallback((value) => (
-    value
-      .replace(/[\\/:*?"<>|]+/g, '-')
-      .replace(/\s+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      || 'wordpress-site'
-  ), []);
-
-  const resolveTargetDir = useCallback((root, folder) => {
-    if (!root) return folder;
-    const normalizedRoot = root.replace(/[\\/]+$/, '');
-    const separator = /\\/.test(normalizedRoot) && !normalizedRoot.includes('/') ? '\\' : '/';
-    return `${normalizedRoot}${separator}${folder}`;
-  }, []);
-
   const openDirectoryPicker = useCallback(async () => {
     try {
       const dir = await window.api.chooseDirectory();
@@ -423,40 +409,17 @@ function App() {
   const handleCreateDirInputChange = useCallback((event) => {
     const inputEl = event.target;
     createDirInputRef.current = inputEl;
-    const finalize = (rawDir) => {
-      const normalized = typeof rawDir === 'string' ? rawDir.replace(/[\\/]+$/, '') : '';
-      if (normalized) {
-        setCreateSiteDir(normalized);
-        setCreateSiteError('');
-      } else {
-        setCreateSiteDir('');
-      }
-    };
     const files = inputEl.files;
     if (!files || files.length === 0) {
       inputEl.value = '';
       return;
     }
 
-    const first = files[0];
-    const relative = first?.webkitRelativePath || '';
-    const rawPath = first?.path || '';
-    let resolved = '';
-
-    if (rawPath) {
-      if (relative) {
-        resolved = rawPath.slice(0, rawPath.length - relative.length);
-      } else {
-        resolved = rawPath.replace(/[\\/][^\\/]*$/, '');
-      }
-    }
-
-    if (!resolved && inputEl.value) {
-      resolved = inputEl.value.replace(/[^\\/]*$/, '');
-    }
-
-    resolved = resolved.replace(/[\\/]+$/, '');
-    finalize(resolved);
+    const resolved = directoryFromFileEntry(files[0], inputEl.value);
+    setCreateSiteDir(resolved);
+    // Clearing the error only when there is a directory: a selection that
+    // resolved to nothing has not fixed anything the message was about.
+    if (resolved) setCreateSiteError('');
     inputEl.value = '';
   }, [setCreateSiteDir, setCreateSiteError]);
 
@@ -527,7 +490,7 @@ function App() {
       clearPendingSites();
       setCreateSubmitting(false);
     }
-  }, [addPendingSite, appendSetupLog, applySetup, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh, resolveTargetDir, sanitizeSiteFolder]);
+  }, [addPendingSite, appendSetupLog, applySetup, clearPendingSites, createSiteDir, createSiteName, moveSetupLog, refresh]);
 
   const closeCreateModal = useCallback(() => {
     if (createSubmitting) return;

--- a/src/renderer/site-folder.cjs
+++ b/src/renderer/site-folder.cjs
@@ -56,9 +56,12 @@ function resolveTargetDir(root, folder) {
 /**
  * The directory an `<input type="file" webkitdirectory>` selection points at.
  *
- * Extracted as it stood, dead branch included, because #216 is a refactor and
- * this is the wrong PR to change what it answers. What it answers today is
- * wrong, and #228 is where that gets decided:
+ * Nothing reaches this by the intended route: the input's click and keyboard
+ * handlers are intercepted and go to the native dialog. It runs only when a
+ * folder is dropped onto the control, which is a second route the app does not
+ * currently support — see #228, where supporting it or closing it off gets
+ * decided. Extracted as it stood, dead branch included, because #216 is a
+ * refactor and not the place to change what it answers:
  *
  * - `path` plus `webkitRelativePath`, and `path` alone, are the two shapes this
  *   was written for. Electron removed the `path` augmentation on `File` in v32
@@ -68,9 +71,6 @@ function resolveTargetDir(root, folder) {
  *   value is empty or the literal `C:\fakepath\` prefix on every platform. So a
  *   dropped folder resolves to '' or to `C:\fakepath`, and the modal presents
  *   the second as a real destination.
- *
- * The click and keyboard handlers on that input are intercepted and go to the
- * native dialog, so nothing here runs unless a folder is dropped onto it.
  *
  * @param {*} file       The first entry of the input's `files` list.
  * @param {*} inputValue The input's `value`, read only when `file` has no path.

--- a/src/renderer/site-folder.cjs
+++ b/src/renderer/site-folder.cjs
@@ -58,10 +58,10 @@ function resolveTargetDir(root, folder) {
  *
  * Nothing reaches this by the intended route: the input's click and keyboard
  * handlers are intercepted and go to the native dialog. It runs only when a
- * folder is dropped onto the control, which is a second route the app does not
- * currently support — see #228, where supporting it or closing it off gets
- * decided. Extracted as it stood, dead branch included, because #216 is a
- * refactor and not the place to change what it answers:
+ * folder is dropped onto the control — a route the app deliberately does not
+ * support, decided in #228 and closed there. Extracted as it stood, dead branch
+ * included, because #216 is a refactor and not the place to change what it
+ * answers:
  *
  * - `path` plus `webkitRelativePath`, and `path` alone, are the two shapes this
  *   was written for. Electron removed the `path` augmentation on `File` in v32

--- a/src/renderer/site-folder.cjs
+++ b/src/renderer/site-folder.cjs
@@ -1,0 +1,100 @@
+// Where a new site goes, and what its folder is called.
+//
+// Three decisions the Create site modal makes before `setupWordPress` is ever
+// called, all of them string work on paths the renderer cannot hand to Node's
+// `path` module: it has none. The chosen root arrives in the platform's native
+// form — `C:\Users\me` on Windows, `/Users/me` elsewhere — so joining a folder
+// name onto it means picking the separator by looking at the string.
+//
+// They lived inside the component until #216, where nothing in the suite could
+// reach them: `index.jsx` cannot be loaded without a DOM, so a wrong separator,
+// or a name sanitised down to nothing, was visible only by creating a site by
+// hand on the platform in question.
+'use strict';
+
+// Everything a folder name may not contain on Windows, which is the stricter of
+// the two platforms. One rule everywhere keeps a name from working on macOS and
+// failing on Windows.
+const ILLEGAL_FOLDER_CHARS = /[\\/:*?"<>|]+/g;
+
+// What a name that sanitises down to nothing becomes. Any folder is better than
+// the alternative, which is creating the site directly in the chosen root.
+const FALLBACK_FOLDER = 'wordpress-site';
+
+/**
+ * A site name as typed, turned into a folder name that is legal everywhere.
+ *
+ * @param {*} value
+ * @return {string}
+ */
+function sanitizeSiteFolder(value) {
+	return String(value ?? '')
+		.replace(ILLEGAL_FOLDER_CHARS, '-')
+		.replace(/\s+/g, '-')
+		.replace(/^-+|-+$/g, '') || FALLBACK_FOLDER;
+}
+
+/**
+ * The chosen root joined to the folder name, using the separator the root
+ * already uses.
+ *
+ * A root written entirely in backslashes is Windows and gets a backslash.
+ * Everything else — including the mixed separators Windows itself accepts —
+ * gets a forward slash, which Windows also accepts.
+ *
+ * @param {*} root
+ * @param {*} folder
+ * @return {string}
+ */
+function resolveTargetDir(root, folder) {
+	if (!root) return String(folder ?? '');
+	const normalizedRoot = String(root).replace(/[\\/]+$/, '');
+	const separator = /\\/.test(normalizedRoot) && !normalizedRoot.includes('/') ? '\\' : '/';
+	return `${normalizedRoot}${separator}${folder}`;
+}
+
+/**
+ * The directory an `<input type="file" webkitdirectory>` selection points at.
+ *
+ * Extracted as it stood, dead branch included, because #216 is a refactor and
+ * this is the wrong PR to change what it answers. What it answers today is
+ * wrong, and #228 is where that gets decided:
+ *
+ * - `path` plus `webkitRelativePath`, and `path` alone, are the two shapes this
+ *   was written for. Electron removed the `path` augmentation on `File` in v32
+ *   in favour of `webUtils.getPathForFile`; this app pins Electron 43 and
+ *   bridges no `webUtils`, so neither branch is reachable.
+ * - What is left is the input's own `value`, which is a fiction: a file input's
+ *   value is empty or the literal `C:\fakepath\` prefix on every platform. So a
+ *   dropped folder resolves to '' or to `C:\fakepath`, and the modal presents
+ *   the second as a real destination.
+ *
+ * The click and keyboard handlers on that input are intercepted and go to the
+ * native dialog, so nothing here runs unless a folder is dropped onto it.
+ *
+ * @param {*} file       The first entry of the input's `files` list.
+ * @param {*} inputValue The input's `value`, read only when `file` has no path.
+ * @return {string} The directory without a trailing separator, or '' when none
+ *                  could be derived.
+ */
+function directoryFromFileEntry(file, inputValue) {
+	const relative = file?.webkitRelativePath || '';
+	const rawPath = file?.path || '';
+	let resolved = '';
+
+	if (rawPath) {
+		if (relative) {
+			resolved = rawPath.slice(0, rawPath.length - relative.length);
+		} else {
+			resolved = rawPath.replace(/[\\/][^\\/]*$/, '');
+		}
+	}
+
+	if (!resolved && inputValue) {
+		resolved = String(inputValue).replace(/[^\\/]*$/, '');
+	}
+
+	return resolved.replace(/[\\/]+$/, '');
+}
+
+module.exports = { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry, FALLBACK_FOLDER };

--- a/test/site-folder.test.cjs
+++ b/test/site-folder.test.cjs
@@ -1,0 +1,96 @@
+// The Create site modal's path arithmetic, which decides where a site is
+// cloned before anything is cloned. Both platforms are exercised from one
+// machine: nothing here reads `process.platform`, the separator is chosen from
+// the shape of the root string, so a macOS run covers the Windows branch too.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+	sanitizeSiteFolder,
+	resolveTargetDir,
+	directoryFromFileEntry,
+	FALLBACK_FOLDER
+} = require('../src/renderer/site-folder.cjs');
+
+test('sanitizeSiteFolder replaces characters Windows refuses in a folder name', () => {
+	assert.equal(sanitizeSiteFolder('feature/45678'), 'feature-45678');
+	assert.equal(sanitizeSiteFolder('trac:45678'), 'trac-45678');
+	assert.equal(sanitizeSiteFolder('a\\b*c?d"e<f>g|h'), 'a-b-c-d-e-f-g-h');
+});
+
+test('sanitizeSiteFolder collapses whitespace and trims the dashes it created', () => {
+	assert.equal(sanitizeSiteFolder('My Site'), 'My-Site');
+	assert.equal(sanitizeSiteFolder('  My   Site  '), 'My-Site');
+	assert.equal(sanitizeSiteFolder('-already-dashed-'), 'already-dashed');
+});
+
+test('sanitizeSiteFolder falls back rather than returning an empty folder name', () => {
+	// An empty result would join to the root itself, cloning WordPress straight
+	// into the directory the contributor picked.
+	assert.equal(sanitizeSiteFolder('///'), FALLBACK_FOLDER);
+	assert.equal(sanitizeSiteFolder('   '), FALLBACK_FOLDER);
+	assert.equal(sanitizeSiteFolder(''), FALLBACK_FOLDER);
+	assert.equal(sanitizeSiteFolder(null), FALLBACK_FOLDER);
+	assert.equal(sanitizeSiteFolder(undefined), FALLBACK_FOLDER);
+});
+
+test('resolveTargetDir keeps a Windows root on backslashes', () => {
+	assert.equal(resolveTargetDir('C:\\Users\\me\\sites', 'my-site'), 'C:\\Users\\me\\sites\\my-site');
+	assert.equal(resolveTargetDir('C:\\Users\\me\\sites\\', 'my-site'), 'C:\\Users\\me\\sites\\my-site');
+});
+
+test('resolveTargetDir keeps a POSIX root on forward slashes', () => {
+	assert.equal(resolveTargetDir('/Users/me/sites', 'my-site'), '/Users/me/sites/my-site');
+	assert.equal(resolveTargetDir('/Users/me/sites///', 'my-site'), '/Users/me/sites/my-site');
+});
+
+test('resolveTargetDir uses a forward slash for a mixed root', () => {
+	// Windows accepts both, so the only thing this must not do is guess wrong
+	// about a path that already contains a forward slash and produce neither.
+	assert.equal(resolveTargetDir('C:/Users/me\\sites', 'my-site'), 'C:/Users/me\\sites/my-site');
+});
+
+test('resolveTargetDir at a Windows drive root produces an absolute path', () => {
+	// Stripping the trailing separator off `C:\` leaves `C:`, which has no
+	// backslash left to detect — so this takes the forward-slash branch. The
+	// result is still absolute on Windows, which is what matters; `C:my-site`
+	// would have been drive-relative and landed somewhere else entirely.
+	assert.equal(resolveTargetDir('C:\\', 'my-site'), 'C:/my-site');
+});
+
+test('resolveTargetDir with no root is the folder name alone', () => {
+	// The modal blocks submitting without a directory, so this is a guard, not
+	// a path a contributor reaches.
+	assert.equal(resolveTargetDir('', 'my-site'), 'my-site');
+	assert.equal(resolveTargetDir(null, 'my-site'), 'my-site');
+});
+
+// What follows pins what this function does with the entries it actually gets,
+// which is not the same as what it was written for. See #228: the `path`
+// property it prefers was removed from `File` in Electron 32, this app pins
+// Electron 43, and no `webUtils` bridge replaces it — so every real entry takes
+// the fallback. Asserting the `path` shapes would be green and prove nothing.
+
+test('directoryFromFileEntry gets nothing from a real dropped entry', () => {
+	// A File in Electron 43. No `path`, and `webkitRelativePath` alone carries
+	// no absolute part to cut it off.
+	assert.equal(directoryFromFileEntry({ webkitRelativePath: 'sites/inner/file.txt' }, ''), '');
+	assert.equal(directoryFromFileEntry({}, ''), '');
+	assert.equal(directoryFromFileEntry(null, ''), '');
+	assert.equal(directoryFromFileEntry(undefined, undefined), '');
+});
+
+test('directoryFromFileEntry passes C:\\fakepath through — #228', () => {
+	// The bug, pinned rather than endorsed. A file input's `value` is either
+	// empty or this literal prefix on every platform, browsers substituting it
+	// for the real path, so the fallback's "typed path" is a fiction. The
+	// modal shows this as the chosen folder and submit hands it to setup.
+	assert.equal(directoryFromFileEntry({}, 'C:\\fakepath\\my-folder'), 'C:\\fakepath');
+});
+
+test('directoryFromFileEntry returns nothing rather than a wrong directory', () => {
+	// '' is what the caller checks before it clears the chosen directory — a
+	// bare segment is not a directory anyone chose.
+	assert.equal(directoryFromFileEntry({}, 'file.txt'), '');
+	assert.equal(directoryFromFileEntry({}, ''), '');
+});

--- a/test/site-folder.test.cjs
+++ b/test/site-folder.test.cjs
@@ -72,9 +72,9 @@ test('resolveTargetDir with no root is the folder name alone', () => {
 // fallback. Asserting the `path` shapes would be green and prove nothing.
 //
 // The only route that reaches this at all is dropping a folder on the control,
-// which the app does not support; #228 decides whether it should. So these
-// record where that route currently ends, and are the failing tests to write
-// against when it is taken up.
+// which the app deliberately does not support — #228, closed as not planned.
+// So these record where an unsupported route ends, and are the tests a change
+// of mind would have to rewrite.
 
 test('directoryFromFileEntry gets nothing from a real dropped entry', () => {
 	// A File in Electron 43. No `path`, and `webkitRelativePath` alone carries

--- a/test/site-folder.test.cjs
+++ b/test/site-folder.test.cjs
@@ -66,10 +66,15 @@ test('resolveTargetDir with no root is the folder name alone', () => {
 });
 
 // What follows pins what this function does with the entries it actually gets,
-// which is not the same as what it was written for. See #228: the `path`
-// property it prefers was removed from `File` in Electron 32, this app pins
-// Electron 43, and no `webUtils` bridge replaces it — so every real entry takes
-// the fallback. Asserting the `path` shapes would be green and prove nothing.
+// which is not the same as what it was written for. The `path` property it
+// prefers was removed from `File` in Electron 32, this app pins Electron 43,
+// and no `webUtils` bridge replaces it — so every real entry takes the
+// fallback. Asserting the `path` shapes would be green and prove nothing.
+//
+// The only route that reaches this at all is dropping a folder on the control,
+// which the app does not support; #228 decides whether it should. So these
+// record where that route currently ends, and are the failing tests to write
+// against when it is taken up.
 
 test('directoryFromFileEntry gets nothing from a real dropped entry', () => {
 	// A File in Electron 43. No `path`, and `webkitRelativePath` alone carries
@@ -81,10 +86,10 @@ test('directoryFromFileEntry gets nothing from a real dropped entry', () => {
 });
 
 test('directoryFromFileEntry passes C:\\fakepath through — #228', () => {
-	// The bug, pinned rather than endorsed. A file input's `value` is either
-	// empty or this literal prefix on every platform, browsers substituting it
-	// for the real path, so the fallback's "typed path" is a fiction. The
-	// modal shows this as the chosen folder and submit hands it to setup.
+	// Recorded, not endorsed. A file input's `value` is either empty or this
+	// literal prefix on every platform, browsers substituting it for the real
+	// path, so the fallback's "typed path" is a fiction. The modal shows this
+	// as the chosen folder and submit hands it to setup.
 	assert.equal(directoryFromFileEntry({}, 'C:\\fakepath\\my-folder'), 'C:\\fakepath');
 });
 


### PR DESCRIPTION
## Why

#216 asks for a decision, not a patch: `src/renderer/index.jsx` is 4163 lines, mounts itself at module scope, and cannot be loaded without a DOM — so every decision made inside it is untestable by construction. Thirteen pure modules have been factored out of it, each with good tests, and nothing proves the component still reaches them. `test/ipc-wiring.test.cjs` exists because that gap became #180 on the main-process side.

The issue weighs two directions: a DOM harness, or continuing to push decisions into the modules. It asks for that to be settled deliberately rather than one PR at a time. This settles it, and lands the first extraction under the new rule.

## What changes

**The decision is extraction**, recorded as an invariant in §1 of the review standard with a pointer from §5, because that file is the only copy of the standard and the one Copilot reads natively.

The rule states its own limit rather than overselling it. Two things came out of looking at the current state:

- All 23 functions imported from `src/renderer/*.cjs` have a live call site, and `no-unused-vars` already fails the build when the last one goes. The "wire cut by deletion" case is largely covered already.
- The uncovered case is #180's: the module is still called on one path while another path answers inline. Neither lint nor a shallow wiring test catches that, so the rule is enforced by review and nowhere else. It names the trigger for reopening the harness question.

**`src/renderer/site-folder.cjs`** is the first extraction: `sanitizeSiteFolder`, `resolveTargetDir` and `directoryFromFileEntry`, the Create site modal's path arithmetic. Chosen because it was pure, untested, and picked a path separator by inspecting the string — the kind of thing only visible by creating a site by hand on Windows.

Deliberately not in this PR: `executeTerminalCommand` (`index.jsx:1616`), the largest decision left in the file and the only one with a security surface — it holds the `TERMINAL_ALLOWED_SCRIPTS` allow-list and has no tests. It wants the parse-to-a-plan shape `dev-server-command.cjs` already uses, and its own PR.

## How to test this

Platforms: **any** for the suite; the Windows separator branch is covered from any machine, since nothing reads `process.platform`.

There is no behaviour change to observe, so the demonstration is the suite plus one path through the UI that must look identical to before.

```
npm run lint          # clean
npm test              # 621/621
npm run test:electron # 621/621 on Electron's bundled Node
npm run build:once    # the new module has to bundle
```

**Starting state:** the app open, on any machine, with no site selected.

1. Click **Create site**. The modal opens.
2. Type a site name containing characters no folder may have — `trac:45678/fix` will do.
3. Click **Choose files** under **Site location** and pick a parent folder in the native dialog. The folder appears next to the button.
4. Click **Create site**.

Expected: the site is created inside the folder chosen in step 3, in a directory named `trac-45678-fix` — the illegal characters became dashes, and nothing else changed about the name.

**What must not have happened:**

- The site created one level up from the chosen folder, or directly inside it with no directory of its own.
- A directory named `wordpress-site` when the name given was usable — that fallback is only for a name that sanitises down to nothing.
- On Windows, a path built with a forward slash where the chosen root used backslashes.

**Driven on macOS at `5cdf06a`.** Name `trac:45678/fix` in `~/CONTRIBUTIONS` produced
`/Users/…/CONTRIBUTIONS/trac-45678-fix` — inside the chosen folder, both illegal characters
replaced, no fallback — and the sidebar kept `trac:45678/fix` as the label, so `siteName` and
`siteLabel` still reach the handler as the two different values they are. The clone completed and
setup moved on to `npm install`. The Windows separator branch was not driven by hand; it is covered
by `test/site-folder.test.cjs` from any machine, and a signed Windows artifact is available from
Buildkite for anyone who wants to.

## Risks and limitations

Testing this by hand surfaced **#228**, closed as not planned and not addressed here. `directoryFromFileEntry` only runs when a folder is *dropped* on the location control — the click and keyboard handlers both go to the native dialog — and that route is not one the app supports. It is half-present rather than absent: the drop populates the input, and what comes back is `''` or the literal `C:\fakepath`. Supporting drops is a feature, not a gap, and #228 records the decision not to take it up.

The function was extracted exactly as it stood, dead branch included, because changing what it answers was never this PR's to do. Its tests pin where the unsupported route currently ends rather than the shapes the function was written for — see the implementation notes.

The rule this PR adds is enforced by review only. That is stated in the rule itself, and it is the direct consequence of choosing extraction over a harness.

#216 is closed as decided, but not because the gap it names is gone. The proof that `index.jsx` still *calls* its modules does not exist and, under this decision, will not — what changes is how little is left in the component for a competing answer to hide in.

## Related

Settles #216 (closed with the reasoning). Surfaced #228, closed as not planned. Follow-up to #180, #211, #213.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why not the DOM harness.** It needs `App` exported separately from the `createRoot` bootstrap, a stub for the 77 `window.api` call sites, a jsdom devDependency whose behaviour under `@wordpress/components` and `xterm` is unproven, and CI wiring. Against a 4163-line component that buys coverage of the paths the harness happens to drive. The cost is real and the coverage is partial, which is what tipped it.

**Why not a static wiring test.** The obvious cheap analogue of `ipc-wiring.test.cjs` — parse `index.jsx`, assert each module's exports are referenced — was measured and dropped. Every import already has a call site, and `no-unused-vars` fails the build when the last one goes, so such a test would duplicate the linter while catching nothing the linter misses. It would also not catch #180, which is the failure that matters.

**Why this module first.** `site-folder.cjs` is pure, has no IPC, was completely untested, and is cross-platform path handling — a dimension the review standard already treats separately. It makes the rule concrete without the PR turning into a rewrite.

**What was left in the component.** `handleCreateDirInputChange` keeps the DOM work — reading `files`, clearing `value`, calling the setters — and one conditional state assignment. The rule as written does not carve that out; if it should, that clause is worth adding once there is a second example of it.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`/self-review` run against the working tree before this branch had any commits, with the judgement pass dispatched to a subagent given only the diff and the instructions file.

**1 [fix here] · 2 [follow-up] — the [fix here] is fixed; one follow-up filed and closed as not planned, one recorded.**

- 🟡 **Tests, [fix here] — fixed.** Six assertions in `test/site-folder.test.cjs` were built on `{ path: '…' }` fixtures. `File.path` does not exist in this app: Electron removed the augmentation in v32 in favour of `webUtils.getPathForFile`, this repo pins Electron 43, and `src/preload.js` bridges no `webUtils`. The whole `if (rawPath)` branch is unreachable, so those tests were green while proving nothing — one of the shapes §5 names. Two of the fixtures also omitted the leading segment `webkitRelativePath` actually carries, which is the only reason they passed. Rewritten to cover what reaches the function today, with the `C:\fakepath` outcome recorded as where an unsupported route ends and pointed at #228.
- 🟡 **Cross-platform, [follow-up] — filed as #228, closed as not planned.** The consequence on the one live route: click and keyboard are intercepted to the native dialog, but a *drop* still populates the input, and the fallback yields `''` (silently clearing an already-chosen folder) or `C:\fakepath` (handed to `wordpress:setup`, where `fse.ensureDir` would create it). Weighed and declined: the modal's intended route — text field for the name, button for the location — is clear as it stands, and supporting drops is a feature rather than a gap. Note the drop behaviour is read from the code and Chromium's documented handling of `webkitdirectory`; it has not been reproduced by hand.
- 🔵 **Architecture, [follow-up] — recorded, not filed.** `sanitizeSiteFolder` now has a canonical home but its twin is still inline in the `wordpress:setup` handler in `src/main.js` — the same three replacements in the same order, differing only in fallback. It is literally the "second code path answering the same question inline" the new §1 text says nothing catches. Harmless today because main returns `createdPath` and the row adopts it; worth collapsing when either regex next changes. `site-folder.cjs` is dependency-free CJS and `main.js` could require it directly.

The extraction itself was checked line by line and holds. The removed `finalize` helper was a `typeof` guard over a value that was already a string plus a trailing-separator strip the module now does; `setCreateSiteDir(resolved)` with `if (resolved) setCreateSiteError('')` is the old two-branch body exactly. The `useCallback` dependency array was updated.

</details>

<details>
<summary>Implementation notes</summary>

**On testing `directoryFromFileEntry` honestly.** Three options were on the table: keep the `path` fixtures with a note that they cover the legacy Electron <32 shape, delete the dead branch outright, or leave the function untouched and test what actually reaches it. The first is the "green while proving nothing" §5 forbids. The second is a behaviour change inside a PR that advertises none. The third is what shipped: the module's header documents the dead branch and why it cannot run, and the tests assert `''` for a real Electron 43 entry and `C:\fakepath` for the fallback, recorded rather than endorsed and pointing at #228. A file input's `value` is empty or that literal prefix by specification, on every platform, so there is no realistic input for which the old assertions were reachable. If the decision in #228 is ever revisited, these are the tests it has to rewrite.

**On `resolveTargetDir` at a drive root.** `C:\` normalises to `C:`, which has no backslash left to detect, so it takes the forward-slash branch and produces `C:/my-site`. Still absolute on Windows, so not a bug — but it was invisible before and now has a test saying what it does and why that is acceptable, rather than leaving the next reader to re-derive it.

**Files.** `src/renderer/site-folder.cjs` (new, 3 exports + the fallback constant), `test/site-folder.test.cjs` (new, 11 tests), `src/renderer/index.jsx` (44 lines out, 11 in), `.github/instructions/code-review.instructions.md` (the invariant in §1, one pointer in §5).

</details>

<details>
<summary>Screenshots or recording</summary>

Nothing on screen changed. The Create site modal renders and behaves exactly as before; the extraction is invisible to the contributor, which is the point of the manual steps above.

</details>
