### PR TITLE
Link to wp-admin alongside the site URL after the dev server starts

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -33,6 +33,7 @@ import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './
 import { parsePrRef } from '../patch-sources.cjs';
 import { prStateBadge } from './pr-state.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
+import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
 import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
@@ -3440,7 +3441,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             <span style={{ fontSize: 12 }}>
               {starting ? `Starting… (${formatElapsed(startElapsed)})` : null}
               {!starting && serverUrl ? (
-                <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
+                <>
+                  <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
+                  <span aria-hidden="true"> · </span>
+                  <a href={adminUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminUrl(serverUrl)); }}>wp-admin</a>
+                </>
               ) : null}
             </span>
           ) : null}
@@ -3773,8 +3778,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <Button
                 variant="secondary"
                 onClick={() => {
-                  const adminer = (serverUrl || '').replace(/\/$/, '/') + 'adminer.php';
-                  window.api.openExternal(adminer);
+                  window.api.openExternal(adminerUrl(serverUrl));
                 }}
                 style={{ padding: '10px 16px', borderRadius: 10 }}
               >Open Adminer</Button>
@@ -3789,7 +3793,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             <div style={{ fontSize: 13, color: '#1d2327', paddingLeft: 2, display: 'flex', flexDirection: 'column', gap: 4 }}>
               {serverUrl ? (
                 <>
-                  <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
+                    <span aria-hidden="true" style={{ color: '#8c8f94' }}>·</span>
+                    <a href={adminUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminUrl(serverUrl)); }}>wp-admin</a>
+                  </div>
                   <span style={{ fontSize: 12, color: '#3c434a' }}>Log in with <code>admin</code> / <code>password</code>.</span>
                 </>
               ) : (

--- a/src/renderer/site-urls.cjs
+++ b/src/renderer/site-urls.cjs
@@ -1,0 +1,66 @@
+'use strict';
+
+/**
+ * Destinations inside a running dev server: the front end, wp-admin and Adminer
+ * (issue #248).
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly
+ * (same convention as trac-ticket.cjs and setup-steps.cjs).
+ *
+ * Why this is a module rather than a string concatenation at the call site:
+ * `server-runner.js` builds the URL as `http://127.0.0.1:${port}/`, so it has
+ * always ended in a slash, and the renderer's existing `Open Adminer` button
+ * relies on that by writing `serverUrl.replace(/\/$/, '/') + 'adminer.php'`.
+ * That `replace` swaps a trailing slash for a trailing slash — it is a no-op,
+ * not the guard it reads as, so a URL arriving without one would silently
+ * produce `http://127.0.0.1:8881adminer.php`. Deriving both paths here makes
+ * the join correct regardless, and testable.
+ */
+
+/**
+ * Joins a path onto the dev server's base URL.
+ *
+ * Returns '' for a missing base so a caller can use the result's falsiness as
+ * the "no server yet" case, matching how the renderer already guards on
+ * `serverUrl`.
+ *
+ * @param {string} serverUrl    Base URL of the running dev server.
+ * @param {string} relativePath Path below it, with or without a leading slash.
+ * @return {string}
+ */
+function siteUrl(serverUrl, relativePath) {
+	const base = typeof serverUrl === 'string' ? serverUrl.trim() : '';
+	if (!base) return '';
+	const rel = typeof relativePath === 'string' ? relativePath.replace(/^\/+/, '') : '';
+	return `${base.replace(/\/+$/, '')}/${rel}`;
+}
+
+/**
+ * The admin dashboard.
+ *
+ * The trailing slash matters: WordPress redirects `/wp-admin` to `/wp-admin/`,
+ * and asking for the canonical form directly saves the round trip.
+ *
+ * @param {string} serverUrl
+ * @return {string}
+ */
+function adminUrl(serverUrl) {
+	return siteUrl(serverUrl, 'wp-admin/');
+}
+
+/**
+ * The bundled database browser (`src/adminer.php`).
+ *
+ * @param {string} serverUrl
+ * @return {string}
+ */
+function adminerUrl(serverUrl) {
+	return siteUrl(serverUrl, 'adminer.php');
+}
+
+module.exports = {
+	siteUrl,
+	adminUrl,
+	adminerUrl
+};

--- a/test/site-urls.test.cjs
+++ b/test/site-urls.test.cjs
@@ -100,10 +100,15 @@ test('the renderer derives both destinations here, not inline (issue #248)', () 
 	// Counted as calls so a comment naming a helper is not a red suite. The href
 	// specifically, not the click handler: a link could otherwise open the right
 	// page while pointing somewhere else.
-	assert.strictEqual(
+assert.strictEqual(
 		source.split('href={adminUrl(').length - 1,
 		2,
 		'expected both wp-admin anchors to take their href from adminUrl'
+	);
+	assert.strictEqual(
+		source.split('e.preventDefault(); window.api.openExternal(adminUrl(').length - 1,
+		2,
+		'expected both wp-admin anchors to prevent in-app navigation and open adminUrl externally'
 	);
 
 	assert.strictEqual(

--- a/test/site-urls.test.cjs
+++ b/test/site-urls.test.cjs
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { siteUrl, adminUrl, adminerUrl } = require('../src/renderer/site-urls.cjs');
+
+const INDEX_JSX = path.join(__dirname, '..', 'src', 'renderer', 'index.jsx');
+
+// The shape server-runner.js actually produces: `http://127.0.0.1:${port}/`.
+const RUNNING = 'http://127.0.0.1:8881/';
+
+test('adminUrl: the admin of a running site (issue #248)', () => {
+	assert.strictEqual(adminUrl(RUNNING), 'http://127.0.0.1:8881/wp-admin/');
+});
+
+test('adminUrl: keeps the trailing slash WordPress would redirect to (issue #248)', () => {
+	assert.ok(adminUrl(RUNNING).endsWith('/wp-admin/'));
+});
+
+// The bug the old inline `.replace(/\/$/, '/')` could not catch: it swapped a
+// trailing slash for a trailing slash.
+test('adminUrl: a base without a trailing slash does not run the path together (issue #248)', () => {
+	assert.strictEqual(adminUrl('http://127.0.0.1:8881'), 'http://127.0.0.1:8881/wp-admin/');
+});
+
+test('adminerUrl: matches what the Open Adminer button produced before (issue #248)', () => {
+	assert.strictEqual(adminerUrl(RUNNING), 'http://127.0.0.1:8881/adminer.php');
+});
+
+test('adminerUrl: a base without a trailing slash is joined, not concatenated (issue #248)', () => {
+	assert.strictEqual(adminerUrl('http://127.0.0.1:8881'), 'http://127.0.0.1:8881/adminer.php');
+});
+
+// '' keeps the renderer's existing falsy guard working on the derived URL,
+// rather than yielding a link relative to the app.
+test('no dev server yields no URL rather than a relative one (issue #248)', () => {
+	assert.strictEqual(adminUrl(''), '');
+	assert.strictEqual(adminerUrl(''), '');
+	assert.strictEqual(siteUrl('', 'wp-admin/'), '');
+});
+
+test('a non-string base is treated as absent, not coerced (issue #248)', () => {
+	assert.strictEqual(adminUrl(undefined), '');
+	assert.strictEqual(adminUrl(null), '');
+	assert.strictEqual(adminerUrl(undefined), '');
+});
+
+test('siteUrl: a leading slash on the path does not double up (issue #248)', () => {
+	assert.strictEqual(siteUrl(RUNNING, '/wp-admin/'), 'http://127.0.0.1:8881/wp-admin/');
+});
+
+test('siteUrl: several slashes on either side still join once (issue #248)', () => {
+	assert.strictEqual(siteUrl('http://127.0.0.1:8881//', '//wp-admin/'), 'http://127.0.0.1:8881/wp-admin/');
+});
+
+test('siteUrl: whitespace around a base is trimmed (issue #248)', () => {
+	assert.strictEqual(siteUrl('  http://127.0.0.1:8881/  ', 'wp-admin/'), 'http://127.0.0.1:8881/wp-admin/');
+});
+
+test('siteUrl: an empty path yields the base with one trailing slash (issue #248)', () => {
+	assert.strictEqual(siteUrl(RUNNING, ''), 'http://127.0.0.1:8881/');
+});
+
+// A port is part of the origin, and stripping it would point the link at :80.
+test('siteUrl: the port survives (issue #248)', () => {
+	assert.ok(adminUrl('http://127.0.0.1:39372/').startsWith('http://127.0.0.1:39372/'));
+});
+
+// No DOM here, so what is testable is that the renderer reads its URLs from
+// this module rather than restating them — as pr-state.test.cjs does.
+
+test('both places that show the site URL also link wp-admin (issue #248)', () => {
+	const source = fs.readFileSync(INDEX_JSX, 'utf8');
+
+	// The two the issue names: the setup checklist step and the site page.
+	assert.strictEqual(
+		source.split('>wp-admin</a>').length - 1,
+		2,
+		'expected exactly two wp-admin links: the setup checklist step and the site page'
+	);
+});
+
+test('the renderer derives both destinations here, not inline (issue #248)', () => {
+	const source = fs.readFileSync(INDEX_JSX, 'utf8');
+
+	// What made `…:8881adminer.php` possible was concatenating a path onto the
+	// base by hand, so the literals are the guard: without them there is nothing
+	// to concatenate. Searching for the old `.replace()` instead would only
+	// match one spelling of the same mistake.
+	for (const literal of ["'wp-admin", '"wp-admin', "'adminer.php'"]) {
+		assert.strictEqual(
+			source.split(literal).length - 1,
+			0,
+			`index.jsx hardcodes ${literal} instead of deriving it from site-urls.cjs`
+		);
+	}
+
+	// Counted as calls so a comment naming a helper is not a red suite. The href
+	// specifically, not the click handler: a link could otherwise open the right
+	// page while pointing somewhere else.
+	assert.strictEqual(
+		source.split('href={adminUrl(').length - 1,
+		2,
+		'expected both wp-admin anchors to take their href from adminUrl'
+	);
+
+	assert.strictEqual(
+		source.split('adminerUrl(').length - 1,
+		1,
+		'expected exactly one adminerUrl( call: the Open Adminer button'
+	);
+});


### PR DESCRIPTION
## Why

Once the dev server is running the app shows the site's front-end URL and, directly under it, `Log in with admin / password` — credentials for a screen it gives no way to reach. Most of what a contributor does next happens in the admin: checking a setting, reproducing a ticket, switching a theme. Today that means editing the URL by hand.

## What changes

A **wp-admin** link beside the site URL, in both places the URL appears — the setup checklist step and the site page — so it is there whether a contributor is still in setup or returning to a site they have used before.

The URLs are derived in a new `src/renderer/site-urls.cjs` rather than built at the call site. `index.jsx` cannot be loaded without a DOM, so a join written there is untestable; the module keeps it reachable by `node --test`.

`Open Adminer` now derives its URL from that same module. Its old inline join guarded the trailing slash with `.replace(/\/$/, '/')`, which swaps a trailing slash for a trailing slash and so does nothing — harmless today only because the server URL happens to always end in one. Copying that pattern for wp-admin would have duplicated it.

**Not in this PR:** moving `Open Adminer` down onto the same line as the links — that is #249, deliberately separate.

## How to test this

Platforms: any.

**Starting state:** a site with its dev server running.

1. Create or open a site and click **Start dev server**.
2. Under the site name, the front-end URL now reads `http://127.0.0.1:<port>/ · wp-admin`.
3. Click **wp-admin** → opens in your browser at the WordPress login, which returns you to the dashboard after you log in with `admin` / `password`.
4. Click **Open Adminer** in the button row → still opens the database browser.
5. Stop the dev server → both the URL and the wp-admin link disappear together.
6. In a fresh setup, the same link appears on the wizard's **Start dev server** step.

**What must not have happened:** the link must open in your *browser*, not inside the app window — a link that navigates the Electron window replaces the UI with a web page and there is no way back. `Open Adminer` must not have broken: it was rerouted through the new module, so a wrong URL there would be a silent regression of an existing feature.

## Risks and limitations

The rendered links are not covered by an automated test — no DOM test infrastructure exists in this repo, which is the tradeoff #216 chose. Two tests read `index.jsx` as source text to pin the wiring instead, and the visible behaviour was checked by hand against a running server.

`index.jsx:2079` applies the same no-op slash guard before `setServerUrl`. Left alone as out of scope; noted below.

## Related

Fixes #248. See also #249, which moves `Open Adminer` onto this row.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why a module for what looks like string concatenation.** The repo's convention is that renderer logic lives in a `src/renderer/*.cjs` module with its own test — `trac-ticket.cjs` is the closest precedent, also a URL builder. Inline would have been shorter and untestable.

**Why the join is defensive when the base is always the same.** `server-runner.js` builds the URL as `http://127.0.0.1:${port}/`, so it has always ended in a slash. The module strips and rejoins anyway, because the old code's apparent guard against the other case did nothing, and a helper that silently depends on an invariant it does not enforce is how `…:8881wp-admin` gets shipped later.

**Why the wp-admin path keeps its trailing slash.** WordPress redirects `/wp-admin` to `/wp-admin/`; asking for the canonical form skips a round trip.

**Departure from the issue.** #248 suggests copying the `Open Adminer` pattern. That pattern contains the no-op guard described above, so it was fixed and shared instead of copied — one extra hunk, outside the issue's literal scope.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`3 [fix here]` — 2 fixed, 1 deferred. Lint clean; 780 tests pass on both system Node and Electron's Node.

Ran per `.github/instructions/code-review.instructions.md`, with the judgement pass in a fresh context rather than the session that wrote the change.

**Fixed — 🟡 tests: the regression guard could not fire.** It searched `index.jsx` for the old `.replace(/\/$/, '/')` but required a space after the comma, which the repo does not write. Green while a live instance of the pattern sat in the file it read. Replaced with assertions that neither `'wp-admin` nor `'adminer.php'` appears as a literal in `index.jsx` — concatenating a path by hand was the actual bug, and a missing literal cannot be spelled differently.

**Fixed — 🟡 tests: the wiring the PR adds was unasserted.** The source assertions checked the label count and the Adminer call, but nothing tied the anchors' `href` to `adminUrl`. Rewriting a link as `href={serverUrl + 'wp-admin'}` would have kept them green while bypassing the tested module. Added an `href={adminUrl(` count.

Both new assertions were mutation-tested rather than assumed: bypassing `adminUrl` on one anchor, and deleting one link, each turn the suite red.

**Deferred — 🔵 architecture: `index.jsx:2079`.** `url.replace(/\/$/,'/')` before `setServerUrl` is the same no-op, and `main.js:2403` already trims the parsed value. Pre-existing and outside this issue; left for a separate change. The test guard no longer depends on it either way.

Verified and not findings: `serverUrl` only ever holds `http://127.0.0.1:${port}/`; `Open Adminer` is observably unchanged; `openExternal` still validates through `external-url.js`; nothing new crosses IPC.

Also applied from the review's style notes: both links now use an `aria-hidden` separator, rather than one bare interpunct that a screen reader would announce.

</details>

<details>
<summary>Implementation notes</summary>

Three commits, each green on its own: the module, the call sites, then the tests. The tests read `index.jsx` and assert its contents, so they land last — committing them earlier would leave a red commit mid-branch.

`site-urls.cjs` exports `siteUrl(base, path)` plus `adminUrl` and `adminerUrl`. `siteUrl` returns `''` for a missing or non-string base, so the renderer's existing `serverUrl ? … : null` guards keep working on the derived value instead of producing a link relative to the app itself.

</details>

<details>
<summary>Screenshots or recording</summary>

https://github.com/user-attachments/assets/2215a6d1-77ad-4c23-9277-88551a6c6819

</details>
