### PR TITLE
Highlight any block that is showing work in progress

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3514,6 +3514,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const nextAction = deriveNextAction({
     skipInit,
     currentSetupStep,
+    isApplying,
     updateIncomplete,
     isUpdating,
     stale: age.stale,
@@ -4150,7 +4151,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
 
           {isApplying ? (
-            <div style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #dcdcde', borderRadius: 8 }}>
+            <div {...cueProps('applying-patch')} style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #dcdcde', borderRadius: 8 }}>
               {applyStepStates.map((state, i) => {
                 const step = applySteps[i];
                 const mark = UPDATE_STEP_MARKS[state.status];

--- a/src/renderer/next-action.cjs
+++ b/src/renderer/next-action.cjs
@@ -29,6 +29,7 @@
  * @param {Object}  state
  * @param {boolean} state.skipInit         Init wizard skipped; post-init view shown.
  * @param {?string} state.currentSetupStep The checklist's current step key, or null.
+ * @param {boolean} state.isApplying       A patch is being applied or reverted now.
  * @param {boolean} state.updateIncomplete Code updated but built assets are stale.
  * @param {boolean} state.isUpdating       A trunk update is running now.
  * @param {boolean} state.stale            The trunk snapshot is old (#94).
@@ -54,17 +55,26 @@ function deriveNextAction(state = {}) {
 		return null;
 	}
 
-	if (Boolean(state.updateIncomplete) && !Boolean(state.isUpdating)) {
+	// An operation in flight is the thing happening, not an action to take — but
+	// it is still where attention belongs, so a contributor who looked away can
+	// find where the work is (and see it is not stuck). It outranks the
+	// stale-state warnings below, which are only warnings; an applying or
+	// reverting patch is live. `isApplying` covers both — a revert runs through
+	// the same apply machinery — and the two operations that own the working tree
+	// (this and a trunk update) never run at once.
+	if (Boolean(state.isApplying)) {
+		return { id: 'applying-patch', reason: 'A patch is being applied or reverted.' };
+	}
+
+	if (Boolean(state.isUpdating)) {
+		return { id: 'updating', reason: 'The trunk update in progress.' };
+	}
+
+	if (Boolean(state.updateIncomplete)) {
 		return {
 			id: 'retry-install-build',
 			reason: 'The update left the build stale; install and build to recover.'
 		};
-	}
-
-	// An update in flight is not an action, but it is the thing happening — point
-	// at its tracker so a contributor who looked away can find where the work is.
-	if (Boolean(state.isUpdating)) {
-		return { id: 'updating', reason: 'The trunk update in progress.' };
 	}
 
 	if (Boolean(state.stale)) {

--- a/test/next-action.test.cjs
+++ b/test/next-action.test.cjs
@@ -56,6 +56,27 @@ test('an update in flight suppresses the retry banner and points at its tracker'
 	assert.strictEqual(next.id, 'updating');
 });
 
+test('a patch being applied or reverted points at its progress block', () => {
+	// One flag: a revert runs through the same apply machinery, so the resolver
+	// sees the same isApplying for both and there is no separate reverting id.
+	const next = deriveNextAction({ skipInit: true, isApplying: true });
+
+	assert.strictEqual(next.id, 'applying-patch');
+});
+
+test('an in-flight patch operation outranks the stale-state warnings', () => {
+	const next = deriveNextAction({
+		skipInit: true,
+		isApplying: true,
+		updateIncomplete: true,
+		stale: true,
+		hasChanges: true,
+		ticketLinked: false
+	});
+
+	assert.strictEqual(next.id, 'applying-patch');
+});
+
 test('a stale tree outranks the routine steps', () => {
 	const next = deriveNextAction({
 		skipInit: true,


### PR DESCRIPTION
## Why

The next-action cue (#252) points at the block a contributor should act on next. A block that is *doing* work — a trunk update, a patch apply or revert — is where attention belongs too: it should scroll into view and glow like any other cue target, so a contributor who looked away can see where the work is and that it isn't stuck. The trunk-update tracker was already highlighted; this completes the idea so **any block displaying work in progress** gets the same treatment.

## What changes

- `next-action.cjs`: a new high-priority rule — when `isApplying` is true, point at the `applying-patch` block (the patch apply/revert step tracker). It sits above the stale-state warnings: a live operation outranks a warning. One flag covers both operations — a revert runs through the same apply machinery (`runApply({ reverse: true })`), so there is no separate "reverting" id.
- Reordered the ladder so the two in-flight, tree-owning operations (`isApplying`, `isUpdating`) are checked before `updateIncomplete`, and dropped the now-redundant `!isUpdating` guard. Behaviour-preserving for the pre-existing cases.
- `index.jsx`: passes `isApplying` to the resolver and spreads `cueProps('applying-patch')` onto the tracker (the block that only renders while the operation runs).

After this, every in-progress block in the site view is a cue target: the trunk-update tracker (wired earlier in the stack) and the patch apply/revert tracker (here). Each glows and — with the assertive scroll from the base PR — is centered in view when it starts, and the cue clears when it ends.

## How to test this

**Platforms:** any (renderer-only). Stacked on #254 + #256 + #258 — test this branch's Buildkite artifact to exercise the whole stack.

**Starting state:** an initialized site, wizard skipped, with the *Apply a patch or PR* panel visible.

1. Apply a PR or a `.diff`/`.patch` file (paste a PR URL → **Apply PR** → **Apply and rebuild**). → While it runs, the **step tracker block glows** (soft amber) and the view scrolls to center it.
2. Let it finish. → The glow clears from the tracker (the block unmounts); the cue moves on to the next pending action.
3. With a patch applied, click **Revert this patch**. → The same tracker block glows while the revert runs.
4. Trigger **Update to latest trunk** (on a stale site). → Its progress tracker glows and scrolls into view the same way — confirming the treatment is general, not apply-only.

**What must not have happened:**

- The glow must not linger after an operation ends (the tracker unmounts when `isApplying` is false).
- While applying/reverting, the cue must be on the tracker — not on start-dev / review-changes / link-ticket.
- The screen-reader live region announces "Next step: A patch is being applied or reverted."

## Risks and limitations

- `isApplying` and `isUpdating` own the working tree and never run at once (each disables the other's controls), so the ordering between them is not observable in practice; `isApplying` is placed first regardless.
- Renderer-only. Not hand-verified by the author (no local app run — the EBADENGINE install constraint); `eslint .` clean, `npm test` **796** (2 new). Buildkite artifact is the hand-test path.

## Related

Part of #252. Stacked on #258 (base branch `juanmaguitar/setup-step-ready-label`) → #256 → #254. Merge bottom-up.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**No findings across the five dimensions** (0 [fix here] · 0 [follow-up]). Judgement pass ran in a fresh `Explore` subagent given only the diff and the review standard, per `/self-review`.

Verified: `isApplying` is true for both apply and revert (`runApply` sets `applyState` unconditionally, revert calls `runApply({reverse:true})`); the ladder reorder is behaviour-preserving across all `updateIncomplete`/`isUpdating` combinations, and dropping the `!isUpdating` guard is safe now that `isUpdating` is checked first; the two tree-owning operations are mutually exclusive (both bail on the shared `running` flag), so `isApplying` winning is moot in practice and reasonable otherwise; and the `applying-patch` id and its DOM block appear/disappear together (`cueProps` in scope).

**One change applied from the review** (a style note, not a finding): removed a second test that fed the resolver the same input as the first — the apply/revert distinction lives in `runApply`, not the resolver, so a resolver test can't prove it. Kept one test documenting the shared-flag behaviour.

Deterministic layer: `eslint .` clean; `npm test` **796 pass** (2 new).

_Note: reviewed as the apply/revert-specific change; the reframing to "any block showing work in progress" is a title/description change only — no code changed since review._

</details>
