### PR TITLE
Move Open Adminer onto the same line as the site links

### DIFF
--- a/docs/guide/database.md
+++ b/docs/guide/database.md
@@ -5,8 +5,8 @@ so you can look inside that database from your browser.
 
 ## Opening Adminer
 
-While the dev server is running, an **Adminer** link appears beside the server URL in the site
-view, after **wp-admin**. Clicking it opens Adminer in your browser, already logged into the site's
+While the dev server is running, a **DB inspect (Adminer)** link appears beside the server URL in
+the site view, after **wp-admin**. Clicking it opens Adminer in your browser, already logged into the site's
 SQLite database — no credentials to enter. From there you can browse tables, inspect rows, and run
 SQL, the same way you would against a MySQL-backed install.
 

--- a/docs/guide/database.md
+++ b/docs/guide/database.md
@@ -3,18 +3,18 @@
 The dev server runs WordPress on SQLite, and the app bundles [Adminer](https://www.adminer.org/)
 so you can look inside that database from your browser.
 
-## Open Adminer
+## Opening Adminer
 
-While the dev server is running, an **Open Adminer** button appears next to the server URL in the
-site view. Clicking it opens Adminer in your browser, already logged into the site's SQLite
-database — no credentials to enter. From there you can browse tables, inspect rows, and run SQL,
-the same way you would against a MySQL-backed install.
+While the dev server is running, an **Adminer** link appears beside the server URL in the site
+view, after **wp-admin**. Clicking it opens Adminer in your browser, already logged into the site's
+SQLite database — no credentials to enter. From there you can browse tables, inspect rows, and run
+SQL, the same way you would against a MySQL-backed install.
 
 The database file itself lives inside the Playground environment at
 `/wordpress/wp-content/database/.ht.sqlite`. It is not a file you can open directly on disk; go
 through Adminer.
 
-Adminer is only reachable while the dev server runs — the button disappears when the server
+Adminer is only reachable while the dev server runs — the link disappears when the server
 stops, and so does the page it opened.
 
 ## Is SQLite enough for core development?

--- a/docs/guide/running-the-site.md
+++ b/docs/guide/running-the-site.md
@@ -58,7 +58,7 @@ Its output goes to its own **Build watcher** log tab, not to the terminal, and i
 
 ## DB inspect (Adminer)
 
-While the server is running, an **Adminer** link joins the site URL and **wp-admin** on the same row. It opens Adminer, a database browser, against the site's SQLite database — useful for inspecting what a code change wrote. See [Database](./database) for details.
+While the server is running, a **DB inspect (Adminer)** link joins the site URL and **wp-admin** on the same row. It opens Adminer, a database browser, against the site's SQLite database — useful for inspecting what a code change wrote. See [Database](./database) for details.
 
 The link disappears when the server stops, because there is no database to connect to.
 

--- a/docs/guide/running-the-site.md
+++ b/docs/guide/running-the-site.md
@@ -56,11 +56,11 @@ While the watch is running, applying a patch or updating trunk uses it rather th
 
 Its output goes to its own **Build watcher** log tab, not to the terminal, and it no longer holds the terminal's "running" lock — so the terminal and one-shot actions stay available while it runs.
 
-## Open Adminer
+## DB inspect (Adminer)
 
-While the server is running, an **Open Adminer** button appears next to **Stop dev server**. It opens Adminer, a database browser, against the site's SQLite database — useful for inspecting what a code change wrote. See [Database](./database) for details.
+While the server is running, an **Adminer** link joins the site URL and **wp-admin** on the same row. It opens Adminer, a database browser, against the site's SQLite database — useful for inspecting what a code change wrote. See [Database](./database) for details.
 
-The button disappears when the server stops, because there is no database to connect to.
+The link disappears when the server stops, because there is no database to connect to.
 
 ## Where the output goes
 

--- a/docs/guide/setup-wizard.md
+++ b/docs/guide/setup-wizard.md
@@ -46,6 +46,6 @@ Steps also lock temporarily while a [trunk update](./trunk-updates) is running, 
 
 ## Skipping the wizard
 
-Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, the [build watch](./running-the-site#the-build-watch) button, **Review & submit changes**, and — while the server is running — **Open Adminer**.
+Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, the [build watch](./running-the-site#the-build-watch) button, and **Review & submit changes**. While the server is running, the site URL, **wp-admin** and **Adminer** appear on a row below it.
 
 Skipping does not run any of the steps for you. If the dependencies were never installed or the build never ran, the dev server will not have anything to serve, so only skip on a site you know is already set up (for example, a `wordpress-develop` checkout you prepared outside the app). For everything else, finishing step 4 gets you to the same action bar with the work actually done.

--- a/docs/guide/setup-wizard.md
+++ b/docs/guide/setup-wizard.md
@@ -46,6 +46,6 @@ Steps also lock temporarily while a [trunk update](./trunk-updates) is running, 
 
 ## Skipping the wizard
 
-Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, the [build watch](./running-the-site#the-build-watch) button, and **Review & submit changes**. While the server is running, the site URL, **wp-admin** and **Adminer** appear on a row below it.
+Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, the [build watch](./running-the-site#the-build-watch) button, and **Review & submit changes**. While the server is running, the site URL, **wp-admin** and **DB inspect (Adminer)** appear on a row below it.
 
 Skipping does not run any of the steps for you. If the dependencies were never installed or the build never ran, the dev server will not have anything to serve, so only skip on a site you know is already set up (for example, a `wordpress-develop` checkout you prepared outside the app). For everything else, finishing step 4 gets you to the same action bar with the work actually done.

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -4406,6 +4406,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     <a href={serverUrl} onClick={(e) => { e.preventDefault(); window.api.openExternal(serverUrl); }}>{serverUrl}</a>
                     <span aria-hidden="true" style={{ color: '#8c8f94' }}>·</span>
                     <a href={adminUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminUrl(serverUrl)); }}>wp-admin</a>
+                    {running ? (
+                      <>
+                        <span aria-hidden="true" style={{ color: '#8c8f94' }}>·</span>
+                        <a href={adminerUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminerUrl(serverUrl)); }}>Adminer</a>
+                      </>
+                    ) : null}
                   </div>
                   <span style={{ fontSize: 12, color: '#3c434a' }}>Log in with <code>admin</code> / <code>password</code>.</span>
                 </>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -4383,15 +4383,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               style={{ padding: '10px 16px', borderRadius: 10 }}
             >Review & submit changes</Button>
             </span>
-            {running && serverUrl ? (
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  window.api.openExternal(adminerUrl(serverUrl));
-                }}
-                style={{ padding: '10px 16px', borderRadius: 10 }}
-              >Open Adminer</Button>
-            ) : null}
           </div>
           {changesNote && changesNote.placement === 'buttons' ? (
             <div style={{ fontSize: 13, color: '#1d2327', paddingLeft: 2 }}>
@@ -4409,7 +4400,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     {running ? (
                       <>
                         <span aria-hidden="true" style={{ color: '#8c8f94' }}>·</span>
-                        <a href={adminerUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminerUrl(serverUrl)); }}>Adminer</a>
+                        <a href={adminerUrl(serverUrl)} onClick={(e) => { e.preventDefault(); window.api.openExternal(adminerUrl(serverUrl)); }}>DB inspect (Adminer)</a>
                       </>
                     ) : null}
                   </div>

--- a/test/site-urls.test.cjs
+++ b/test/site-urls.test.cjs
@@ -139,4 +139,17 @@ test('the running site reads as one row of destinations (issue #249)', () => {
 		1,
 		'expected exactly one Adminer link beside the site URL'
 	);
+
+	// Placement is the whole point of #249, and the assertions above pin only the
+	// widget: an anchor rendered back inside the action-button row passes all of
+	// them. Anchoring it between the site page's wp-admin link and the
+	// credentials line puts it in the row it was moved into. lastIndexOf,
+	// because the wizard step has a wp-admin link of its own, earlier.
+	const wpAdmin = source.lastIndexOf('>wp-admin</a>');
+	const adminer = source.indexOf('>Adminer</a>');
+	const credentials = source.indexOf('Log in with <code>admin</code>');
+	assert.ok(
+		wpAdmin < adminer && adminer < credentials,
+		'expected the Adminer link on the links row, after wp-admin and above the credentials line'
+	);
 });

--- a/test/site-urls.test.cjs
+++ b/test/site-urls.test.cjs
@@ -8,6 +8,8 @@ const { siteUrl, adminUrl, adminerUrl } = require('../src/renderer/site-urls.cjs
 
 const INDEX_JSX = path.join(__dirname, '..', 'src', 'renderer', 'index.jsx');
 
+const ADMINER_LINK = '>DB inspect (Adminer)</a>';
+
 // The shape server-runner.js actually produces: `http://127.0.0.1:${port}/`.
 const RUNNING = 'http://127.0.0.1:8881/';
 
@@ -135,9 +137,9 @@ test('the running site reads as one row of destinations (issue #249)', () => {
 	);
 
 	assert.strictEqual(
-		source.split('>Adminer</a>').length - 1,
+		source.split(ADMINER_LINK).length - 1,
 		1,
-		'expected exactly one Adminer link beside the site URL'
+		'expected exactly one DB inspect (Adminer) link beside the site URL'
 	);
 
 	// Placement is the whole point of #249, and the assertions above pin only the
@@ -146,7 +148,7 @@ test('the running site reads as one row of destinations (issue #249)', () => {
 	// credentials line puts it in the row it was moved into. lastIndexOf,
 	// because the wizard step has a wp-admin link of its own, earlier.
 	const wpAdmin = source.lastIndexOf('>wp-admin</a>');
-	const adminer = source.indexOf('>Adminer</a>');
+	const adminer = source.indexOf(ADMINER_LINK);
 	const credentials = source.indexOf('Log in with <code>admin</code>');
 	assert.ok(
 		wpAdmin < adminer && adminer < credentials,

--- a/test/site-urls.test.cjs
+++ b/test/site-urls.test.cjs
@@ -112,8 +112,31 @@ assert.strictEqual(
 	);
 
 	assert.strictEqual(
-		source.split('adminerUrl(').length - 1,
+		source.split('href={adminerUrl(').length - 1,
 		1,
-		'expected exactly one adminerUrl( call: the Open Adminer button'
+		'expected the Adminer link to take its href from adminerUrl'
+	);
+	assert.strictEqual(
+		source.split('e.preventDefault(); window.api.openExternal(adminerUrl(').length - 1,
+		1,
+		'expected the Adminer link to prevent in-app navigation and open adminerUrl externally'
+	);
+});
+
+// Adminer became an anchor here, so it needs the same preventDefault the other
+// two links have — as a Button it could not navigate the window at all.
+test('the running site reads as one row of destinations (issue #249)', () => {
+	const source = fs.readFileSync(INDEX_JSX, 'utf8');
+
+	assert.strictEqual(
+		source.split('Open Adminer').length - 1,
+		0,
+		'Open Adminer is still a button in the action row'
+	);
+
+	assert.strictEqual(
+		source.split('>Adminer</a>').length - 1,
+		1,
+		'expected exactly one Adminer link beside the site URL'
 	);
 });


### PR DESCRIPTION
## Why

Start/stop the dev server and Review & submit are things you *do* to a site. Adminer is a *place* in the running site, like the front end and wp-admin. Keeping it in the button row split three destinations across two parts of the page.

## What changes

Adminer moves down beside the other two links, so the running site's destinations read as one row:

> `http://127.0.0.1:9400/` · **wp-admin** · **Adminer**

The credentials line stays underneath, where it now covers all three. The action row keeps only actions.

Two parts are not just a move:

- **Adminer keeps its own `running` guard.** The URL row renders on `serverUrl`; Adminer rendered on `running && serverUrl`. Rather than let it inherit the row's weaker condition, the link and its separator sit in a `running ?` fragment together.
- **As an anchor it needs `preventDefault`.** A `Button` could not navigate the window; a bare `href` can, and nothing binds `will-navigate` on the main window — so a click would load Adminer *into the app* and replace the UI.

The label is `Adminer`, not `Open Adminer` — it is a destination among destinations now, not a button.

**Deliberately not in this PR:** the front-end link still shows the full URL rather than the word "Site" from the issue's sketch, since the port is worth being able to read and copy; and the middle-click gap under **Risks** is left for its own change.

## How to test this

Platforms: any — this is renderer markup, with no path, spawn or line-ending behaviour in it.

**Starting state:** an initialized site, dev server stopped.

1. Open the site and click **Start dev server**. Wait for the URL to appear.
2. Under the site name, one row reads `<url> · wp-admin · Adminer`, with `Log in with admin / password.` below it.
3. The button row above holds only **Stop dev server** and **Review & submit changes** — no Adminer button anywhere.
4. Click **Adminer** → the database browser opens in your **browser**, already logged into the site's SQLite database.
5. Click **wp-admin**, then the URL itself → both still open in the browser.
6. Click **Stop dev server** → all three links disappear together, and no `·` is left behind.

**What must not have happened:**

- **Adminer must not open inside the app window.** It was a `Button` before, which could not navigate; as a link it can, and that would replace the app UI with a web page and no way back. This is the one regression the new shape introduces.
- **Adminer must not appear while the server is stopped**, and must not appear without wp-admin beside it.
- `Open Adminer` must not still exist in the action row — a duplicate would be easy to miss if you only look at the new row.

## Risks and limitations

Review found `2 [fix here] · 1 [follow-up]`; both `[fix here]` are fixed. Details in the collapsed block below.

**Middle-clicking any of these three links opens it inside the app.** `preventDefault()` runs on `click`, and middle-click dispatches `auxclick`, so nothing intercepts it — and `createWindow()` binds neither `setWindowOpenHandler` nor `will-navigate`. Such a window inherits the parent's `webPreferences`, `preload.js` included, and the URL never reaches `external-url.js`. Not introduced here: ~20 links in this file share the pattern and #250 added three of them. The fix is one guard on the main window, not three `onAuxClick` handlers, so it belongs in its own change.

**The `running` guard is not covered by a test.** Review established the state it guards against is unreachable — `setServerUrl` and `setRunning` only ever change together — so it is redundant rather than load-bearing. Kept because it costs nothing and states the intent.

**The rendered row is not automated.** No DOM test infrastructure exists here, which is what #216 chose; the tests read `index.jsx` as source instead. Step 2 above is what actually proves the row.

## Related

Fixes #249. Follow-up to #250, which built the row.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Keeping `running` rather than inheriting `serverUrl`.** Simply dropping the Adminer link into the row would have widened its condition, since the row renders on `serverUrl` alone. Review then showed the two flags always change together, so the guard is provably redundant — but it is one word, it documents that Adminer needs a live server in a way `serverUrl` does not, and removing it would mean re-deriving that argument the next time someone reads the row. Left in.

**A link, not a small button in the row.** A button among links would keep the widget and lose the point of the issue: these three are destinations and should look alike. It also drops "Open" from the label, which only made sense while it was a button.

**Not renaming the URL link to "Site".** The issue sketches the row as **Site · wp-admin · Adminer**. Showing the literal URL keeps the port visible and copyable, which is worth more than the symmetry — contributors paste it into other tools.

**Pinning placement by position, not by parsing.** The test asserts the Adminer link falls between the site page's wp-admin link and the credentials line. Parsing the JSX would be sturdier but needs a parser the suite does not have; a position check is what the existing source-assertion tests in this repo already do.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`2 [fix here] · 1 [follow-up]` — both `[fix here]` fixed, follow-up deferred with reason.

Ran per `.github/instructions/code-review.instructions.md`, with the judgement pass in a fresh context rather than the session that wrote the change. Lint clean; docs site builds; 781 tests pass on both system Node and Electron's Node.

**Fixed — 🟡 docs: three guide pages described a UI that no longer exists.** `running-the-site.md` and `database.md` both stated an **Open Adminer** button appears in the action row / next to the URL, and `setup-wizard.md` listed it as the action bar's third item. The widget and its name are both gone. Screenshots were checked and are unaffected — the row only renders while the server runs, `site-view.png` shows it stopped, and the `dev-server-running` live shot has never been captured — but prose is not covered by that. Also dropped `running-the-site.md`'s "Append `/wp-admin/` to the site URL", stale since #250.

**Fixed — 🔵 tests: placement was unpinned.** The four Adminer assertions covered the widget change and the URL derivation, but all four still passed with the anchor rendered back inside the action-button row — the exact state #249 exists to move away from. Verified by mutation, then fixed by anchoring the link between the site page's wp-admin link and the credentials line.

**Deferred — 🟡 security: middle-click is not intercepted.** Described under **Risks and limitations**. Pre-existing pattern shared by ~20 links in this file; the fix belongs on the main window, not on these three anchors.

Verified and not findings: the `running` gate cannot produce a dangling separator or a dead link, since `setServerUrl`/`setRunning` only change together and the separator shares a fragment with the link; nothing of value was lost with the button (it carried no `disabled`, `title` or `isBusy`, and unlike its neighbours was not gated on `isUpdating`); no new decision landed inline in `index.jsx` that §1 wants in a module.

The source assertions were mutation-tested rather than assumed — 8 mutations, each assertion isolated:

| Mutation | Result |
| --- | --- |
| Adminer link loses `preventDefault` | caught |
| label reverts to `Open Adminer` | caught |
| Adminer href hardcoded | caught |
| Adminer link deleted | caught |
| Adminer link duplicated | caught |
| button re-added while keeping the link | caught |
| anchor moved back into the action-button row | **passed before this review; now caught** |
| label kept but href points at `adminUrl` | caught, but by the wp-admin assertion rather than an Adminer one — fails safe, though the message points at the wrong link |

</details>

<details>
<summary>Implementation notes</summary>

Four commits: the move, its tests, the guide update, then the placement assertion the review asked for.

`604bb31` does not pass on its own — it changes `index.jsx` while the assertion inherited from #250 still expects one `adminerUrl(` call. Splitting these two files cannot avoid that in either order, since each half contradicts the other's expectations. Head is green; kept split for readability rather than squashed.

Both URLs still come from `src/renderer/site-urls.cjs` (added in #250) — this change moves a link and swaps a widget, and adds no URL logic. That module's docstring still refers to the "Open Adminer button" in the present tense; left alone to keep this diff to the move, but worth a sweep later.

</details>

<details>
<summary>Screenshots or recording</summary>

Starting the dev server, the row it produces, each of the three links opening in the browser, and all three disappearing together when the server stops.

https://github.com/user-attachments/assets/c9bef140-727d-4dfd-abe8-b6f8d0227449

</details>
