### PR TITLE
[Add] Work on a Gutenberg issue and open a pull request to it (#251)

### DIFF
--- a/src/github-pr.cjs
+++ b/src/github-pr.cjs
@@ -46,13 +46,32 @@ const UPSTREAM_REPO = 'wordpress-develop';
  * sandbox needs a `trunk` branch and must not be owned by the signed-in
  * account, since an account cannot fork its own repository.
  *
+ * The site's project type supplies the repository for everything that is not a
+ * sandbox run (#251), so a Gutenberg site forks and targets WordPress/gutenberg.
+ * The environment override still wins, because its whole purpose is to redirect
+ * a real run away from a real upstream.
+ *
+ * @param {Object} [project] The project type's `upstream` config.
  * @return {{owner: string, repo: string}}
  */
-function upstream() {
+function upstream(project) {
 	const raw = process.env.WP_DEV_ENV_GITHUB_UPSTREAM;
 	const match = typeof raw === 'string' && /^([^/\s]+)\/([^/\s]+)$/.exec(raw.trim());
 	if (match) return { owner: match[1], repo: match[2] };
+	if (project && project.owner && project.repo) return { owner: project.owner, repo: project.repo };
 	return { owner: UPSTREAM_OWNER, repo: UPSTREAM_REPO };
+}
+
+/**
+ * The branch a pull request targets. Both projects call it `trunk` today, but
+ * reading it from the project type rather than a constant is what keeps a third
+ * one from needing a second code path.
+ *
+ * @param {Object} [project] The project type's `upstream` config.
+ * @return {string}
+ */
+function baseBranchFor(project) {
+	return (project && project.base) || BASE_BRANCH;
 }
 
 /**
@@ -77,6 +96,10 @@ function isDryRun() {
  * @return {{dryRun: boolean, target: string}|null}
  */
 function testMode() {
+	// Deliberately without a project: this answers "is the environment
+	// redirecting a real run somewhere else", which is an env-override question.
+	// Reading a project's own upstream here would report every Gutenberg site as
+	// sandboxed simply for not being wordpress-develop.
 	const up = upstream();
 	const target = `${up.owner}/${up.repo}`;
 	const sandboxed = target !== `${UPSTREAM_OWNER}/${UPSTREAM_REPO}`;
@@ -176,16 +199,22 @@ const MAX_NOTES_LENGTH = 20000;
  * @param {number|string} root0.ticketId
  * @param {string}        [root0.handle]
  * @param {string}        [root0.event]
- * @param {string}        [root0.notes]  Free text from the contributor.
+ * @param {string}        [root0.notes]   Free text from the contributor.
+ * @param {Object}        [root0.project] The project type's `pr` config plus its work-item URL.
  * @return {string}
  */
-function buildPullRequestBody({ ticketId, handle, event, notes } = {}) {
+function buildPullRequestBody({ ticketId, handle, event, notes, project } = {}) {
 	const lines = [];
 
 	const written = typeof notes === 'string' ? notes.trim().slice(0, MAX_NOTES_LENGTH) : '';
 	if (written) lines.push(written, '');
 
-	lines.push(`Trac ticket: ${ticketUrl(ticketId)}`);
+	// How a pull request names its work item is the project's own convention
+	// (#251): Core cites the Trac URL, Gutenberg closes the issue with
+	// `Fixes #1234`. Defaults to Core's when no project is supplied.
+	lines.push(project && typeof project.bodyLine === 'function'
+		? project.bodyLine(ticketId, project.workItemUrl || ticketUrl(ticketId))
+		: `Trac ticket: ${ticketUrl(ticketId)}`);
 	// The same two facts the mentor-handoff header carries (#166), for the same
 	// reason: props follow whoever wrote the patch, and a contributor-day room
 	// is worth naming while it is still happening.
@@ -196,14 +225,19 @@ function buildPullRequestBody({ ticketId, handle, event, notes } = {}) {
 }
 
 /**
- * A branch name for a ticket, and the alternatives to try if it is taken.
+ * A branch name for a work item, and the alternatives to try if it is taken.
+ *
+ * The prefix comes from the project type (#251) — `trac-` for a Core ticket,
+ * `fix/issue-` for a Gutenberg issue — so the branch reads correctly in the
+ * repository it is pushed to.
  *
  * @param {number|string} ticketId
  * @param {number}        attempt  Zero for the first try.
+ * @param {string}        [prefix] Defaults to Core's.
  * @return {string}
  */
-function branchNameFor(ticketId, attempt = 0) {
-	const base = `trac-${String(ticketId).replace(/[^0-9]/g, '')}`;
+function branchNameFor(ticketId, attempt = 0, prefix = 'trac-') {
+	const base = `${prefix}${String(ticketId).replace(/[^0-9]/g, '')}`;
 	return attempt === 0 ? base : `${base}-${attempt + 1}`;
 }
 
@@ -224,7 +258,7 @@ async function ensureFork({ token, login }, deps = {}) {
 	const post = deps.post || postJson;
 	const wait = deps.sleep || sleep;
 	const attempts = deps.forkPollAttempts || FORK_POLL_ATTEMPTS;
-	const up = upstream();
+	const up = upstream(deps.project);
 	const forkUrl = `${API}/repos/${login}/${up.repo}`;
 
 	// A repository under the fork's name is only usable if it actually is a
@@ -247,7 +281,7 @@ async function ensureFork({ token, login }, deps = {}) {
 	// surfaces at the very last write — the branch — as an opaque 404. Found
 	// by hand on the first real run against this repository, which is big
 	// enough for that window to be minutes wide.
-	const readRefs = () => get(`${forkUrl}/git/ref/heads/${BASE_BRANCH}`, { token });
+	const readRefs = () => get(`${forkUrl}/git/ref/heads/${baseBranchFor(deps.project)}`, { token });
 
 	let existing;
 	try {
@@ -323,16 +357,16 @@ async function ensureFork({ token, login }, deps = {}) {
 async function resolveBase({ token, login, baseSha }, deps = {}) {
 	const get = deps.get || getJson;
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${upstream().repo}`;
+	const repo = `${API}/repos/${login}/${upstream(deps.project).repo}`;
 
 	try {
 		// Always fast-forward first, so "the tip" means today's trunk and not
 		// wherever the fork was left. 409 here is a diverged fork, which is a
 		// normal state for someone who has contributed before — not a failure
 		// to report; the branch then bases on the fork's own tip.
-		await post(`${repo}/merge-upstream`, { branch: BASE_BRANCH }, { token });
+		await post(`${repo}/merge-upstream`, { branch: baseBranchFor(deps.project) }, { token });
 
-		const ref = await get(`${repo}/git/ref/heads/${BASE_BRANCH}`, { token });
+		const ref = await get(`${repo}/git/ref/heads/${baseBranchFor(deps.project)}`, { token });
 		if (ref.status !== 200 || !ref.json || !ref.json.object || !ref.json.object.sha) {
 			return failure(ref, 'Could not read your fork’s trunk');
 		}
@@ -374,7 +408,7 @@ async function resolveBase({ token, login, baseSha }, deps = {}) {
  */
 async function staleTouchedPaths({ token, login, tipSha, files }, deps = {}) {
 	const get = deps.get || getJson;
-	const repo = `${API}/repos/${login}/${upstream().repo}`;
+	const repo = `${API}/repos/${login}/${upstream(deps.project).repo}`;
 
 	const clashes = [];
 	try {
@@ -418,7 +452,7 @@ async function staleTouchedPaths({ token, login, tipSha, files }, deps = {}) {
  */
 async function createTree({ token, login, baseTreeSha, files }, deps = {}) {
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${upstream().repo}`;
+	const repo = `${API}/repos/${login}/${upstream(deps.project).repo}`;
 	const entries = [];
 
 	try {
@@ -466,7 +500,7 @@ async function createTree({ token, login, baseTreeSha, files }, deps = {}) {
  */
 async function commitAndBranch({ token, login, ticketId, message, treeSha, parentSha }, deps = {}) {
 	const post = deps.post || postJson;
-	const repo = `${API}/repos/${login}/${upstream().repo}`;
+	const repo = `${API}/repos/${login}/${upstream(deps.project).repo}`;
 
 	try {
 		const commit = await post(`${repo}/git/commits`, {
@@ -479,7 +513,7 @@ async function commitAndBranch({ token, login, ticketId, message, treeSha, paren
 
 		let lastRes = null;
 		for (let attempt = 0; attempt < MAX_BRANCH_ATTEMPTS; attempt++) {
-			const branch = branchNameFor(ticketId, attempt);
+			const branch = branchNameFor(ticketId, attempt, deps.branchPrefix);
 			const ref = await post(`${repo}/git/refs`, { ref: `refs/heads/${branch}`, sha }, { token });
 			if (ref.status === 201) return { ok: true, branch, sha };
 			// A 404 here is the fork's ref database still initialising — the
@@ -520,12 +554,12 @@ async function commitAndBranch({ token, login, ticketId, message, treeSha, paren
 async function createPullRequest({ token, login, branch, title, body }, deps = {}) {
 	const post = deps.post || postJson;
 	try {
-		const up = upstream();
+		const up = upstream(deps.project);
 		const res = await post(`${API}/repos/${up.owner}/${up.repo}/pulls`, {
 			title,
 			body,
 			head: `${login}:${branch}`,
-			base: BASE_BRANCH,
+			base: baseBranchFor(deps.project),
 			maintainer_can_modify: true
 		}, { token });
 		if (res.status !== 201 || !res.json || !res.json.html_url) return failure(res, 'Could not open the pull request');
@@ -551,11 +585,19 @@ async function createPullRequest({ token, login, branch, title, body }, deps = {
  * @param {Array}         root0.files
  * @param {string}        root0.title
  * @param {string}        root0.body
+ * @param {Object}        [root0.project]    The project type's `upstream` + branch prefix.
  * @param {Function}      [root0.onProgress]
  * @param {Object}        [deps]
  * @return {Promise<{ok: true, url: string, number: number, branch: string, exactBase: boolean}|{ok: false, reason: string, error: string, stage: string}>}
  */
-async function openPullRequest({ token, login, ticketId, baseSha, files, title, body, onProgress }, deps = {}) {
+async function openPullRequest({ token, login, ticketId, baseSha, files, title, body, project, onProgress }, deps = {}) {
+	// The project type rides in `deps` so every helper below — fork, sync, tree,
+	// branch, pull request — targets the same repository and base branch without
+	// each one growing its own parameter (#251). Absent, they all default to
+	// wordpress-develop, which is what a site with no project type is.
+	if (project) {
+		deps = { ...deps, project: project.upstream, branchPrefix: project.branchPrefix };
+	}
 	const get = deps.get || getJson;
 	const report = typeof onProgress === 'function' ? onProgress : () => {};
 	const at = (stage, result) => ({ ...result, stage });
@@ -596,7 +638,7 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 	// the wrong one silently produces a tree with no history behind it.
 	let baseCommit;
 	try {
-		baseCommit = await get(`${API}/repos/${login}/${upstream().repo}/git/commits/${base.sha}`, { token });
+		baseCommit = await get(`${API}/repos/${login}/${upstream(deps.project).repo}/git/commits/${base.sha}`, { token });
 	} catch (e) {
 		return at('syncing', { ok: false, reason: 'offline', error: String(e && e.message ? e.message : e) });
 	}
@@ -627,7 +669,7 @@ async function openPullRequest({ token, login, ticketId, baseSha, files, title, 
 		return {
 			ok: true,
 			dryRun: true,
-			url: `https://github.com/${login}/${upstream().repo}/tree/${branched.branch}`,
+			url: `https://github.com/${login}/${upstream(deps.project).repo}/tree/${branched.branch}`,
 			number: null,
 			branch: branched.branch,
 			exactBase: base.exact

--- a/src/main.js
+++ b/src/main.js
@@ -790,7 +790,7 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
     const provider = siteWorkItemProvider(meta);
     const title = typeof options.title === 'string' && options.title.trim()
         ? options.title.trim()
-        : `${provider.noun.charAt(0).toUpperCase()}${provider.noun.slice(1)} #${ticketId}`;
+        : provider.defaultPrTitle(ticketId);
 
     const result = await openPullRequest({
         token: githubToken,

--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,7 @@ const SWITCH_PROGRESS_CHANNEL = 'switch:progress';
 // step of an operation, and describing it as progress would have the panel say
 // "Saving your work…" about trunk — which is the one thing this refuses to do.
 const CARRIED_WORK_CHANNEL = 'ticket:carried-work';
-const { parseTicketRef } = require('./renderer/trac-ticket.cjs');
+const { workItemProvider } = require('./work-item.cjs');
 const { parseHandle } = require('./wporg-handle.cjs');
 const { parseEventName, buildProvenanceHeader, handoffFilename } = require('./patch-provenance.cjs');
 const { describeRefused } = require('./safe-log');
@@ -619,10 +619,16 @@ ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
             const s = await getStore();
             const meta = (s.get('siteMeta') || {})[sitePath] || {};
             const { wporgHandle: handle = null, contributionEvent: event = null } = s.get('preferences') || {};
+            // The work item is named the way this site's project names it
+            // (#251) — a Gutenberg patch must not cite a core.trac ticket that
+            // merely shares its number.
+            const wi = siteWorkItemProvider(meta);
             header = buildProvenanceHeader({
                 handle,
                 event,
                 ticketId: meta.tracTicket,
+                workItemLabel: wi.kind === 'trac' ? 'Ticket' : 'Issue',
+                workItemUrl: meta.tracTicket ? wi.urlFor(meta.tracTicket) : null,
                 // The base the patch was actually diffed against, which on a
                 // ticket branch is the trunk it was born at — not the site's
                 // current trunk, which "Update to latest trunk" may have moved
@@ -766,8 +772,11 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
     const s = await getStore();
     const meta = (s.get('siteMeta') || {})[sitePath] || {};
     const ticketId = meta.tracTicket;
+    // What the work item is called, and where its pull request goes, both follow
+    // the site's project (#251).
+    const projectType = projectTypeForSite(meta);
     if (!ticketId) {
-        return { ok: false, reason: 'no-ticket', error: 'Link a Trac ticket to this site first.', stage: 'auth' };
+        return { ok: false, reason: 'no-ticket', error: `Link a ${projectType.workItem.label} to this site first — a pull request has to cite one.`, stage: 'auth' };
     }
     const { wporgHandle: handle = null, contributionEvent = null } = s.get('preferences') || {};
 
@@ -778,9 +787,10 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
         return { ok: false, reason: 'error', error: String(e), stage: 'collect' };
     }
 
+    const provider = siteWorkItemProvider(meta);
     const title = typeof options.title === 'string' && options.title.trim()
         ? options.title.trim()
-        : `Ticket #${ticketId}`;
+        : `${provider.noun.charAt(0).toUpperCase()}${provider.noun.slice(1)} #${ticketId}`;
 
     const result = await openPullRequest({
         token: githubToken,
@@ -789,7 +799,14 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
         baseSha: collected.baseOid,
         files: collected.files,
         title,
-        body: buildPullRequestBody({ ticketId, handle, event: contributionEvent, notes: options.notes }),
+        project: { upstream: projectType.upstream, branchPrefix: projectType.pr.branchPrefix },
+        body: buildPullRequestBody({
+            ticketId,
+            handle,
+            event: contributionEvent,
+            notes: options.notes,
+            project: { bodyLine: projectType.pr.bodyLine, workItemUrl: provider.urlFor(ticketId) }
+        }),
         onProgress: (stage) => {
             if (!event.sender.isDestroyed()) event.sender.send('github:pr:progress', { sitePath, stage });
         }
@@ -1327,6 +1344,11 @@ const upstreamRepoPath = (meta) => {
     const up = projectTypeForSite(meta).upstream;
     return `${up.owner}/${up.repo}`;
 };
+
+// The work-item provider for a site — Trac tickets for Core, GitHub issues for
+// Gutenberg (#251). Defaults to Trac for a site with no project type.
+const siteWorkItemProvider = (meta) =>
+    workItemProvider(projectTypeForSite(meta).workItem.provider, upstreamRepoPath(meta));
 
 ipcMain.handle('git:list-ticket-patches', async (_e, sitePath) => {
     try {
@@ -1869,7 +1891,10 @@ ipcMain.handle('sites:set-ticket', async (event, sitePath, ref, options) => with
 		return { ok: true, ticket: null, branch: TRUNK };
 	}
 
-	const parsed = parseTicketRef(raw);
+	// What counts as a work item follows the site's project (#251): a Trac ticket
+	// for Core, a GitHub issue for Gutenberg. Both parse to a number, so the
+	// `ticket/<id>` branch key and every reader of `tracTicket` are unchanged.
+	const parsed = siteWorkItemProvider(await readSiteMeta(sitePath)).parseRef(raw);
 	if (!parsed.ok) return { ok: false, error: parsed.error };
 
 	const blocked = await midSwitchBlock(sitePath);

--- a/src/patch-provenance.cjs
+++ b/src/patch-provenance.cjs
@@ -124,15 +124,17 @@ function ticketNumber(ticketId) {
  * recorded.
  *
  * @param {Object}        details
- * @param {string}        [details.handle]      WordPress.org handle, already validated.
- * @param {string}        [details.event]       Where it was written — a WordCamp, a meetup.
+ * @param {string}        [details.handle]        WordPress.org handle, already validated.
+ * @param {string}        [details.event]         Where it was written — a WordCamp, a meetup.
  * @param {number|string} [details.ticketId]
+ * @param {string}        [details.workItemLabel] 'Ticket' (default) or 'Issue'.
+ * @param {string}        [details.workItemUrl]   Defaults to the Trac ticket URL.
  * @param {string}        [details.trunkOid]
- * @param {string}        [details.trunkDate]   ISO timestamp of the base commit.
- * @param {string}        [details.generatedAt] ISO timestamp for "now".
+ * @param {string}        [details.trunkDate]     ISO timestamp of the base commit.
+ * @param {string}        [details.generatedAt]   ISO timestamp for "now".
  * @return {string}
  */
-function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, generatedAt } = {}) {
+function buildProvenanceHeader({ handle, event, ticketId, workItemLabel, workItemUrl, trunkOid, trunkDate, generatedAt } = {}) {
 	const lines = [];
 
 	const contributor = field(handle);
@@ -145,8 +147,12 @@ function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, g
 	const where = field(event);
 	if (where) lines.push(`# Event: ${where}`);
 
+	// The work item, named the way its own project names it (#251): a Core patch
+	// cites a Trac ticket, a Gutenberg one its GitHub issue. `workItemUrl` is
+	// supplied by the caller, which knows the site's project; without it this
+	// falls back to Trac, which is what every existing caller meant.
 	const ticket = ticketNumber(ticketId);
-	if (ticket) lines.push(`# Ticket: ${ticketUrl(ticket)}`);
+	if (ticket) lines.push(`# ${workItemLabel || 'Ticket'}: ${workItemUrl || ticketUrl(ticket)}`);
 
 	const oid = field(trunkOid);
 	const based = day(trunkDate);

--- a/src/project-type.cjs
+++ b/src/project-type.cjs
@@ -54,7 +54,13 @@ const PROJECT_TYPES = {
 		// src/wp-includes layout (patch-plan.cjs mapToSrcLayout).
 		patch: { layout: 'src-layout' },
 
-		workItem: { provider: 'trac' },
+		workItem: {
+			provider: 'trac',
+			// What the panel calls it, and where a newcomer goes to find one.
+			label: 'Trac ticket',
+			browseUrl: 'https://core.trac.wordpress.org/tickets/good-first-bugs',
+			browseLabel: 'Browse good first bugs on Trac'
+		},
 
 		pr: {
 			branchPrefix: 'trac-',
@@ -94,7 +100,12 @@ const PROJECT_TYPES = {
 		// (packages/…); no src-layout rewrite.
 		patch: { layout: 'repo-relative' },
 
-		workItem: { provider: 'github-issue' },
+		workItem: {
+			provider: 'github-issue',
+			label: 'GitHub issue',
+			browseUrl: 'https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+First+Issue%22',
+			browseLabel: 'Browse good first issues on GitHub'
+		},
 
 		pr: {
 			branchPrefix: 'fix/issue-',

--- a/src/renderer/github-issue.cjs
+++ b/src/renderer/github-issue.cjs
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * Reading what a contributor typed when asked which GitHub issue they are
+ * working on (#251) — the Gutenberg counterpart of trac-ticket.cjs.
+ *
+ * Same shape as the Trac parser on purpose: a contributor arrives from a
+ * browser, so the input is as likely to be a pasted URL — with a comment
+ * anchor, a trailing slash or a query still attached — as it is a bare `#1234`.
+ * Keeping the two behind one interface is what lets the rest of the app ask
+ * "which work item is this site on?" without knowing where the answer lives.
+ *
+ * Kept pure and dependency-free so it can be unit tested without a DOM: the
+ * renderer bundle imports it and `node --test` requires it directly.
+ */
+
+const GITHUB_HOST = 'github.com';
+
+// Gutenberg is in the 70,000s. Seven digits leaves decades of headroom while
+// still rejecting a pasted timestamp — the same bound, and the same reasoning,
+// as the Trac parser's.
+const MAX_ISSUE_ID = 9999999;
+
+/**
+ * Canonical URL for an issue in a repository.
+ *
+ * @param {number|string} id
+ * @param {string}        repoPath `owner/repo`.
+ */
+function issueUrl(id, repoPath) {
+	return `https://${GITHUB_HOST}/${repoPath}/issues/${id}`;
+}
+
+/**
+ * Resolves free-form input to an issue id. Accepts `1234`, `#1234` and an issue
+ * URL for this site's own repository; rejects everything else with a message
+ * meant for the contributor, not for a log.
+ *
+ * A pull-request URL is rejected by name rather than falling through to the
+ * generic message: pasting the PR instead of the issue it fixes is the obvious
+ * mistake here, and "that is a pull request" is the answer that unsticks it.
+ *
+ * @param {string} input
+ * @param {Object} [options]
+ * @param {string} [options.repoPath] `owner/repo` whose issues this site tracks.
+ * @return {{ok: true, id: number, url: string}|{ok: false, error: string}}
+ */
+function parseIssueRef(input, { repoPath = 'WordPress/gutenberg' } = {}) {
+	const notAnIssue = `Enter an issue number like 1234, or a ${repoPath} issue URL.`;
+	const raw = typeof input === 'string' ? input.trim() : '';
+	if (!raw) return { ok: false, error: 'Enter an issue number or URL.' };
+
+	// Both branches below go through this, the way the Trac parser routes both of
+	// its own through fromDigits. A URL's digits are no more trustworthy than a
+	// typed one's: `/issues/0` would otherwise store a falsy id that every
+	// `ticketId ? …` reads as "no work item" while the site sits on `ticket/0`,
+	// and a 20-digit path would become a branch named after a float.
+	const fromDigits = (digits) => {
+		const id = Number(digits);
+		if (!Number.isSafeInteger(id) || id < 1 || id > MAX_ISSUE_ID) {
+			return { ok: false, error: notAnIssue };
+		}
+		return { ok: true, id, url: issueUrl(id, repoPath) };
+	};
+
+	const bare = raw.replace(/^#/, '');
+	if (/^\d+$/.test(bare)) return fromDigits(bare);
+
+	// Anything else has to be a URL. Accept it without a scheme too — copying a
+	// host out of an address bar often drops it. But `new URL` is lenient
+	// (`new URL('https://abc')` succeeds), so only take this branch when the
+	// input actually looks like a URL; otherwise a bare word would be reported
+	// as a wrong host rather than as not-an-issue.
+	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw);
+	if (!hasScheme && !raw.includes('/') && !raw.includes('.')) {
+		return { ok: false, error: notAnIssue };
+	}
+
+	let parsed;
+	try {
+		parsed = new URL(hasScheme ? raw : `https://${raw}`);
+	} catch {
+		return { ok: false, error: notAnIssue };
+	}
+
+	if (parsed.hostname.toLowerCase() !== GITHUB_HOST) {
+		return { ok: false, error: `Only ${GITHUB_HOST} issues are supported.` };
+	}
+
+	// Reading the id off the path drops ?foo= and #issuecomment- for free.
+	const match = /^\/([^/]+\/[^/]+)\/(issues|pull)\/(\d+)\/?$/.exec(parsed.pathname);
+	if (!match) return { ok: false, error: notAnIssue };
+	if (match[2] === 'pull') {
+		return { ok: false, error: 'That is a pull request. Link the issue it fixes instead.' };
+	}
+	if (match[1].toLowerCase() !== String(repoPath).toLowerCase()) {
+		return { ok: false, error: `Only ${repoPath} issues can be linked here.` };
+	}
+	return fromDigits(match[3]);
+}
+
+module.exports = {
+	GITHUB_HOST,
+	MAX_ISSUE_ID,
+	issueUrl,
+	parseIssueRef
+};

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -35,7 +35,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { prStateBadge } from './pr-state.cjs';
-import { ticketUrl, attachUrl } from './trac-ticket.cjs';
+import { workItemProvider } from '../work-item.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
 import { describeSwitchProgress } from '../switch-progress.cjs';
@@ -80,7 +80,6 @@ const PR_FAILURE_MESSAGES = {
   unauthorized: 'That GitHub sign-in is no longer valid. Sign in again, or save the patch file instead.',
   'rate-limited': 'GitHub is rate-limiting this connection. It usually clears within the hour.',
   offline: 'No connection to GitHub.',
-  'no-ticket': 'Link a Trac ticket to this site first — a pull request has to cite one.',
   empty: 'There are no changes to open a pull request with.'
 };
 // Per-status wording for the update chain card (#94), following the issue's
@@ -119,7 +118,6 @@ const TICKET_PATCH_STATUS_MESSAGE = {
   offline: 'Could not reach GitHub.',
   error: 'Could not read the pull requests from GitHub.'
 };
-const TRAC_TICKET_LISTS_URL = 'https://core.trac.wordpress.org/tickets/good-first-bugs';
 const CREATE_SITE_MODAL_STYLE_ID = 'create-site-modal-theme';
 
 function formatEmailDate(email) {
@@ -1283,6 +1281,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const allowedScripts = projectBuildConfig.allowedScripts;
   // `owner/repo` this site's pull requests come from and go to.
   const upstreamRepoPath = `${projectConfig.upstream.owner}/${projectConfig.upstream.repo}`;
+  // The work item this site tracks — a Trac ticket for Core, a GitHub issue for
+  // Gutenberg (#251). `workItem.attachUrlFor` is null where the concept does not
+  // exist, which is what the attachments panel keys off.
+  const workItemConfig = projectConfig.workItem;
+  const workItem = workItemProvider(workItemConfig.provider, upstreamRepoPath);
+  const isTracWorkItem = workItem.kind === 'trac';
   const [statusLoading, setStatusLoading] = useState(true);
   const [waitingForWatch, setWaitingForWatch] = useState(false);
   // Trac ticket association (#109)
@@ -3297,7 +3301,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // an attach form with nothing to attach.
   const saveForTrac = async () => {
     const filePath = await savePatchFile();
-    if (filePath && tracTicket) window.api.openExternal(attachUrl(tracTicket));
+    if (filePath && tracTicket && workItem.attachUrlFor) window.api.openExternal(workItem.attachUrlFor(tracTicket));
   };
 
   const saveForHandoff = async () => {
@@ -3452,7 +3456,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 {prLinkCopied ? 'Link copied' : 'Copy the link'}
               </Button>
               {tracTicket ? (
-                <Button variant="primary" onClick={()=>window.api.openExternal(ticketUrl(tracTicket))} style={{ justifyContent:'center' }}>
+                <Button variant="primary" onClick={()=>window.api.openExternal(workItem.urlFor(tracTicket))} style={{ justifyContent:'center' }}>
                   Open #{tracTicket} to comment
                 </Button>
               ) : null}
@@ -3573,7 +3577,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             </>
           ) : (
             <div style={{ fontSize:12, color:'#6c6f72' }}>
-              No ticket is linked to this site. A pull request has to cite one — link it in the Trac card.
+              No work item is linked to this site. A pull request has to cite one — link it in the {workItemConfig.label} card.
             </div>
           )}
           {prStage ? (
@@ -4218,7 +4222,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       ) : null}
       {skipInit ? (
       <div {...cueProps('link-ticket')} style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
-        <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Trac ticket</div>
+        <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>{workItemConfig.label}</div>
         {tracTicket ? (
           <>
             <div style={{ marginTop: 12, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
@@ -4229,7 +4233,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <span style={{ display: 'inline-flex', alignItems: 'center', padding: '4px 12px', borderRadius: 999, fontSize: 18, fontWeight: 600, letterSpacing: '0.01em', background: '#f0f0f1', color: '#1d2327' }}>
                 #{tracTicket}
               </span>
-              <Button variant="link" onClick={() => window.api.openExternal(ticketUrl(tracTicket))}>Open in Trac</Button>
+              <Button variant="link" onClick={() => window.api.openExternal(workItem.urlFor(tracTicket))}>{isTracWorkItem ? 'Open in Trac' : 'Open on GitHub'}</Button>
               <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketActionsBlocked}>Unlink</Button>
             </div>
             {changesNote && changesNote.placement === 'ticket' ? (
@@ -4297,12 +4301,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
             </div>
 
-            {latestIsAttachment ? (
+            {latestIsAttachment && isTracWorkItem ? (
               <div style={{ marginTop: 12, padding: '8px 10px', background: '#e7f1ff', border: '1px solid #9ec5f0', borderRadius: 6, fontSize: 12, color: '#0b5d95' }}>
                 The most recent patch on this ticket is a file attachment, not a pull request — see Trac attachments below.
               </div>
             ) : null}
 
+            {/* Only Trac carries patch attachments (#251). A GitHub issue's work
+                arrives as a pull request, which the panel above already lists —
+                and offering "Show Trac attachments" on a Gutenberg site would
+                open a core.trac ticket that merely shares its number, then offer
+                its Core patch for apply into a Gutenberg checkout. */}
+            {isTracWorkItem ? (
             <div style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
                 <div style={{ fontWeight: 600, fontSize: 13, color: '#1d2327' }}>Trac attachments</div>
@@ -4369,11 +4379,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 </div>
               ) : null}
             </div>
+            ) : null}
           </>
         ) : (
           <>
             <div style={{ marginTop: 4, fontSize: 13, color: '#3c434a' }}>
-              Tell the app which ticket you are working on. It is stored with the site, so it survives restarts, and you can change or remove it at any time.
+              Tell the app which work item you are on. It is stored with the site, so it survives restarts, and you can change or remove it at any time.
             </div>
             <div style={{ marginTop: 12, display: 'flex', alignItems: 'flex-start', gap: 8, flexWrap: 'wrap' }}>
               <div style={{ minWidth: 260 }}>
@@ -4382,8 +4393,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   onChange={(value) => { setTicketInput(value); setTicketError(''); }}
                   onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
                   disabled={ticketActionsBlocked}
-                  placeholder="Ticket number or URL, e.g. 62281"
-                  aria-label="Trac ticket number or URL"
+                  placeholder={isTracWorkItem ? 'Ticket number or URL, e.g. 62281' : 'Issue number or URL, e.g. 71234'}
+                  aria-label={`${workItemConfig.label} number or URL`}
                 />
               </div>
               <Button
@@ -4412,8 +4423,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         {blockedPanel}
         {tracTicket ? null : (
           <div style={{ marginTop: 8 }}>
-            <Button variant="link" onClick={() => window.api.openExternal(TRAC_TICKET_LISTS_URL)} style={{ fontSize: 12 }}>
-              Not sure yet? Browse good first bugs on Trac
+            <Button variant="link" onClick={() => window.api.openExternal(workItemConfig.browseUrl)} style={{ fontSize: 12 }}>
+              Not sure yet? {workItemConfig.browseLabel}
             </Button>
           </div>
         )}
@@ -4932,6 +4943,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   </DestinationGroup>
 
                   <DestinationGroup>
+                    {/* Attaching a patch file to the work item is a Trac concept
+                        (#251). A GitHub issue takes no attachments — Gutenberg
+                        work arrives as a pull request, which the destination
+                        above already offers — so this is hidden rather than
+                        rendered with a button that saves the file and then
+                        silently has nowhere to send it. */}
+                    {isTracWorkItem ? (
                     <Destination
                       title="Attach to Trac"
                       cost="A WordPress.org account — needed anyway, for props and to comment."
@@ -4951,8 +4969,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                             onChange={(value) => { setTicketInput(value); setTicketError(''); }}
                             onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
                             disabled={ticketActionsBlocked}
-                            placeholder="Ticket number or URL, e.g. 62281"
-                            aria-label="Trac ticket number or URL"
+                            placeholder={isTracWorkItem ? 'Ticket number or URL, e.g. 62281' : 'Issue number or URL, e.g. 71234'}
+                            aria-label={`${workItemConfig.label} number or URL`}
                           />
                           <Button
                             variant="secondary"
@@ -4968,6 +4986,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </>
                       )}
                     </Destination>
+                    ) : null}
 
                     <Destination
                       title="Hand it to a mentor"

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3449,9 +3449,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           */}
           {!prResult.dryRun && (
             <>
-              <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
-                Triage and props live on the ticket, so the link belongs there too.
-              </div>
+              {/*
+                Core-only: on Trac the pull request is a link somebody has to
+                carry back to the ticket, which is why this flow ends there. On
+                GitHub the pull request is the venue — saying the same thing
+                would send a Gutenberg contributor looking for a step that does
+                not exist.
+              */}
+              {isTracWorkItem ? (
+                <div style={{ fontSize:12, color:'#3c434a', lineHeight:1.5 }}>
+                  Triage and props live on the ticket, so the link belongs there too.
+                </div>
+              ) : null}
               <Button variant="secondary" onClick={copyPrLink} icon={prLinkCopied ? checkIcon : copyIcon} style={{ justifyContent:'center' }}>
                 {prLinkCopied ? 'Link copied' : 'Copy the link'}
               </Button>
@@ -3524,7 +3533,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               />
               {!prTitle.trim() ? (
                 <div style={{ fontSize:12, color:'#6c6f72', marginTop:-4 }}>
-                  Left empty, it will be titled <strong>Ticket #{tracTicket}</strong>.
+                  Left empty, it will be titled <strong>{workItem.defaultPrTitle(tracTicket)}</strong>.
                 </div>
               ) : null}
               {/*
@@ -3549,7 +3558,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 this flow ends on the point rather than the postscript, so they
                 are stated before the button, not after the pull request
                 exists.
+
+                Both are false for Gutenberg, where the pull request IS the
+                review venue and IS what gets merged — and the audience least
+                able to spot that the app is describing a different project is
+                exactly this one. Core-only until the Gutenberg counterpart is
+                written.
               */}
+              {isTracWorkItem ? (
               <details style={{ fontSize:12, color:'#6c6f72' }}>
                 <summary style={{ cursor:'pointer', color:'#3858e9' }}>How pull requests work in core</summary>
                 <div style={{ padding:'8px 0 0', lineHeight:1.6, display:'flex', flexDirection:'column', gap:6 }}>
@@ -3562,6 +3578,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   >The handbook page on pull requests</Button>
                 </div>
               </details>
+              ) : null}
               {/*
                 The button says what it will actually do. A dry run's button
                 reading "Open pull request" is the label lying about the mode,
@@ -4393,7 +4410,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   onChange={(value) => { setTicketInput(value); setTicketError(''); }}
                   onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
                   disabled={ticketActionsBlocked}
-                  placeholder={isTracWorkItem ? 'Ticket number or URL, e.g. 62281' : 'Issue number or URL, e.g. 71234'}
+                  placeholder={workItem.refPlaceholder}
                   aria-label={`${workItemConfig.label} number or URL`}
                 />
               </div>
@@ -4969,7 +4986,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                             onChange={(value) => { setTicketInput(value); setTicketError(''); }}
                             onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); linkTicket(); } }}
                             disabled={ticketActionsBlocked}
-                            placeholder={isTracWorkItem ? 'Ticket number or URL, e.g. 62281' : 'Issue number or URL, e.g. 71234'}
+                            placeholder={workItem.refPlaceholder}
                             aria-label={`${workItemConfig.label} number or URL`}
                           />
                           <Button

--- a/src/work-item.cjs
+++ b/src/work-item.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * One interface over the two kinds of work item a site can be on (#251): a
+ * WordPress Trac ticket, or a GitHub issue on the project's own repository.
+ *
+ * The rest of the app asks "parse what they typed", "where does this live", and
+ * "what do we call it" without knowing which kind it is — the site's project
+ * type picks the provider. Everything Trac-specific still lives in
+ * renderer/trac-ticket.cjs and everything GitHub-specific in
+ * renderer/github-issue.cjs; this only chooses between them, so neither path
+ * had to change to gain the other.
+ *
+ * Pure and dependency-free (both parsers are too), so `node --test` requires it
+ * directly and the renderer bundles it.
+ */
+
+const { parseTicketRef, ticketUrl, attachUrl } = require('./renderer/trac-ticket.cjs');
+const { parseIssueRef, issueUrl } = require('./renderer/github-issue.cjs');
+
+/**
+ * The provider for a work-item kind, defaulting to Trac for anything unknown —
+ * the same default-to-Core rule the project-type registry follows, so a site
+ * with no type behaves exactly as it always did.
+ *
+ * `repoPath` is only meaningful for GitHub issues; the Trac provider ignores it.
+ *
+ * @param {string} provider   'trac' (default) or 'github-issue'.
+ * @param {string} [repoPath] `owner/repo`, for the GitHub provider.
+ * @return {{kind: string, noun: string, parseRef: Function, urlFor: Function, attachUrlFor: (Function|null)}}
+ */
+function workItemProvider(provider, repoPath) {
+	if (provider === 'github-issue') {
+		return {
+			kind: 'github-issue',
+			noun: 'issue',
+			parseRef: (input) => parseIssueRef(input, { repoPath }),
+			urlFor: (id) => issueUrl(id, repoPath),
+			// GitHub issues carry no patch attachments — work arrives as a pull
+			// request, which the linked-PR panel already lists. Null rather than a
+			// no-op so a caller has to decide what to show rather than rendering an
+			// "attach" affordance that leads nowhere.
+			attachUrlFor: null
+		};
+	}
+	return {
+		kind: 'trac',
+		noun: 'ticket',
+		parseRef: parseTicketRef,
+		urlFor: ticketUrl,
+		attachUrlFor: attachUrl
+	};
+}
+
+module.exports = { workItemProvider };

--- a/src/work-item.cjs
+++ b/src/work-item.cjs
@@ -27,13 +27,20 @@ const { parseIssueRef, issueUrl } = require('./renderer/github-issue.cjs');
  *
  * @param {string} provider   'trac' (default) or 'github-issue'.
  * @param {string} [repoPath] `owner/repo`, for the GitHub provider.
- * @return {{kind: string, noun: string, parseRef: Function, urlFor: Function, attachUrlFor: (Function|null)}}
+ * @return {{kind: string, noun: string, refPlaceholder: string, defaultPrTitle: Function, parseRef: Function, urlFor: Function, attachUrlFor: (Function|null)}}
  */
 function workItemProvider(provider, repoPath) {
 	if (provider === 'github-issue') {
 		return {
 			kind: 'github-issue',
 			noun: 'issue',
+			refPlaceholder: 'Issue number or URL, e.g. 71234',
+			// The title a pull request gets when the contributor leaves the field
+			// empty. Lives here because both the handler that sends it and the
+			// hint that promises it need the same string; when they were written
+			// separately the hint said "Ticket #" on a Gutenberg site while the
+			// handler sent "Issue #".
+			defaultPrTitle: (id) => `Issue #${id}`,
 			parseRef: (input) => parseIssueRef(input, { repoPath }),
 			urlFor: (id) => issueUrl(id, repoPath),
 			// GitHub issues carry no patch attachments — work arrives as a pull
@@ -46,6 +53,8 @@ function workItemProvider(provider, repoPath) {
 	return {
 		kind: 'trac',
 		noun: 'ticket',
+		refPlaceholder: 'Ticket number or URL, e.g. 62281',
+		defaultPrTitle: (id) => `Ticket #${id}`,
 		parseRef: parseTicketRef,
 		urlFor: ticketUrl,
 		attachUrlFor: attachUrl

--- a/test/github-issue.test.cjs
+++ b/test/github-issue.test.cjs
@@ -1,0 +1,101 @@
+'use strict';
+
+// The Gutenberg counterpart of trac-ticket.test.cjs (#251). A contributor
+// arrives from a browser, so what they paste is as likely to be a URL — with an
+// anchor, a query or a trailing slash still on it — as a bare `#1234`.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { parseIssueRef, issueUrl } = require('../src/renderer/github-issue.cjs');
+
+const GB = 'WordPress/gutenberg';
+
+test('issueUrl builds the canonical issue address', () => {
+	assert.strictEqual(issueUrl(71234, GB), 'https://github.com/WordPress/gutenberg/issues/71234');
+});
+
+test('parseIssueRef: a bare number, with or without the #', () => {
+	assert.deepStrictEqual(parseIssueRef('71234'), { ok: true, id: 71234, url: issueUrl(71234, GB) });
+	assert.deepStrictEqual(parseIssueRef('#71234'), { ok: true, id: 71234, url: issueUrl(71234, GB) });
+	assert.deepStrictEqual(parseIssueRef('  71234  '), { ok: true, id: 71234, url: issueUrl(71234, GB) });
+});
+
+test('parseIssueRef: an issue URL, with the noise a copy-paste brings', () => {
+	for (const input of [
+		'https://github.com/WordPress/gutenberg/issues/71234',
+		'https://github.com/WordPress/gutenberg/issues/71234/',
+		'github.com/WordPress/gutenberg/issues/71234',
+		'https://github.com/WordPress/gutenberg/issues/71234#issuecomment-123456',
+		'https://github.com/WordPress/gutenberg/issues/71234?foo=bar'
+	]) {
+		const res = parseIssueRef(input);
+		assert.strictEqual(res.ok, true, `${input}: ${res.error}`);
+		assert.strictEqual(res.id, 71234, input);
+	}
+});
+
+// Pasting the pull request instead of the issue it fixes is the obvious mistake
+// here, so it gets an answer that unsticks it rather than the generic one.
+test('parseIssueRef: a pull request URL is refused by name', () => {
+	const res = parseIssueRef('https://github.com/WordPress/gutenberg/pull/4496');
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /pull request/i);
+});
+
+// The repo guard is what stops a site tracking an issue from another project,
+// whose number would then be cited in a pull request that has nothing to do
+// with it.
+test('parseIssueRef: another repository’s issue is refused', () => {
+	const res = parseIssueRef('https://github.com/WordPress/wordpress-develop/issues/1234');
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /WordPress\/gutenberg/);
+
+	// And the guard moves with the site.
+	const ok = parseIssueRef('https://github.com/WordPress/wordpress-develop/issues/1234', { repoPath: 'WordPress/wordpress-develop' });
+	assert.strictEqual(ok.ok, true);
+	assert.strictEqual(ok.id, 1234);
+});
+
+test('parseIssueRef: another host is refused', () => {
+	const res = parseIssueRef('https://gitlab.com/WordPress/gutenberg/issues/1');
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /github\.com/);
+});
+
+test('parseIssueRef: empty and nonsense input are rejected with a reason', () => {
+	assert.strictEqual(parseIssueRef('').ok, false);
+	assert.strictEqual(parseIssueRef('   ').ok, false);
+	assert.strictEqual(parseIssueRef(undefined).ok, false);
+	// A bare word must read as not-an-issue, not as a wrong host: `new URL` is
+	// lenient enough to accept `https://nonsense` as a valid hostname.
+	const res = parseIssueRef('nonsense');
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /issue number/i);
+});
+
+test('parseIssueRef: zero and absurd numbers are rejected', () => {
+	assert.strictEqual(parseIssueRef('0').ok, false);
+	assert.strictEqual(parseIssueRef('99999999999').ok, false, 'a pasted timestamp is not an issue');
+});
+
+// The URL branch has to apply the same bounds as the typed one — it reads digits
+// off a pasted address, which are no more trustworthy. Each of these parsed
+// before the guard was shared:
+//
+//   /issues/0   → a falsy id, so the site sits on branch `ticket/0` while every
+//                 `ticketId ? …` reads it as having no work item at all, and
+//                 "open a pull request" refuses on a site that looks linked.
+//   /issues/<20 digits> → Number() overflows to a float, and the branch is named
+//                 after it (`fix/issue-100000000000000000000`).
+//   /issues/012 → id 12, but a url still pointing at `/012`.
+test('parseIssueRef: a URL’s number is bounds-checked like a typed one', () => {
+	const url = (n) => `https://github.com/WordPress/gutenberg/issues/${n}`;
+
+	assert.strictEqual(parseIssueRef(url(0)).ok, false, 'issue 0 is not a work item');
+	assert.strictEqual(parseIssueRef(url('99999999999999999999')).ok, false, 'an overflowing number is not an issue');
+	// A padded number resolves to the canonical id and a canonical URL.
+	const padded = parseIssueRef(url('012'));
+	assert.strictEqual(padded.ok, true);
+	assert.strictEqual(padded.id, 12);
+	assert.strictEqual(padded.url, url(12), 'the URL is rebuilt from the parsed id, not echoed back');
+});

--- a/test/github-pr.test.cjs
+++ b/test/github-pr.test.cjs
@@ -687,3 +687,101 @@ test('openPullRequest refuses an empty change before it touches GitHub', async (
 	assert.strictEqual(res.reason, 'empty');
 	assert.deepStrictEqual(api.calls, []);
 });
+
+// --- per-project pull requests (#251) --------------------------------------
+
+test('branchNameFor uses the project’s prefix, and still de-duplicates', () => {
+	// Core, unchanged.
+	assert.strictEqual(branchNameFor(62281), 'trac-62281');
+	assert.strictEqual(branchNameFor(62281, 1), 'trac-62281-2');
+	// Gutenberg: the branch has to read correctly in the repository it lands in.
+	assert.strictEqual(branchNameFor(71234, 0, 'fix/issue-'), 'fix/issue-71234');
+	assert.strictEqual(branchNameFor(71234, 1, 'fix/issue-'), 'fix/issue-71234-2');
+});
+
+test('buildPullRequestBody cites the work item the project’s way', () => {
+	// Core, unchanged: the Trac URL, on its own line.
+	const core = buildPullRequestBody({ ticketId: 62281 });
+	assert.ok(core.includes('Trac ticket: https://core.trac.wordpress.org/ticket/62281'), core);
+
+	// Gutenberg: a closing keyword, so merging the PR closes the issue.
+	const gutenberg = buildPullRequestBody({
+		ticketId: 71234,
+		project: { bodyLine: (id) => `Fixes #${id}`, workItemUrl: 'https://github.com/WordPress/gutenberg/issues/71234' }
+	});
+	assert.ok(gutenberg.includes('Fixes #71234'), gutenberg);
+	assert.ok(!gutenberg.includes('core.trac.wordpress.org'), 'a Gutenberg PR must not cite Trac');
+	// The rest of the body is unchanged — it is not project-specific.
+	assert.ok(gutenberg.includes('Opened from the WordPress Contributor Toolkit.'));
+});
+
+test('buildPullRequestBody keeps the contributor’s notes above the citation', () => {
+	const body = buildPullRequestBody({
+		ticketId: 71234,
+		notes: 'What it does.',
+		project: { bodyLine: (id) => `Fixes #${id}` }
+	});
+	assert.ok(body.indexOf('What it does.') < body.indexOf('Fixes #71234'), body);
+});
+
+// The single highest-risk behaviour of the per-project flow: a Gutenberg run has
+// to fork, sync, branch and open against WordPress/gutenberg. Every helper reads
+// the project out of `deps`, so one that forgets would silently open a pull
+// request against wordpress-develop — a real PR, on the wrong project, from a
+// contributor who asked for neither. Pinned end to end rather than per helper.
+test('a Gutenberg project opens its pull request against WordPress/gutenberg', async () => {
+	const api = router({
+		'GET repos/janedoe/gutenberg': { status: 200, json: { fork: true, parent: { full_name: 'WordPress/gutenberg' } } },
+		'GET repos/janedoe/gutenberg/git/ref/heads/trunk': { status: 200, json: { object: { sha: 'abc123' } } },
+		'POST merge-upstream': { status: 200 },
+		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } },
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 201 },
+		'POST repos/WordPress/gutenberg/pulls': { status: 201, json: { html_url: 'https://github.com/WordPress/gutenberg/pull/1', number: 1 } }
+	});
+
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 71234, baseSha: 'abc123',
+		files: [{ path: 'packages/a/index.js', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b',
+		project: { upstream: { owner: 'WordPress', repo: 'gutenberg', base: 'trunk' }, branchPrefix: 'fix/issue-' }
+	}, api);
+
+	assert.strictEqual(res.ok, true, res.error);
+	assert.strictEqual(res.url, 'https://github.com/WordPress/gutenberg/pull/1');
+	// The branch reads correctly in the repository it landed in.
+	assert.strictEqual(res.branch, 'fix/issue-71234');
+	// And nothing in the whole sequence — fork, ref read, sync, tree, commit,
+	// branch, pull request — went near the other project.
+	assert.strictEqual(api.calls.some((c) => c.url.includes('wordpress-develop')), false, 'a Gutenberg run must not touch wordpress-develop');
+	// The fork it uses is the Gutenberg one, not a wordpress-develop fork.
+	assert.ok(api.calls.some((c) => c.url.includes('repos/janedoe/gutenberg')), 'the fork is the project’s own');
+});
+
+// The other side of the same coin: with no project, every call still goes to
+// wordpress-develop exactly as it always did.
+test('with no project the flow still targets wordpress-develop', async () => {
+	const api = router({
+		'GET repos/janedoe/wordpress-develop': { status: 200, json: { fork: true, parent: { full_name: 'WordPress/wordpress-develop' } } },
+		'GET repos/janedoe/wordpress-develop/git/ref/heads/trunk': { status: 200, json: { object: { sha: 'abc123' } } },
+		'POST merge-upstream': { status: 200 },
+		'GET git/commits/abc123': { status: 200, json: { tree: { sha: 'basetree' } } },
+		'POST git/blobs': { status: 201, json: { sha: 'blob1' } },
+		'POST git/trees': { status: 201, json: { sha: 'tree1' } },
+		'POST git/commits': { status: 201, json: { sha: 'commit1' } },
+		'POST git/refs': { status: 201 },
+		'POST repos/WordPress/wordpress-develop/pulls': { status: 201, json: { html_url: 'https://github.com/WordPress/wordpress-develop/pull/9', number: 9 } }
+	});
+
+	const res = await openPullRequest({
+		token: TOKEN, login: LOGIN, ticketId: 62281, baseSha: 'abc123',
+		files: [{ path: 'src/a.php', kind: 'modify', content: Buffer.from('x'), mode: '100644' }],
+		title: 't', body: 'b'
+	}, api);
+
+	assert.strictEqual(res.ok, true, res.error);
+	assert.strictEqual(res.branch, 'trac-62281');
+	assert.strictEqual(api.calls.some((c) => c.url.includes('gutenberg')), false);
+});

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1077,6 +1077,58 @@ test('git:save-patch with handoff asks patch-provenance for the header and the n
 	assert.equal(path.basename(main.calls.showSaveDialog[0].defaultPath), '62281.janedoe.diff');
 });
 
+// The two halves of the same header on a Gutenberg site. Nothing pinned this
+// before: the builder was tested (label/url in -> right line out) and the
+// handler was tested for Core, but the wiring between them — the label and the
+// URL the handler derives from the site's provider — was unexercised for either
+// project. A regression that dropped them leaves a Gutenberg patch citing
+// core.trac.wordpress.org/ticket/71234, a Core ticket that merely shares its
+// number, which is the exact confusion this wiring exists to prevent.
+test('git:save-patch names the work item the way a Gutenberg site names it', async (t) => {
+	const dir = await fixtureRepo(t);
+	const buildProvenanceHeader = spy(() => '# header\n\n');
+	const handoffFilename = spy(() => '71234.janedoe.diff');
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				siteMeta: { [dir]: { projectType: 'gutenberg', tracTicket: 71234, trunkOid: 'abcdef1234567890', trunkDate: '2026-08-05T09:14:00.000Z' } },
+				preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' }
+			}).stubs,
+			'./patch-provenance.cjs': { buildProvenanceHeader, handoffFilename }
+		}
+	});
+
+	await main.invoke('git:save-patch', dir, { handoff: true });
+
+	const details = buildProvenanceHeader.calls[0][0];
+	assert.equal(details.workItemLabel, 'Issue', 'a Gutenberg patch must not call its work item a ticket');
+	assert.equal(details.workItemUrl, 'https://github.com/WordPress/gutenberg/issues/71234');
+});
+
+// And the Core half of the same pair, which the test above would otherwise let
+// regress in the opposite direction.
+test('git:save-patch still names a Core site’s work item a Trac ticket', async (t) => {
+	const dir = await fixtureRepo(t);
+	const buildProvenanceHeader = spy(() => '# header\n\n');
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				siteMeta: { [dir]: { tracTicket: 62281, trunkOid: 'abcdef1234567890', trunkDate: '2026-08-05T09:14:00.000Z' } },
+				preferences: { wporgHandle: 'janedoe', contributionEvent: 'WordCamp Europe 2026' }
+			}).stubs,
+			'./patch-provenance.cjs': { buildProvenanceHeader, handoffFilename: () => '62281.janedoe.diff' }
+		}
+	});
+
+	await main.invoke('git:save-patch', dir, { handoff: true });
+
+	const details = buildProvenanceHeader.calls[0][0];
+	assert.equal(details.workItemLabel, 'Ticket');
+	assert.equal(details.workItemUrl, 'https://core.trac.wordpress.org/ticket/62281');
+});
+
 // A handoff header names the base the patch was diffed against, and on a ticket
 // branch that is the trunk the branch was born at — not the site's current
 // trunk, which "Update to latest trunk" moves forward while existing branches

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1780,6 +1780,29 @@ test('sites:set-ticket validates the reference through trac-ticket', async () =>
 	assert.deepEqual(result, { ok: false, error: 'not a ticket' });
 });
 
+// A Gutenberg site's work item is a GitHub issue, so the same handler has to
+// validate through the issue parser instead (#251) — otherwise pasting an issue
+// URL would be rejected as "not a core.trac.wordpress.org ticket".
+test('sites:set-ticket validates a Gutenberg site’s reference as a GitHub issue', async () => {
+	const settings = fakeSettingsStore({ sites: ['/sites/gb'], siteMeta: { '/sites/gb': { projectType: 'gutenberg' } } });
+	const parseIssueRef = spy(() => ({ ok: false, error: 'not an issue' }));
+	const parseTicketRef = spy(() => ({ ok: true, id: 1 }));
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./renderer/github-issue.cjs': { parseIssueRef },
+			'./renderer/trac-ticket.cjs': { parseTicketRef }
+		}
+	});
+
+	const result = await main.invoke('sites:set-ticket', '/sites/gb', 'https://github.com/WordPress/gutenberg/issues/71234');
+
+	assert.equal(parseIssueRef.calls.length, 1, 'a Gutenberg site parses issues');
+	assert.deepEqual(parseTicketRef.calls, [], 'and must not fall through to the Trac parser');
+	assert.deepEqual(result, { ok: false, error: 'not an issue' });
+});
+
 test('sites:set-ticket refuses unregistered site paths before writing metadata', async () => {
 	const settings = fakeSettingsStore({ sites: ['/sites/wp'] });
 	const parseTicketRef = spy(() => ({ ok: true, id: 62281 }));
@@ -3545,10 +3568,59 @@ test('github:open-pr asks github-pr to open one, for the ticket this site is lin
 	// The ticket comes from the site's stored metadata, not from the caller: the
 	// renderer must not be able to file against a different one.
 	assert.equal(args.ticketId, 62281);
+	// Where the pull request goes follows the site's project (#251); a site with
+	// no type is Core's.
+	assert.deepEqual(args.project.upstream, { owner: 'WordPress', repo: 'wordpress-develop', base: 'trunk' });
+	assert.equal(args.project.branchPrefix, 'trac-');
 	// The notes are the caller's to supply — unlike the ticket, the handle and
 	// the event, which are read from stored state so the renderer cannot claim
 	// a different contributor or a different ticket than this site's.
-	assert.deepEqual(buildPullRequestBody.calls, [[{ ticketId: 62281, handle: 'janedoe', event: 'WordCamp Europe 2026', notes: 'What it does, and how to see it.' }]]);
+	const [bodyArgs] = buildPullRequestBody.calls[0];
+	assert.equal(bodyArgs.ticketId, 62281);
+	assert.equal(bodyArgs.handle, 'janedoe');
+	assert.equal(bodyArgs.event, 'WordCamp Europe 2026');
+	assert.equal(bodyArgs.notes, 'What it does, and how to see it.');
+	// And how it cites its work item, which is the project's own convention.
+	assert.equal(bodyArgs.project.bodyLine(62281, 'URL'), 'Trac ticket: URL');
+	assert.equal(bodyArgs.project.workItemUrl, 'https://core.trac.wordpress.org/ticket/62281');
+});
+
+// The same handler for a Gutenberg site: the project it hands github-pr decides
+// which repository the pull request is opened against, so this is what stops a
+// Gutenberg contribution landing on wordpress-develop.
+test('github:open-pr targets a Gutenberg site’s own project', async (t) => {
+	const dir = await fixtureRepo(t);
+	const auth = fakeGithubAuth({ login: 'janedoe' });
+	const openPullRequest = spy(async () => ({ ok: true, url: 'https://github.com/WordPress/gutenberg/pull/1', number: 1, branch: 'fix/issue-71234', exactBase: true }));
+	const buildPullRequestBody = spy(() => 'BODY');
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: { [dir]: { tracTicket: 71234, projectType: 'gutenberg' } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./github-auth.cjs': auth,
+			'./github-pr.cjs': { openPullRequest, buildPullRequestBody }
+		}
+	});
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+
+	await main.invoke('github:open-pr', dir, {});
+
+	const [args] = openPullRequest.calls[0];
+	assert.deepEqual(args.project.upstream, { owner: 'WordPress', repo: 'gutenberg', base: 'trunk' });
+	assert.equal(args.project.branchPrefix, 'fix/issue-');
+	// The default title uses the project's noun, not "Ticket".
+	assert.equal(args.title, 'Issue #71234');
+	// And the body closes the issue rather than citing a Trac URL.
+	const [bodyArgs] = buildPullRequestBody.calls[0];
+	assert.equal(bodyArgs.project.bodyLine(71234), 'Fixes #71234');
+	assert.equal(bodyArgs.project.workItemUrl, 'https://github.com/WordPress/gutenberg/issues/71234');
 	// The changed file the fixture leaves in the working tree, in the shape the
 	// tree API takes rather than as a diff.
 	assert.deepEqual(args.files.map((f) => [f.path, f.kind]), [['text.txt', 'modify']]);

--- a/test/patch-provenance.test.cjs
+++ b/test/patch-provenance.test.cjs
@@ -168,3 +168,20 @@ test('handoffFilename: a handle that never passed validation does not reach the 
 	}
 	assert.strictEqual(handoffFilename(), 'wordpress.patch');
 });
+
+// A handed-off patch names its work item the way the project does (#251). The
+// header used to derive a Trac URL from the number alone, so a Gutenberg site's
+// patch cited a core.trac ticket that merely shared its issue number — the same
+// wrong-project confusion the app guards against elsewhere.
+test('the header cites the work item the caller names, not always Trac', () => {
+	const core = buildProvenanceHeader({ ticketId: 62281 });
+	assert.ok(core.includes('# Ticket: https://core.trac.wordpress.org/ticket/62281'), core);
+
+	const gutenberg = buildProvenanceHeader({
+		ticketId: 71234,
+		workItemLabel: 'Issue',
+		workItemUrl: 'https://github.com/WordPress/gutenberg/issues/71234'
+	});
+	assert.ok(gutenberg.includes('# Issue: https://github.com/WordPress/gutenberg/issues/71234'), gutenberg);
+	assert.ok(!gutenberg.includes('core.trac.wordpress.org'), 'a Gutenberg patch must not cite Trac');
+});

--- a/test/ticket-branch-list.test.cjs
+++ b/test/ticket-branch-list.test.cjs
@@ -151,12 +151,15 @@ test('card: the list renders once, in its own card between the ticket card and t
 	// name so that a comment naming the helper is not a red suite.
 	assert.strictEqual(source.split('renderBranchRows(').length - 1, 1, 'expected exactly one renderBranchRows( call: the single card that renders the list');
 
-	// Between the two cards it used to sit inside of and above.
-	const ticketCard = source.indexOf('>Trac ticket<');
+	// Between the two cards it used to sit inside of and above. The work-item
+	// card's heading is per project since #251 ("Trac ticket" / "GitHub issue"),
+	// so the anchor is the expression that renders it rather than one project's
+	// wording.
+	const ticketCard = source.indexOf('>{workItemConfig.label}<');
 	const listCard = source.indexOf('{ticketsCard.heading}');
 	const patchCard = source.indexOf('>Apply a patch or PR<');
 	assert.ok(ticketCard !== -1 && listCard !== -1 && patchCard !== -1, 'one of the three card headings is missing from index.jsx');
-	assert.ok(ticketCard < listCard && listCard < patchCard, 'the tickets card is not between the Trac ticket card and the patch card');
+	assert.ok(ticketCard < listCard && listCard < patchCard, 'the tickets card is not between the work-item card and the patch card');
 });
 
 // --- relativeTimeLabel ------------------------------------------------------

--- a/test/work-item.test.cjs
+++ b/test/work-item.test.cjs
@@ -1,0 +1,58 @@
+'use strict';
+
+// The dispatcher that lets the app ask "which work item is this site on?"
+// without knowing whether the answer is a Trac ticket or a GitHub issue (#251).
+// What matters here is that it picks the right one and defaults to Trac, since
+// every site created before project types existed has no provider recorded.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { workItemProvider } = require('../src/work-item.cjs');
+const { getProjectType } = require('../src/project-type.cjs');
+
+test('the Trac provider is the default for anything unknown or missing', () => {
+	for (const provider of [undefined, null, '', 'nonsense', 'TRAC']) {
+		const wi = workItemProvider(provider);
+		assert.strictEqual(wi.kind, 'trac', `expected trac for ${JSON.stringify(provider)}`);
+		assert.strictEqual(wi.noun, 'ticket');
+	}
+});
+
+test('the Trac provider parses tickets and knows how to attach to one', () => {
+	const wi = workItemProvider('trac');
+
+	assert.deepStrictEqual(wi.parseRef('62281'), {
+		ok: true, id: 62281, url: 'https://core.trac.wordpress.org/ticket/62281'
+	});
+	assert.strictEqual(wi.urlFor(62281), 'https://core.trac.wordpress.org/ticket/62281');
+	assert.match(wi.attachUrlFor(62281), /attachment\/ticket\/62281\/\?action=new$/);
+});
+
+test('the GitHub provider parses issues against the site’s own repository', () => {
+	const wi = workItemProvider('github-issue', 'WordPress/gutenberg');
+
+	assert.strictEqual(wi.kind, 'github-issue');
+	assert.strictEqual(wi.noun, 'issue');
+	assert.deepStrictEqual(wi.parseRef('#71234'), {
+		ok: true, id: 71234, url: 'https://github.com/WordPress/gutenberg/issues/71234'
+	});
+	assert.strictEqual(wi.urlFor(71234), 'https://github.com/WordPress/gutenberg/issues/71234');
+	// A Trac URL is not a GitHub issue, and must not quietly parse as one.
+	assert.strictEqual(wi.parseRef('https://core.trac.wordpress.org/ticket/62281').ok, false);
+});
+
+// Null rather than a no-op: a caller has to decide what to show instead of
+// rendering an "attach a patch" affordance that leads nowhere. GitHub issues
+// carry no patch attachments — that work arrives as a pull request.
+test('the GitHub provider has no attachment destination', () => {
+	assert.strictEqual(workItemProvider('github-issue', 'WordPress/gutenberg').attachUrlFor, null);
+});
+
+// The tie-back: the provider a site gets is the one its project type names.
+test('each project type selects its own provider', () => {
+	assert.strictEqual(workItemProvider(getProjectType('core').workItem.provider).kind, 'trac');
+	assert.strictEqual(
+		workItemProvider(getProjectType('gutenberg').workItem.provider, 'WordPress/gutenberg').kind,
+		'github-issue'
+	);
+});


### PR DESCRIPTION
## Why

The last piece of #251. A Gutenberg site can now clone, build, serve (#255, #261) and have a
Gutenberg pull request applied to it (#264) — but a contributor still could not **work on a
Gutenberg issue and open a pull request for it**. Linking a work item and authoring a PR were both
Trac- and wordpress-develop-shaped.

> Stacked on #264. The final PR of the Gutenberg feature, which **merges atomically** — see #255.
> Do not merge alone.

## What changes

- **`src/renderer/github-issue.cjs`** (new) — the Gutenberg counterpart of `trac-ticket.cjs`.
  Accepts `1234`, `#1234` and an issue URL with the noise a copy-paste brings; refuses another
  repository's issue, another host, and — by name, because it is the obvious mistake — a **pull
  request URL pasted instead of the issue it fixes**.
- **`src/work-item.cjs`** (new) — one interface over the two kinds, chosen by the site's project
  type. The rest of the app asks "parse this", "where does it live", "what is it called" without
  knowing which it is. Defaults to Trac, so a site with no project type is untouched.
- **`sites:set-ticket`** validates through the site's provider. Both kinds parse to a number, so the
  `ticket/<id>` branch key and every reader of `tracTicket` are unchanged — no migration.
- **`github-pr.cjs`** takes the project's upstream, base branch and branch prefix through the `deps`
  each helper already receives; `buildPullRequestBody` takes the project's citation line. A
  Gutenberg PR goes to **`WordPress/gutenberg`**, on a **`fix/issue-<n>`** branch, saying
  **`Fixes #<n>`** so merging it closes the issue.
- **The handoff patch header** cites the same work item instead of deriving a Trac URL from the
  number.
- **UI follows the project:** the work-item card, its input and the browse link. Both Trac-only
  surfaces are hidden on a Gutenberg site — the attachments panel, and the "Attach to Trac"
  destination.

`testMode()` deliberately still reads the environment override rather than the project, so a
Gutenberg site is not reported as sandboxed merely for not being wordpress-develop.

## How to test this

Platforms: **any**. Needs a Gutenberg site from the earlier PRs, and a signed-in GitHub account for
step 4.

1. On a **Gutenberg** site, the work-item card says **GitHub issue**. Paste
   `https://github.com/WordPress/gutenberg/issues/71234` (or `#71234`). → Linked; "Open on GitHub"
   goes to the issue. A `core.trac.wordpress.org` URL is refused here, and a **pull request** URL is
   refused with "That is a pull request. Link the issue it fixes instead."
2. The **Trac attachments** panel and the **Attach to Trac** destination are **not shown**.
3. Make an edit, then **Save patch for handoff**. → The header says
   `# Issue: https://github.com/WordPress/gutenberg/issues/71234`, not a Trac URL.
4. **Open a pull request.** → It targets `WordPress/gutenberg`, the branch is `fix/issue-71234`, the
   title defaults to `Issue #71234`, and the body's first line is `Fixes #71234`.
5. **On a Core site, everything is as before:** "Trac ticket" card, `62281` links, attachments panel
   present, handoff header says `# Ticket: …/ticket/62281`, PR targets `wordpress-develop` on
   `trac-62281` citing the Trac URL.

**What must not have happened:**
- A Gutenberg pull request must **never** reach `wordpress-develop` — that is a real PR on the wrong
  project. `test/github-pr.test.cjs` drives the whole sequence (fork → ref → sync → tree → commit →
  branch → PR) against a fake API and asserts **no call touches wordpress-develop**, and the mirror
  test asserts a project-less run touches no gutenberg.
- A Gutenberg site must not be offered a Core patch, or a button that saves a file and then does
  nothing.
- `WP_DEV_ENV_GITHUB_UPSTREAM` must still redirect a run to a sandbox (it is checked before the
  project, on purpose).

Automated: `npm run lint` clean; **844 tests pass**. New: `test/github-issue.test.cjs`,
`test/work-item.test.cjs`; extended `github-pr`, `patch-provenance`, `ipc-wiring`.

## Risks and limitations

- Some Core framing remains in copy this PR did not touch (e.g. "Edited files in `src/`?", the
  stale-trunk note's "may not apply on Trac"). Cosmetic on a Gutenberg site; a copy pass is a
  follow-up.
- `workItemProvider('github-issue')` with no `repoPath` would build a `github.com/undefined/...`
  URL. Not reachable — both call sites pass the site's upstream — but the two halves of that object
  disagree about their contract, worth tightening later.

## Related

Part of #251 — completes it. Stacked on #264.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**5 [fix here] · 1 [follow-up] — all 5 fixed.** Ran the review in
`.github/instructions/code-review.instructions.md`; judgement pass in a fresh subagent. Lint clean,
844 tests pass.

- 🟡 Architecture · **fixed** — the "Attach to Trac" destination was the one Trac surface left
  ungated; on a Gutenberg site its button saved a patch and then silently did nothing
  (`attachUrlFor` is null). Now hidden, like the attachments panel.
- 🟡 Security · **fixed** — `parseIssueRef`'s URL branch skipped the bounds check its bare-number
  branch applied, so `/issues/0` produced a falsy id (a site on `ticket/0` that reads as unlinked
  and cannot open a PR) and a 20-digit path produced a float-named branch. Both branches now share
  one guard; regression tests added.
- 🟡 Architecture · **fixed** — the handoff patch header derived a Trac URL from the number, so a
  Gutenberg patch cited a core.trac ticket sharing its issue number. It now takes the work item from
  the caller.
- 🟡 Tests · **fixed** — nothing pinned that a Gutenberg run targets the right repo through the whole
  flow (only the pure helpers were tested). Added an end-to-end `openPullRequest` test per project
  asserting no call reaches the other one, plus a Gutenberg `github:open-pr` wiring test.
- 🔵 Architecture · **fixed** — the per-project `no-ticket` message was unreachable behind the
  renderer's message map; dropped the duplicate so the main-process one (which knows the project)
  is what the user sees.
- 🔵 Architecture · [follow-up] — `urlFor` without a `repoPath` (documented in Risks; unreachable).
- Verified clean: Core byte-identity of `upstream()`/`baseBranchFor()`/`branchNameFor()`/
  `buildPullRequestBody()` with no project; the env override still wins over a project;
  `testMode()` ignoring the project is correct; the attachments gating leaves no orphaned effect or
  loader that could open a Trac window on a Gutenberg site; `parseIssueRef` rejects
  `https://github.com@evil.com/…` and builds its URL from the configured repo, not the input.

</details>
