### PR TITLE
Let Stop end a running npm install

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -203,6 +203,12 @@ const runningScripts = {};
 const cancelledChildren = new WeakSet();
 /** @type {Record<string, string>} */
 const runIdByDirectory = {};
+// The same directory index for installs. The renderer knows a script's runId
+// (`npm:run-script` returns it before the first log line) but never an
+// installId — `runNpmInstall` keeps that correlation id to itself in the
+// preload — so a directory is all a Stop control can offer for an install.
+/** @type {Record<string, string>} */
+const installIdByDirectory = {};
 /** @type {Record<string, { child: import('child_process').ChildProcess, url?: string }>} */
 const playgroundServers = {};
 // The sites being created right now — liveness, not truth, which is why it is
@@ -2261,6 +2267,7 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		retryOnEngineMismatch: true,
 		register: (child) => {
 			runningInstalls[installId] = child;
+			installIdByDirectory[directoryPath] = installId;
 		},
 		onLog: (type, data) => {
 			event.sender.send('npm:install:log', { installId, type, data });
@@ -2280,6 +2287,12 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 			} catch {}
 			event.sender.send('npm:install:done', { installId, code });
 			delete runningInstalls[installId];
+			// Guarded on identity: a second install for the same directory has
+			// already claimed the slot, and clearing it blind would leave that
+			// one unkillable.
+			if (installIdByDirectory[directoryPath] === installId) {
+				delete installIdByDirectory[directoryPath];
+			}
 		}
 	});
 
@@ -2328,12 +2341,23 @@ ipcMain.handle('npm:kill', async (_event, { runId, directoryPath }) => {
 		const id = runIdByDirectory[directoryPath];
 		child = runningScripts[id];
 	}
+	// An install is the other thing a directory can be busy with, and until this
+	// fallback existed it was unstoppable: Stop resolved nothing, returned "No
+	// running script", and the install ran to completion regardless. Checked
+	// after the scripts because a runId can only ever mean a script, and the two
+	// never run for the same directory at once.
+	if (!child && directoryPath && installIdByDirectory[directoryPath]) {
+		child = runningInstalls[installIdByDirectory[directoryPath]];
+	}
 	if (!child) return { ok: false, error: 'No running script' };
 	try {
+		// Also what stops `runNpmWithEngineRetry` respawning an install that a
+		// cancel pushed into a non-zero exit — it reads this set to tell a real
+		// engine mismatch from a stop.
 		cancelledChildren.add(child);
 		// A script is a tree — runner -> npm -> shell -> grunt — and child.kill()
 		// signals only the first link, so stopping a build left the rest of it
-		// running (#83, #146).
+		// running (#83, #146). An install is the same shape: runner -> npm.
 		killChildTree(child);
 		// Last resort for a child that ignores SIGTERM. Only the direct child: by
 		// this point the tree has had its chance, and the runner dying takes the

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1428,6 +1428,47 @@ test('npm:kill ends the script tree rather than signalling the runner alone', as
 	assert.deepEqual(cp.children[0].kill.calls, []);
 });
 
+// The install is the other thing a directory can be busy with, and it was the
+// one Stop could not reach: `npm:kill` resolved children out of the script
+// registry alone, so a running install answered "No running script" and carried
+// on to completion. Nothing exercised that path, because nothing in the app
+// stopped an install until the setup chain (#246) needed to.
+//
+// A directory is all the caller can offer here — `npm:install` keeps its
+// installId inside the preload, so unlike a script there is no id to pass back.
+test('npm:kill ends a running install, which only its directory can name', async (t) => {
+	const cp = stubbedSpawn();
+	const killChildTree = spy();
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			// Same reason as the quit sweep below: npm:install's onDone reaches
+			// getStore() to record installFailed, and the close emitted at the end
+			// of this test would otherwise pull in the real electron-store, and
+			// through it the real electron package the harness must never load.
+			...fakeSettingsStore().stubs,
+			'child_process': { spawn: cp.spawn },
+			'./kill-tree': { killChildTree }
+		}
+	});
+
+	await main.invoke('npm:install', '/sites/wp');
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+
+	assert.deepEqual(await main.invoke('npm:kill', { directoryPath: '/sites/wp' }), { ok: true });
+
+	assert.deepEqual(killChildTree.calls, [[cp.children[0]]]);
+	assert.deepEqual(cp.children[0].kill.calls, []);
+
+	// A stopped install exits non-zero, which is indistinguishable from an engine
+	// mismatch on Windows (the kill surfaces as a plain code, not a signal). The
+	// handler marks the child cancelled so `runNpmWithEngineRetry` does not read
+	// the stop as a failure worth retrying and respawn the install the
+	// contributor just stopped.
+	cp.children[0].emit('close', 1, null);
+	assert.equal(cp.spawned.length, 1);
+});
+
 // Spins until the stubbed spawn has been called `count` times, so a test can wait
 // for a handler that spawns after an await without knowing how many microtasks
 // that takes. Unlike reachSpawn it counts cumulatively, so several handlers can be


### PR DESCRIPTION
## Why

Nothing in the app can stop a running `npm install`. `npm:kill` resolves a child out of the script registry only — by `runId`, or by the directory index `npm:run-script` maintains — and a running install lives in a different map, `runningInstalls`, keyed by an `installId` the preload never hands back. So Stop answers `{ok: false, error: 'No running script'}` and the install runs to completion.

Nobody has hit it because nothing had asked to stop one: install is reached from the checklist button, and the terminal's Ctrl+C is only wired up during chains that do not include it. #246 changes that — it starts install unattended after the clone, and being able to stop it is the condition that makes running unattended reasonable at all.

## What changes

`installIdByDirectory`, beside the existing `runIdByDirectory`, and a fallback in `npm:kill` that consults it once the two script lookups miss. A directory is all a caller can offer for an install, and the two never run for the same directory at once. Everything downstream is already generic: `cancelledChildren`, `killChildTree`, the 3-second `SIGKILL` backstop.

No `src/preload.js` change — `npmKill` already forwards `{ runId, directoryPath }`, and during an install `currentRunIdRef.current` is null, so the directory branch is the one that runs.

Marking the child cancelled matters more for an install than for a script. A stopped install exits non-zero, and on Windows a kill surfaces as a plain exit code rather than a signal, so without it `runNpmWithEngineRetry` would read the stop as an engine mismatch and respawn the install the contributor just stopped. `test/npm-runner.test.cjs` already pins that `cancelled` short-circuits the retry; this makes the install path reach it.

**Not in this PR:** any caller. The Stop control that uses it ships in the stacked PR for #246. On its own this is reachable only through the terminal's Ctrl+C during a chain that runs an install.

## How to test this

Platforms: **macOS and Windows both** — process-tree killing is the one thing that differs, and this is a kill path.

This has no button of its own until the stacked PR lands, so it is driven from the terminal.

**Starting state:** a site whose clone has finished and whose dependencies are **not** installed.

1. Click **Install npm dependencies**. Wait for npm to start producing output in the Terminal.
2. Press **Ctrl+C** in the Terminal.
3. The install stops. Check no `node`/`npm` child of the app survives — Activity Monitor on macOS, Task Manager on Windows.
4. The **Install npm dependencies** step now offers **Retry npm install**, and the build step stays locked.
5. Click the retry. It starts a fresh install rather than resuming a dead one.

Before this change, step 2 does nothing at all and the install runs to completion.

**What must not have happened:**

- No orphaned `npm`/`node` process left behind after the stop. That is the failure mode `killChildTree` exists for (#83, #146), and an install is a tree too.
- The stop must **not** be retried as an engine mismatch — watch for a second `npm install` starting itself a moment after you stopped the first. On Windows this is the likely shape of a regression, since the kill there produces a plain non-zero code with no signal.
- The site must **not** read as having completed the install step. A cancelled install leaves a partial `node_modules`, and `installFailed` is recorded so it does not read as done (#42).

Covered by `npm:kill ends a running install, which only its directory can name` in `test/ipc-wiring.test.cjs`, which fails on the old code (the handler returns `{ok: false}` and never reaches kill-tree).

## Risks and limitations

Small and additive: one map, one fallback branch, no change to any existing lookup. The blast radius is a `npm:kill` call that used to fail and now succeeds.

The lifetime of `installIdByDirectory` mirrors `runIdByDirectory` exactly, including the identity-guarded delete, so a second install for the same directory cannot be made unkillable by the first one's exit.

Not tested by hand on Windows by me — the artifact from this branch is the way to do that.

## Related

Groundwork for #246. Does not close anything on its own.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**A separate `npm:install-kill` channel** was the obvious alternative. Rejected: the renderer already calls `npmKill({runId, directoryPath})` from one place (`killCurrent`), and it does not know whether the thing it is stopping is an install or a script — that is precisely the knowledge the main process has. Two channels would have pushed that question back into the renderer for no gain.

**Returning the `installId` to the renderer** so an install could be killed by id like a script. Rejected: the preload deliberately keeps `installId` private, correlating log and done events internally so callers get a plain `(onLog, onDone)` pair. Widening that to hand out the id would change the shape of the API for every caller to serve one.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

1 [fix here] · 0 [follow-up] — fixed.

**tests 🟡 [fix here]** — the new test passed under Electron's Node but failed under `npm test` on `.nvmrc`'s Node: emitting `close` reaches `npm:install`'s `onDone`, which calls `getStore()`, which pulled in the real `electron-store` and through it the real `electron` package, tripping the harness's own guard. Fixed by adding `fakeSettingsStore()` to the stubs, the same way the quit-sweep test does for the same reason. This is exactly the "green on one of the two runtimes" shape the review standard names; both runtimes are green now (840 tests each).

The judgement pass was run in this session rather than dispatched to a subagent — the tooling in use blocked spawning one. Flagging it because the standard prefers fresh context for that pass, and a self-review is the weaker version.

</details>

<details>
<summary>Screenshots or recording</summary>

Nothing on screen changes. The behaviour is in the main process; the control that exposes it ships in the stacked PR.

</details>
