### PR TITLE
Say on the card when there are unsubmitted changes, and give them a way out

### DIFF
--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -19,20 +19,36 @@ const DISCARD_CONFIRM_MESSAGE = 'Discard all local changes? This cannot be undon
  * `changedCount` can be missing: the dirty probe may have answered before a
  * count existed, and "You have changes" is still true then.
  *
+ * The action labels move with the placement. By the buttons the modal has
+ * not been named yet, so the link says what it produces — a patch. In the
+ * ticket card the sentence already says where the changes are going, so the
+ * link borrows the modal's own name, "review and submit". The ticket card
+ * also carries a reassurance the buttons never need: Unlink sits right
+ * above, and the changes must not look like they hang on it.
+ *
  * @param {{dirty?: boolean, changedCount?: number, tracTicket?: *}} state
  * @return {{placement: 'buttons'|'ticket', lead: string, patchLabel: string,
- *          middle: string, discardLabel: string, end: string}|null}
+ *          middle: string, discardLabel: string, end: string,
+ *          unlinkNote?: string}|null}
  */
 function changesNoteParts({ dirty, changedCount, tracTicket } = {}) {
 	if (!dirty) return null;
 	const count = Number.isInteger(changedCount) && changedCount > 0 ? changedCount : null;
 	const noun = count === 1 ? 'change' : 'changes';
-	const lead = tracTicket
-		? `You have ${count === null ? '' : `${count} `}unsubmitted ${noun} for ticket #${tracTicket}. You can `
-		: `You have ${count === null ? '' : `${count} `}${noun} not assigned to any ticket. You can `;
+	if (tracTicket) {
+		return {
+			placement: 'ticket',
+			lead: `You have ${count === null ? '' : `${count} `}unsubmitted ${noun} for ticket #${tracTicket}. You can `,
+			patchLabel: 'review and submit',
+			middle: ' or ',
+			discardLabel: 'discard your changes',
+			end: '.',
+			unlinkNote: 'Unlinking this ticket does not touch your changes — they stay in this site, ready for when you link it again.'
+		};
+	}
 	return {
-		placement: tracTicket ? 'ticket' : 'buttons',
-		lead,
+		placement: 'buttons',
+		lead: `You have ${count === null ? '' : `${count} `}${noun} not assigned to any ticket. You can `,
 		patchLabel: 'create and save a patch',
 		middle: ' or ',
 		discardLabel: 'discard your changes',

--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -43,7 +43,7 @@ function changesNoteParts({ dirty, changedCount, tracTicket } = {}) {
 			middle: ' or ',
 			discardLabel: 'discard your changes',
 			end: '.',
-			unlinkNote: 'Unlinking this ticket does not touch your changes — they stay in this site, ready for when you link it again.'
+			unlinkNote: 'Unlinking this ticket doesn\'t affect your local changes for this ticket — they remain attached to it in this site, ready for when you link it again.'
 		};
 	}
 	return {

--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -1,0 +1,83 @@
+// What the card says about unsubmitted changes, and when a discard may run.
+//
+// The note under the buttons is the first place the app admits the working
+// tree is dirty without the contributor opening the patch modal to find out.
+// Its sentence branches three ways — clean tree, dirty with a linked ticket,
+// dirty without one — and where it renders moves with the ticket: a change
+// that belongs to #12345 is news for the ticket card, a change that belongs
+// to nothing is news for the buttons that would give it somewhere to go.
+'use strict';
+
+// Byte-identical to the confirm the dirty-update modal has always used, so
+// the same action reads the same everywhere it can be triggered.
+const DISCARD_CONFIRM_MESSAGE = 'Discard all local changes? This cannot be undone.';
+
+/**
+ * The changes note, split into parts the component interleaves with its two
+ * link buttons, or null when there is nothing to say.
+ *
+ * `changedCount` can be missing: the dirty probe may have answered before a
+ * count existed, and "You have changes" is still true then.
+ *
+ * @param {{dirty?: boolean, changedCount?: number, tracTicket?: *}} state
+ * @return {{placement: 'buttons'|'ticket', lead: string, patchLabel: string,
+ *          middle: string, discardLabel: string, end: string}|null}
+ */
+function changesNoteParts({ dirty, changedCount, tracTicket } = {}) {
+	if (!dirty) return null;
+	const count = Number.isInteger(changedCount) && changedCount > 0 ? changedCount : null;
+	const noun = count === 1 ? 'change' : 'changes';
+	const lead = tracTicket
+		? `You have ${count === null ? '' : `${count} `}unsubmitted ${noun} for ticket #${tracTicket}. You can `
+		: `You have ${count === null ? '' : `${count} `}${noun} not assigned to any ticket. You can `;
+	return {
+		placement: tracTicket ? 'ticket' : 'buttons',
+		lead,
+		patchLabel: 'create and save a patch',
+		middle: ' or ',
+		discardLabel: 'discard your changes',
+		end: '.'
+	};
+}
+
+/**
+ * A `git:discard-changes` reply turned into something the card can render.
+ * Failure always carries a message — a discard that silently did nothing
+ * would leave the contributor believing their tree is clean.
+ *
+ * @param {*} res
+ * @return {{ok: true}|{ok: false, message: string}}
+ */
+function discardOutcome(res) {
+	if (res && res.ok) return { ok: true };
+	return { ok: false, message: `Failed to discard changes: ${res && res.error ? res.error : 'Unknown error'}` };
+}
+
+/**
+ * Whether the modal's discard link is inert: while the diff is loading there
+ * is nothing to confirm against, with no changes there is nothing to lose,
+ * and mid-discard a second click would race the first.
+ *
+ * @param {{patchLoading?: boolean, patchHasChanges?: boolean, discarding?: boolean}} state
+ * @return {boolean}
+ */
+function modalDiscardDisabled({ patchLoading, patchHasChanges, discarding } = {}) {
+	return Boolean(patchLoading || discarding || !patchHasChanges);
+}
+
+/**
+ * Whether a discard may run at all right now. The same states that block
+ * starting a trunk update block a discard, and for the same reason: both
+ * rewrite the tree under whatever npm is doing to it, and a force checkout
+ * under a running install, build or dev server leaves a tree neither side
+ * finished.
+ *
+ * @param {{isUpdating?: boolean, installing?: boolean, building?: boolean,
+ *          devServerActive?: boolean, discarding?: boolean}} state
+ * @return {boolean}
+ */
+function discardBlocked({ isUpdating, installing, building, devServerActive, discarding } = {}) {
+	return Boolean(isUpdating || installing || building || devServerActive || discarding);
+}
+
+module.exports = { changesNoteParts, discardOutcome, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2482,10 +2482,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // One discard for both entry points — the note's link and the modal's. The
   // confirm is the same native one the dirty-update modal uses; the user has
   // already chosen, this is the last chance to notice they chose wrong.
-  // Both links disable through discardBlocked, and the handler re-checks it:
-  // the states it names can flip while the confirm dialog is up.
+  // Both links disable through discardBlocked; no re-check in here. The
+  // native confirm blocks the renderer, so the states discardBlocked names
+  // cannot flip while the dialog is up — a check after it would read the
+  // same render-time values the disabled prop already enforced.
   const discardAllChanges = () => confirmAnd(DISCARD_CONFIRM_MESSAGE, async () => {
-    if (discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })) return;
     setDiscarding(true);
     setDiscardError(null);
     try {

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3448,6 +3448,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             {changesNote && changesNote.placement === 'ticket' ? (
               <div style={{ marginTop: 8, fontSize: 13, color: '#1d2327' }}>
                 {changesNoteBody}
+                <div style={{ marginTop: 4, fontSize: 12, color: '#6c6f72' }}>{changesNote.unlinkNote}</div>
               </div>
             ) : null}
 

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -34,6 +34,7 @@ import { parsePrRef } from '../patch-sources.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { highlightDiff } from './diff-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
+import { changesNoteParts, discardOutcome, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // Shared by both log panes so the tabs cannot drift apart visually.
@@ -1032,6 +1033,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // the first press's timer, and so an unmount does not leave one running.
   const copyFeedbackTimer = useRef(null);
   const [patchSaveError, setPatchSaveError] = useState('');
+  // The unsubmitted-changes note. Null until the first probe answers, so a
+  // card never opens on a note that a clean tree then takes away.
+  const [worktreeDirty, setWorktreeDirty] = useState(null);
+  const [discarding, setDiscarding] = useState(false);
+  const [discardError, setDiscardError] = useState(null);
   const [handleInput, setHandleInput] = useState('');
   const [eventInput, setEventInput] = useState('');
   const [handleError, setHandleError] = useState('');
@@ -1373,6 +1379,46 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     finally { setStatusLoading(false); }
   }, [sitePath]);
   useEffect(()=>{ loadStatus(); }, [loadStatus]);
+
+  // The note's probe. A failed probe keeps the last answer rather than
+  // reporting: the note is advisory, and losing it over a transient git error
+  // would read as "your changes are gone".
+  //
+  // The ref guards two races the probe's cost makes real — it walks the whole
+  // checkout, so it can still be in flight when the next focus fires or when
+  // a discard answers the question locally. `inFlight` keeps walks from
+  // stacking; `generation` lets a local answer outrank a probe that started
+  // before it, so a stale "dirty" cannot resurrect the note over a tree that
+  // was just reset.
+  const dirtyProbeRef = useRef({ inFlight: false, generation: 0 });
+  const markTreeClean = () => {
+    dirtyProbeRef.current.generation++;
+    setWorktreeDirty({ dirty: false, changedCount: 0 });
+  };
+  const refreshDirty = useCallback(async () => {
+    const probe = dirtyProbeRef.current;
+    if (probe.inFlight) return;
+    probe.inFlight = true;
+    const generation = probe.generation;
+    try {
+      const res = await window.api.isWorktreeDirty(sitePath);
+      if (res && res.ok && probe.generation === generation) {
+        setWorktreeDirty({ dirty: Boolean(res.dirty), changedCount: res.changedCount });
+      }
+    } catch {}
+    finally { probe.inFlight = false; }
+  }, [sitePath]);
+
+  // Only the open card probes, and only while it is open: the probe walks the
+  // whole checkout, which is too much to pay for every card on the shelf. The
+  // edits themselves happen in an external editor, so returning focus to the
+  // app is the moment the answer can have changed.
+  useEffect(() => {
+    if (!isActive) return undefined;
+    refreshDirty();
+    window.addEventListener('focus', refreshDirty);
+    return () => window.removeEventListener('focus', refreshDirty);
+  }, [isActive, refreshDirty]);
 
   // Linking and unlinking are the same write (#109): an empty ref clears the
   // association, so Unlink needs no second channel.
@@ -1961,6 +2007,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // --- Update to latest trunk (#94) ---
   const age = trunkAgeInfo({ trunkDate });
   const isUpdating = updateState !== 'idle';
+  // Where the note goes moves with the ticket: a change that belongs to
+  // #12345 is news for the ticket card, one that belongs to nothing is news
+  // for the buttons that would give it somewhere to go.
+  const changesNote = changesNoteParts({ ...(worktreeDirty || {}), tracTicket });
   const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
   const updateStepStates = updateStepStatuses(updateSteps, updateState);
 
@@ -1970,6 +2020,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setUpdateState('idle');
     if (message) writeToTerminal(message);
     loadStatus().catch(() => {});
+    refreshDirty();
   };
 
   // Steps 2 and 3 of the chain: npm install (only when the lockfile moved,
@@ -2047,6 +2098,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setApplyState('idle');
     if (message) writeToTerminal(message);
     loadStatus().catch(() => {});
+    refreshDirty();
   };
 
   const runApplyInstallAndBuild = (needsInstall, verb) => {
@@ -2350,6 +2402,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         return;
       }
       savedPatchPathRef.current = res.filePath;
+      markTreeClean();
       setDirtyModalOpen(false);
       writeToTerminal(`\nSaved your changes to ${res.filePath} and reset the working tree.\n`);
       beginTrunkUpdate();
@@ -2358,13 +2411,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     }
   };
 
-  const dirtyDiscardAndUpdate = () => confirmAnd('Discard all local changes? This cannot be undone.', async () => {
+  const dirtyDiscardAndUpdate = () => confirmAnd(DISCARD_CONFIRM_MESSAGE, async () => {
     setDirtyError(null);
     const d = await window.api.discardChanges(sitePath);
     if (!d || !d.ok) {
       setDirtyError(`Failed to discard changes: ${d && d.error ? d.error : 'Unknown error'}`);
       return;
     }
+    markTreeClean();
     setDirtyModalOpen(false);
     writeToTerminal('\nDiscarded local changes.\n');
     beginTrunkUpdate();
@@ -2387,13 +2441,29 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     runUpdateInstallAndBuild(true);
   };
 
+  // The diff fetch, shared by opening the modal and by a discard that happens
+  // while it is open — the pane has to show what the tree now holds, which
+  // after a discard is the "nothing to send" banner.
+  const loadPatchText = async () => {
+    setPatchLoading(true);
+    try {
+      const res = await window.api.getPatch(sitePath);
+      if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
+      else setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
+    } catch (e) {
+      setPatchText(`Error: ${e && e.message ? e.message : String(e)}`);
+    } finally {
+      setPatchLoading(false);
+    }
+  };
+
   const openPatchModal = async ()=>{
     setIsPatchOpen(true);
-    setPatchLoading(true);
     setPatchText('');
     // Last time's outcome belongs to last time's patch.
     setPatchSaved(null);
     setPatchSaveError('');
+    setDiscardError(null);
     setHandleError('');
     setEditingHandle(false);
     // Same rule for the pull request card: last time's outcome belongs to last
@@ -2406,16 +2476,51 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setGithubError('');
     setGithubDeclined(false);
     loadGithubAccount();
-    try {
-      const res = await window.api.getPatch(sitePath);
-      if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
-      else setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
-    } catch (e) {
-      setPatchText(`Error: ${e && e.message ? e.message : String(e)}`);
-    } finally {
-      setPatchLoading(false);
-    }
+    await loadPatchText();
   };
+
+  // One discard for both entry points — the note's link and the modal's. The
+  // confirm is the same native one the dirty-update modal uses; the user has
+  // already chosen, this is the last chance to notice they chose wrong.
+  // Both links disable through discardBlocked, and the handler re-checks it:
+  // the states it names can flip while the confirm dialog is up.
+  const discardAllChanges = () => confirmAnd(DISCARD_CONFIRM_MESSAGE, async () => {
+    if (discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })) return;
+    setDiscarding(true);
+    setDiscardError(null);
+    try {
+      let outcome;
+      try {
+        outcome = discardOutcome(await window.api.discardChanges(sitePath));
+      } catch (e) {
+        // A rejected invoke never returns a reply object; shape it into one so
+        // the failure reaches the same red line instead of vanishing.
+        outcome = discardOutcome({ ok: false, error: e && e.message ? e.message : String(e) });
+      }
+      if (!outcome.ok) {
+        setDiscardError(outcome.message);
+        return;
+      }
+      markTreeClean();
+      setAppliedPatch(null);
+      writeToTerminal('\nDiscarded local changes.\n');
+      if (isPatchOpen) await loadPatchText();
+    } finally {
+      setDiscarding(false);
+    }
+  });
+
+  // The sentence is one thing wherever it renders; only the wrapper differs.
+  const changesNoteBody = changesNote ? (
+    <>
+      {changesNote.lead}
+      <Button variant="link" onClick={openPatchModal} disabled={isUpdating}>{changesNote.patchLabel}</Button>
+      {changesNote.middle}
+      <Button variant="link" isDestructive onClick={discardAllChanges} disabled={discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}>{changesNote.discardLabel}</Button>
+      {changesNote.end}
+      {discardError ? <div style={{ color: '#d63638', fontSize: 12, marginTop: 4 }}>{discardError}</div> : null}
+    </>
+  ) : null;
 
   // Copying is the one action here with no visible result: the clipboard is
   // somewhere else, the diff does not move, and a button that answers nothing
@@ -3297,7 +3402,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               onClick={openPatchModal}
               disabled={isUpdating}
               style={{ padding: '10px 16px', borderRadius: 10 }}
-            >Submit changes</Button>
+            >Review & submit changes</Button>
             {running && serverUrl ? (
               <Button
                 variant="secondary"
@@ -3309,6 +3414,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               >Open Adminer</Button>
             ) : null}
           </div>
+          {changesNote && changesNote.placement === 'buttons' ? (
+            <div style={{ fontSize: 13, color: '#1d2327', paddingLeft: 2 }}>
+              {changesNoteBody}
+            </div>
+          ) : null}
           {(isServerStarting || serverUrl) ? (
             <div style={{ fontSize: 13, color: '#1d2327', paddingLeft: 2, display: 'flex', flexDirection: 'column', gap: 4 }}>
               {serverUrl ? (
@@ -3334,6 +3444,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <Button variant="link" onClick={() => window.api.openExternal(ticketUrl(tracTicket))}>Open in Trac</Button>
               <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketSaving}>Unlink</Button>
             </div>
+            {changesNote && changesNote.placement === 'ticket' ? (
+              <div style={{ marginTop: 8, fontSize: 13, color: '#1d2327' }}>
+                {changesNoteBody}
+              </div>
+            ) : null}
 
             <div style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
@@ -3810,7 +3925,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       ) : null}
       {isPatchOpen && (
         <Modal
-          title="Submit changes"
+          title="Review & submit changes"
           onRequestClose={()=>setIsPatchOpen(false)}
           shouldCloseOnClickOutside
           isFullScreen
@@ -3854,8 +3969,22 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div className="patch-diff">
                 <div style={{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:12, flexWrap:'wrap' }}>
                   <div>
-                    <div style={{ fontWeight:600, fontSize:14, color:'#1d2327' }}>Your changes</div>
+                    <div style={{ fontWeight:600, fontSize:14, color:'#1d2327', display:'flex', alignItems:'baseline', gap:4, flexWrap:'wrap' }}>
+                      Your changes
+                      <span style={{ fontWeight:400 }}>
+                        {'('}
+                        <Button
+                          variant="link"
+                          isDestructive
+                          onClick={discardAllChanges}
+                          disabled={modalDiscardDisabled({ patchLoading, patchHasChanges, discarding }) || discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}
+                          style={{ fontSize: 12 }}
+                        >Discard all changes</Button>
+                        {')'}
+                      </span>
+                    </div>
                     <div style={{ fontSize:12, color:'#6c6f72' }}>Everything this site has that its copy of trunk does not.</div>
+                    {discardError ? <div style={{ color:'#d63638', fontSize:12, marginTop:4 }}>{discardError}</div> : null}
                   </div>
                   {/*
                     Out of the diff and into the header: these used to float

--- a/test/changes-note.test.cjs
+++ b/test/changes-note.test.cjs
@@ -43,7 +43,7 @@ test('changesNoteParts reassures about Unlink only where Unlink is', () => {
 	const ticket = changesNoteParts({ dirty: true, changedCount: 1, tracTicket: '12345' });
 	assert.equal(
 		ticket.unlinkNote,
-		'Unlinking this ticket does not touch your changes — they stay in this site, ready for when you link it again.'
+		'Unlinking this ticket doesn\'t affect your local changes for this ticket — they remain attached to it in this site, ready for when you link it again.'
 	);
 	assert.equal(changesNoteParts({ dirty: true, changedCount: 1, tracTicket: null }).unlinkNote, undefined);
 });

--- a/test/changes-note.test.cjs
+++ b/test/changes-note.test.cjs
@@ -31,6 +31,23 @@ test('changesNoteParts places a ticketed note in the ticket card and names the t
 	assert.equal(parts.lead, 'You have 3 unsubmitted changes for ticket #12345. You can ');
 });
 
+test('changesNoteParts names the modal in the ticket card and the patch by the buttons', () => {
+	// The ticket sentence already says where the changes go, so its link
+	// borrows the modal's own name; by the buttons the link says what it
+	// produces instead.
+	assert.equal(changesNoteParts({ dirty: true, tracTicket: '12345' }).patchLabel, 'review and submit');
+	assert.equal(changesNoteParts({ dirty: true, tracTicket: null }).patchLabel, 'create and save a patch');
+});
+
+test('changesNoteParts reassures about Unlink only where Unlink is', () => {
+	const ticket = changesNoteParts({ dirty: true, changedCount: 1, tracTicket: '12345' });
+	assert.equal(
+		ticket.unlinkNote,
+		'Unlinking this ticket does not touch your changes — they stay in this site, ready for when you link it again.'
+	);
+	assert.equal(changesNoteParts({ dirty: true, changedCount: 1, tracTicket: null }).unlinkNote, undefined);
+});
+
 test('changesNoteParts uses the singular for one change', () => {
 	assert.equal(
 		changesNoteParts({ dirty: true, changedCount: 1, tracTicket: null }).lead,
@@ -57,12 +74,13 @@ test('changesNoteParts stays true when the count is missing', () => {
 	);
 });
 
-test('changesNoteParts always offers the same two actions', () => {
-	const parts = changesNoteParts({ dirty: true, changedCount: 2, tracTicket: null });
-	assert.equal(parts.patchLabel, 'create and save a patch');
-	assert.equal(parts.middle, ' or ');
-	assert.equal(parts.discardLabel, 'discard your changes');
-	assert.equal(parts.end, '.');
+test('changesNoteParts always offers a discard, in the same words', () => {
+	for (const tracTicket of [null, '12345']) {
+		const parts = changesNoteParts({ dirty: true, changedCount: 2, tracTicket });
+		assert.equal(parts.middle, ' or ');
+		assert.equal(parts.discardLabel, 'discard your changes');
+		assert.equal(parts.end, '.');
+	}
 });
 
 test('the confirm message matches the dirty-update modal byte for byte', () => {

--- a/test/changes-note.test.cjs
+++ b/test/changes-note.test.cjs
@@ -1,0 +1,110 @@
+// The changes note's sentence and placement, and the discard guards. All the
+// branching lives in changes-note.cjs so this suite can reach it without a
+// DOM; index.jsx only interleaves the parts with its two link buttons.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+	changesNoteParts,
+	discardOutcome,
+	modalDiscardDisabled,
+	discardBlocked,
+	DISCARD_CONFIRM_MESSAGE
+} = require('../src/renderer/changes-note.cjs');
+
+test('changesNoteParts says nothing about a clean tree', () => {
+	assert.equal(changesNoteParts({ dirty: false, changedCount: 0, tracTicket: null }), null);
+	assert.equal(changesNoteParts({ dirty: false, changedCount: 3, tracTicket: '12345' }), null);
+	assert.equal(changesNoteParts({}), null);
+	assert.equal(changesNoteParts(), null);
+});
+
+test('changesNoteParts places an unticketed note by the buttons', () => {
+	const parts = changesNoteParts({ dirty: true, changedCount: 3, tracTicket: null });
+	assert.equal(parts.placement, 'buttons');
+	assert.equal(parts.lead, 'You have 3 changes not assigned to any ticket. You can ');
+});
+
+test('changesNoteParts places a ticketed note in the ticket card and names the ticket', () => {
+	const parts = changesNoteParts({ dirty: true, changedCount: 3, tracTicket: '12345' });
+	assert.equal(parts.placement, 'ticket');
+	assert.equal(parts.lead, 'You have 3 unsubmitted changes for ticket #12345. You can ');
+});
+
+test('changesNoteParts uses the singular for one change', () => {
+	assert.equal(
+		changesNoteParts({ dirty: true, changedCount: 1, tracTicket: null }).lead,
+		'You have 1 change not assigned to any ticket. You can '
+	);
+	assert.equal(
+		changesNoteParts({ dirty: true, changedCount: 1, tracTicket: '12345' }).lead,
+		'You have 1 unsubmitted change for ticket #12345. You can '
+	);
+});
+
+test('changesNoteParts stays true when the count is missing', () => {
+	// A dirty answer can arrive without a usable count; "changes" is still
+	// accurate where "0 changes" would be a lie next to a discard link.
+	for (const changedCount of [undefined, 0, -1, 2.5]) {
+		assert.equal(
+			changesNoteParts({ dirty: true, changedCount, tracTicket: null }).lead,
+			'You have changes not assigned to any ticket. You can '
+		);
+	}
+	assert.equal(
+		changesNoteParts({ dirty: true, tracTicket: '12345' }).lead,
+		'You have unsubmitted changes for ticket #12345. You can '
+	);
+});
+
+test('changesNoteParts always offers the same two actions', () => {
+	const parts = changesNoteParts({ dirty: true, changedCount: 2, tracTicket: null });
+	assert.equal(parts.patchLabel, 'create and save a patch');
+	assert.equal(parts.middle, ' or ');
+	assert.equal(parts.discardLabel, 'discard your changes');
+	assert.equal(parts.end, '.');
+});
+
+test('the confirm message matches the dirty-update modal byte for byte', () => {
+	// index.jsx used this literal before the note existed; one action, one
+	// wording, wherever it is triggered from.
+	assert.equal(DISCARD_CONFIRM_MESSAGE, 'Discard all local changes? This cannot be undone.');
+});
+
+test('discardOutcome passes a success through', () => {
+	assert.deepEqual(discardOutcome({ ok: true }), { ok: true });
+});
+
+test('discardOutcome always carries a message on failure', () => {
+	assert.deepEqual(discardOutcome({ ok: false, error: 'EACCES' }), {
+		ok: false,
+		message: 'Failed to discard changes: EACCES'
+	});
+	assert.deepEqual(discardOutcome({ ok: false }), {
+		ok: false,
+		message: 'Failed to discard changes: Unknown error'
+	});
+	assert.deepEqual(discardOutcome(null), {
+		ok: false,
+		message: 'Failed to discard changes: Unknown error'
+	});
+});
+
+test('modalDiscardDisabled frees the link only for a loaded diff with changes', () => {
+	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: false }), false);
+	assert.equal(modalDiscardDisabled({ patchLoading: true, patchHasChanges: true, discarding: false }), true);
+	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: false, discarding: false }), true);
+	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: true }), true);
+	assert.equal(modalDiscardDisabled({}), true);
+	assert.equal(modalDiscardDisabled(), true);
+});
+
+test('discardBlocked holds the discard while anything is rewriting the tree', () => {
+	// The same states that block starting a trunk update: a force checkout
+	// under a running install, build or dev server corrupts both.
+	assert.equal(discardBlocked({}), false);
+	assert.equal(discardBlocked(), false);
+	for (const flag of ['isUpdating', 'installing', 'building', 'devServerActive', 'discarding']) {
+		assert.equal(discardBlocked({ [flag]: true }), true, flag);
+	}
+});


### PR DESCRIPTION
The card never admitted the working tree was dirty. A contributor's edits were invisible until they opened the patch modal, and the only way to discard them was buried inside the "Update to latest trunk?" dirty-tree flow.

## What this does

- **Renames "Submit changes" to "Review & submit changes"** (button and modal title) — the modal shows the diff *and* submits it, and the old name said only half of that.
- **Adds a note when the tree has unsubmitted changes**, with the two exits inline. Where it renders — and what the links say — moves with the ticket:
  - No ticket linked → under the buttons: "You have 3 changes not assigned to any ticket. You can *create and save a patch* or *discard your changes*."
  - Ticket linked → inside the Trac ticket card: "You have 1 unsubmitted change for ticket #62881. You can *review and submit* or *discard your changes*." — the link borrows the modal's own name there, since the sentence already says where the changes go. A muted line follows, because Unlink sits right above: "Unlinking this ticket doesn't affect your local changes for this ticket — they remain attached to it in this site, ready for when you link it again."
- **Adds a "(Discard all changes)" red link in the modal**, next to the "Your changes" heading, disabled while the diff loads or when there is nothing to lose. After a discard the pane re-fetches and shows the existing "nothing to send" banner.

## How

No main-process or preload changes: `git:worktree-dirty` and `git:discard-changes` already existed (and were already tested) — they were just only reachable from the dirty-update modal.

- The sentence variants, placement, discard guards and outcome shaping live in `src/renderer/changes-note.cjs` with their own suite, per the renderer-decisions-in-modules rule.
- The probe runs only for the open card, on activation and window focus (edits happen in an external editor, so refocus is when the answer can have changed). An in-flight guard keeps walks from stacking, and a generation counter lets a locally-known answer (a discard just succeeded) outrank a probe that started before it.
- Discarding is blocked by the same states that block starting a trunk update (`isUpdating`, install, build, dev server): a force checkout under a running build leaves a tree neither side finished. The native confirm blocks the renderer, so the disabled predicate is the whole guard — there is deliberately no post-confirm re-check, and the comment in the code says why.
- One shared discard handler for both entry points, using the same native confirm string as the dirty-update modal, byte for byte. Failures surface as red text next to whichever link was pressed; a rejected invoke is shaped into the same message.

## How to test this

Platforms: any.

1. Open a site, and from an external editor edit a tracked file and add a new untracked file. Refocus the app: the note appears under the buttons with the right count and pluralization.
2. Link a Trac ticket: the note moves into the Trac ticket card, names the ticket, reads "review and submit or discard your changes", and shows the unlink reassurance line under it. Unlink: the note moves back under the buttons with the patch wording.
3. Click *create and save a patch* (or *review and submit*): the modal opens, titled "Review & submit changes", showing the diff.
4. Click "(Discard all changes)" in the modal, confirm: the diff refreshes to "There is nothing to send yet…", the link disables. Close the modal: the note is gone.
5. Repeat via the note's *discard your changes* link with the modal closed. Cancel on the confirm first and verify nothing changed.
6. Start a build or the dev server: both discard links disable.

What must NOT have happened after a discard:

- `node_modules/` is still present and intact (the reset preserves it).
- The untracked file is deleted; the tracked file is back to trunk's content.
- No "patch applied" revert banner is left behind (`appliedPatch` is cleared).
- The note does not reappear on the next window refocus.
- A cancelled confirm leaves every file untouched.

## Risks and limitations

- The note refreshes on activation and window focus, not continuously — edits made while the app keeps focus appear on the next refocus.
- `changedCount` counts changed files, worded as "changes"; two edits in one file read as "1 change".

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Two self-review rounds (`.github/instructions/code-review.instructions.md`, judgement pass in a fresh subagent each time). `eslint .` and the full suite (634 tests) clean on both.

Round 1 — 4 [fix here] · 1 [follow-up]; all four fixed in-branch:
- performance 🟡 — focus probes could stack full-checkout walks → in-flight guard in `refreshDirty`.
- architecture 🟡 — a stale probe could resurrect the note over a just-reset tree → generation counter, local answers outrank older probes.
- architecture 🔵 — the new discard links bypassed the busy guard `startTrunkUpdate` has → `discardBlocked()` in the module, wired to both links.
- tests/architecture 🔵 — the disabled predicate lived inline in `index.jsx` and `discardError` outlived the modal → predicate extracted and tested; `openPatchModal` clears the error.

Round 2 — reconciled all round-1 findings as resolved, 0 [fix here] · 4 [follow-up]:
- architecture 🔵 (fixed anyway, in-branch) — the post-confirm `discardBlocked` re-check was a no-op whose comment claimed otherwise; removed, comment now states why the disabled predicate is the whole guard.
- performance 🟡 — every refocus still pays one full `statusMatrix` walk (serialized, not throttled); a minimum-interval timestamp would cap it.
- tests 🟡 — the probe's in-flight/generation rules live in `index.jsx` where the suite cannot reach them; extractable to a `dirty-probe.cjs`.
- correctness 🔵 — a refresh requested by `finishApply` while a probe is mid-flight is dropped rather than queued; self-corrects on next focus.
- (pre-existing, shared with `startTrunkUpdate`) — `refreshDirty`'s silent catch never reaches the log stream; fix both together.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)