### PR TITLE
Highlight a staged patch preview as the next action

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3515,6 +3515,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     skipInit,
     currentSetupStep,
     isApplying,
+    applyPreview: Boolean(applyPreview),
     updateIncomplete,
     isUpdating,
     stale: age.stale,
@@ -4123,7 +4124,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
 
           {applyPreview && !isApplying ? (
-            <div style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #dcdcde', borderRadius: 8 }}>
+            <div {...cueProps('apply-preview')} style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #dcdcde', borderRadius: 8 }}>
               <div style={{ fontSize: 13, color: '#1d2327' }}>
                 <strong>{applyPreview.label}</strong> changes {applyPreview.paths.length} file{applyPreview.paths.length === 1 ? '' : 's'}:
               </div>

--- a/src/renderer/next-action.cjs
+++ b/src/renderer/next-action.cjs
@@ -30,6 +30,7 @@
  * @param {boolean} state.skipInit         Init wizard skipped; post-init view shown.
  * @param {?string} state.currentSetupStep The checklist's current step key, or null.
  * @param {boolean} state.isApplying       A patch is being applied or reverted now.
+ * @param {boolean} state.applyPreview     A patch is staged, awaiting apply or cancel.
  * @param {boolean} state.updateIncomplete Code updated but built assets are stale.
  * @param {boolean} state.isUpdating       A trunk update is running now.
  * @param {boolean} state.stale            The trunk snapshot is old (#94).
@@ -68,6 +69,15 @@ function deriveNextAction(state = {}) {
 
 	if (Boolean(state.isUpdating)) {
 		return { id: 'updating', reason: 'The trunk update in progress.' };
+	}
+
+	// A staged patch preview is not work in flight, but it is the one thing the
+	// contributor just set up and is looking at: they pasted a PR, it previewed,
+	// and the decision to apply or cancel is now theirs. It outranks the
+	// stale-state warnings and routine steps below — an explicit, waiting choice
+	// beats a standing suggestion.
+	if (Boolean(state.applyPreview)) {
+		return { id: 'apply-preview', reason: 'A patch is staged — apply and rebuild, or cancel.' };
 	}
 
 	if (Boolean(state.updateIncomplete)) {

--- a/test/next-action.test.cjs
+++ b/test/next-action.test.cjs
@@ -77,6 +77,33 @@ test('an in-flight patch operation outranks the stale-state warnings', () => {
 	assert.strictEqual(next.id, 'applying-patch');
 });
 
+test('a staged patch preview is pointed at as the next action', () => {
+	const next = deriveNextAction({ skipInit: true, applyPreview: true, running: true });
+
+	assert.strictEqual(next.id, 'apply-preview');
+});
+
+test('a staged preview outranks the stale-state warnings and routine steps', () => {
+	const next = deriveNextAction({
+		skipInit: true,
+		applyPreview: true,
+		updateIncomplete: true,
+		stale: true,
+		running: false,
+		ticketLinked: false
+	});
+
+	assert.strictEqual(next.id, 'apply-preview');
+});
+
+test('an in-flight apply outranks a staged preview (the preview block is gone by then)', () => {
+	// Once applying starts the preview block unmounts, so the cue must follow to
+	// the progress tracker, not stay on a preview that is no longer on screen.
+	const next = deriveNextAction({ skipInit: true, applyPreview: true, isApplying: true });
+
+	assert.strictEqual(next.id, 'applying-patch');
+});
+
 test('a stale tree outranks the routine steps', () => {
 	const next = deriveNextAction({
 		skipInit: true,


### PR DESCRIPTION
## Why

When a contributor pastes a PR or picks a `.diff`/`.patch` file, the app shows a **staged preview** — "<label> changes N files" with **Apply and rebuild** / **Cancel**. That block is a clear next action: they set it up and the decision to apply is theirs. But it was not a cue target, so nothing pointed at it. This highlights it like the other next-action blocks.

## What changes

- `next-action.cjs`: a new rule — when `applyPreview` is staged, point at the `apply-preview` block. Placed **after** the in-flight operations (`isApplying`, `isUpdating`) and **before** the stale-state warnings and routine steps: an explicit, waiting choice beats a standing suggestion, but a live operation still wins. The ordering matters — the preview block renders only under `applyPreview && !isApplying`, so once applying starts the cue must move to the progress tracker; checking `isApplying` first guarantees the id follows the visible block.
- `index.jsx`: passes `applyPreview` to the resolver and spreads `cueProps('apply-preview')` onto the preview block.

## How to test this

**Platforms:** any (renderer-only). Stacked on #254 + #256 + #258 + #260 — test this branch's Buildkite artifact to exercise the whole stack.

**Starting state:** an initialized site, wizard skipped, *Apply a patch or PR* panel visible.

1. Paste a PR URL (or number) and click **Apply PR** — or choose a `.diff`/`.patch` file. → The **preview block** (with *Apply and rebuild* / *Cancel*) glows and the view scrolls to center it.
2. Click **Apply and rebuild**. → The preview unmounts and the glow follows to the **progress tracker** (from #260).
3. Instead, click **Cancel**. → The preview clears and the cue moves on to the next pending action.

**What must not have happened:**

- The glow must not stay on the preview once applying begins (the preview block is gone by then).
- No glow on the preview when there is nothing staged.
- Screen reader announces "Next step: A patch is staged — apply and rebuild, or cancel."

## Risks and limitations

- Renderer-only. Not hand-verified by the author (no local app run — the EBADENGINE install constraint); `eslint .` clean, `npm test` **799** (3 new). Buildkite artifact is the hand-test path.

## Related

Part of #252. Stacked on #260 (base branch `juanmaguitar/highlight-patch-progress`) → #258 → #256 → #254. Merge bottom-up.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**No findings across the five dimensions** (0 [fix here] · 0 [follow-up]). Judgement pass ran in a fresh `Explore` subagent given only the diff and the review standard, per `/self-review`.

Verified: the resolver checks `isApplying` before `apply-preview`, so when applying starts the preview block unmounts and the cue follows to the progress tracker in the same render (locked by a new test); `Boolean(applyPreview)` is the right null-vs-object coercion, and the id is returned only when the preview block is actually rendered (no id-without-block window); `cueProps` in scope; full suite green. The reviewer also confirmed a staged preview + in-flight trunk update can coexist and `updating` correctly wins — placing `apply-preview` below `isUpdating` is intentional, and the cue still lands on a rendered block.

Deterministic layer: `eslint .` clean; `npm test` **799 pass** (3 new).

</details>
