### PR TITLE
Say "Ready" for the next setup step until its action runs

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -20,7 +20,7 @@ import { plus, chevronLeft, chevronRight, chevronDown, copy as copyIcon, check a
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
-import { computeSetupStepState } from './setup-steps.cjs';
+import { computeSetupStepState, setupStepLabel } from './setup-steps.cjs';
 import { deriveNextAction } from './next-action.cjs';
 import { shouldShowTerminalHints, computeTerminalBusy } from './terminal-hints.cjs';
 import { planDevServerStart, formatElapsed } from './dev-server-command.cjs';
@@ -3351,9 +3351,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     ? { background: '#e7f6e7', color: '#0f5132' }
     : { background: '#fff4ce', color: '#8a6d1c' };
 
+  // Colours and indicator per step status. The status *word* is not here — it
+  // lives in `setupStepLabel`, the one place that distinguishes a step that is
+  // merely next from one that is running (#257).
   const checklistVisuals = {
     complete: {
-      label: 'Completed',
       color: '#0f5132',
       background: '#f4fbf4',
       border: '#94d3ae',
@@ -3363,7 +3365,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       indicatorContent: '✓'
     },
     current: {
-      label: 'In progress',
       color: '#0b5d95',
       background: '#e8f3ff',
       border: '#66afe9',
@@ -3373,7 +3374,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       indicatorContent: '•'
     },
     pending: {
-      label: 'Pending',
       color: '#6c6f72',
       background: '#f8f9f9',
       border: '#dcdcde',
@@ -3383,7 +3383,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       indicatorContent: '•'
     },
     locked: {
-      label: 'Locked',
       color: '#6c6f72',
       background: '#f5f5f7',
       border: '#dcdcde',
@@ -3417,7 +3416,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       description: isPending
         ? 'Cloning the WordPress develop repository… the next step unlocks when it finishes.'
         : 'Clone the WordPress develop repository.',
-      ...stepState.download
+      ...stepState.download,
+      running: isPending
     },
     {
       key: 'install',
@@ -3428,6 +3428,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         ? 'Installed. Added a dependency to package.json since? Run npm install in the Terminal below.'
         : 'Install npm packages so commands can run.',
       ...stepState.install,
+      running: installing,
       action: (
         <Button
           isBusy={installing}
@@ -3444,6 +3445,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         ? 'Built. Edited files in src/ since? Run npm run build in the Terminal below so the site picks them up — updates and applied patches rebuild on their own.'
         : 'Compile WordPress Core to generate the dist files. Later updates rebuild automatically.',
       ...stepState.build,
+      running: building,
       action: (
         <Button
           isBusy={building}
@@ -3458,6 +3460,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       label: 'Start dev server & finish wizard',
       description: 'Launch the development server once to complete the WordPress setup wizard.',
       ...stepState.dev,
+      running: starting,
       action: (
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <Button
@@ -3798,7 +3801,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   </div>
                   <div style={{ gridColumn: '2 / 3', display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12, minWidth: 0, flexWrap: 'wrap' }}>
                     <div style={{ fontWeight: 600, color: '#1d2327', lineHeight: 1.4 }}>{step.label}</div>
-                    <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: visuals.color, marginLeft: 'auto', whiteSpace: 'nowrap' }}>{visuals.label}</div>
+                    <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: visuals.color, marginLeft: 'auto', whiteSpace: 'nowrap' }}>{setupStepLabel(step.status, step.running)}</div>
                   </div>
                   <div style={{ gridColumn: '2 / 3', fontSize: 12, color: '#3c434a', lineHeight: 1.5 }}>{step.description}</div>
                   <div style={{ gridRow: '1 / span 2', gridColumn: '3 / 4', alignSelf: 'center', display: 'flex', alignItems: 'center' }}>

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -56,4 +56,38 @@ function computeSetupStepState(flags = {}) {
 	};
 }
 
-module.exports = { computeSetupStepState };
+/**
+ * The status word shown on a checklist step.
+ *
+ * `current` is the step a contributor should act on next — but being next is
+ * not the same as being under way (#257). Its old label, "In progress", read as
+ * "the app is already doing this" on a step whose button had not been touched:
+ * on a fresh site *Install npm dependencies* announced itself as running while
+ * nothing was, so a contributor waited instead of clicking. The distinction the
+ * label was missing is `isRunning` — whether the step's own action (the clone,
+ * install, build or dev-server start) is actually in flight — which the caller
+ * already knows from the flags that drive the buttons. A current step reads
+ * "Ready" until that is true, and "In progress" only once it is.
+ *
+ * Kept here, pure and tested, rather than as a lookup in the component: it is a
+ * decision with branches, and those belong in a module by this project's own
+ * rule.
+ *
+ * @param {string}  status    One of complete|current|pending|locked.
+ * @param {boolean} isRunning The current step's action is under way.
+ * @return {string}
+ */
+function setupStepLabel(status, isRunning) {
+	switch (status) {
+		case 'complete':
+			return 'Completed';
+		case 'pending':
+			return 'Pending';
+		case 'locked':
+			return 'Locked';
+		default:
+			return isRunning ? 'In progress' : 'Ready';
+	}
+}
+
+module.exports = { computeSetupStepState, setupStepLabel };

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { computeSetupStepState } = require('../src/renderer/setup-steps.cjs');
+const { computeSetupStepState, setupStepLabel } = require('../src/renderer/setup-steps.cjs');
 
 test('while the clone is still running, the install step is locked (issue #47)', () => {
 	const steps = computeSetupStepState({ isPending: true });
@@ -107,4 +107,22 @@ test('a finished update releases the checklist again', () => {
 	assert.strictEqual(steps.install.disabled, true, 'nothing left to install');
 	assert.strictEqual(steps.build.disabled, true, 'nothing left to build');
 	assert.strictEqual(steps.dev.disabled, false);
+});
+
+test('the current step reads "Ready" until its action starts (#257)', () => {
+	// The exact case from the report: a fresh site, install is the next step,
+	// nothing is running. It must not claim to be under way.
+	assert.strictEqual(setupStepLabel('current', false), 'Ready');
+});
+
+test('the current step reads "In progress" once its action is running (#257)', () => {
+	assert.strictEqual(setupStepLabel('current', true), 'In progress');
+});
+
+test('the other statuses keep their fixed labels regardless of the running flag', () => {
+	for (const running of [true, false]) {
+		assert.strictEqual(setupStepLabel('complete', running), 'Completed');
+		assert.strictEqual(setupStepLabel('pending', running), 'Pending');
+		assert.strictEqual(setupStepLabel('locked', running), 'Locked');
+	}
 });


### PR DESCRIPTION
## Why

The initial setup checklist labelled the **current** step "In progress" the moment it became the next actionable step — before the contributor clicked anything and before any work was happening. On a fresh site, *Install npm dependencies* announced itself as "In progress" while nothing was installing (#257), which reads as "the app is already doing this" and invites a contributor to wait instead of clicking. The next-action ring (#252) made it worse by drawing the eye straight to the wrong word.

## What changes

Root cause: the checklist's `current` status — "first ready, not-done step" — always mapped to the "In progress" label, conflating *next* with *running*. The running signal (`installing` / `building` / `starting`, and `isPending` for the clone) already existed for the buttons but the label ignored it.

- New pure `setupStepLabel(status, isRunning)` in `src/renderer/setup-steps.cjs`: a current step reads **"Ready"** until its action is under way, and **"In progress"** only once it is. Other statuses keep their fixed words.
- The render passes each step's own running flag (download↔`isPending`, install↔`installing`, build↔`building`, dev↔`starting`).
- Removed the now-dead `label` keys from the `checklistVisuals` object so the status word has one source of truth (the object keeps only colours/indicator).

## How to test this

**Platforms:** any (renderer-only). Stacked on #254 + #256 — test this branch's Buildkite artifact to exercise all three.

**Starting state:** a freshly created site, on the **Initial setup checklist**, clone finished.

1. Look at the current step (*Install npm dependencies*) before clicking. → It reads **"Ready"**, not "In progress".
2. Click **Install npm dependencies**. → While it runs, the status reads **"In progress"**.
3. Let it finish. → Install reads **"Completed"**; **Run full build** becomes current and reads **"Ready"** (not "In progress"). Repeat for build → dev.
4. While the initial clone is still running (a brand-new site), the **Download** step reads **"In progress"** — because it genuinely is.

**What must not have happened:**

- No step reads "In progress" while its button is idle and clickable.
- Completed / pending / locked steps are unchanged ("Completed" / "Pending" / "Locked").
- The next-action ring and scroll (from #254/#256) still behave exactly as before — only the status word changed.

## Risks and limitations

- Renderer-only; no behavioural change beyond the status word. Not hand-verified by the author (no local app run — the repo's EBADENGINE install constraint); `eslint .` is clean and `npm test` passes (**794**, incl. 3 new for `setupStepLabel`). The Buildkite artifact is the hand-test path.

## Related

Closes #257. Stacked on #256 (base branch `juanmaguitar/next-action-post-init-panels`), which is stacked on #254. Merge #254 → #256 → this.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**No findings across the five dimensions** (0 [fix here] · 0 [follow-up]). Judgement pass ran in a fresh `Explore` subagent given only the diff and the review standard, per `/self-review`.

Verified: only `complete`/`current`/`pending`/`locked` reach the switch, so `default` is exclusively `current`; each step's `running` flag matches the flag that drives its own button (and `isPending` for the clone, which is the only time download is `current`); no other reader of the removed `visuals.label` remains; the `running` spread never collides with `computeSetupStepState`'s keys; and the new tests fail on the old hard-coded "In progress" behaviour.

Deterministic layer: `eslint .` clean; `npm test` **794 pass** (3 new). Both run in the worktree with node_modules symlinked.

</details>
