### PR TITLE
Read the log panes in the terminal's font, with severity colour

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -39,13 +39,20 @@ import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
 import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
+import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 import { changesNoteParts, discardOutcome, noteAfterDiscard, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
 import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
-// Shared by both log panes so the tabs cannot drift apart visually.
-const LOG_PANE_STYLE = { whiteSpace: 'pre-wrap', background: '#111', color: '#eee', padding: 12, borderRadius: 6, height: 220, overflow: 'auto' };
+// One face for everything that is process output: the terminal below and every
+// log pane above it. Shared rather than repeated because the panes had drifted
+// into the app's sans-serif, which does not line up a stack trace and does not
+// read as a console even though that is exactly what it is.
+const TERMINAL_FONT = { fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace', fontSize: 13 };
+// Shared by every log pane so the tabs cannot drift apart visually. The line
+// height is looser than xterm's: this is wrapped text in a div, not painted rows.
+const LOG_PANE_STYLE = { ...TERMINAL_FONT, lineHeight: 1.4, whiteSpace: 'pre-wrap', background: '#111', color: '#eee', padding: 12, borderRadius: 6, height: 220, overflow: 'auto' };
 // What the Copy button says about the press just made. Keyed rather than
 // nested ternaries, so a fourth state is a line here instead of another branch
 // in the middle of the JSX.
@@ -856,7 +863,7 @@ function App() {
                     </div>
                   </div>
                   {webError ? (<div style={{ marginTop:6, color:'#C00', fontSize:12 }}>{webError}</div>) : null}
-                  <div ref={webLogRef} style={{ marginTop:8, whiteSpace:'pre-wrap', background:'#111', color:'#eee', padding:8, borderRadius:6, height:140, overflow:'auto' }}>{webLogs}</div>
+                  <div ref={webLogRef} style={{ ...LOG_PANE_STYLE, marginTop:8, padding:8, height:140 }}><LogText text={webLogs} /></div>
                 </CardBody>
               </Card>
             ) : null}
@@ -1033,6 +1040,51 @@ function DiffText({ text }) {
       {line.text || ' '}
     </span>
   ));
+}
+
+// What each kind of log line looks like. Same split as the diff pane: the
+// classification is in log-highlight.cjs, the colours are a property of this
+// pane. Colour is never the only signal — the words `Fatal error`, `Warning`,
+// `Deprecated` stay in the text, and the severity is a re-statement of them, so
+// nothing is lost without colour vision.
+const LOG_LINE_STYLES = {
+  fatal: { color: '#ffa198' },
+  warning: { color: '#ffb86c' },
+  deprecated: { color: '#e3d16a' },
+  notice: { color: '#e3d16a' },
+  // Stack frames and node's "(Use `…`)" follow-ups: they belong to the line
+  // above and are most of the volume in a full pane, so they recede.
+  trace: { color: '#8b949e' },
+  ready: { color: '#7ee787', fontWeight: 600 },
+  plain: {}
+};
+// The `[11-Aug-2026 …]` every debug.log line opens with. It is worth keeping —
+// it is how two runs of the same request are told apart — but it is the same 26
+// characters on every line, so it is the last thing that should catch the eye.
+const LOG_STAMP_STYLE = { color: '#6e7681' };
+
+// A log pane, painted. Memoised on the text because a running dev server streams
+// chunks into it: without this, an unrelated SiteRow re-render re-splits the
+// whole buffer. Only the tail is turned into per-line spans (see
+// MAX_HIGHLIGHTED_LINES); everything older is one plain string, so the element
+// count stays flat however long the server runs.
+function LogText({ text }) {
+  const painted = useMemo(() => highlightLog(text), [text]);
+  if (!painted) return null;
+  return (
+    <>
+      {painted.head}
+      {painted.lines.map((line, index) => (
+        // A log line has no identity beyond its position, and lines only ever
+        // arrive at the end.
+        <span key={index} style={{ display: 'block', ...LOG_LINE_STYLES[line.kind] }}>
+          {line.stamp ? <span style={LOG_STAMP_STYLE}>{line.stamp}</span> : null}
+          {/* A blank line still has to occupy one, same as in the diff pane. */}
+          {line.stamp === '' && line.text === '' ? ' ' : line.text}
+        </span>
+      ))}
+    </>
+  );
 }
 
 // One destination for a finished patch (#166): what it is, what it costs to
@@ -2071,8 +2123,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       scrollback: 4000,
       convertEol: false,
       theme: { background: '#111', foreground: '#f5f5f5' },
-      fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
-      fontSize: 13
+      ...TERMINAL_FONT
     });
     terminalRef.current = term;
     term.open(container);
@@ -4326,15 +4377,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           <div style={{ fontWeight: 600, marginBottom: 8 }}>Logs</div>
           <TabPanel className="log-tabs" activeClass="is-active" onSelect={selectLogTab} tabs={logTabs}>
             {(tab) => (tab.name === 'runtime' ? (
-              <div ref={runtimeRef} onScroll={makeOnScroll('runtime')} style={LOG_PANE_STYLE}>{runtimeLogs}</div>
+              <div ref={runtimeRef} onScroll={makeOnScroll('runtime')} style={LOG_PANE_STYLE}><LogText text={runtimeLogs} /></div>
             ) : (
               <>
                 <div ref={debugRef} onScroll={makeOnScroll('debug')} style={LOG_PANE_STYLE}>
-                  {debugLogs || (
+                  {debugLogs ? <LogText text={debugLogs} /> : (
                     // An empty pane reads as broken, which is what this one was
                     // for as long as WP_DEBUG_LOG was never set. Say what fills
-                    // it instead.
-                    <span style={{ color:'#888' }}>No PHP notices or errors yet. Anything WordPress or your code writes — <code>error_log()</code>, notices, deprecations, fatals — appears here while the dev server runs.</span>
+                    // it instead. In the app's own font, not the terminal's:
+                    // this is interface copy rather than log output, and it is
+                    // what keeps the `<code>` bits in it distinguishable.
+                    <span style={{ color:'#888', fontFamily:'-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif' }}>No PHP notices or errors yet. Anything WordPress or your code writes — <code>error_log()</code>, notices, deprecations, fatals — appears here while the dev server runs.</span>
                   )}
                 </div>
                 <div style={{ display:'flex', gap:8, marginTop:8, alignItems:'center', justifyContent:'space-between', flexWrap:'wrap' }}>

--- a/src/renderer/log-highlight.cjs
+++ b/src/renderer/log-highlight.cjs
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Reading a log pane as coloured lines.
+ *
+ * The Server and debug.log panes are where a contributor finds out why the site
+ * is broken, and both arrive as one undifferentiated wall: a fatal, a notice and
+ * the line saying the server is up all weigh exactly the same. Severity is the
+ * one thing worth answering at a glance, so that is all this classifies.
+ *
+ * Same shape as diff-highlight.cjs, and for the same reason: the first words of
+ * a line are the whole grammar here. There is no PHP parser and no dependency —
+ * what is being read is the severity and the file that raised it, not the
+ * language. Pure and DOM-free so `node --test` can require it; the renderer
+ * turns the classified lines into spans and owns every colour.
+ */
+
+// The prefix error_log() writes, e.g. `[11-Aug-2026 10:02:11 UTC]`. Anchored and
+// specific about its shape so a log line that merely opens with a bracket — a
+// var_dump of an array, a tool that prefixes `[info]` — is not mistaken for one
+// and dimmed away.
+const LOG_TIMESTAMP = /^\[\d{1,2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2}[^\]]*\]/;
+
+// Past this many lines, only the tail is classified and everything older is
+// returned as one plain string. A log grows for as long as the server runs, so
+// the diff pane's answer — stop colouring entirely once it is large — would mean
+// the colour disappears exactly when a session gets long enough to need it. The
+// element count React reconciles per chunk is what has to stay bounded, not the
+// text, and the tail is the part anyone is looking at.
+const MAX_HIGHLIGHTED_LINES = 2000;
+
+/**
+ * The `[timestamp]` prefix and the rest of the line, so the pane can dim one
+ * without dimming the other. `stamp` is empty when the line carries none, which
+ * is every line of the server's own output.
+ *
+ * @param {string} line
+ * @return {{stamp: string, rest: string}}
+ */
+function splitStamp(line) {
+	// The `\r` of a CRLF stream is dropped here rather than at the point of
+	// comparison, because the pane renders `rest` inside a block-level span under
+	// `white-space: pre-wrap` — where a lone CR is a second segment break, and
+	// every line on Windows would gain a blank one after it. It survived the old
+	// pane only because a single text node normalises CRLF to one break.
+	const text = String(line ?? '').replace(/\r$/, '');
+	const match = text.match(LOG_TIMESTAMP);
+	if (!match) return { stamp: '', rest: text };
+	return { stamp: match[0], rest: text.slice(match[0].length) };
+}
+
+/**
+ * What a single log line is.
+ *
+ * Classified on the text after the timestamp, so `[…] PHP Warning: …` is a
+ * warning rather than something starting with a bracket. `trace` covers the
+ * continuation lines that belong to the entry above — the stack frames, the
+ * `thrown in`, node's `(Use \`…\` to show where the warning was created)` —
+ * which are the bulk of the noise in a full pane and say nothing on their own.
+ *
+ * @param {string} line
+ * @return {'fatal'|'warning'|'deprecated'|'notice'|'trace'|'ready'|'plain'}
+ */
+function classifyLogLine(line) {
+	const { rest } = splitStamp(line);
+	const text = rest.trim();
+	if (text === '') return 'plain';
+
+	// Before the severity checks: a stack frame quotes the line that raised the
+	// error, so `#3 … Uncaught Error` would read as a second fatal and a pane
+	// full of one error would look like a pane full of many.
+	if (/^#\d+\s/.test(text)) return 'trace';
+	// Both spellings: an uncaught error's own trace is introduced by a bare
+	// `Stack trace:` on the line after the fatal, and PHP's own trace logging
+	// prefixes it like every other line it writes.
+	if (text.startsWith('Stack trace:') || text.startsWith('PHP Stack trace:')) return 'trace';
+	if (text.startsWith('thrown in ')) return 'trace';
+	if (text.startsWith('(Use `')) return 'trace';
+
+	// Both spellings of every level, and all four levels either way. PHP writes
+	// the `PHP ` prefix through error_log() and drops it when the same message
+	// goes to stdout — so matching the prefixed form only for some levels would
+	// colour a server pane's fatals while leaving its deprecations plain, which
+	// are the ones a contributor is usually there to read.
+	if (/^(PHP )?(Fatal error|Parse error)\b/.test(text)) return 'fatal';
+	if (/^(PHP )?Warning\b/.test(text)) return 'warning';
+	if (/^(PHP )?Deprecated\b/.test(text)) return 'deprecated';
+	if (/^(PHP )?Notice\b/.test(text)) return 'notice';
+	// Node's own throw, and the second line of a PHP fatal that wrapped.
+	if (/^(Uncaught |Error: )/.test(text)) return 'fatal';
+
+	// The server pane, where the output is npm's and node's rather than PHP's.
+	// `DeprecationWarning` is named rather than matched loosely: it arrives
+	// behind node's own `(node:123) [DEP0180] ` prefix, and the general rules
+	// above stay anchored so a line that merely mentions a warning is not
+	// painted as one. A pane that states a severity the line does not have is
+	// worse than a pane with no colour.
+	if (text.startsWith('npm error') || text.startsWith('npm ERR!')) return 'fatal';
+	if (text.startsWith('npm warn') || text.startsWith('npm WARN')) return 'warning';
+	if (/\bDeprecationWarning:/.test(text)) return 'warning';
+
+	// The one line in a server log anybody is waiting for.
+	if (text.startsWith('Ready!') || text.startsWith('SERVER_URL:')) return 'ready';
+	if (text.includes('WordPress is running on')) return 'ready';
+
+	return 'plain';
+}
+
+/**
+ * The log, line by line, each with its severity and its timestamp split off.
+ *
+ * Returns null when there is nothing to paint, so the caller can render its own
+ * empty state. `head` holds the lines older than `limit` as a single string: no
+ * colour, but no per-line element either, which is what keeps a long-running
+ * pane cheap to re-render on every arriving chunk.
+ *
+ * The tail is found by walking back over `limit` newlines rather than splitting
+ * the whole buffer, so the work per arriving chunk is proportional to what gets
+ * painted and not to how long the server has been running. Splitting first cost
+ * two passes over the entire log — one string allocated per line, then the head
+ * joined back into a copy — on every chunk of a buffer that only grows.
+ *
+ * `head` carries no trailing newline: the first classified line is rendered as
+ * a block, which starts its own line, and a preserved `\n` under `pre-wrap`
+ * would put a blank one at the seam. So the log is `head`, a newline, then the
+ * lines joined — not a plain concatenation.
+ *
+ * @param {string} text
+ * @param {number} limit Lines to classify, counted from the end.
+ * @return {{head: string, lines: Array<{stamp: string, text: string, kind: string}>}|null}
+ */
+function highlightLog(text, limit = MAX_HIGHLIGHTED_LINES) {
+	if (typeof text !== 'string' || text === '') return null;
+
+	// Where the last `limit` lines begin, or -1 when the log is shorter than that
+	// and there is no head at all.
+	let cut = text.length;
+	for (let seen = 0; seen < limit; seen++) {
+		const boundary = text.lastIndexOf('\n', cut - 1);
+		if (boundary === -1) {
+			cut = -1;
+			break;
+		}
+		cut = boundary;
+	}
+
+	const head = cut === -1 ? '' : text.slice(0, cut);
+	const tail = cut === -1 ? text : text.slice(cut + 1);
+
+	const lines = tail.split('\n').map((line) => {
+		const { stamp, rest } = splitStamp(line);
+		return { stamp, text: rest, kind: classifyLogLine(line) };
+	});
+
+	return { head, lines };
+}
+
+module.exports = { LOG_TIMESTAMP, MAX_HIGHLIGHTED_LINES, splitStamp, classifyLogLine, highlightLog };

--- a/test/log-highlight.test.cjs
+++ b/test/log-highlight.test.cjs
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { splitStamp, classifyLogLine, highlightLog } = require('../src/renderer/log-highlight.cjs');
+
+const STAMP = '[11-Aug-2026 10:02:11 UTC]';
+
+test('classifyLogLine: each PHP level keeps its own severity through the timestamp', () => {
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Fatal error:  Uncaught Error: Call to a member function get() on null`), 'fatal');
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Parse error:  syntax error, unexpected ';'`), 'fatal');
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Warning:  Undefined variable $x`), 'warning');
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Deprecated:  Creation of dynamic property`), 'deprecated');
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Notice:  Function _load_textdomain_just_in_time was called incorrectly`), 'notice');
+	assert.strictEqual(classifyLogLine(`${STAMP} a bare error_log() call`), 'plain');
+});
+
+// A frame quotes the line that raised the error, so matching severities first
+// would turn one fatal into a pane full of them.
+test('classifyLogLine: the lines belonging to the entry above recede', () => {
+	// An uncaught error's own trace is introduced by a bare `Stack trace:` on the
+	// line after the fatal — the spelling a real WordPress debug.log carries.
+	assert.strictEqual(classifyLogLine('Stack trace:'), 'trace');
+	assert.strictEqual(classifyLogLine('PHP Stack trace:'), 'trace');
+	assert.strictEqual(classifyLogLine('#0 /wp/src/wp-includes/class-wp-hook.php(324): my_fn()'), 'trace');
+	assert.strictEqual(classifyLogLine('#3 {main}'), 'trace');
+	// The reason the trace checks come first: a frame quotes the call that raised
+	// the error, so matching severity first would turn one fatal into a pane
+	// full of them.
+	assert.strictEqual(classifyLogLine('#0 /wp/src/wp-includes/class-wp-hook.php(324): trigger(): Uncaught Error: x'), 'trace');
+	assert.strictEqual(classifyLogLine('  thrown in /wp/src/wp-content/themes/x/functions.php on line 42'), 'trace');
+	assert.strictEqual(classifyLogLine('(Use `WordPress Contributor Toolkit --trace-deprecation ...` to show where the warning was created)'), 'trace');
+});
+
+// PHP drops the `PHP ` prefix when the same message goes to stdout instead of
+// through error_log(), and a pane that colours the fatals but not the
+// deprecations is worse than one that colours neither.
+test('classifyLogLine: a level is a level with or without the PHP prefix', () => {
+	assert.strictEqual(classifyLogLine('Fatal error: Uncaught Error: x in /wp/src/x.php:3'), 'fatal');
+	assert.strictEqual(classifyLogLine('Warning: Undefined variable $x in /wp/src/x.php on line 3'), 'warning');
+	assert.strictEqual(classifyLogLine('Deprecated: Creation of dynamic property in /wp/src/x.php on line 3'), 'deprecated');
+	assert.strictEqual(classifyLogLine('Notice: Function was called incorrectly in /wp/src/x.php on line 3'), 'notice');
+});
+
+// The one thing colour must not do is claim a severity the line does not have.
+test('classifyLogLine: a line that merely mentions a level is not that level', () => {
+	assert.strictEqual(classifyLogLine(`${STAMP} checking for Warning: in the response body`), 'plain');
+	assert.strictEqual(classifyLogLine('wrote /wp/src/wp-content/plugins/Fatal error: handler.php'), 'plain');
+});
+
+test('classifyLogLine: the server pane speaks npm and node, not PHP', () => {
+	assert.strictEqual(classifyLogLine('(node:55626) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.'), 'warning');
+	assert.strictEqual(classifyLogLine('npm error code EBADENGINE'), 'fatal');
+	assert.strictEqual(classifyLogLine('npm warn deprecated glob@7.2.3'), 'warning');
+	assert.strictEqual(classifyLogLine('added 733 packages in 41s'), 'plain');
+});
+
+test('classifyLogLine: the line the contributor is waiting for is the one that stands out', () => {
+	assert.strictEqual(classifyLogLine('Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)'), 'ready');
+	assert.strictEqual(classifyLogLine('SERVER_URL:http://127.0.0.1:9400/'), 'ready');
+});
+
+test('classifyLogLine: a CRLF line ending does not change what a line is', () => {
+	assert.strictEqual(classifyLogLine(`${STAMP} PHP Warning:  Undefined variable $x\r`), 'warning');
+	assert.strictEqual(classifyLogLine('Ready! WordPress is running on http://127.0.0.1:9400\r'), 'ready');
+});
+
+// Not cosmetic: each line is rendered as its own block under `white-space:
+// pre-wrap`, where a lone CR left on the end is a second line break — so a
+// Windows log would come out double-spaced.
+test('highlightLog: a Windows line ending does not survive into the text', () => {
+	const painted = highlightLog('one\r\ntwo\r\n');
+	assert.deepStrictEqual(painted.lines.map((l) => l.text), ['one', 'two', '']);
+});
+
+test('splitStamp: only an actual error_log() timestamp is dimmed away', () => {
+	assert.deepStrictEqual(splitStamp(`${STAMP} PHP Warning:  x`), { stamp: STAMP, rest: ' PHP Warning:  x' });
+	// Server output carries none, and a line that merely opens with a bracket —
+	// a var_dump, a tool prefixing its own tag — is not one.
+	assert.deepStrictEqual(splitStamp('Ready! WordPress is running'), { stamp: '', rest: 'Ready! WordPress is running' });
+	assert.deepStrictEqual(splitStamp('[info] building'), { stamp: '', rest: '[info] building' });
+	assert.deepStrictEqual(splitStamp('[0] => wp-login.php'), { stamp: '', rest: '[0] => wp-login.php' });
+});
+
+test('highlightLog: nothing to paint is the caller\'s own empty state', () => {
+	assert.strictEqual(highlightLog(''), null);
+	assert.strictEqual(highlightLog(undefined), null);
+});
+
+test('highlightLog: a short log is classified whole, with no plain head', () => {
+	const painted = highlightLog(`Ready! WordPress is running\n${STAMP} PHP Notice:  x\n`);
+	assert.strictEqual(painted.head, '');
+	// The trailing newline makes a final empty line, which still occupies one.
+	assert.deepStrictEqual(painted.lines.map((l) => l.kind), ['ready', 'notice', 'plain']);
+	assert.strictEqual(painted.lines[1].stamp, STAMP);
+});
+
+// The colour has to survive a long session: a server running all afternoon must
+// not end up with a pane that has quietly stopped highlighting.
+test('highlightLog: past the cap only the head goes plain, and the tail is what is kept', () => {
+	const lines = Array.from({ length: 30 }, (_, i) => `line ${i}`);
+	lines.push('Ready! WordPress is running');
+	const painted = highlightLog(lines.join('\n'), 10);
+
+	assert.strictEqual(painted.lines.length, 10);
+	assert.strictEqual(painted.lines.at(-1).kind, 'ready');
+	assert.ok(painted.head.startsWith('line 0\n'));
+	// No trailing newline on the head: the first classified line is a block of
+	// its own, and a preserved one would show as a blank line at the seam.
+	assert.ok(painted.head.endsWith('line 20'));
+	// Nothing is dropped and nothing is duplicated: head, a newline, then the
+	// lines, is the log exactly.
+	assert.strictEqual(`${painted.head}\n${painted.lines.map((l) => l.stamp + l.text).join('\n')}`, lines.join('\n'));
+});


### PR DESCRIPTION
## Why

The **Logs** panes and the **Terminal** below them show the same kind of thing — raw process output — in two different fonts. The Terminal uses Menlo at 13px; the panes inherited the app's UI sans-serif, so the columns of a PHP stack trace do not line up and neither pane reads as the console it is.

Neither pane highlighted anything either. In a Server pane with four repeated `DeprecationWarning` lines, the one line anybody is waiting for — `Ready! WordPress is running on http://127.0.0.1:9400` — has exactly the same weight as the noise around it. In `debug.log` it is worse: a fatal and a notice sit in the same wall of grey, and a newcomer reading a debug log for the first time has no way to tell which line ended the request.

## What changes

**One font.** `TERMINAL_FONT` is a single constant used by both the xterm instance and every log pane, rather than the two declarations that had drifted apart. The Playground web-server pane, which was carrying its own inline copy of `LOG_PANE_STYLE`, now uses the shared style too — so there are three panes with one appearance instead of two-and-a-half.

**Colour by severity, per line.** New `src/renderer/log-highlight.cjs`, deliberately in the shape of `diff-highlight.cjs` (#166): the first words of a line are the whole grammar, there is no language parser and no new dependency, and the module names *kinds* while the pane owns the colours. It classifies `fatal · warning · deprecated · notice · trace · ready · plain`, splits off the `[11-Aug-2026 …]` prefix so 26 identical characters per line can recede, and handles both spellings of every PHP level (`error_log()` writes `PHP Warning:`, stdout writes `Warning:`).

Two decisions a reviewer would otherwise have to reverse-engineer:

- **Trace lines are matched before severity.** A stack frame quotes the call that raised the error, so matching `Uncaught Error` first turns one fatal into a pane that looks full of them.
- **Every severity rule is anchored.** The pane stating a severity a line does not have is worse than a pane with no colour at all, so a line that merely *mentions* `Warning:` stays plain. `DeprecationWarning` is named explicitly because node puts its own `(node:123) [DEP0180] ` prefix in front of it.

**Deliberately not in this PR:** no tokenising of file paths, line numbers or URLs inside a line (agreed up front — it buys a click-to-open feature this PR is not building, at a per-chunk render cost); no ANSI escape handling; no colour in the Terminal itself, which xterm already owns.

## How to test this

Platforms: **any**. The only platform-specific behaviour is the CRLF handling, which is covered by a unit test — but if you are on Windows, step 4 is the one worth doing there.

**Starting state:** an initialized site, dev server stopped.

1. Select the site and look at the **Logs** card, **Server** tab, then at the **Terminal** card below it. → Both use the same monospace face at the same size. Before this change the panes were sans-serif; the give-away is that two consecutive log lines no longer align column-for-column.
2. Click **Start dev server** and watch the Server tab fill. → `npm warn …` and node's `DeprecationWarning` lines are amber, the `(Use \`…\`)` follow-up under each one is dimmed, and `Ready! WordPress is running on …` is green and bold. The URL line `SERVER_URL:…` is green too.
3. Add to the active theme's `functions.php`: `error_log('plain line'); trigger_error('boom'); $x = null; $x->nope();` — then load the site once and open the **debug.log** tab. → The timestamps are grey; the notice/deprecation lines are yellow; the warning is amber; `PHP Fatal error: Uncaught Error: …` is red; and `Stack trace:`, `#0 …`, `#1 {main}`, `thrown in …` are all dimmed as one block under it. The plain `error_log('plain line')` line stays white — it has no severity to claim.
4. **On Windows**, with the dev server running, scroll the Server pane. → The lines are single-spaced. (This is the CRLF case: each line is now its own block under `white-space: pre-wrap`, where a lone `\r` left on the end would render as a second line break and double-space the whole pane.)
5. Click **Copy** on the debug.log tab and paste somewhere. → Plain text, exactly what the file holds, with no markup and no lost characters.

**What must not have happened:**

- **The panes must still stick to the bottom.** Both tabs autoscroll while new output arrives, and stop when you scroll up (`logStick`). The pane content is now a list of elements rather than one text node, which is exactly the kind of change that quietly breaks a `scrollHeight` calculation — check both tabs, and check that scrolling up mid-stream still pins the view.
- **The unread badge on the debug.log tab must still count.** It comes from `countLines`, untouched, but it is easy to break by accident nearby.
- **No line may be swallowed or duplicated.** Past 2000 lines the pane keeps the older part as one plain string and only colours the tail; `test/log-highlight.test.cjs` asserts head + tail reconstructs the log exactly, but a long `npm install` in the Terminal followed by a scroll to the top of the pane is the human version of that check.
- **The empty debug.log state must still be readable.** It stays in the UI font on purpose — it is interface copy, not log output, and that is what keeps the `error_log()` in it looking like code.

## Risks and limitations

- Purely presentational: no IPC surface, no new dependency, no persistence change.
- **Colour is never the only signal.** The words `Fatal error`, `Warning`, `Deprecated` remain in the text — the classification is a restatement of them, not a replacement — so nothing is lost without colour vision. `deprecated` and `notice` currently share one colour; the classifier distinguishes them for the future, the pane does not.
- The palette was picked against the pane's `#111` background and checked in a screenshot, not against a contrast tool.
- Review outcome: 4 `[fix here]` · 2 `[follow-up]` — all four fixed, both follow-ups are pre-existing and listed below.

## Related

Follow-ups this review surfaced, neither introduced here:

- `runtimeLogs` and `webLogs` grow without any ceiling (`setRuntimeLogs((v) => v + chunk)`), unlike `debugLogs`, which goes through `appendBounded`. A dev server left running all afternoon is exactly the case these panes are for.
- The `debug-log` documentation screenshot photographs the *empty state*, not a seeded log: its `getByText('PHP Notice', { exact: false })` wait matches case-insensitively, so it is satisfied by the "No PHP notices or errors yet" empty-state copy and passes without ever seeing log content.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why not reuse `highlightDiff`'s "stop colouring past the cap" rule.** A patch is finite, so dropping to plain text past 4000 lines costs nothing. A log is not: the same rule means the colour disappears exactly when a session has been running long enough to need it. So the cap here bounds *elements*, not colour — the last 2000 lines are classified, everything older is returned as one plain string, and the tail keeps its colour however long the server runs.

**Why the tail is found by walking back over newlines.** The first version split the whole buffer and joined the head back — two passes over everything, on every arriving chunk, on a string that only grows. Now `lastIndexOf` walks back `limit` newlines and the two slices come out directly, so per-chunk work is proportional to what is painted rather than to the length of the session. The memoisation on `LogText` does *not* help this: the text changes on exactly the renders that matter. It only covers unrelated `SiteRow` re-renders, which are frequent.

**Why no syntax highlighting of the PHP inside a line.** Same reasoning as the diff pane: what is being read is the severity and the file that raised it, not the language. A path/URL tokeniser would earn its cost if the paths were clickable — worth doing, as its own change.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`npm run lint` clean, `npm test` 823/823. The judgement pass ran in a fresh context against `.github/instructions/code-review.instructions.md`.

**4 [fix here] · 2 [follow-up] — all 4 fixed.**

1. **cross-platform 🟡** — `classifyLogLine` stripped the trailing `\r` before matching but `highlightLog` returned the text un-stripped, so on a CRLF stream every line kept a lone CR inside its own block span. Under `pre-wrap` that is a second segment break: the whole Server pane double-spaced on Windows, and a regression rather than a pre-existing bug, since one text node normalises CRLF to a single break. Fixed by stripping in `splitStamp` so classification and display agree, with a `highlightLog('one\r\ntwo\r\n')` assertion — the old CRLF test only exercised `classifyLogLine` and would not have caught it.
2. **performance 🟡** — the whole buffer was split and the head re-joined on every chunk. Replaced with the backwards newline walk described above.
3. **architecture 🔵** — the un-prefixed severity rules were asymmetric (`Fatal error:` and `Warning:` matched without `PHP `, `Deprecated:` and `Notice:` only with it), and the warning rule was the one unanchored pattern, so any line containing `Warning:` anywhere was painted as a warning. All four levels now match both spellings, all anchored; `DeprecationWarning` is matched by name.
4. **tests 🔵** — the trace-before-severity ordering, the one non-obvious decision in the classifier, had no case containing a severity word, so reordering the checks kept the suite green. Added `#0 …: trigger(): Uncaught Error: …` → `trace`, plus cases for the un-prefixed levels and for lines that merely mention one.

**[follow-up] ×2** — the two items under **Related**. The first is pre-existing and orthogonal (bounding a buffer is a behaviour change: it decides what the contributor loses); the second is a bug in the screenshot harness, not in the app.

Not re-reported, verified rather than assumed: no `dangerouslySetInnerHTML`, no new IPC surface, no new dependency, and the §1 renderer-module invariant holds — `index.jsx` keeps only colours, JSX and the call.

</details>

<details>
<summary>Implementation notes</summary>

- `src/renderer/log-highlight.cjs` — `splitStamp`, `classifyLogLine`, `highlightLog`, `LOG_TIMESTAMP`, `MAX_HIGHLIGHTED_LINES`. Pure and DOM-free so `node --test` requires it directly, same convention as `debug-log.cjs` and `diff-highlight.cjs`.
- `LOG_TIMESTAMP` is specific about its shape (`[1-2 digits]-[3 letters]-[4 digits] HH:MM:SS…`) so a line that merely opens with a bracket — a `var_dump` of an array, a tool printing `[info]` — is not mistaken for a timestamp and dimmed away. Tested.
- `head` deliberately carries no trailing newline: the first classified line is a block that starts its own line, and a preserved `\n` under `pre-wrap` would show a blank line at the seam. So the reconstruction is `head` + `\n` + the joined lines, which is what the test asserts.
- The screenshots below were taken with the real component through the repo's own Playwright/Electron shots harness, with the two log states seeded temporarily; the seeding is not part of the diff.

</details>

<details>
<summary>Screenshots</summary>

To be attached — the Server tab and the debug.log tab, both captured through the shots harness with log content seeded.

</details>
