### PR TITLE
Run the initial setup steps as one chain

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -21,7 +21,7 @@ import { plus, chevronLeft, chevronRight, chevronDown, copy as copyIcon, check a
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
-import { computeSetupStepState, setupStepLabel } from './setup-steps.cjs';
+import { computeSetupStepState, setupStepStatuses, setupStepCopy, setupAutoStartDecision, setupStepLabel } from './setup-steps.cjs';
 import { deriveNextAction } from './next-action.cjs';
 import { shouldShowTerminalHints, computeTerminalBusy } from './terminal-hints.cjs';
 import { planDevServerStart, formatElapsed, watchTabLabel } from './dev-server-command.cjs';
@@ -29,7 +29,7 @@ import { appendBounded, countLines } from './debug-log.cjs';
 import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
-import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP } from './update-plan.cjs';
+import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
@@ -1253,6 +1253,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [building, setBuilding] = useState(false);
   const [hasNodeModules, setHasNodeModules] = useState(false);
   const [installFailed, setInstallFailed] = useState(false);
+  // The build's counterpart to installFailed — session-local, because only the
+  // install outcome is persisted (main.js records it on the site's meta). After
+  // a restart a failed build reads "Ready" again, which is the honest fallback:
+  // the app knows there is no build on disk, just not that the last attempt lost.
+  const [buildFailed, setBuildFailed] = useState(false);
   const [hasBuilt, setHasBuilt] = useState(false);
   const [skipInit, setSkipInit] = useState(false);
   const [statusLoading, setStatusLoading] = useState(true);
@@ -1288,6 +1293,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [trunkDate, setTrunkDate] = useState(null);
   const [updateIncomplete, setUpdateIncomplete] = useState(false);
   const [updateState, setUpdateState] = useState('idle'); // idle | fetching | installing | building
+  // Initial setup chain (#246): install then build, started by the clone
+  // finishing rather than by a click. Same shape as the two chains below.
+  const [setupChainState, setSetupChainState] = useState('idle'); // idle | installing | building
+  // How the last chain ended, or null while one is running or none has run.
+  const [setupChainEnd, setSetupChainEnd] = useState(null);
   // Applying someone else's patch (#11)
   const [applyState, setApplyState] = useState('idle'); // idle | applying | installing | building
   const [applyPreview, setApplyPreview] = useState(null);
@@ -1599,8 +1609,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         if (s?.trunkDate) patch.trunkDate = s.trunkDate;
         metaPatchRef.current(sitePath, patch);
       }
+      // Returned as well as stored: the setup chain (#246) re-probes when the
+      // clone finishes and has to decide from that read, not from state React
+      // has not committed yet.
+      return s;
     } catch {}
     finally { setStatusLoading(false); }
+    return null;
   }, [sitePath]);
   useEffect(()=>{ loadStatus(); }, [loadStatus]);
 
@@ -1872,7 +1887,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const runScript = useCallback((name, options = {}) => {
     const { onLog, onDone, args = [], track = true, mirrorToNpm = true, onStart } = options;
     ensureStick('npm');
-    if (name === 'build') setBuilding(true);
+    // Clearing the failure here rather than on the next exit is what stops the
+    // step reading "Failed" while its own retry is streaming to the terminal.
+    if (name === 'build') { setBuilding(true); setBuildFailed(false); }
     if (track) currentRunIdRef.current = null;
     return window.api.runNpmScript(sitePath, name, args, ({ data }) => {
       if (mirrorToNpm) appendNpm(data);
@@ -1881,6 +1898,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       if (mirrorToNpm) appendNpm(`\n${name} exited with code ${code}\n`);
       if (name === 'build') {
         setBuilding(false);
+        setBuildFailed(code !== 0);
         try { await loadStatus(); } catch {}
       }
       if (track) currentRunIdRef.current = null;
@@ -1963,7 +1981,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     if (terminalStickRef.current) term.scrollToBottom();
   }, [normalizeForTerminal]);
 
+  // Taking a step back by hand is the answer to "Setup stopped." — so the
+  // notice goes away here rather than lingering over work already resumed.
   const runInstallWithTerminal = useCallback(() => {
+    setSetupChainEnd(null);
     writeToTerminal('Running npm install…\n');
     runInstall({
       onLog: (chunk) => writeToTerminal(chunk),
@@ -1974,6 +1995,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   }, [runInstall, writeToTerminal]);
 
   const runBuildWithTerminal = useCallback(() => {
+    setSetupChainEnd(null);
     writeToTerminal('Running npm run build…\n');
     runScript('build', {
       onLog: (chunk) => writeToTerminal(chunk),
@@ -2688,6 +2710,125 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   });
   const applySteps = planApplySteps({ needsInstall: applyNeedsInstall, buildByWatcher: applyBuildByWatcher });
   const applyStepStates = updateStepStatuses(applySteps, applyState, APPLY_STATE_TO_STEP);
+
+  // --- Initial setup, as one chain (#246) ---
+  // The third chain, and the only one nobody starts: between the clone, the
+  // install and the build there is no decision to make, so making the
+  // contributor notice each one end and click the next was work the app was
+  // handing back for nothing. It runs on its own once the clone finishes.
+  //
+  // What makes that reasonable rather than presumptuous is that it is visible
+  // and it stops: the checklist names the running step, and Stop actually ends
+  // the child (an install included, since the kill path learned to reach one).
+  const isSettingUp = setupChainState !== 'idle';
+  const setupSteps = planSetupSteps();
+  const setupStepStates = updateStepStatuses(setupSteps, setupChainState, SETUP_STATE_TO_STEP);
+  // Whether this chain is ending because the contributor asked it to. A killed
+  // npm exits non-zero — on Windows without even a signal — so the exit code
+  // cannot tell a stop from a failure; only the fact that we asked for the kill
+  // can.
+  const setupStoppedRef = useRef(false);
+
+  // One sentence per way the chain can end, and `setupOutcome` is what picks
+  // between them. Every one of them ends by naming where the rest of the work
+  // now lives, because the chain going quiet is otherwise indistinguishable
+  // from the app having forgotten about the site.
+  const SETUP_END_MESSAGES = {
+    done: '\nSetup complete — start the dev server when you are ready.\n',
+    stopped: '\nSetup stopped. The remaining steps are in the checklist above — run them whenever you are ready.\n',
+    'failed-install': '\nnpm install failed — setup stopped here. Its output is above; retry the install from the checklist.\n',
+    'failed-build': '\nThe build failed — dependencies are installed. Its output is above; retry the build from the checklist.\n'
+  };
+
+  const finishSetupChain = (outcome) => {
+    markTerminalRunning(false);
+    terminalKillRef.current = null;
+    setSetupChainState('idle');
+    setSetupChainEnd(outcome);
+    writeToTerminal(SETUP_END_MESSAGES[outcome] || '');
+    if (outcome === 'done') confirm('This site is ready to work on');
+  };
+
+  const stopSetupChain = () => {
+    setupStoppedRef.current = true;
+    writeToTerminal('\nStopping setup…\n');
+    killCurrent().catch(() => {});
+  };
+
+  const startSetupChain = () => {
+    const state = terminalStateRef.current;
+    if (state.running) return;
+    setupStoppedRef.current = false;
+    setSetupChainEnd(null);
+    markTerminalRunning(true);
+    terminalKillRef.current = () => { stopSetupChain(); };
+    setSetupChainState('installing');
+    writeToTerminal('\nSetting this site up — running npm install…\n');
+    runInstall({
+      onLog: (chunk) => writeToTerminal(chunk),
+      onDone: ({ code }) => {
+        const stopped = setupStoppedRef.current;
+        // Stopping at the first failure is not politeness — a build on a
+        // half-installed tree cannot work, and its failure would bury the one
+        // that mattered (#42).
+        if (stopped || code !== 0) {
+          finishSetupChain(setupOutcome({ stopped, installCode: code }));
+          return;
+        }
+        // Checked again here: Stop is reachable in the moment between the
+        // install ending and the build being spawned, and a stop that quietly
+        // started a half-hour build would be the worst possible answer to it.
+        if (setupStoppedRef.current) {
+          finishSetupChain(setupOutcome({ stopped: true }));
+          return;
+        }
+        setSetupChainState('building');
+        writeToTerminal('\nRunning npm run build…\n');
+        runScript('build', {
+          onLog: (chunk) => writeToTerminal(chunk),
+          onDone: ({ code: buildCode }) => {
+            finishSetupChain(setupOutcome({
+              stopped: setupStoppedRef.current,
+              installCode: 0,
+              buildCode
+            }));
+          }
+        });
+      }
+    });
+  };
+
+  // The chain is started by an edge, not by a state: the clone finishing. The
+  // ref keeps that edge reachable from an effect that must not re-run whenever
+  // the chain's own callbacks are rebuilt on a render.
+  const startSetupChainRef = useRef(startSetupChain);
+  useEffect(() => { startSetupChainRef.current = startSetupChain; });
+
+  const wasPendingRef = useRef(isPending);
+  const setupChainArmedRef = useRef(false);
+  useEffect(() => {
+    const gate = {
+      wasPending: wasPendingRef.current,
+      isPending,
+      alreadyArmed: setupChainArmedRef.current
+    };
+    wasPendingRef.current = isPending;
+    // Two calls, because the decision is: is this the clone-finished edge (so
+    // reading the site's state off disk is worth it), and then does that state
+    // say this is a fresh clone we should drive. See setupAutoStartDecision.
+    if (setupAutoStartDecision(gate) !== 'probe') return undefined;
+    setupChainArmedRef.current = true;
+    let cancelled = false;
+    (async () => {
+      // The status this row is holding was probed while the clone was still
+      // running, so it is re-read here rather than trusted.
+      const status = (await loadStatus()) || null;
+      if (cancelled) return;
+      if (setupAutoStartDecision({ ...gate, status }) !== 'start') return;
+      startSetupChainRef.current();
+    })();
+    return () => { cancelled = true; };
+  }, [isPending, loadStatus]);
 
   // The single most recent patch across whatever is loaded — PRs always, Trac
   // attachments once the contributor has opened them (#11). Drives the "Latest"
@@ -3655,6 +3796,15 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       indicatorBorder: 'none',
       indicatorContent: '•'
     },
+    failed: {
+      color: '#8a1f21',
+      background: '#fcf0f1',
+      border: '#d63638',
+      indicatorBg: '#d63638',
+      indicatorColor: '#fff',
+      indicatorBorder: 'none',
+      indicatorContent: '✕'
+    },
     pending: {
       color: '#6c6f72',
       background: '#f8f9f9',
@@ -3675,7 +3825,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     }
   };
 
-  const stepState = computeSetupStepState({
+  const setupFlags = {
     isPending,
     statusLoading,
     hasNodeModules,
@@ -3684,19 +3834,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     building,
     starting,
     installFailed,
+    buildFailed,
     isUpdating
-  });
-
-  let installLabel = 'Install npm dependencies';
-  if (stepState.install.done) installLabel = 'Dependencies installed';
-  else if (installFailed) installLabel = 'Retry npm install';
+  };
+  const stepState = computeSetupStepState(setupFlags);
+  const { installLabel, installDescription, buildLabel, buildDescription } = setupStepCopy(setupFlags);
 
   const baseSteps = [
     {
       key: 'download',
       label: 'Download WordPress development version',
       description: isPending
-        ? 'Cloning the WordPress develop repository… the next step unlocks when it finishes.'
+        // The clone is also the trigger for everything after it (#246), so the
+        // step says what happens next rather than implying a click is coming.
+        ? 'Cloning the WordPress develop repository… install and build start on their own when it finishes.'
         : 'Clone the WordPress develop repository.',
       ...stepState.download,
       running: isPending
@@ -3704,11 +3855,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     {
       key: 'install',
       label: 'Install npm dependencies',
-      // Once done, this button never re-enables (#182), so the step says where
-      // a later install lives rather than leaving a dead control unexplained.
-      description: stepState.install.done
-        ? 'Installed. Added a dependency to package.json since? Run npm install in the Terminal below.'
-        : 'Install npm packages so commands can run.',
+      description: installDescription,
       ...stepState.install,
       running: installing,
       action: (
@@ -3723,9 +3870,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     {
       key: 'build',
       label: 'Run full build',
-      description: hasBuilt
-        ? 'Built. Edited files in src/ since? Run npm run build in the Terminal below so the site picks them up — updates and applied patches rebuild on their own.'
-        : 'Compile WordPress Core to generate the dist files. Later updates rebuild automatically.',
+      description: buildDescription,
       ...stepState.build,
       running: building,
       action: (
@@ -3734,7 +3879,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           variant={hasBuilt ? 'secondary' : 'primary'}
           onClick={runBuildWithTerminal}
           disabled={stepState.build.disabled}
-        >{hasBuilt ? 'Build complete' : 'Run full build'}</Button>
+        >{buildLabel}</Button>
       )
     },
     {
@@ -3771,28 +3916,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     }
   ];
 
-  let currentStepCaptured = false;
-  const stepItems = baseSteps.map((step) => {
-    let status;
-    if (step.done) {
-      status = 'complete';
-    } else if (!currentStepCaptured && step.ready) {
-      status = 'current';
-      currentStepCaptured = true;
-    } else if (step.ready) {
-      status = 'pending';
-    } else {
-      status = 'locked';
-    }
-    return { ...step, status };
-  });
+  const stepItems = setupStepStatuses(baseSteps);
 
   // The one block to point the contributor at next (#252). The checklist has
   // already worked out its own current step; the resolver folds that together
   // with the post-init state into a single id, which the render tags onto the
   // matching block (`data-next-action` + the `.next-action-cue` class) and the
   // cue hook scrolls into view.
-  const currentSetupStep = stepItems.find((s) => s.status === 'current')?.key || null;
+  // A failed step counts as the one to point at: retrying it is exactly what
+  // the contributor should do next, and it consumes no `current` of its own, so
+  // without this a chain that stopped would leave the view with no cue at all.
+  const currentSetupStep = stepItems.find((s) => s.status === 'current' || s.status === 'failed')?.key || null;
   const nextAction = deriveNextAction({
     skipInit,
     currentSetupStep,
@@ -4038,6 +4172,33 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {!skipInit ? (
         <div style={{ padding: 20, border: '1px solid #dcdcde', borderRadius: 12, background: '#fff' }}>
           <div style={{ fontWeight: 600, fontSize: 16, color: '#1d2327' }}>Initial setup checklist</div>
+          {/*
+            Nobody pressed a button to start this, so the banner has to say what
+            is happening, how far along it is and how to stop it — that is the
+            whole licence for running unattended. The step counter comes from
+            the same `updateStepStatuses` the update panel uses.
+          */}
+          {isSettingUp ? (
+            <div role="status" style={{ marginTop: 12, display: 'flex', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap', padding: '12px 16px', background: '#e8f3ff', border: '1px solid #66afe9', borderRadius: 8, fontSize: 13, color: '#0b5d95' }}>
+              <div style={{ flex: '1 1 320px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <strong style={{ color: '#0b5d95' }}>
+                  Setting this site up for you — step {setupStepStates.filter((s) => s.status === 'complete').length + 1} of {setupSteps.length}
+                </strong>
+                <span>
+                  {setupChainState === 'installing'
+                    ? 'Installing dependencies. You can leave this running — the build follows on its own.'
+                    : 'Running the full build. This can take up to half an hour on Windows; the Terminal below shows what it is doing.'}
+                </span>
+              </div>
+              <Button variant="secondary" onClick={stopSetupChain}>Stop setup</Button>
+            </div>
+          ) : null}
+          {!isSettingUp && setupChainEnd === 'stopped' ? (
+            <div style={{ marginTop: 12, padding: '12px 16px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 8, fontSize: 13, color: '#6e5406' }}>
+              <strong style={{ color: '#5c4400' }}>Setup stopped.</strong>{' '}
+              Nothing was lost — pick it back up with the buttons below whenever you want.
+            </div>
+          ) : null}
           <div style={{ marginTop: 4, fontSize: 13, color: '#3c434a' }}>Complete each step to prepare this site for development.</div>
           <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
             {stepItems.map((step) => {

--- a/src/renderer/setup-steps.cjs
+++ b/src/renderer/setup-steps.cjs
@@ -25,6 +25,7 @@ function computeSetupStepState(flags = {}) {
 	const building = Boolean(flags.building);
 	const starting = Boolean(flags.starting);
 	const installFailed = Boolean(flags.installFailed);
+	const buildFailed = Boolean(flags.buildFailed);
 	const isUpdating = Boolean(flags.isUpdating);
 
 	// node_modules existing is not evidence the install succeeded: a failed
@@ -41,11 +42,17 @@ function computeSetupStepState(flags = {}) {
 		install: {
 			done: installOk,
 			ready: !isPending,
+			// A failed attempt is reported as its own state rather than folded
+			// into "not done yet" (#44): the difference between a step nobody
+			// has started and one that ran and lost is the whole reason a
+			// contributor knows to look at the terminal.
+			failed: installFailed && !installing,
 			disabled: isPending || statusLoading || installing || installOk || isUpdating
 		},
 		build: {
 			done: hasBuilt,
 			ready: installOk,
+			failed: buildFailed && !building && !hasBuilt,
 			disabled: statusLoading || building || !installOk || hasBuilt || isUpdating
 		},
 		dev: {
@@ -54,6 +61,49 @@ function computeSetupStepState(flags = {}) {
 			disabled: statusLoading || starting || !hasBuilt || isUpdating
 		}
 	};
+}
+
+/**
+ * Walks the checklist and gives every step its status word.
+ *
+ * The ladder: a finished step is `complete`; a step whose last attempt lost is
+ * `failed`; the first unfinished step whose prerequisites are met is `current`;
+ * later reachable steps are `pending`; anything still waiting on a prerequisite
+ * is `locked`.
+ *
+ * `failed` outranks `current` so a step that ran and lost keeps the row rather
+ * than handing it to whatever comes next — and it does not consume `current`,
+ * because the thing to do next is still to retry it.
+ *
+ * Every one of these states is derived from what is on disk plus the recorded
+ * outcome of the last run, never from the position of a chain — which is what
+ * lets a site reopened days later, with nothing running, still show the truth.
+ *
+ * Lived in the renderer as an inline loop until #246; moved here because it is a
+ * decision with branches, and those belong in a module by this project's own
+ * rule.
+ *
+ * @param {Array} steps Steps carrying `done`, `ready` and optional `failed`.
+ * @return {Array} The same steps, each with a `status`.
+ */
+function setupStepStatuses(steps = []) {
+	let currentCaptured = false;
+	return steps.map((step) => {
+		let status;
+		if (step.done) {
+			status = 'complete';
+		} else if (step.failed) {
+			status = 'failed';
+		} else if (!currentCaptured && step.ready) {
+			status = 'current';
+			currentCaptured = true;
+		} else if (step.ready) {
+			status = 'pending';
+		} else {
+			status = 'locked';
+		}
+		return { ...step, status };
+	});
 }
 
 /**
@@ -73,7 +123,7 @@ function computeSetupStepState(flags = {}) {
  * decision with branches, and those belong in a module by this project's own
  * rule.
  *
- * @param {string}  status    One of complete|current|pending|locked.
+ * @param {string}  status    One of complete|failed|current|pending|locked.
  * @param {boolean} isRunning The current step's action is under way.
  * @return {string}
  */
@@ -81,6 +131,8 @@ function setupStepLabel(status, isRunning) {
 	switch (status) {
 		case 'complete':
 			return 'Completed';
+		case 'failed':
+			return 'Failed';
 		case 'pending':
 			return 'Pending';
 		case 'locked':
@@ -90,4 +142,94 @@ function setupStepLabel(status, isRunning) {
 	}
 }
 
-module.exports = { computeSetupStepState, setupStepLabel };
+/**
+ * The button label and description on the install and build steps.
+ *
+ * Both read differently in four situations — not started, running, done, and
+ * failed — and both are strings a contributor reads to decide what to do, so
+ * they belong here rather than as ternaries in the component. Derived from the
+ * same flags as `computeSetupStepState` so the words and the button state can
+ * never disagree.
+ *
+ * @param {Object} flags The flags computeSetupStepState takes.
+ * @return {{installLabel: string, installDescription: string, buildLabel: string, buildDescription: string}}
+ */
+function setupStepCopy(flags = {}) {
+	const state = computeSetupStepState(flags);
+	const installFailed = Boolean(flags.installFailed);
+	const hasBuilt = Boolean(flags.hasBuilt);
+
+	let installLabel = 'Install npm dependencies';
+	if (state.install.done) installLabel = 'Dependencies installed';
+	else if (installFailed) installLabel = 'Retry npm install';
+
+	let installDescription = 'Install npm packages so commands can run.';
+	if (state.install.done) {
+		// Once done, this button never re-enables (#182), so the step says where a
+		// later install lives rather than leaving a dead control unexplained.
+		installDescription = 'Installed. Added a dependency to package.json since? Run npm install in the Terminal below.';
+	} else if (state.install.failed) {
+		// A failure the contributor did not start (the chain runs install on its
+		// own now) has to say where the evidence is, or "Failed" is all they get.
+		installDescription = 'The install did not finish. Its output is in the Terminal below — retry when you have read it.';
+	}
+
+	let buildLabel = 'Run full build';
+	if (hasBuilt) buildLabel = 'Build complete';
+	else if (state.build.failed) buildLabel = 'Retry the build';
+
+	let buildDescription = 'Compile WordPress Core to generate the dist files. Later updates rebuild automatically.';
+	if (hasBuilt) {
+		buildDescription = 'Built. Edited files in src/ since? Run npm run build in the Terminal below so the site picks them up — updates and applied patches rebuild on their own.';
+	} else if (state.build.failed) {
+		buildDescription = 'The build did not finish. Its output is in the Terminal below — retry when you have read it.';
+	}
+
+	return { installLabel, installDescription, buildLabel, buildDescription };
+}
+
+/**
+ * What the renderer should do about auto-starting the setup chain (#246).
+ *
+ * Three answers, because the decision is taken in two halves: the trigger is an
+ * edge — the clone going from running to finished — and only once that holds is
+ * it worth reading the site's state off disk. So `probe` means "this is the
+ * moment, go and read the status", and the caller comes back with that status
+ * for the second, final call.
+ *
+ * Getting the edge wrong is the difference between a wizard that finishes
+ * itself and one that launches a half-hour build every time the app opens,
+ * which is why this is a tested decision rather than a chain of conditions in
+ * an effect. The refusals, and why each one:
+ *
+ * - not the edge: a site already cloned when its row appeared never triggers,
+ *   which is what makes reopening the app safe;
+ * - already armed: once per mount, so a re-render cannot start a second chain;
+ * - the wizard was skipped: that contributor has said they want the manual path;
+ * - node_modules already exists: this is not the fresh clone it looks like, and
+ *   the tree may be one somebody is already working in.
+ *
+ * @param {Object}  root0
+ * @param {boolean} root0.wasPending     The clone was running on the last render.
+ * @param {boolean} root0.isPending      The clone is running now.
+ * @param {boolean} [root0.alreadyArmed] This row has already triggered once.
+ * @param {?Object} [root0.status]       A fresh site:status read; omit to ask
+ *                                       whether reading one is worthwhile.
+ * @return {'skip'|'probe'|'start'}
+ */
+function setupAutoStartDecision({ wasPending, isPending, alreadyArmed, status } = {}) {
+	if (!wasPending || isPending || alreadyArmed) return 'skip';
+	if (status === undefined) return 'probe';
+	// A read that failed is not evidence the site is fresh, so it refuses.
+	if (!status) return 'skip';
+	if (status.skipInitWizard || status.hasNodeModules) return 'skip';
+	return 'start';
+}
+
+module.exports = {
+	computeSetupStepState,
+	setupStepStatuses,
+	setupStepCopy,
+	setupAutoStartDecision,
+	setupStepLabel
+};

--- a/src/renderer/update-plan.cjs
+++ b/src/renderer/update-plan.cjs
@@ -5,6 +5,12 @@
  * a site's trunk snapshot is, which steps an update runs, and how the chain
  * ends.
  *
+ * It has since become the home of every multi-step chain the renderer runs —
+ * updating (#94), applying a patch (#11) and initial setup (#246) — because all
+ * three share `updateStepStatuses` and the same outcome vocabulary. Keeping the
+ * three plans beside the machinery they share is what stops a fourth chain
+ * growing its own.
+ *
  * Kept as a pure, dependency-free module so it can be unit tested without a
  * DOM: the renderer bundle imports it, `node --test` requires it directly
  * (same convention as setup-steps.cjs and dev-server-command.cjs).
@@ -94,6 +100,32 @@ function planApplySteps({ needsInstall, buildByWatcher } = {}) {
 	];
 }
 
+// Initial setup (#246) is the third chain, and the one the contributor does not
+// start: it runs on its own the moment the clone finishes, so a newcomer who
+// walks away comes back to a built environment instead of a checklist waiting
+// on two clicks with no decision between them.
+const SETUP_STATE_TO_STEP = { cloning: 'download', installing: 'install', building: 'build' };
+
+/**
+ * The chain initial setup runs. Nothing is ever skipped here: a fresh clone has
+ * no node_modules and no build, so both always run — the `skipped` field is kept
+ * only so the three plans share one shape.
+ *
+ * Starting the dev server is deliberately not part of it. It is the step that
+ * marks the initialization wizard finished and hands the contributor to a
+ * WordPress setup wizard in a browser, so running it unattended would end the
+ * checklist on their behalf and leave a server listening that nobody asked for.
+ *
+ * @return {Array}
+ */
+function planSetupSteps() {
+	return [
+		{ key: 'download', label: 'Download WordPress', skipped: false },
+		{ key: 'install', label: 'Install dependencies', skipped: false },
+		{ key: 'build', label: 'Run full build', skipped: false }
+	];
+}
+
 /**
  * How applying a patch (or updating trunk) should treat a running build watch
  * (#247, #262). A watch that is running already recompiles src/ on save, so a
@@ -122,7 +154,8 @@ function planWatchImpact({ needsInstall, watcherActive } = {}) {
  * current, later ones pending; skipped steps stay 'skipped' once passed.
  *
  * The state→step map is a parameter so a different chain can reuse this: the
- * applying chain (#11) has the same three-stage shape with its own state names.
+ * applying chain (#11) has the same three-stage shape with its own state names,
+ * and the setup chain (#246) uses it for its progress counter.
  *
  * @param {Array}  steps
  * @param {string} updateState
@@ -167,16 +200,44 @@ function updateOutcome({ fetchOk, upToDate, moved, installNeeded, installCode, b
 	return 'done';
 }
 
+/**
+ * How the setup chain ended, and the only thing that decides what the
+ * contributor is told. `stopped` is separated from `failed-install` /
+ * `failed-build` on purpose: a chain the contributor stopped is not a problem to
+ * report, and telling someone their install "failed" when they pressed Stop is
+ * how a tool loses their trust.
+ *
+ * A stop and a failure are otherwise indistinguishable from the exit code — a
+ * killed npm exits non-zero, and on Windows without even a signal — so the
+ * caller passes `stopped` from the fact that it asked for the kill, not from
+ * what the process did.
+ *
+ * @param {Object}  root0
+ * @param {boolean} [root0.stopped]     The contributor pressed Stop.
+ * @param {number}  [root0.installCode] Exit code of npm install, if it ran.
+ * @param {number}  [root0.buildCode]   Exit code of npm run build, if it ran.
+ * @return {string}
+ */
+function setupOutcome({ stopped, installCode, buildCode } = {}) {
+	if (stopped) return 'stopped';
+	if (installCode !== 0) return 'failed-install';
+	if (buildCode !== 0) return 'failed-build';
+	return 'done';
+}
+
 module.exports = {
 	STALE_THRESHOLD_DAYS,
 	SKIP_INSTALL_MESSAGE,
 	BUILD_BY_WATCHER_MESSAGE,
 	STATE_TO_STEP,
 	APPLY_STATE_TO_STEP,
+	SETUP_STATE_TO_STEP,
 	planApplySteps,
 	planWatchImpact,
+	planSetupSteps,
 	trunkAgeInfo,
 	planUpdateSteps,
 	updateStepStatuses,
+	setupOutcome,
 	updateOutcome
 };

--- a/test/setup-steps.test.cjs
+++ b/test/setup-steps.test.cjs
@@ -3,7 +3,29 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { computeSetupStepState, setupStepLabel } = require('../src/renderer/setup-steps.cjs');
+const {
+	computeSetupStepState,
+	setupStepStatuses,
+	setupStepCopy,
+	setupAutoStartDecision,
+	setupStepLabel
+} = require('../src/renderer/setup-steps.cjs');
+
+// The four checklist rows, in order, as the renderer builds them — so the ladder
+// tests below read as the screen the contributor is looking at.
+function checklist(flags) {
+	const state = computeSetupStepState(flags);
+	return setupStepStatuses([
+		{ key: 'download', ...state.download },
+		{ key: 'install', ...state.install },
+		{ key: 'build', ...state.build },
+		{ key: 'dev', ...state.dev }
+	]);
+}
+
+function statuses(flags) {
+	return Object.fromEntries(checklist(flags).map((s) => [s.key, s.status]));
+}
 
 test('while the clone is still running, the install step is locked (issue #47)', () => {
 	const steps = computeSetupStepState({ isPending: true });
@@ -122,7 +144,188 @@ test('the current step reads "In progress" once its action is running (#257)', (
 test('the other statuses keep their fixed labels regardless of the running flag', () => {
 	for (const running of [true, false]) {
 		assert.strictEqual(setupStepLabel('complete', running), 'Completed');
+		assert.strictEqual(setupStepLabel('failed', running), 'Failed');
 		assert.strictEqual(setupStepLabel('pending', running), 'Pending');
 		assert.strictEqual(setupStepLabel('locked', running), 'Locked');
 	}
+});
+
+// --- the ladder (#44, #246) ----------------------------------------------
+//
+// #44's acceptance criteria are a matrix: before start, during, after success
+// and after failure, for each asynchronous step. These walk it. What every one
+// of them is really asserting is that the status comes from what is on disk plus
+// the last run's outcome — never from where a chain happens to be — because that
+// is what lets a half-finished site reopened days later still read true.
+
+test('the ladder walks the checklist: exactly one current step, the rest locked behind it', () => {
+	assert.deepStrictEqual(statuses({ isPending: true }), {
+		download: 'current', install: 'locked', build: 'locked', dev: 'locked'
+	});
+});
+
+test('before install starts, install is current and nothing claims to be running (#44)', () => {
+	const rows = checklist({});
+	assert.deepStrictEqual(statuses({}), {
+		download: 'complete', install: 'current', build: 'locked', dev: 'locked'
+	});
+	// The #44 report itself: the next step must not announce itself as under way.
+	assert.strictEqual(setupStepLabel(rows[1].status, false), 'Ready');
+});
+
+test('while install runs, its step says so (#44)', () => {
+	const rows = checklist({ installing: true });
+	assert.strictEqual(rows[1].status, 'current');
+	assert.strictEqual(setupStepLabel(rows[1].status, true), 'In progress');
+});
+
+test('after a successful install the build takes over as current (#44)', () => {
+	assert.deepStrictEqual(statuses({ hasNodeModules: true }), {
+		download: 'complete', install: 'complete', build: 'current', dev: 'locked'
+	});
+});
+
+test('after a failed install the step reads failed, and nothing downstream becomes current (#44)', () => {
+	const rows = checklist({ hasNodeModules: true, installFailed: true });
+	assert.deepStrictEqual(statuses({ hasNodeModules: true, installFailed: true }), {
+		download: 'complete', install: 'failed', build: 'locked', dev: 'locked'
+	});
+	assert.strictEqual(setupStepLabel(rows[1].status, false), 'Failed');
+	// The retry is the point of naming the failure — a failed step with a dead
+	// button is worse than no label at all.
+	assert.strictEqual(rows[1].disabled, false);
+});
+
+test('a retry in flight replaces the failed label rather than sitting under it', () => {
+	// installFailed is still recorded — the flag only clears when the next run
+	// finishes — so without the `installing` guard the step would read "Failed"
+	// while its own retry was streaming output to the terminal.
+	const rows = checklist({ hasNodeModules: true, installFailed: true, installing: true });
+	assert.strictEqual(rows[1].status, 'current');
+	assert.strictEqual(setupStepLabel(rows[1].status, true), 'In progress');
+});
+
+test('after a failed build the step reads failed, and the dev server stays locked (#44)', () => {
+	assert.deepStrictEqual(statuses({ hasNodeModules: true, buildFailed: true }), {
+		download: 'complete', install: 'complete', build: 'failed', dev: 'locked'
+	});
+});
+
+test('a build that succeeded after failing earlier reads complete, not failed', () => {
+	// hasBuilt is the ground truth; a stale buildFailed flag must not outrank it.
+	assert.deepStrictEqual(statuses({ hasNodeModules: true, hasBuilt: true, buildFailed: true }), {
+		download: 'complete', install: 'complete', build: 'complete', dev: 'current'
+	});
+});
+
+test('the dev server step is the last current one and never completes itself', () => {
+	assert.deepStrictEqual(statuses({ hasNodeModules: true, hasBuilt: true }), {
+		download: 'complete', install: 'complete', build: 'complete', dev: 'current'
+	});
+});
+
+// --- the words on the steps (#246) ---------------------------------------
+
+test('the install step says what it is offering in each of its four states', () => {
+	assert.strictEqual(setupStepCopy({}).installLabel, 'Install npm dependencies');
+	assert.strictEqual(setupStepCopy({ hasNodeModules: true }).installLabel, 'Dependencies installed');
+	assert.strictEqual(
+		setupStepCopy({ hasNodeModules: true, installFailed: true }).installLabel,
+		'Retry npm install'
+	);
+	// The retry stays named as a retry while it runs, rather than reverting to
+	// the first-run wording halfway through.
+	assert.strictEqual(
+		setupStepCopy({ hasNodeModules: true, installFailed: true, installing: true }).installLabel,
+		'Retry npm install'
+	);
+});
+
+test('a failed step points at the terminal, since nobody clicked to start it (#246)', () => {
+	// The chain runs install and build unattended, so a bare "Failed" would be
+	// the first a contributor heard of it with nowhere to look.
+	const install = setupStepCopy({ hasNodeModules: true, installFailed: true });
+	assert.match(install.installDescription, /Terminal below/);
+	const build = setupStepCopy({ hasNodeModules: true, buildFailed: true });
+	assert.strictEqual(build.buildLabel, 'Retry the build');
+	assert.match(build.buildDescription, /Terminal below/);
+});
+
+test('a completed step says where a later install or build lives (#182)', () => {
+	const copy = setupStepCopy({ hasNodeModules: true, hasBuilt: true });
+	assert.strictEqual(copy.buildLabel, 'Build complete');
+	assert.match(copy.installDescription, /Terminal below/);
+	assert.match(copy.buildDescription, /Terminal below/);
+});
+
+test('the copy and the button state cannot disagree about a failed install', () => {
+	// Both come from the same flags: node_modules exists but the install failed,
+	// so the step is not done, its button is live, and it says "Retry" (#42).
+	const flags = { hasNodeModules: true, installFailed: true };
+	assert.strictEqual(computeSetupStepState(flags).install.done, false);
+	assert.strictEqual(computeSetupStepState(flags).install.disabled, false);
+	assert.strictEqual(setupStepCopy(flags).installLabel, 'Retry npm install');
+});
+
+// --- auto-starting the chain (#246) --------------------------------------
+//
+// The riskiest decision in the feature: too eager and it launches a half-hour
+// build nobody asked for, too shy and the wizard never finishes itself.
+
+test('the clone finishing is what asks for a status read', () => {
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false }),
+		'probe'
+	);
+});
+
+test('a fresh clone with the wizard still on starts the chain', () => {
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false, status: {} }),
+		'start'
+	);
+});
+
+test('nothing happens while the clone is still running', () => {
+	assert.strictEqual(setupAutoStartDecision({ wasPending: true, isPending: true }), 'skip');
+});
+
+test('a site that was already cloned when its row appeared never auto-starts', () => {
+	// This is what makes reopening the app safe: no edge, no chain, whatever
+	// state the site is in.
+	assert.strictEqual(setupAutoStartDecision({ wasPending: false, isPending: false }), 'skip');
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: false, isPending: false, status: {} }),
+		'skip'
+	);
+});
+
+test('the chain arms once per row, so a re-render cannot start a second one', () => {
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false, alreadyArmed: true }),
+		'skip'
+	);
+});
+
+test('a skipped wizard means the contributor drives, so the chain stays out of it', () => {
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false, status: { skipInitWizard: true } }),
+		'skip'
+	);
+});
+
+test('an existing node_modules is not the fresh clone it looks like', () => {
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false, status: { hasNodeModules: true } }),
+		'skip'
+	);
+});
+
+test('a status read that failed refuses rather than assuming the site is fresh', () => {
+	// null is a failed probe, not an empty one. Guessing here would run npm
+	// install against a tree nothing is known about.
+	assert.strictEqual(
+		setupAutoStartDecision({ wasPending: true, isPending: false, status: null }),
+		'skip'
+	);
 });

--- a/test/update-plan.test.cjs
+++ b/test/update-plan.test.cjs
@@ -5,9 +5,12 @@ const assert = require('node:assert');
 const {
 	STALE_THRESHOLD_DAYS,
 	SKIP_INSTALL_MESSAGE,
+	SETUP_STATE_TO_STEP,
 	trunkAgeInfo,
 	planUpdateSteps,
+	planSetupSteps,
 	updateStepStatuses,
+	setupOutcome,
 	updateOutcome
 } = require('../src/renderer/update-plan.cjs');
 
@@ -125,4 +128,61 @@ test('updateOutcome: full chain success (issue #94)', () => {
 		updateOutcome({ fetchOk: true, upToDate: false, moved: true, installNeeded: true, installCode: 0, buildCode: 0 }),
 		'done'
 	);
+});
+
+// --- the setup chain (#246) ----------------------------------------------
+
+test('planSetupSteps: clone, install, build — and nothing is ever skipped (issue #246)', () => {
+	const steps = planSetupSteps();
+
+	assert.deepStrictEqual(steps.map((s) => s.key), ['download', 'install', 'build']);
+	// The update and apply chains skip the install when the lockfile did not
+	// move; a fresh clone has no node_modules at all, so there is nothing this
+	// chain can honestly skip.
+	assert.deepStrictEqual(steps.map((s) => s.skipped), [false, false, false]);
+	// Starting the dev server is deliberately outside the chain: it marks the
+	// wizard finished and hands the contributor to a browser wizard.
+	assert.ok(!steps.some((s) => s.key === 'dev'), 'the dev server is not part of the chain');
+});
+
+test('the setup chain reuses updateStepStatuses with its own state names (issue #246)', () => {
+	const steps = planSetupSteps();
+	const at = (state) => updateStepStatuses(steps, state, SETUP_STATE_TO_STEP)
+		.map((s) => s.status);
+
+	assert.deepStrictEqual(at('cloning'), ['current', 'pending', 'pending']);
+	assert.deepStrictEqual(at('installing'), ['complete', 'current', 'pending']);
+	assert.deepStrictEqual(at('building'), ['complete', 'complete', 'current']);
+	assert.deepStrictEqual(at('done'), ['complete', 'complete', 'complete']);
+});
+
+test('an idle setup chain claims no step (issue #246)', () => {
+	// 'idle' is not in the map, so nothing is current and nothing is complete —
+	// which is what keeps the banner off the screen when no chain is running.
+	assert.deepStrictEqual(
+		updateStepStatuses(planSetupSteps(), 'idle', SETUP_STATE_TO_STEP).map((s) => s.status),
+		['pending', 'pending', 'pending']
+	);
+});
+
+test('setupOutcome: install and build both succeeded -> done (issue #246)', () => {
+	assert.strictEqual(setupOutcome({ installCode: 0, buildCode: 0 }), 'done');
+});
+
+test('setupOutcome: a failed install never reaches the build (issue #246)', () => {
+	// buildCode is undefined because the build never ran — the outcome has to
+	// name the install, not read the missing build as the failure.
+	assert.strictEqual(setupOutcome({ installCode: 1 }), 'failed-install');
+});
+
+test('setupOutcome: a failed build after a good install (issue #246)', () => {
+	assert.strictEqual(setupOutcome({ installCode: 0, buildCode: 2 }), 'failed-build');
+});
+
+test('setupOutcome: Stop is not a failure, whatever exit code the kill produced (issue #246)', () => {
+	// A killed npm exits non-zero, and on Windows without even a signal, so the
+	// exit code cannot tell a stop from a failure. Telling a contributor their
+	// install "failed" when they pressed Stop is how a tool loses their trust.
+	assert.strictEqual(setupOutcome({ stopped: true, installCode: 1 }), 'stopped');
+	assert.strictEqual(setupOutcome({ stopped: true, installCode: 0, buildCode: 143 }), 'stopped');
 });


### PR DESCRIPTION
> **Stacked on #274.** Review that one first — it is the kill path this PR's Stop button depends on. The diff below is this branch against #274, not against trunk.

## Why

After the clone finishes, the setup checklist stops and waits. **Install npm dependencies**, then **Run full build** — two clicks, with no decision to make between them. The contributor's only job is to notice a step ended and press the next button.

That is the wrong shape for a wizard. Someone who walks away during the clone — which is what you do during a ten-minute clone at a Contributor Day — comes back to a checklist waiting on them rather than to an environment they can work in. #246 makes the case at length.

## What changes

Setup becomes the third chain of the shape the app already runs twice: `planUpdateSteps` (fetch → install → build) for a trunk update, `planApplySteps` (apply → install → build) for a patch, both sharing `updateStepStatuses` and `updateOutcome`. `planSetupSteps` joins them, and **the chain starts on its own when the clone finishes** — no button.

What makes running unattended reasonable rather than presumptuous, and each of these is the reason the issue gives:

- **It is visible.** A banner names the running step and counts it (`step 2 of 3`), and every line of npm output still goes to the Terminal (#41).
- **It stops.** **Stop setup**, and Ctrl+C in the Terminal, end the child — install included, which is what #274 is for.
- **It stops at the first failure.** A build on a half-installed tree cannot work, and its failure would bury the one that mattered (#42).
- **It starts once, on an edge.** The clone going from running to finished, once per row. A site already cloned when its row appears never triggers, so reopening the app on a half-finished site lands on the manual checklist rather than launching a half-hour build nobody asked for.

**Deliberately not in it:** starting the dev server. #246 lists it as the fourth link, and I left it out — that step also calls `markSkipWizard()` and hands the contributor to a WordPress setup wizard in a browser, so running it unattended would end the checklist on their behalf and leave a server listening that nobody asked for. Also not in it: resuming the chain after a stop. Retry is a plain button on the failed step; a cancel followed by a retry must not silently restart a half-hour build.

**It also closes the open half of #44.** The checklist ladder moves out of `index.jsx` into `setupStepStatuses` and gains a `failed` state, so a step whose last attempt lost says **Failed**, keeps its retry, and does not hand `current` to the next step. #258 fixed the label half ("Ready" until an action runs); the explicit failed/retryable state was the acceptance criterion still open, and a chain that can stop is what made it necessary rather than nice.

## How to test this

Platforms: **any** for 1 and 4–6; do **2 and 3 on both macOS and Windows** — process-tree killing is where they differ.

**Starting state:** the app, with no site for the WordPress repo you are about to create. This is a real clone plus a real install plus a real build, so budget for it — the point of steps 2 and 3 is that you do not have to sit through the build.

1. **Create a WordPress Core site.** Watch the *Download WordPress development version* step. It should say the install and build start on their own when it finishes.
2. **When the clone finishes, click nothing.** The blue banner appears, *Install npm dependencies* turns **In progress**, and npm output streams into the Terminal. When install ends, the build follows on its own and the banner reads *step 3 of 3*.
   - *Start dev server & finish wizard* must still read **Ready** and must **not** have started.
3. **Press Stop setup** while npm install is running. The install actually dies — check no `node`/`npm` child of the app survives. The build never starts, the banner is replaced by *Setup stopped*, and the install step offers **Retry npm install**.
4. **Press Stop setup during the build** instead (create a second site, let install finish). The whole Grunt tree dies, not just the runner (#83, #146).
5. **A failing install.** Easiest is to pull the network mid-install. The step reads **Failed** in red with its retry live, the build stays **Locked**, and the chain does not advance.
6. **Reopen mid-setup.** Quit during the build, relaunch, open the site. The checklist shows the real state from disk and the chain does **not** restart by itself.
7. **Skip initialization wizard** during a running chain. The checklist goes away, the chain keeps running, the Terminal still shows it.

**What must not have happened:**

- **The dev server must not have started, and the wizard must not be marked skipped.** The chain ends at the build. If you land on a running server or a post-init view without clicking, that is the regression.
- **No orphaned `npm`/`node` process after a Stop**, on either platform.
- **A stop must not be reported as a failure.** A killed npm exits non-zero — on Windows without even a signal — so the step must read *Setup stopped*, not *npm install failed*.
- **A stop must not respawn itself.** Watch for a second install starting a moment after you stopped the first (that is #274's `cancelled` flag doing its job).
- **Reopening the app must not start anything.** Step 6 is the one that would be easy not to notice: it only misbehaves on a site you left half-finished, and the symptom is your laptop quietly building for half an hour.

## Risks and limitations

**The end-to-end chain has not been driven by hand.** I could not: this Electron build does not expose its accessibility tree to the automation available here, and creating a site needs a native folder picker. What I did verify is that the renderer bundles and mounts with these changes, lint is clean, and both Node runtimes are green (840 tests). **Steps 1–7 above are unverified and want a human**, and step 3 in particular is the one that justifies the whole feature.

`buildFailed` is session-local. Only the install outcome is persisted (`src/main.js` records it on the site's meta), so after a restart a failed build reads **Ready** again rather than **Failed**. That is the honest fallback — the app still knows there is no build on disk, just not that the last attempt lost — and persisting it is a separate change.

Auto-start is once per row **mount**, not once per site. Switching away from a site and back during a clone remounts the row; if the clone finishes after that remount the chain still fires, which is the wanted behaviour, but it does mean the guard is memory, not state on disk. The `hasNodeModules` check is what stops that mattering.

The banner says the build can take up to half an hour on Windows (#72). It runs a production build where a dev build would do — that is #92, untouched here, and auto-starting makes it more worth fixing, not less.

## Related

Closes #246. Closes the remaining acceptance criterion of #44. Depends on #274. Makes #57 (the redundant nested `npm install` between the two steps) easier to fix now the two are one run.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**The checklist rows are not driven by `updateStepStatuses`.** #246 suggests they could be — "it already returns the complete/current/pending/skipped states the checklist needs". They cannot, and this is the one place I departed from the issue. Those states are derived from disk (`hasNodeModules`, `hasBuilt`, `installFailed`) precisely so a site reopened days later, with nothing running, still shows the truth; driving them from chain position would show every step `pending` on a reopened half-finished site. So the reuse is real but narrower: `planSetupSteps` + `updateStepStatuses` + `setupOutcome` drive the **banner** — progress counter, Stop, how it ended — exactly as they drive the update panel, and the rows keep their own ladder.

**`planSetupSteps` lives in `update-plan.cjs`** rather than in `setup-steps.cjs`, following the `planApplySteps` precedent: the module is where the chains and the machinery they share live, and splitting the third one off would have meant importing `updateStepStatuses` across modules to save a rename. Its docblock now says it owns three chains.

**`setupOutcome` separates `stopped` from `failed-install`/`failed-build`** even though the exit codes are identical. Telling a contributor their install "failed" when they pressed Stop is how a tool loses their trust, and the exit code genuinely cannot tell the two apart — so `stopped` comes from the fact that we asked for the kill, not from what the process did.

**Auto-start is a tri-state decision, not a chain of `if`s in an effect.** `setupAutoStartDecision` returns `skip` / `probe` / `start`, because the decision is taken in two halves: is this the clone-finished edge (so reading status off disk is worth it), and then does that status say this is a fresh clone. Being able to test that is worth more than the shape being slightly unusual — it is the riskiest behaviour in the PR.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

2 [fix here] · 0 [follow-up] — both fixed.

**architecture 🟡 [fix here]** — the auto-start decision lived inline in a `useEffect` in `index.jsx`, which the suite cannot reach. Per §1, the finding is the missing module, not the missing test — and this was the riskiest decision in the change (too eager and it launches a half-hour build unasked, too shy and the wizard never finishes itself). Extracted to `setupAutoStartDecision` with nine tests covering the edge, the arming, the two refusals and a failed status probe.

**architecture 🟡 [fix here]** — four branchy user-facing strings (install and build labels and descriptions) were derived inline in `index.jsx`. §1 names "a string the user reads" explicitly. Extracted to `setupStepCopy`, which takes the same flags as `computeSetupStepState` so the words and the button state cannot disagree; four tests, including one pinning that pairing for the #42 case.

The judgement pass was run in this session rather than dispatched to a subagent — the tooling in use blocked spawning one. Flagging it because the standard prefers fresh context for that pass, and self-review is the weaker version. Worth a second pair of eyes on the effect in `index.jsx` in particular.

</details>

<details>
<summary>Implementation notes</summary>

The chain reuses the wizard's own `runInstall` / `runScript` wrappers, the same way `runUpdateInstallAndBuild` does, so exit codes, retries, terminal streaming and the post-run status reload all behave identically to every other path. Nothing new crosses IPC.

`runScript` gained one line: it clears `buildFailed` when a build starts and records it on exit. Clearing on start rather than on the next exit is what stops a step reading **Failed** while its own retry is streaming output — there is a test for that shape on the install side.

`deriveNextAction` is unchanged. The call site now passes a failed step as the current one, since retrying it is what the contributor should do next and a `failed` row consumes no `current` — without that, a stopped chain would leave the view with no cue at all.

</details>

<details>
<summary>Screenshots or recording</summary>

None — see the limitation above: I could not drive the app's UI from this environment, so there is no shot of the banner or the failed row. This is the part of the PR that most wants a human with the Buildkite artifact.

</details>
