### PR TITLE
Show the Trac ticket card only after the setup wizard is done

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3323,6 +3323,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
         </div>
       ) : null}
+      {skipInit ? (
       <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
         <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Trac ticket</div>
         {tracTicket ? (
@@ -3502,6 +3503,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           </div>
         )}
       </div>
+      ) : null}
       {skipInit ? (
         <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
           <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Apply a patch or PR</div>


### PR DESCRIPTION
## Why

While a new site is still cloning, the "Trac ticket" card sits below the "Initial setup checklist", inviting the contributor to link a ticket to a site that cannot do anything with one yet — the ticket's pull requests and attachments panels only matter once the environment can apply and run them. The neighbouring "Apply a patch or PR" card already waits for the wizard; this one didn't.

## What changes

The Trac ticket card now renders under the same `skipInit` gate as the "Apply a patch or PR" card. `skipInit` is set both by the wizard's final step ("Start dev server & finish wizard") and by the "Skip initialization wizard" link, so the card appears exactly when the setup checklist disappears, on either path. No logic moved: the ticket-loading effects already key off the linked ticket, not off the card being mounted.

## How to test this

Platforms: any.

**Starting state:** the app open, no site selected.

1. Create a new site. While the "Initial setup checklist" is showing (even mid-clone), scroll down.
   - **Expected:** there is no "Trac ticket" card between the checklist and the Terminal.
2. Click **Skip initialization wizard**.
   - **Expected:** the checklist is replaced by the dev-server controls and the "Trac ticket" card appears, with the "Apply a patch or PR" card below it.
3. On another new site, complete the wizard instead: run the install and build steps, then click **Start dev server and finish the wizard**.
   - **Expected:** the "Trac ticket" card appears at that moment.
4. Open a site that was initialized before this change and has a ticket linked.
   - **Expected:** the card is still there, showing its ticket, with "Open in Trac" and "Unlink" working.

**What must not have happened:** an already-linked ticket must not have been forgotten — hiding the card is presentation only, the stored `tracTicket` survives untouched. The "Apply a patch or PR" card must not have changed when it appears.

## Risks and limitations

One pre-existing edge case, deferred (see review outcome): a site whose ticket was linked *before* its wizard was finished — possible until this change — now shows no ticket UI until the wizard is completed or skipped. The state is recoverable through the "Skip initialization wizard" link, which is always visible in the checklist.

## Related

Follow-up to #109 (the ticket card) and #229 (which settled where renderer decisions live).

---

<details>
<summary>Design decisions and alternatives considered</summary>

- Gate on `skipInit` rather than `initialized`: `skipInit` is what already splits the page between "wizard showing" and "wizard behind us" (checklist at one end, dev-server controls and the patch card at the other), and it covers the skipped-wizard path, which `initialized` does not.
- No `src/renderer/*.cjs` decision module (the #216 invariant): the condition is a bare existing boolean with no derivation — a `shouldShowTracCard(skipInit)` module would wrap an identity function. The invariant targets inline logic with branches, not a visibility toggle that makes two cards consistent.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 1 [follow-up] — the follow-up deferred.

- architecture · 🔵 low · [follow-up] — a site can already hold `tracTicket` with `skipInitWizard` false (linked pre-wizard, which this change makes impossible going forward); such a site shows no ticket UI until the wizard is done or skipped, and its loader effect still spends one unauthenticated GitHub request per activation on a list nothing renders. Recoverable via the always-visible skip link. Cheap close if wanted: treat `tracTicket && !skipInitWizard` as skipped when reading site status.
- §1 renderer-modules invariant and §5 test rules checked and not tripped: no decision to extract, so no module and no reachable test surface; `eslint .` and the full suite (621 tests) pass on both counts.

</details>

<details>
<summary>Screenshots or recording</summary>

Before: the state in the report — an uninitialized, still-cloning site showing the checklist with the Trac ticket card beneath it. After: the same page shows checklist → Terminal → Logs, with the ticket card absent until the wizard finishes or is skipped, then identical to today's post-wizard page.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
