### PR TITLE
Bump the version to 1.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "0.1.2",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "0.1.2",
+      "version": "1.0.0-beta.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "0.1.2",
+  "version": "1.0.0-beta.1",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",


### PR DESCRIPTION
## Why

The next release is the first 1.0, shipped as a public **beta** so contributors can test it before the stable tag. The version reaches two places a contributor sees, and both must carry the real build:

- **Artifact filenames.** electron-builder embeds it, so the release assets identify themselves as `1.0.0-beta.1`.
- **The app log.** `src/logging.js` writes `app <version>` as its first line, so a problem report from the beta names the build it came from.

`v1.0-beta` is not valid semver and electron-builder would reject it, so the beta is tagged `v1.0.0-beta.1`; a second beta becomes `beta.2`.

## What

`npm version 1.0.0-beta.1 --no-git-tag-version`. Only the two root `version` fields change, in `package.json` and `package-lock.json`; the lockfile's dependency versions are untouched.

## Testing

- `npm run lint` — clean
- `npm test` — 621 passing
- Diff limited to the two version fields

## After merge

1. Tag the merge commit `v1.0.0-beta.1` and push the tag.
2. Let the signed builds run; download the artifacts.
3. Create the GitHub Release, attach the artifacts, and **mark it as a pre-release** so the "Latest release" badge keeps pointing at the last stable build.