### PR TITLE
Confirm completed actions with an accessible toast (#253)

### DIFF
--- a/src/renderer/confirmations.cjs
+++ b/src/renderer/confirmations.cjs
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * The queue behind the app's "that worked" confirmations (#253).
+ *
+ * Actions used to complete silently, or leave an inline sentence the
+ * contributor may not be looking at, and none of the success notices reached a
+ * screen reader. This is the one place a completed action is confirmed: a
+ * transient message that `SnackbarList` renders and speaks. The reducer holds
+ * the list; the renderer only dispatches and paints.
+ *
+ * Kept as a pure, dependency-free module so it can be unit tested without a
+ * DOM: the renderer bundle imports it, `node --test` requires it directly. The
+ * `id` comes from a running counter rather than a timestamp or random value so
+ * the reducer stays deterministic under test.
+ *
+ * Tone drives accessibility, not just colour:
+ *   - `success` speaks politely and clears itself on a timer — a confirmation
+ *     the contributor does not have to act on.
+ *   - `error` speaks assertively and stays until dismissed, so it is not gone
+ *     before it has been read. Supported here so successes and errors can share
+ *     one mechanism (#253); this pass only emits successes.
+ */
+
+// At most this many confirmations are kept on screen at once. A burst — a
+// double-click, a chain of steps finishing together — collapses to the most
+// recent few rather than stacking into a wall.
+const MAX_NOTICES = 3;
+
+const initialConfirmations = { seq: 0, notices: [] };
+
+function politenessFor(tone) {
+	return tone === 'error' ? 'assertive' : 'polite';
+}
+
+/**
+ * @param {Object} state  The queue: `{ seq, notices }`.
+ * @param {Object} action `{ type: 'add', content, tone }` or `{ type: 'remove', id }`.
+ */
+function confirmationReducer(state = initialConfirmations, action = {}) {
+	switch (action.type) {
+		case 'add': {
+			const content = action.content;
+			// Nothing to announce, nothing to queue.
+			if (!content) return state;
+			const tone = action.tone === 'error' ? 'error' : 'success';
+
+			// Ignore a repeat of what is already on top: a double-click on Save
+			// should read as one confirmation, not two identical ones.
+			const newest = state.notices[state.notices.length - 1];
+			if (newest && newest.content === content && newest.tone === tone) {
+				return state;
+			}
+
+			const seq = state.seq + 1;
+			const notice = {
+				id: seq,
+				content,
+				tone,
+				politeness: politenessFor(tone),
+				explicitDismiss: tone === 'error'
+			};
+			const notices = [...state.notices, notice].slice(-MAX_NOTICES);
+			return { seq, notices };
+		}
+		case 'remove': {
+			const notices = state.notices.filter((n) => n.id !== action.id);
+			// Referential stability matters to React: an id that matched nothing
+			// should not hand back a fresh array and a needless re-render.
+			if (notices.length === state.notices.length) return state;
+			return { seq: state.seq, notices };
+		}
+		default:
+			return state;
+	}
+}
+
+/**
+ * The confirmation line for a completed pull-request attempt (#253). A dry run
+ * (WP_DEV_ENV_GITHUB_DRY_RUN) stops after the branch and opens no request, so it
+ * says so rather than announcing a "pull request #undefined". Kept here, beside
+ * the rest of the confirmation logic, because it is a user-read string chosen by
+ * a branch — the kind that must not live untested in index.jsx.
+ *
+ * @param {{ dryRun?: boolean, number?: number }} res The main process's result.
+ */
+function prConfirmationMessage(res = {}) {
+	if (res.dryRun) return 'Dry run — branch created, no pull request opened';
+	return `Opened pull request #${res.number}`;
+}
+
+module.exports = { initialConfirmations, confirmationReducer, prConfirmationMessage, MAX_NOTICES };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -79,6 +79,43 @@
       white-space: nowrap;
       border: 0;
     }
+    /*
+      The confirmation toasts (#253). SnackbarList ships
+      `position: absolute; width: 100%` so it can anchor inside a sized editor
+      region; ours lives in a fixed, shrink-to-fit corner wrapper, where that
+      absolute list collapses to zero width and the toast never shows. Letting
+      it flow normally hands positioning back to the wrapper: the stack sits at
+      the wrapper's bottom-left and the newest notice lands nearest the corner.
+    */
+    .toolkit-snackbars.components-snackbar-list { position: static; width: auto; }
+    /* Right anchor: keep each toast flush to the right so a shorter one does not
+       drift left of a taller stack. */
+    .toolkit-snackbars .components-snackbar-list__notice-container { display: flex; justify-content: flex-end; }
+    /*
+      The default snackbar is a faint, translucent pill that is easy to miss —
+      too quiet for a confirmation that has to register (#253). This gives it
+      weight: a solid surface, a larger bolder line, a real shadow, and a
+      status-coloured left edge with a matching icon so "it worked" reads at a
+      glance and an error stands apart from a success.
+    */
+    .toolkit-snackbars .components-snackbar.toolkit-toast {
+      background: #1e1e1e;
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+      font-size: 14px;
+      font-weight: 500;
+      padding: 14px 20px;
+      border-radius: 8px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32), 0 2px 6px rgba(0, 0, 0, 0.24);
+    }
+    /* Give the status icon room and centre it — its default -8px offset tucks it
+       behind the coloured edge we add below. */
+    .toolkit-snackbars .toolkit-toast .components-snackbar__content-with-icon { padding-left: 30px; }
+    .toolkit-snackbars .toolkit-toast .components-snackbar__icon { left: 0; top: 50%; transform: translateY(-50%); }
+    .toolkit-snackbars .toolkit-toast--success { border-left: 5px solid #00a32a; }
+    .toolkit-snackbars .toolkit-toast--success .components-snackbar__icon { color: #4ab866; }
+    .toolkit-snackbars .toolkit-toast--error { border-left: 5px solid #f86368; }
+    .toolkit-snackbars .toolkit-toast--error .components-snackbar__icon { color: #f86368; }
   </style>
   <link rel="stylesheet" href="index.css" />
   <script defer src="index.js"></script>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
   Button,
@@ -12,6 +12,7 @@ import {
   MenuGroup,
   MenuItem,
   Modal,
+  SnackbarList,
   TextControl,
   TextareaControl,
   Spinner
@@ -40,6 +41,7 @@ import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 import { changesNoteParts, discardOutcome, noteAfterDiscard, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
+import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // Shared by both log panes so the tabs cannot drift apart visually.
@@ -252,8 +254,28 @@ function useSites() {
   return { sites: state.sites, siteMeta: state.siteMeta, refresh, setSiteMeta, applySetup };
 }
 
+// The one way any panel confirms a completed action (#253). `confirm(message)`
+// queues a transient, screen-reader-announced notice; the provider below renders
+// the queue once for the window. The default is a no-op so a component rendered
+// outside the provider (a test, say) does not throw on a stray confirm.
+const ConfirmationContext = createContext(() => {});
+
+function useConfirmation() {
+  return useContext(ConfirmationContext);
+}
+
 function App() {
   const { sites, siteMeta, refresh, setSiteMeta, applySetup } = useSites();
+  // The confirmation queue for the whole window. It lives here, above every
+  // SiteRow, because only one row is visible at a time and a per-row toast would
+  // be hidden along with its inactive row. See ConfirmationContext above.
+  const [confirmations, dispatchConfirmation] = useReducer(confirmationReducer, initialConfirmations);
+  const confirm = useCallback((content, options = {}) => {
+    dispatchConfirmation({ type: 'add', content, tone: options.tone });
+  }, []);
+  const removeConfirmation = useCallback((id) => {
+    dispatchConfirmation({ type: 'remove', id });
+  }, []);
   // One answer for the window, shared by every site row: which applications this
   // machine has is a fact about the machine, not about a site.
   const detectedApplications = useDetectedEditors();
@@ -664,6 +686,7 @@ function App() {
   }, []);
 
   return (
+    <ConfirmationContext.Provider value={confirm}>
     <div style={{ display: 'flex', height: '100vh', fontFamily: '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif' }}>
       <div style={{ width: sidebarCollapsed ? 56 : 280, background: '#1f1f1f', color: '#f7f7f7', display: 'flex', flexDirection: 'column', transition: 'width 0.2s ease', borderRight: '1px solid #2b2b2b' }}>
         <div style={{ padding: sidebarCollapsed ? '12px 8px' : '16px', borderBottom: '1px solid #2b2b2b' }}>
@@ -949,6 +972,31 @@ function App() {
         </Modal>
       ) : null}
     </div>
+    {/* One toast region for the window (#253). Anchored top-right and sized to
+        its content so it never covers the rest of the UI; SnackbarList announces
+        each message via aria-live. The z-index clears the modal overlay
+        (components-modal__screen-overlay is 100000, and a modal is a later body
+        portal that would otherwise win the tie) so a confirmation for an action
+        taken inside a modal — saving a patch, opening a PR — is still seen. It
+        stays below popovers/dropdowns (1000000), which should sit over it. */}
+    <div style={{ position: 'fixed', right: 24, top: 24, zIndex: 100001, pointerEvents: 'none' }}>
+      <SnackbarList
+        className="toolkit-snackbars"
+        // The icon and the tone class are added here, at render, rather than in
+        // the reducer — an icon is a React element and the tone class is styling,
+        // neither of which belongs in the DOM-free confirmations module.
+        notices={confirmations.notices.map((n) => ({
+          ...n,
+          // Wrapped in <Icon> so it renders at a set size with the tone colour;
+          // Snackbar drops the raw icon element straight into the DOM, where the
+          // bare @wordpress/icons export has no dimensions of its own.
+          icon: n.tone === 'error' ? undefined : <Icon icon={checkIcon} size={20} />,
+          className: n.tone === 'error' ? 'toolkit-toast toolkit-toast--error' : 'toolkit-toast toolkit-toast--success'
+        }))}
+        onRemove={removeConfirmation}
+      />
+    </div>
+    </ConfirmationContext.Provider>
   );
 }
 
@@ -1056,6 +1104,10 @@ function TerminalCommandLink({ command, onPrefill, disabled }) {
 }
 
 function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onDelete, onRename, editor, wporg, isPending = false, setupLogs = '', isActive = false, switchProgress = null, carriedWork = null, onClearSwitchNotices = null }) {
+  // The window's confirmation queue (#253): confirm(message) after an action
+  // completes, so the outcome is announced rather than left silent or buried in
+  // the terminal.
+  const confirm = useConfirmation();
   // Kept in a ref so loadStatus's dependency list stays [sitePath] — a
   // recreated callback prop must not retrigger the status-loading effect.
   const metaPatchRef = useRef(onSiteMetaPatch);
@@ -2416,6 +2468,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             try { await window.api.markUpdateComplete(sitePath); } catch {}
             const elapsedSeconds = updateStartRef.current ? Math.round((Date.now() - updateStartRef.current) / 1000) : null;
             setLastUpdateSummary({ lockfileChanged, elapsedSeconds, savedPatchPath: savedPatchPathRef.current });
+            confirm('Updated to the latest trunk');
             finishUpdate('\nUpdate complete — this site is now on the latest trunk.\n');
           } else {
             finishUpdate('\nUpdate incomplete — the build failed. The code is new but the built assets are old; retry install & build from the banner above.\n');
@@ -2497,6 +2550,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       runScript('build', {
         onLog: (chunk) => writeToTerminal(chunk),
         onDone: ({ code }) => {
+          // Only now is the apply genuinely done — the patch is on disk and the
+          // site is rebuilt around it, so "open the site to try it out" is true
+          // (#253). A failed build leaves stale assets and its own banner, so it
+          // gets no success confirmation.
+          if (code === 0) confirm(`${verb} the patch`);
           finishApply(code === 0
             ? `\n${verb} — open the site to try it out.\n`
             : `\nThe patch is ${verb.toLowerCase()} but the build failed, so the site still runs the old assets.\n`);
@@ -2721,6 +2779,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           return;
         }
         setApplyPreview(null);
+        // The confirmation waits until the rebuild finishes (see runBuildStep) —
+        // the patch is on disk now, but the site is not usable until it is built
+        // around it, so announcing "applied" here would be premature.
         runApplyInstallAndBuild(needsInstall, reverse ? 'Reverted' : 'Applied');
       }
     ).catch((e) => {
@@ -2746,9 +2807,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     updateStartRef.current = Date.now();
     setUpdateState('fetching');
     window.api.updateTrunk(sitePath, ({ data }) => writeToTerminal(data), (res) => {
-      if (!res || !res.ok || res.upToDate) {
-        // The main process already wrote the failure or "Already up to
-        // date." message to the stream.
+      if (!res || !res.ok) {
+        // The main process already wrote the failure message to the stream.
+        finishUpdate();
+        return;
+      }
+      if (res.upToDate) {
+        // Nothing to fetch — but "Already up to date." only reaching the
+        // terminal left the contributor unsure the check had even run (#253).
+        // The confirmation says so where it will be seen; there is no install
+        // or build to follow.
+        confirm('Already up to date with trunk');
         finishUpdate();
         return;
       }
@@ -2794,6 +2863,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       applyDiscardToNote(discardOutcome(d));
       setDirtyModalOpen(false);
       writeToTerminal(`\nSaved your changes to ${res.filePath} and reset the working tree.\n`);
+      // This ran as the contributor closed the modal; the confirmation is the
+      // only trace of it outside the terminal (#253).
+      confirm(`Saved your changes to ${pathBasename(res.filePath)} and reset the working tree`);
       beginTrunkUpdate();
     } finally {
       setDirtySaving(false);
@@ -2958,6 +3030,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       const res = await window.api.savePatch(sitePath, options);
       if (res && res.ok && res.filePath) {
         setPatchSaved(res.filePath);
+        // The green line below is the record of where it went; this is the
+        // announcement, for a contributor who saved from a menu and is no
+        // longer looking at the pane (#253).
+        confirm(`Patch saved to ${pathBasename(res.filePath)}`);
         return res.filePath;
       }
       if (res && res.canceled) return null;
@@ -3058,6 +3134,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       const res = await window.api.openPullRequest(sitePath, { title: prTitle, notes: prNotes });
       if (res && res.ok) {
         setPrResult(res);
+        // The result panel below carries the link; this announces the outcome
+        // for a contributor who looked away during the slow fork step (#253).
+        confirm(prConfirmationMessage(res));
       } else {
         setPrError(res || { reason: 'error', error: 'The pull request could not be opened.' });
         // A revoked authorization is forgotten in the main process, so the card

--- a/test/confirmations.test.cjs
+++ b/test/confirmations.test.cjs
@@ -1,0 +1,104 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+	initialConfirmations,
+	confirmationReducer,
+	prConfirmationMessage,
+	MAX_NOTICES
+} = require('../src/renderer/confirmations.cjs');
+
+test('a success confirmation speaks politely and clears itself (issue #253)', () => {
+	const state = confirmationReducer(initialConfirmations, { type: 'add', content: 'Patch saved to my.patch' });
+
+	assert.strictEqual(state.notices.length, 1);
+	const [notice] = state.notices;
+	assert.strictEqual(notice.content, 'Patch saved to my.patch');
+	assert.strictEqual(notice.tone, 'success');
+	assert.strictEqual(notice.politeness, 'polite', 'a confirmation must not interrupt the screen reader');
+	assert.strictEqual(notice.explicitDismiss, false, 'a success must auto-dismiss');
+});
+
+test('the tone defaults to success when none is given', () => {
+	const state = confirmationReducer(initialConfirmations, { type: 'add', content: 'Reverted' });
+
+	assert.strictEqual(state.notices[0].tone, 'success');
+});
+
+test('an error confirmation speaks assertively and stays until dismissed (issue #253)', () => {
+	const state = confirmationReducer(initialConfirmations, { type: 'add', content: 'Could not save', tone: 'error' });
+
+	const [notice] = state.notices;
+	assert.strictEqual(notice.tone, 'error');
+	assert.strictEqual(notice.politeness, 'assertive', 'an error must be read out at once');
+	assert.strictEqual(notice.explicitDismiss, true, 'an error must not vanish before it is read');
+});
+
+test('every confirmation gets a distinct id from a running counter', () => {
+	let state = confirmationReducer(initialConfirmations, { type: 'add', content: 'First' });
+	state = confirmationReducer(state, { type: 'add', content: 'Second' });
+
+	assert.deepStrictEqual(state.notices.map((n) => n.id), [1, 2]);
+});
+
+test('a repeat of the confirmation already on top is ignored', () => {
+	let state = confirmationReducer(initialConfirmations, { type: 'add', content: 'Up to date with trunk' });
+	state = confirmationReducer(state, { type: 'add', content: 'Up to date with trunk' });
+
+	assert.strictEqual(state.notices.length, 1, 'a double-click reads as one confirmation');
+});
+
+test('the same message with a different tone is not treated as a duplicate', () => {
+	let state = confirmationReducer(initialConfirmations, { type: 'add', content: 'Saved' });
+	state = confirmationReducer(state, { type: 'add', content: 'Saved', tone: 'error' });
+
+	assert.strictEqual(state.notices.length, 2);
+});
+
+test('an empty message queues nothing', () => {
+	const state = confirmationReducer(initialConfirmations, { type: 'add', content: '' });
+
+	assert.strictEqual(state, initialConfirmations, 'the state is handed back untouched');
+});
+
+test('only the most recent confirmations are kept when a burst arrives', () => {
+	let state = initialConfirmations;
+	for (let i = 1; i <= MAX_NOTICES + 2; i += 1) {
+		state = confirmationReducer(state, { type: 'add', content: `Step ${i}` });
+	}
+
+	assert.strictEqual(state.notices.length, MAX_NOTICES);
+	assert.strictEqual(state.notices[0].content, `Step ${3}`, 'the oldest ones drop off the front');
+	assert.strictEqual(state.notices[state.notices.length - 1].content, `Step ${MAX_NOTICES + 2}`);
+});
+
+test('removing a confirmation by id drops just that one', () => {
+	let state = confirmationReducer(initialConfirmations, { type: 'add', content: 'First' });
+	state = confirmationReducer(state, { type: 'add', content: 'Second' });
+	state = confirmationReducer(state, { type: 'remove', id: 1 });
+
+	assert.deepStrictEqual(state.notices.map((n) => n.content), ['Second']);
+});
+
+test('removing an id that matches nothing returns the same state object', () => {
+	const state = confirmationReducer(initialConfirmations, { type: 'add', content: 'First' });
+	const after = confirmationReducer(state, { type: 'remove', id: 999 });
+
+	assert.strictEqual(after, state, 'no needless re-render for a no-op removal');
+});
+
+test('an opened pull request is confirmed by its number (issue #253)', () => {
+	assert.strictEqual(
+		prConfirmationMessage({ ok: true, number: 42 }),
+		'Opened pull request #42'
+	);
+});
+
+test('a dry run says no pull request was opened rather than "#undefined" (issue #253)', () => {
+	assert.strictEqual(
+		prConfirmationMessage({ ok: true, dryRun: true, branch: 'fix/thing' }),
+		'Dry run — branch created, no pull request opened'
+	);
+});


### PR DESCRIPTION
Closes #253.

## Why

Actions across the app complete silently, or leave only an inline sentence the contributor may not be looking at — patch saved, trunk updated, patch applied, PR opened, working tree reset. There was no consistent "that worked", and **none of the success notices reached a screen reader** (the failure notices had `role="alert"`; the success ones had nothing, and apply/revert and save-and-reset only ever printed to the terminal). #253 asks for one mechanism that surfaces a *completed* action: brief, non-blocking, announced to assistive tech, self-dismissing.

## What changes

One window-level confirmation service:

- **`src/renderer/confirmations.cjs`** — a pure, tested reducer holding the queue. Tone drives accessibility, not just colour: `success` → `politeness: 'polite'`, auto-dismiss; `error` → `'assertive'`, stays until dismissed. Plus consecutive-duplicate dedupe (a double-click reads as one) and a 3-notice cap. `prConfirmationMessage(res)` lives here too, so the one user-read string chosen by a branch (dry-run vs opened) is tested rather than inline in `index.jsx`.
- **`index.jsx`** — a `ConfirmationContext` + `useConfirmation()` hook, a `useReducer` in `App`, and a single `SnackbarList` (top-right, above the modal overlay so a confirmation for an action taken *inside* a modal is still seen). `SiteRow` calls `confirm(...)` at the **completion** point of six flows.
- **`index.html`** — CSS to make the toast register (solid surface, bolder line, shadow, tone-coloured edge + icon), and to let the list flow inside the fixed wrapper (WordPress's `SnackbarList` ships `position:absolute; width:100%`, which collapsed to zero width in a shrink-to-fit corner).

**Confirm at completion, not initiation** — apply/revert and trunk-update fire only after the rebuild succeeds (a failed build keeps its "incomplete" banner and gets no success toast); "already up to date" is confirmed distinctly from "updated".

**Deliberately not in this PR:** self-announcing button labels (Copy→Copied), block-anchored notices and field-level `role="alert"` errors stay put — the issue's open question about which notices move vs. stay. The reducer already supports `tone:'error'` so a later PR can route non-anchored errors through the same mechanism with no new plumbing.

<details>
<summary>Self-review outcome</summary>

Ran per AGENTS.md (judgement pass dispatched to a fresh subagent). Deterministic layer clean: `npm run lint` clean, `npm test` 811/0.

- 🟡 **[fix here]** architecture — the PR message was an inline two-branch ternary in `index.jsx` (untestable there, per §1). **Fixed**: extracted to `prConfirmationMessage()` in the module, with tests.
- 🔵 **[follow-up]** — flagged that `pointer-events: none` on the wrapper might make a future error toast's ✕ unclickable. **Verified false**: `.components-snackbar` sets `pointer-events: auto`, re-enabling clicks on the pill. No change.

No findings across security / performance / cross-platform.
</details>

## How to test this

Platform: any (macOS used for the manual pass).

**Starting state:**

1. An initialised site with at least one change against its copy of trunk.
2. Save a patch (**Review & submit changes → Save**) → a toast appears **top-right**: "Patch saved to <name>", auto-dismisses, does not block the UI, and announces politely under VoiceOver.
3. **Update to latest trunk** on a current site → "Already up to date with trunk"; on a stale site → "Updated to the latest trunk" when the rebuild finishes.
4. Apply a patch → "Applied the patch" fires only *after* install/build completes, not when `git apply` returns.

**What must not have happened:**

- No toast should fire on *initiation* (it must wait for the rebuild), and a **failed** apply/build must not show a success toast.
- The green "Saved to…" line and the "Up to date as of today" banner must still appear — the toast is added alongside them, not in place of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)