### PR TITLE
Add a screenshot harness that photographs the app for the docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,3 +140,11 @@ npm ci --prefix docs
 - `npm run docs:build` — what CI runs. It fails on dead links, so run it before pushing.
 - `npm run docs:preview` — serves the built site exactly as GitHub Pages will, clean URLs and all.
   This is the one to check a change against before opening a PR.
+
+Its screenshots are captured by `npm run shots` (see `scripts/screenshots/`), not by CI: the harness
+launches the app against a seeded, throwaway site registry and photographs each screen at a fixed
+size. **A PR that changes what a documented screen looks like re-runs `npm run shots` and commits
+the new images** — nothing automated catches a stale screenshot. Shots the fixture registry cannot
+reach (a running dev server, a real diff) are listed in the live tier: `npm run shots -- --tier=live`
+pauses per shot while you set the real screen up, and those images show real paths, so look at each
+one before committing it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "electron": "^43.2.0",
         "electron-builder": "^26.15.3",
         "esbuild": "^0.23.0",
-        "eslint": "^9.39.5"
+        "eslint": "^9.39.5",
+        "playwright-core": "^1.62.1"
       }
     },
     "node_modules/@ariakit/core": {
@@ -15197,6 +15198,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:electron": "node scripts/run-tests-electron.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "shots": "npm run build:once && node scripts/screenshots/capture.cjs",
     "docs:dev": "npm --prefix docs run dev",
     "docs:build": "npm --prefix docs run build",
     "docs:preview": "npm --prefix docs run preview"
@@ -88,7 +89,8 @@
     "electron": "^43.2.0",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.23.0",
-    "eslint": "^9.39.5"
+    "eslint": "^9.39.5",
+    "playwright-core": "^1.62.1"
   },
   "allowScripts": {
     "electron@43.2.0": true,

--- a/scripts/screenshots/capture.cjs
+++ b/scripts/screenshots/capture.cjs
@@ -1,0 +1,143 @@
+// Captures the documentation screenshots in docs/public/screenshots/.
+//
+//   npm run shots                    # fixture tier: fully automatic (builds the renderer first)
+//   npm run shots -- --tier=live     # live tier: pauses per shot, maintainer drives
+//   npm run shots -- --only=terminal # one shot, by slug
+//
+// Fixture tier launches the repo's own Electron binary through playwright-core's
+// Electron driver, pointed at a throwaway userData dir (TOOLKIT_USER_DATA_DIR —
+// see the guarded hook in src/main.js), so the contributor's real site registry
+// is never touched. One launch per fixture variant, and every shot starts from
+// a freshly reloaded window, so no shot depends on the one before it.
+//
+// Live tier launches the app against the real registry with no seeding at all:
+// the harness prints what to set up, waits for Enter, and takes the picture —
+// a camera with a timer, not automation. Screenshots taken this way show real
+// paths; review each image before committing it.
+//
+// playwright-core rather than playwright: it ships the same Electron driver
+// with no postinstall script and no browser download — the only browser needed
+// is the Electron already in devDependencies. If #70 lands `@playwright/test`,
+// this can require the driver from there instead and the direct dependency goes.
+//
+// It lives under scripts/ rather than e2e/ because it is a CLI, not a test:
+// e2e/ is the Playwright `testDir`, and nothing here is run by `npm run test:e2e`.
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { _electron } = require('playwright-core');
+const { buildFixture, cleanFixtureSites } = require('./fixtures.cjs');
+const { shots } = require('./shots.cjs');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const outDir = path.join(repoRoot, 'docs', 'public', 'screenshots');
+
+// Every image the same size, every run: a fixed window and DPR 1. Without the
+// scale-factor switch a retina display doubles the pixel size of half the
+// screenshots and the docs pages render them inconsistently.
+const WINDOW = { width: 1200, height: 800 };
+const ELECTRON_SWITCHES = ['--force-device-scale-factor=1'];
+
+function parseArgs(argv) {
+	const args = { tier: 'fixture', only: null };
+	for (const arg of argv.slice(2)) {
+		if (arg.startsWith('--tier=')) args.tier = arg.slice('--tier='.length);
+		else if (arg.startsWith('--only=')) args.only = arg.slice('--only='.length);
+		else throw new Error(`Unknown argument: ${arg}`);
+	}
+	if (args.tier !== 'fixture' && args.tier !== 'live') {
+		throw new Error(`--tier must be "fixture" or "live", got "${args.tier}"`);
+	}
+	return args;
+}
+
+async function launchApp(env) {
+	const app = await _electron.launch({
+		// From plain Node, require('electron') resolves to the binary's path —
+		// the same trick scripts/run-tests-electron.cjs uses.
+		executablePath: require('electron'),
+		args: [...ELECTRON_SWITCHES, repoRoot],
+		env: { ...process.env, ...env }
+	});
+	const page = await app.firstWindow();
+	await app.evaluate(({ BrowserWindow }, bounds) => {
+		const win = BrowserWindow.getAllWindows()[0];
+		win.setBounds({ x: 40, y: 40, ...bounds });
+	}, WINDOW);
+	return { app, page };
+}
+
+async function captureShot(page, shot) {
+	const file = path.join(outDir, `${shot.slug}.png`);
+	if (shot.target) {
+		await shot.target(page).screenshot({ path: file });
+	} else {
+		await page.screenshot({ path: file });
+	}
+	console.log(`  ✓ ${shot.slug}.png`);
+}
+
+async function runFixtureTier(selected) {
+	const variants = [...new Set(selected.map((s) => s.variant))];
+	for (const variant of variants) {
+		const { userDataDir } = buildFixture(variant);
+		const { app, page } = await launchApp({ TOOLKIT_USER_DATA_DIR: userDataDir });
+		try {
+			for (const shot of selected.filter((s) => s.variant === variant)) {
+				// Fresh renderer per shot: open menus and modals from the
+				// previous shot cannot leak into this one.
+				await page.reload();
+				await shot.prepare(page);
+				// Let @wordpress/components' open/close animations settle.
+				await page.waitForTimeout(300);
+				await captureShot(page, shot);
+			}
+		} finally {
+			await app.close();
+		}
+	}
+	cleanFixtureSites();
+}
+
+async function runLiveTier(selected) {
+	// Explicitly undefined rather than omitted: launchApp spreads process.env, so a
+	// TOOLKIT_USER_DATA_DIR exported while debugging the fixture tier would silently
+	// point the "real sites" tier at fixture state, and the images would be wrong in
+	// a way only a careful look at the sidebar reveals.
+	const { app, page } = await launchApp({ TOOLKIT_USER_DATA_DIR: undefined });
+	const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+	const ask = (q) => new Promise((resolve) => rl.question(q, resolve));
+	try {
+		console.log('\nLive tier: the app just opened against your real sites.');
+		console.log('Screenshots will show real paths — review every image before committing.\n');
+		for (const shot of selected) {
+			console.log(`\n${shot.slug}:\n  ${shot.instructions}`);
+			await ask('  Press Enter when the screen is ready… ');
+			await captureShot(page, shot);
+		}
+	} finally {
+		rl.close();
+		await app.close();
+	}
+}
+
+async function main() {
+	const args = parseArgs(process.argv);
+	const selected = shots.filter(
+		(s) => s.tier === args.tier && (!args.only || s.slug === args.only)
+	);
+	if (!selected.length) {
+		const known = shots.filter((s) => s.tier === args.tier).map((s) => s.slug);
+		throw new Error(`No ${args.tier}-tier shot matches. Known slugs: ${known.join(', ')}`);
+	}
+	fs.mkdirSync(outDir, { recursive: true });
+	console.log(`Capturing ${selected.length} ${args.tier}-tier screenshot(s) into ${path.relative(repoRoot, outDir)}/`);
+	if (args.tier === 'fixture') await runFixtureTier(selected);
+	else await runLiveTier(selected);
+}
+
+main().catch((err) => {
+	console.error(err.stack || String(err));
+	process.exit(1);
+});

--- a/scripts/screenshots/fixtures.cjs
+++ b/scripts/screenshots/fixtures.cjs
@@ -1,0 +1,108 @@
+// Builds the throwaway state the screenshot harness points the app at.
+//
+// Two directories come out of this:
+//   - a userData dir holding a seeded settings.json, handed to the app via
+//     TOOLKIT_USER_DATA_DIR (see the guarded hook in src/main.js), so the
+//     contributor's real site registry is never read or written;
+//   - fake site directories under a deliberately username-free path, because
+//     every path the app renders ends up in published pixels. safe-log.js
+//     redacts logs; nothing redacts a screenshot, so the fixture path is the
+//     mitigation.
+//
+// The fake sites are empty directories (plus a canned debug.log): the renderer
+// tolerates a site whose git metadata cannot be read — it shows the site with
+// no snapshot date rather than crashing — so no real clone is needed.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// /tmp, not os.tmpdir(): on macOS os.tmpdir() is a /var/folders/... maze that
+// reads as noise in a screenshot. Windows has no /tmp, so fall back there.
+const FIXTURE_ROOT =
+	process.platform === 'win32'
+		? path.join(os.tmpdir(), 'wpct-docs-fixture')
+		: '/tmp/wpct-docs-fixture';
+
+const DEBUG_LOG_LINES = [
+	'[10-Aug-2026 09:12:44 UTC] PHP Notice:  Undefined variable $post in /wordpress/wp-content/themes/twentytwentyfive/functions.php on line 112',
+	'[10-Aug-2026 09:12:45 UTC] PHP Deprecated:  Function get_page_by_title is deprecated since version 6.2.0! Use WP_Query instead.',
+	''
+].join('\n');
+
+/**
+ * Creates the fixture site directories and a seeded userData dir.
+ *
+ * @param {string} variant 'seeded' for a populated site list, 'empty' for a
+ *                         first-launch app with no sites.
+ * @return {{userDataDir: string, sites: Object<string,string>}} Paths the
+ *         harness needs: where the app's state lives and where each fake site is.
+ */
+function buildFixture(variant) {
+	const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-userdata-'));
+
+	if (variant === 'empty') {
+		writeSettings(userDataDir, { sites: [], siteMeta: {}, preferences: {} });
+		return { userDataDir, sites: {} };
+	}
+
+	const wizardSite = path.join(FIXTURE_ROOT, 'wordpress-develop');
+	const readySite = path.join(FIXTURE_ROOT, 'my-first-patch');
+	const staleSite = path.join(FIXTURE_ROOT, 'older-site');
+
+	for (const site of [wizardSite, readySite, staleSite]) {
+		fs.mkdirSync(path.join(site, 'wp-content'), { recursive: true });
+	}
+	fs.writeFileSync(path.join(readySite, 'wp-content', 'debug.log'), DEBUG_LOG_LINES);
+
+	// Dates are fixed, not computed from "now": the amber staleness dot needs
+	// staleSite to be more than 14 days behind, and the other two to be fresh
+	// enough not to be flagged. Retaking the screenshots years from now flips
+	// the fresh sites amber too — bump these dates when that happens.
+	writeSettings(userDataDir, {
+		sites: [wizardSite, readySite, staleSite],
+		siteMeta: {
+			[wizardSite]: {
+				initialized: true,
+				createdAt: '2026-08-09T10:00:00.000Z',
+				label: 'wordpress-develop',
+				trunkDate: '2026-08-09T09:00:00.000Z'
+			},
+			[readySite]: {
+				initialized: true,
+				createdAt: '2026-08-01T10:00:00.000Z',
+				label: 'my-first-patch',
+				trunkDate: '2026-08-08T09:00:00.000Z',
+				skipInitWizard: true,
+				tracTicket: '60000'
+			},
+			[staleSite]: {
+				initialized: true,
+				createdAt: '2026-06-01T10:00:00.000Z',
+				label: 'older-site',
+				trunkDate: '2026-06-01T09:00:00.000Z',
+				skipInitWizard: true
+			}
+		},
+		preferences: {
+			wporgHandle: 'contributor',
+			contributionEvent: 'WordCamp Example 2026'
+		}
+	});
+
+	return { userDataDir, sites: { wizardSite, readySite, staleSite } };
+}
+
+function writeSettings(userDataDir, settings) {
+	fs.writeFileSync(
+		path.join(userDataDir, 'settings.json'),
+		JSON.stringify(settings, null, '\t')
+	);
+}
+
+/** Removes the fixture site directories. userData dirs live under os.tmpdir() and are left to the OS. */
+function cleanFixtureSites() {
+	fs.rmSync(FIXTURE_ROOT, { recursive: true, force: true });
+}
+
+module.exports = { buildFixture, cleanFixtureSites, FIXTURE_ROOT };

--- a/scripts/screenshots/shots.cjs
+++ b/scripts/screenshots/shots.cjs
@@ -1,0 +1,183 @@
+// The declarative list of documentation screenshots.
+//
+// Each entry is { slug, tier, variant, prepare, target }:
+//   - slug: the output filename, docs/public/screenshots/<slug>.png — docs pages
+//     reference these names, so renaming one is a docs change too;
+//   - tier 'fixture': captured fully automatically against seeded state;
+//     tier 'live': needs a real, initialized site and a maintainer at the
+//     keyboard (the harness pauses and says what to set up);
+//   - variant: which fixture the shot needs ('seeded' or 'empty');
+//   - prepare(page): drives the UI to the state worth photographing. Selectors
+//     go by the words on screen, same as the repo's hand-testing convention —
+//     if a label changes, the shot fails loudly instead of photographing the
+//     wrong thing;
+//   - target (optional): a locator for an element screenshot instead of the
+//     whole window. Panels read better cropped; whole-window shots orient.
+
+/**
+ * Clicks a site in the sidebar and waits for its view to render.
+ *
+ * @param {import('playwright-core').Page} page
+ * @param {string}                         label
+ */
+async function selectSite(page, label) {
+	await page.getByText(label, { exact: true }).first().click();
+}
+
+/**
+ * Locates a site-view card by its heading text (the cards are styled divs, not
+ * landmarks). Every site's view is in the DOM at once — only the selected one
+ * is visible — so the visibility filter is what picks the right card.
+ *
+ * @param {import('playwright-core').Page} page
+ * @param {string}                         heading
+ */
+function card(page, heading) {
+	return page
+		.locator(`div:has(> div:text-is("${heading}"))`)
+		.filter({ visible: true })
+		.last();
+}
+
+const shots = [
+	{
+		slug: 'empty-state',
+		tier: 'fixture',
+		variant: 'empty',
+		prepare: async (page) => {
+			await page.getByText('No sites yet.').first().waitFor();
+		}
+	},
+	{
+		slug: 'create-site-modal',
+		tier: 'fixture',
+		variant: 'empty',
+		prepare: async (page) => {
+			await page.getByRole('button', { name: 'Create WordPress Core site' }).click();
+			await page.getByRole('dialog').getByText('Site name').waitFor();
+		}
+	},
+	{
+		slug: 'setup-wizard',
+		tier: 'fixture',
+		variant: 'seeded',
+		prepare: async (page) => {
+			await selectSite(page, 'wordpress-develop');
+			await page.getByText('Initial setup checklist').waitFor();
+		}
+	},
+	{
+		slug: 'site-view',
+		tier: 'fixture',
+		variant: 'seeded',
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await page.getByRole('button', { name: 'Submit changes' }).waitFor();
+		}
+	},
+	{
+		slug: 'site-menu',
+		tier: 'fixture',
+		variant: 'seeded',
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await page.getByRole('button', { name: 'More' }).click();
+			await page.getByRole('menuitem', { name: 'Update to latest trunk' }).waitFor();
+		}
+	},
+	{
+		slug: 'stale-site-notice',
+		tier: 'fixture',
+		variant: 'seeded',
+		prepare: async (page) => {
+			await selectSite(page, 'older-site');
+			await page.getByText(/days old/).first().waitFor();
+		}
+	},
+	{
+		slug: 'trac-ticket-panel',
+		tier: 'fixture',
+		variant: 'seeded',
+		target: (page) => card(page, 'Trac ticket'),
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await page.getByText('#60000').waitFor();
+		}
+	},
+	{
+		slug: 'apply-patch-panel',
+		tier: 'fixture',
+		variant: 'seeded',
+		target: (page) => card(page, 'Apply a patch or PR'),
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await card(page, 'Apply a patch or PR').waitFor();
+		}
+	},
+	{
+		slug: 'terminal',
+		tier: 'fixture',
+		variant: 'seeded',
+		target: (page) => card(page, 'Terminal'),
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await card(page, 'Terminal').waitFor();
+		}
+	},
+	{
+		slug: 'debug-log',
+		tier: 'fixture',
+		variant: 'seeded',
+		target: (page) => card(page, 'Logs'),
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await page.getByRole('tab', { name: /debug\.log/ }).filter({ visible: true }).click();
+			await page.getByText('PHP Notice', { exact: false }).filter({ visible: true }).first().waitFor();
+		}
+	},
+	{
+		slug: 'mail-panel',
+		tier: 'fixture',
+		variant: 'seeded',
+		target: (page) => card(page, 'Mail'),
+		prepare: async (page) => {
+			await selectSite(page, 'my-first-patch');
+			await page.getByText('No emails yet.').filter({ visible: true }).waitFor();
+		}
+	},
+
+	// ---- Live tier: real site, maintainer present. `instructions` is what the
+	// harness prints before pausing.
+	{
+		slug: 'dev-server-running',
+		tier: 'live',
+		instructions:
+			'Select an initialized site and click "Start dev server". Wait until the site URL and "Log in with admin / password" are visible.'
+	},
+	{
+		slug: 'submit-changes-diff',
+		tier: 'live',
+		instructions:
+			'On a site with edited files, click "Submit changes" and wait for the diff to finish generating.'
+	},
+	{
+		slug: 'submit-destinations',
+		tier: 'live',
+		instructions:
+			'In the "Submit changes" modal, continue past the diff until the three destination cards (pull request / Trac / mentor) are visible.'
+	},
+	{
+		slug: 'github-sign-in',
+		tier: 'live',
+		instructions:
+			'Choose "Open a pull request" while signed out, so the GitHub sign-in screen is visible. Stop before entering the device code.'
+	},
+	{
+		slug: 'trunk-update-progress',
+		tier: 'live',
+		instructions:
+			'Start "Update to latest trunk" on a site and wait until the step list is mid-run.'
+	}
+];
+
+module.exports = { shots };

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,28 @@ const { parseEventName, buildProvenanceHeader, handoffFilename } = require('./pa
 const { describeRefused } = require('./safe-log');
 const { detectEditors, matchDetectedEditor, openSiteInEditor, REFUSAL_REASONS } = require('./editor-launch');
 
+// Screenshot harness only (scripts/screenshots/): point userData at a throwaway
+// directory so a seeded settings.json is read instead of the contributor's real
+// site registry. Must run before `ready` — electron-store resolves its file path
+// from userData on first use. Guarded to dev runs: a packaged app ignores the
+// variable, so no installed build can be redirected to an attacker-chosen store
+// path via environment.
+//
+// The call is wrapped because `setPath` throws when the directory does not exist,
+// and this runs at module scope — before initLogging() and before any window, so
+// an uncaught throw here kills `npm start` with a stack on stdout and nothing in
+// the log file. A stale variable left in a shell profile, or a temp directory the
+// OS has since reaped, is enough to hit it. Falling back to the real userData is
+// wrong for the harness but right for the contributor, and the harness always
+// passes a directory it just created.
+if (!app.isPackaged && process.env.TOOLKIT_USER_DATA_DIR) {
+	try {
+		app.setPath('userData', process.env.TOOLKIT_USER_DATA_DIR);
+	} catch (e) {
+		process.stderr.write(`Ignoring TOOLKIT_USER_DATA_DIR: ${String(e && e.message ? e.message : e)}\n`);
+	}
+}
+
 const WORDPRESS_GIT_URL = 'https://github.com/WordPress/wordpress-develop.git';
 
 // Provide a PATH shim so npm's spawned scripts can find a 'node' binary that maps to Electron's Node

--- a/test/user-data-override.test.cjs
+++ b/test/user-data-override.test.cjs
@@ -1,0 +1,113 @@
+'use strict';
+
+// The screenshot harness (scripts/screenshots/) redirects the app's userData with
+// TOOLKIT_USER_DATA_DIR so a seeded settings.json is read instead of the
+// contributor's real site registry. That redirect is deliberately narrow: it
+// must work in a dev run and be dead in a packaged app, because an installed
+// build that honours it could be pointed at an attacker-chosen store path
+// through nothing but an environment variable.
+//
+// These tests load src/main.js under a stubbed `electron` (the same
+// Module._load trick as test/ipc-wiring.test.cjs) and assert both sides of
+// that guard — cut either condition in main.js and one of them fails.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
+
+const MAIN_PATH = path.join(__dirname, '..', 'src', 'main.js');
+
+function createElectronStub({ isPackaged, setPathThrows = false }) {
+	const setPathCalls = [];
+	class BrowserWindowStub {
+		static getAllWindows() { return []; }
+		on() {}
+		once() {}
+	}
+	return {
+		setPathCalls,
+		electron: {
+			app: {
+				isPackaged,
+				setPath: (name, value) => {
+					setPathCalls.push({ name, value });
+					// Electron throws here when the directory does not exist.
+					if (setPathThrows) throw new Error('Failed to set path');
+				},
+				// Never settles: nothing in the ready path is under test here.
+				whenReady: () => new Promise(() => {}),
+				on() {},
+				quit() {},
+				exit() {},
+				getPath: () => os.tmpdir(),
+				getAppPath: () => path.join(__dirname, '..'),
+				getName: () => 'wordpress-contributor-toolkit',
+				setName() {},
+				getVersion: () => '0.0.0-test'
+			},
+			BrowserWindow: BrowserWindowStub,
+			Menu: { buildFromTemplate: (t) => ({ t }), setApplicationMenu() {} },
+			ipcMain: { handle() {}, handleOnce() {}, on() {}, once() {} },
+			dialog: {},
+			shell: {}
+		}
+	};
+}
+
+// main.js runs the guard at require time, so each case needs a fresh load:
+// swap Module._load, set the environment, require, then restore everything.
+function loadMainWith({ isPackaged, envValue, setPathThrows = false }) {
+	const stub = createElectronStub({ isPackaged, setPathThrows });
+	const originalLoad = Module._load;
+	const originalEnv = process.env.TOOLKIT_USER_DATA_DIR;
+	if (envValue === undefined) delete process.env.TOOLKIT_USER_DATA_DIR;
+	else process.env.TOOLKIT_USER_DATA_DIR = envValue;
+	Module._load = function (request, parent, isMain) {
+		if (request === 'electron') return stub.electron;
+		return originalLoad.call(this, request, parent, isMain);
+	};
+	try {
+		delete require.cache[require.resolve(MAIN_PATH)];
+		require(MAIN_PATH);
+	} finally {
+		Module._load = originalLoad;
+		delete require.cache[require.resolve(MAIN_PATH)];
+		if (originalEnv === undefined) delete process.env.TOOLKIT_USER_DATA_DIR;
+		else process.env.TOOLKIT_USER_DATA_DIR = originalEnv;
+	}
+	return stub.setPathCalls;
+}
+
+test('dev run with TOOLKIT_USER_DATA_DIR set redirects userData to that dir', () => {
+	const target = path.join(os.tmpdir(), 'wpct-userdata-test');
+	const calls = loadMainWith({ isPackaged: false, envValue: target });
+	assert.deepEqual(calls, [{ name: 'userData', value: target }]);
+});
+
+test('dev run without the variable leaves userData alone', () => {
+	const calls = loadMainWith({ isPackaged: false, envValue: undefined });
+	assert.deepEqual(calls, []);
+});
+
+test('a directory that no longer exists does not stop the app from starting', () => {
+	// setPath throws when the target is missing — a stale variable in a shell
+	// profile, or a temp directory the OS has reaped. This runs at module scope,
+	// before any logging or window exists, so an uncaught throw here would be a
+	// stack on stdout and a launch that never happens.
+	const target = path.join(os.tmpdir(), 'wpct-userdata-gone');
+	let calls;
+	assert.doesNotThrow(() => {
+		calls = loadMainWith({ isPackaged: false, envValue: target, setPathThrows: true });
+	});
+	assert.deepEqual(calls, [{ name: 'userData', value: target }]);
+});
+
+test('a packaged app ignores TOOLKIT_USER_DATA_DIR entirely', () => {
+	const calls = loadMainWith({
+		isPackaged: true,
+		envValue: path.join(os.tmpdir(), 'wpct-userdata-test')
+	});
+	assert.deepEqual(calls, []);
+});


### PR DESCRIPTION
## Why

A user guide needs pictures of the screens it describes, and they have to be **retakeable** by
whoever changes the UI — a screenshot nobody can regenerate is a screenshot that goes stale and
starts lying. This adds the harness. The images themselves land with the guide in #232.

Stacked on #230; review that one first.

## What changes

- `npm run shots` launches the repo's own Electron binary through **playwright-core**'s Electron
  driver, drives each documented screen by the words on it, and writes a fixed-size PNG into
  `docs/public/screenshots/`. Eleven screens are declared today.
- A new **`TOOLKIT_USER_DATA_DIR`** hook in `src/main.js` (10 lines) points `userData` at a
  throwaway directory holding a seeded `settings.json`, so the harness never reads or writes the
  contributor's real site registry.
- `test/user-data-override.test.cjs` pins **both sides** of that hook's guard.
- Screens a seeded registry cannot reach — a running dev server, a real diff, the GitHub
  device-code screen — are declared as a **live tier** rather than faked:
  `npm run shots -- --tier=live` prompts for each and waits.

<details>
<summary>Why these specific choices</summary>

**`playwright-core`, not `playwright`** — same Electron driver, no postinstall script, no browser
download, so no new entry in `allowScripts`. If #70 lands `@playwright/test`, this direct
dependency can go and the harness can require the driver from there; the note is in the file.

**Under `scripts/`, not `e2e/`** — it is a CLI, not a test. #70 makes `e2e/` the Playwright
`testDir`, and nothing here is run by `npm run test:e2e`. It also means no new ESLint exemption:
`scripts/**/*.cjs` already allows `console`.

**Username-free fixture paths** (`/tmp/wpct-docs-fixture/...`) — `safe-log.js` redacts logs, but
nothing redacts a screenshot, and every path the app renders ends up in a published image.

**Captured locally, not in CI** — capturing needs the app running against a seeded site, which is
minutes of flaky work on a runner for images that change rarely.
</details>

## How to test this

**Starting state:** a machine that has used the app before, so you have **real sites registered**.
`npm ci` done on this branch.

1. Launch the app normally (`npm start`) and note your real sites in the sidebar. Quit.
2. `npm run shots` — the app opens and closes a few times; expect eleven `✓ <name>.png` lines and
   the files under `docs/public/screenshots/`.
3. Open each PNG. Every path visible must start `/tmp/wpct-docs-fixture/` — **your home directory
   must appear nowhere**.
4. `npm start` again — your real sites are still there, exactly as in step 1.
5. `npm run shots -- --only=terminal` captures just that one; `--only=nope` fails and lists the
   valid slugs.
6. `npm test` — green, including the three new guard tests.

**Must not have happened:** your real `settings.json` must be untouched (step 4 is the check), and
no packaged build may honour the variable — the third guard test is what pins that.

**Platforms:** driven on macOS. The fixture root falls back to `os.tmpdir()` on Windows, which is
the part most worth a second pair of eyes; the harness is a developer tool, so a Windows failure
costs a retake, not a shipped bug.

## Risks

`src/main.js` gains an environment-driven `app.setPath` call. It is guarded by `!app.isPackaged`,
so an installed build ignores it — that guard is the whole security story here and the reason the
test asserts the packaged case explicitly.

Nothing automated catches a **stale** screenshot. CONTRIBUTING now says a UI-changing PR re-runs
`npm run shots`; that is a convention, not a gate.

## Related

Stack: #230 → this → #232 (guide content).
Related to #70: it defines `e2e/` as the Playwright test directory, which is why this lives in
`scripts/`. No change needed there.

---

<details>
<summary><b>Self-review</b> — 2 findings fixed, 1 follow-up taken anyway, security guard verified</summary>

Ran `.github/instructions/code-review.instructions.md` with the judgement pass in a fresh context.
Deterministic layer was clean.

**2 [fix here] · 1 [follow-up]. All three fixed:**

| Dimension | Was | Now |
|---|---|---|
| architecture 🔵 | `app.setPath` throws when the directory does not exist (Electron typings, `electron.d.ts:1781`). It sat at module scope, before `initLogging()` and before any window, so a stale `TOOLKIT_USER_DATA_DIR` in a shell profile — or a temp dir the OS reaped — killed `npm start` with a stack on stdout and nothing in the log file | wrapped; a bad value is reported on stderr and the real userData is kept. A fourth test covers it, and it **fails without the fix** (verified by reverting the guard) |
| cross-platform 🔵 | `spawnSync('npm', …, { shell: true on Windows })` — a bare host `npm` and a Windows shell, both shapes the standard calls out | deleted. `"shots": "npm run build:once && node …"` does the same job with no spawn, no shell, no `existsSync` |
| architecture 🔵 | the live tier called `launchApp({})`, and `launchApp` spreads `process.env` — so an exported `TOOLKIT_USER_DATA_DIR` (easiest to acquire while debugging the fixture tier) would silently point the "your real sites" tier at fixture state, producing committed screenshots that are wrong in a way only a careful look at the sidebar reveals | passes `TOOLKIT_USER_DATA_DIR: undefined` explicitly. Taken despite being `[follow-up]`: one line, and the failure mode is a wrong published image |

**The security guard was checked hard and stands.** Nothing required above the hook resolves
`userData` at require time — `settings-store.js` defers its `import('electron-store')` to the first
`getStore()`, and `logging.js` only reads `app.getPath('logs')` inside `initLogging()`. `sessionData`
follows the override too, since it resolves lazily from `userData` pre-`ready`. A packaged build is
genuinely dead to the variable.

**And the test was checked against the "green while proving nothing" list.** It requires the real
`src/main.js` under a stubbed `electron` and asserts on calls the real guard makes; deleting either
condition fails a case. `Module._load`, `process.env` and the require-cache entry all restore in a
`finally`, and `node --test` gives each file its own process, so there is no cross-file leak.

**Also verified:** `playwright-core` has no `scripts` field and no `hasInstallScript` in the
lockfile, so it owes no `allowScripts` entry and downloads no browsers. `cleanFixtureSites` can only
remove the one module-level fixture root; userData dirs come from `mkdtempSync`; an unexpected
`variant` still writes only under those roots.
</details>
