### PR TITLE
Point the contributor at the next action in the post-init view

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -66,6 +66,19 @@
       border-radius: 10px;
       box-shadow: 0 0 0 3px rgba(240, 184, 73, 0.45), 0 0 14px 3px rgba(240, 184, 73, 0.30);
     }
+    /* Visually hidden but read aloud — the spoken half of the next-action cue
+       (#252), for the live region that names the next step. */
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
   <link rel="stylesheet" href="index.css" />
   <script defer src="index.js"></script>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3521,8 +3521,27 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const nextActionId = nextAction ? nextAction.id : null;
   useNextActionCue(nextActionId, isActive, nextActionSectionRef);
 
+  // Tags a block as a cue target: the `data-next-action` the hook scrolls to,
+  // and the `.next-action-cue` class React draws the ring with when this block
+  // is the one. Spread onto the block that carries the id's action.
+  const cueProps = (id) => ({
+    'data-next-action': id,
+    className: nextActionId === id ? 'next-action-cue' : undefined
+  });
+
   return (
     <section ref={nextActionSectionRef} style={{ display: 'flex', flexDirection: 'column', gap: 24, paddingBottom: 48 }}>
+      {/* The glow on the next-action block is purely visual, invisible to a
+          screen reader. This is its spoken equivalent: a polite live region that
+          names the next step as the cue moves, so a non-sighted contributor gets
+          the same hint. The region is always mounted and only its text toggles —
+          a live region that appears already holding text is not reliably read,
+          whereas a change to one already in the DOM is. Only the active row ever
+          holds text, so only the visible site speaks; it clears to nothing when
+          there is no next action. */}
+      <div className="sr-only" role="status" aria-live="polite">
+        {isActive && nextAction ? `Next step: ${nextAction.reason}` : ''}
+      </div>
       <Flex align="flex-start" justify="space-between" style={{ gap: 16, flexWrap: 'wrap' }}>
         <div style={{ flex: '1 1 440px', minWidth: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
@@ -3657,7 +3676,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       </Flex>
       {updateIncomplete && !isUpdating ? (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 8, fontSize: 13, color: '#8a1f21' }}>
+        <div {...cueProps('retry-install-build')} style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 8, fontSize: 13, color: '#8a1f21' }}>
           <span style={{ flex: '1 1 320px' }}>
             <strong>Update incomplete</strong> — the code is new but the built assets are old. The site may not run correctly until install and build succeed.
           </span>
@@ -3670,7 +3689,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       ) : null}
       {age.stale && !updateIncomplete && !isUpdating ? (
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '14px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
+        <div {...cueProps('update-trunk')} style={{ display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '14px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
           <div style={{ flex: '1 1 320px', display: 'flex', flexDirection: 'column', gap: 4 }}>
             <strong style={{ color: '#5c4400' }}>This site&apos;s WordPress code is {age.ageDays} days old</strong>
             <span>Patches you create now may not apply on Trac. Updating takes a few minutes.</span>
@@ -3684,7 +3703,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       ) : null}
       {isUpdating ? (
-        <div style={{ padding: '14px 16px', background: '#fff', border: '1px solid #dcdcde', borderRadius: 8 }}>
+        <div {...cueProps('updating')} style={{ padding: '14px 16px', background: '#fff', border: '1px solid #dcdcde', borderRadius: 8 }}>
           <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
             <span style={{ fontWeight: 600, fontSize: 14, color: '#1d2327' }}>Updating to latest trunk</span>
             <span style={{ fontSize: 12, color: '#6c6f72' }}>
@@ -3799,6 +3818,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {skipInit ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <div style={{ display: 'flex', alignItems: 'stretch', gap: 12, flexWrap: 'wrap' }}>
+            <span {...cueProps('start-dev')} style={{ display: 'inline-flex' }}>
             <Button
               isBusy={isServerStarting}
               variant={isDevProcessActive ? 'secondary' : 'primary'}
@@ -3822,12 +3842,15 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
               <span style={{ fontWeight: 600 }}>{devServerButtonLabel}</span>
             </Button>
+            </span>
+            <span {...cueProps('review-changes')} style={{ display: 'inline-flex' }}>
             <Button
               variant="secondary"
               onClick={openPatchModal}
               disabled={isUpdating}
               style={{ padding: '10px 16px', borderRadius: 10 }}
             >Review & submit changes</Button>
+            </span>
             {running && serverUrl ? (
               <Button
                 variant="secondary"
@@ -3862,7 +3885,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         </div>
       ) : null}
       {skipInit ? (
-      <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
+      <div {...cueProps('link-ticket')} style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
         <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Trac ticket</div>
         {tracTicket ? (
           <>


### PR DESCRIPTION
## Why

PR #254 pointed the contributor at the next action in the **setup checklist**, but the resolver already decides a next action for the **post-init** view too — and nothing carried those ids onto the screen yet, so the cue silently did nothing once the wizard was skipped. This finishes #252: the same "start here" ring and scroll now reach every panel, and the cue gains a spoken equivalent for screen-reader users.

## What changes

- **Wires the post-init panels as cue targets.** A tiny `cueProps(id)` helper spreads `data-next-action` + the `.next-action-cue` class onto: the *update-incomplete* banner (`retry-install-build`), the *stale-trunk* banner (`update-trunk`), the *update-in-progress* tracker (`updating`), the **Start dev server** and **Review & submit changes** buttons (each wrapped so the ring hugs the button), and the **Trac ticket** panel (`link-ticket`). No resolver change — it already returned these ids; this just gives them a home in the DOM.
- **Adds the accessibility equivalent** flagged in PR #254's review. The "Start here" pill is a decorative CSS `::before`; this adds a visually-hidden `role="status" aria-live="polite"` region that announces `Next step: <reason>` as the cue moves, using the `reason` the resolver already returns. Gated on the active row so only the visible site speaks, cleared to nothing when there's no next action. `.sr-only` added to `index.html`.

**Not in this PR:** no new resolver logic or ids — the ladder and its tests shipped in PR #254. The changes here are JSX markup plus one trivial props helper, so no new `*.cjs` decision module was introduced (consistent with the §1 invariant: the only decision, `deriveNextAction`, is already a tested module).

## How to test this

**Platforms:** any (renderer-only). **Stacked on PR #254** — test this branch's Buildkite artifact and you exercise both PRs at once.

**Starting state:** an initialized site with the wizard skipped (the main dev view, not the checklist).

1. Open a site that is **not running** and has no changes. → The **Start dev server** button wears the ring + "Start here", and the view scrolls to it.
2. Start the server. → The cue **clears from Start dev**. Make an edit in `src/` so the tree is dirty. → The cue moves to **Review & submit changes**.
3. Discard/submit so the tree is clean, with **no ticket linked**. → The cue moves to the **Trac ticket** panel ("Link a ticket"). Link one. → With a running, clean, linked site, **no cue shows** (nothing pending).
4. Force an **Update incomplete** state (update, interrupt before build). → The red *Retry install & build* banner is ringed, outranking everything.
5. Trigger **Update to latest trunk** on a stale site. → The stale banner is ringed; while the update runs, the cue sits on the **progress tracker**.
6. **Screen reader** (VoiceOver / NVDA): as each of the above transitions happens, hear "Next step: …" announced once. Nothing is announced for a background (inactive) site.
7. **Reduce Motion** on: rings are static, scrolling is instant (unchanged from PR #254).

**What must not have happened:**

- The two wrapped action-bar buttons must still line up in the row (the `<span>` wrappers are `inline-flex`; they must not collapse or misalign the buttons).
- A **linked** ticket panel must **not** be ringed — `link-ticket` only activates when unlinked, even though the shared wrapper carries the `data-next-action`.
- No background/inactive site scrolls or announces.
- The live region must not chatter on every render — it speaks only when the step actually changes.

## Risks and limitations

- The Start-dev / Review-changes buttons are now each wrapped in an `inline-flex` span so the ring can hug them. This is the one layout-affecting change; visually confirm the row is unchanged when no cue is active.
- **Not hand-verified by the author:** `node_modules` couldn't be installed here (the repo's EBADENGINE constraint), so no local `eslint`/full suite/app run. The resolver test passes directly and the renderer transpiles clean; the Buildkite artifact is the path to drive the steps above.

## Related

Closes #252. Stacked on #254 (base branch `juanmaguitar/nothing-points-the-contributor-at-the-next-thing`) — merge #254 first.

---

<details>
<summary>Design decisions and alternatives considered</summary>

- **`cueProps` spread over per-block className expressions.** One helper keeps the tag and the class in lockstep and reads the same at every call site.
- **One section-level live region, not per-block.** A single polite region announcing the resolver's `reason` gives the "what's next" signal without threading a visually-hidden node into six panels, and it naturally follows the cue as it moves.
- **Tag the shared ticket-panel wrapper.** `data-next-action="link-ticket"` sits on the wrapper used for both linked and unlinked states; harmless because the `.next-action-cue` class only activates when the resolver returns `link-ticket`, which it only does when no ticket is linked.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**No findings across the five dimensions** (0 [fix here] · 0 [follow-up]). The judgement pass ran in a fresh `Explore` subagent given only the diff and the review standard, per `/self-review`.

Verified: `cueProps` and the live region add no new decision to `index.jsx` (the only decision, `deriveNextAction`, is already a tested module — matches the §1 invariant); the six cue ids match the resolver's returned ids exactly; span-wrapping the two action-bar buttons leaves the rendered layout unchanged (each `inline-flex` span becomes the stretched flex child, the button fills it); `data-next-action="link-ticket"` on the shared ticket panel is inert when a ticket is linked (the class only activates when the resolver returns `link-ticket`).

**One improvement applied from the review** (a non-dimension robustness note, not a finding): the live region is now mounted **unconditionally** with only its text toggling, rather than the element being conditionally rendered — a `role="status"` region that appears already holding text isn't reliably announced, whereas a text change to one already in the DOM is.

Deterministic layer: `npm run lint` and full `npm test` could **not** run (no `node_modules` — EBADENGINE); the resolver test passes directly (**11/11**) and the renderer transpiles clean via esbuild.

</details>
