### PR TITLE
Rank the "Latest" pill by the newest commit, not the newest touch

### DIFF
--- a/src/github-prs.js
+++ b/src/github-prs.js
@@ -17,19 +17,165 @@
  * the rest of the app already relies on, and adds nothing to install. That
  * request primitive now lives in github-http.cjs, because opening a pull
  * request (#167) needs the same one with a method and a body.
+ *
+ * The list costs one request; ranking it costs a few more. That is not a
+ * regression against the care taken above — it is the price of the list meaning
+ * anything (#281). See resolveCommitDates for how few it settles for.
  */
 
-const { parseLinkedPrs, classifyHttpFailure } = require('./patch-sources.cjs');
+const { parseLinkedPrs, orderByCommitDate, classifyHttpFailure } = require('./patch-sources.cjs');
 const { httpGet } = require('./github-http.cjs');
 
 const REPO = 'WordPress/wordpress-develop';
+
+/**
+ * How many pull requests may have their commit date looked up for one ticket.
+ *
+ * Each lookup is one request against the shared unauthenticated 60/hour, so the
+ * ranking below spends them only while they can still change the answer and
+ * stops at this cap regardless. Four covers every ticket seen in practice
+ * except one caught inside a fresh upstream force-push sweep, where no number
+ * of lookups is obviously right and admitting the ranking is incomplete is
+ * better than emptying the quota.
+ */
+const MAX_COMMIT_LOOKUPS = 4;
+
+/**
+ * The date of a pull request's most recent commit, or null when it cannot be
+ * read (issue #281).
+ *
+ * `search/issues` — the one request the list is built from — carries no commit
+ * date, so this is the extra cost of ranking by code rather than by touch. The
+ * documented `pulls/{n}/commits` is used rather than a ref trick against
+ * `commits/{sha}`: this file already avoids undocumented GitHub behaviour on
+ * the `.diff` routes, and the same reasoning applies here.
+ *
+ * The list is ascending and paginated at 100. Nearly every pull request fits in
+ * one page; a longer one is followed once, to the `rel="last"` page named in
+ * the Link header. GitHub truncates the list at 250 commits, so a pull request
+ * longer than that resolves to the newest of the 250 it lists — off by nothing
+ * that matters for "which of these is fresher", and never silently absent.
+ *
+ * @param {number}   number
+ * @param {Function} get    httpGet, injected so the loop is testable.
+ * @param {Object}   spent  Mutable `{count}` — every request made is counted.
+ * @return {Promise<{ok: true, date: string|null}|{ok: false, status: string}>}
+ */
+async function fetchPrCommitDate(number, get, spent) {
+	const base = `https://api.github.com/repos/${REPO}/pulls/${number}/commits?per_page=100`;
+
+	const page = async (url) => {
+		spent.count += 1;
+		let res;
+		try {
+			res = await get(url, { Accept: 'application/vnd.github+json' });
+		} catch {
+			return { ok: false, status: 'offline' };
+		}
+		if (res.status !== 200) return { ok: false, status: classifyHttpFailure(res.status, res.headers) };
+		let json;
+		try { json = JSON.parse(res.body); } catch { return { ok: false, status: 'error' }; }
+		return { ok: true, commits: Array.isArray(json) ? json : [], headers: res.headers || {} };
+	};
+
+	const first = await page(base);
+	if (!first.ok) return first;
+
+	// Only the last page can hold the newest commit, so a paginated pull request
+	// costs a second request and not a walk through the middle.
+	const lastPage = lastPageNumber(first.headers.link);
+	let commits = first.commits;
+	if (lastPage > 1) {
+		const rest = await page(`${base}&page=${lastPage}`);
+		// A failure here leaves the first page's commits in hand: older than the
+		// truth, and using them would be a confident wrong answer.
+		if (!rest.ok) return rest;
+		commits = rest.commits;
+	}
+
+	let newest = null;
+	for (const entry of commits) {
+		// `committer.date` is when the commit last took its current form — the
+		// one a rebase or amend moves. `author.date` is the fallback for the
+		// rare entry that omits it.
+		const c = entry && entry.commit ? entry.commit : null;
+		const text = (c && c.committer && c.committer.date) || (c && c.author && c.author.date) || '';
+		const ms = text ? Date.parse(text) : NaN;
+		if (!Number.isFinite(ms)) continue;
+		if (newest === null || ms > Date.parse(newest)) newest = text;
+	}
+	return { ok: true, date: newest };
+}
+
+/**
+ * The page number in a Link header's `rel="last"`, or 0 when there is none.
+ *
+ * @param {string} [link]
+ * @return {number}
+ */
+function lastPageNumber(link) {
+	if (typeof link !== 'string' || !link) return 0;
+	for (const part of link.split(',')) {
+		if (!/rel="?last"?/.test(part)) continue;
+		const m = /[?&]page=(\d+)/.exec(part);
+		if (m) return Number(m[1]);
+	}
+	return 0;
+}
+
+/**
+ * Fills in the commit date of as many pull requests as the answer needs, in
+ * place, and reports whether the resulting ranking is complete (issue #281).
+ *
+ * The saving that makes this affordable: GitHub's `updated_at` is at or after
+ * the last commit date — a comment or a bot sweep can only push it later, never
+ * earlier — so on a list already sorted by `updated_at` descending it is a
+ * per-row *upper bound*. Once a resolved commit date beats the next row's
+ * bound, no row below can win and the walk stops. A ticket with one pull
+ * request, or with a clear winner, costs one extra request; only a ticket whose
+ * bounds are all identical — which is exactly what a force-push sweep produces,
+ * and the bug this exists to fix — walks down to the cap.
+ *
+ * "Complete" means the tail was ruled out rather than merely unread: true when
+ * the walk stopped on the bound or ran out of rows, false when it stopped on
+ * the cap or on a failed lookup. The caller shows no "Latest" pill on an
+ * incomplete ranking, because an unread row could be the real winner.
+ *
+ * @param {Array}    prs Sorted by `updatedAt` descending; mutated in place.
+ * @param {Function} get
+ * @return {Promise<boolean>} Whether the ranking is complete.
+ */
+async function resolveCommitDates(prs, get) {
+	const spent = { count: 0 };
+	let bestMs = -Infinity;
+	let complete = true;
+
+	for (const pr of prs) {
+		const boundMs = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;
+		// Nothing from here down can beat what is already resolved.
+		if (Number.isFinite(boundMs) && bestMs >= boundMs) break;
+		if (spent.count >= MAX_COMMIT_LOOKUPS) { complete = false; break; }
+
+		const res = await fetchPrCommitDate(pr.number, get, spent);
+		// A spent rate limit or a dead network will not fix itself on the next
+		// row, and each attempt costs a request the contributor may need for the
+		// diff they are about to apply.
+		if (!res.ok) { complete = false; break; }
+
+		pr.commitDate = res.date;
+		const ms = res.date ? Date.parse(res.date) : NaN;
+		if (Number.isFinite(ms) && ms > bestMs) bestMs = ms;
+	}
+
+	return complete;
+}
 
 /**
  * The pull requests that cite a ticket, newest first.
  *
  * @param {number|string} ticketId
  * @param {Object}        [deps]
- * @return {Promise<{status: 'ok'|'rate-limited'|'error'|'offline', items: Array, error?: string}>}
+ * @return {Promise<{status: 'ok'|'rate-limited'|'error'|'offline', items: Array, rankComplete?: boolean, error?: string}>}
  */
 async function fetchLinkedPrs(ticketId, deps = {}) {
 	const get = deps.httpGet || httpGet;
@@ -67,7 +213,12 @@ async function fetchLinkedPrs(ticketId, deps = {}) {
 		return { status: 'error', items: [], error: 'Too many results to list reliably' };
 	}
 
-	return { status: 'ok', items: parseLinkedPrs(json, id) };
+	const items = parseLinkedPrs(json, id);
+	// The list arrives ordered by `updatedAt`, which is the bound the walk needs
+	// and not an ordering worth showing (#281). Rank it by real commit dates,
+	// then reorder for display.
+	const rankComplete = await resolveCommitDates(items, get);
+	return { status: 'ok', items: orderByCommitDate(items), rankComplete };
 }
 
 /**
@@ -92,4 +243,4 @@ async function fetchPrDiff(number) {
 	return { ok: true, text: res.body };
 }
 
-module.exports = { fetchLinkedPrs, fetchPrDiff, httpGet };
+module.exports = { MAX_COMMIT_LOOKUPS, fetchLinkedPrs, fetchPrDiff, httpGet };

--- a/src/github-prs.js
+++ b/src/github-prs.js
@@ -45,6 +45,13 @@ const REPO = 'WordPress/wordpress-develop';
 const MAX_COMMIT_LOOKUPS = 4;
 
 /**
+ * How far ahead of now a commit date may sit before it is treated as a wrong
+ * clock rather than a fresh commit. Machines drift by minutes; a commit dated
+ * next month is not a fix anyone can apply.
+ */
+const CLOCK_SKEW_TOLERANCE_MS = 10 * 60 * 1000;
+
+/**
  * The date of a pull request's most recent commit, or null when it cannot be
  * read (issue #281).
  *
@@ -86,13 +93,18 @@ async function fetchPrCommitDate(number, get, spent) {
 	if (!first.ok) return first;
 
 	// Only the last page can hold the newest commit, so a paginated pull request
-	// costs a second request and not a walk through the middle.
+	// costs a second request and not a walk through the middle. That second one
+	// is checked against the cap here rather than only at the top of the walk:
+	// the cap counts requests, and a guard that admits a row and then spends two
+	// makes the real ceiling one higher than the number it is written as.
 	const lastPage = lastPageNumber(first.headers.link);
 	let commits = first.commits;
 	if (lastPage > 1) {
+		// Refusing is the honest outcome, not falling back to the first page: its
+		// newest commit is the oldest part of this pull request, so using it would
+		// be a confident wrong answer rather than a missing one.
+		if (spent.count >= MAX_COMMIT_LOOKUPS) return { ok: false, status: 'capped' };
 		const rest = await page(`${base}&page=${lastPage}`);
-		// A failure here leaves the first page's commits in hand: older than the
-		// truth, and using them would be a confident wrong answer.
 		if (!rest.ok) return rest;
 		commits = rest.commits;
 	}
@@ -163,27 +175,34 @@ async function resolveCommitDates(prs, get, known) {
 	let bestMs = -Infinity;
 	let complete = true;
 
-	// A commit dated ahead of now is a contributor's clock, not a fresher fix.
-	// It has to be discarded rather than merely ignored for the pill: as
+	// A commit dated well ahead of now is a contributor's clock, not a fresher
+	// fix. It has to be discarded rather than merely ignored for the pill: as
 	// `bestMs` it would clear every remaining bound at once, ending the walk and
 	// reporting the whole ranking complete on the strength of the one date that
-	// is wrong.
-	const nowMs = Date.now();
+	// is wrong. The tolerance is for the ordinary case of a machine a few
+	// minutes out — a just-pushed commit is the freshest thing on the ticket and
+	// should not be thrown away over a clock, which is the failure this guard
+	// could otherwise cause instead of prevent.
+	const horizonMs = Date.now() + CLOCK_SKEW_TOLERANCE_MS;
 	const usable = (date) => {
 		const ms = date ? Date.parse(date) : NaN;
-		return Number.isFinite(ms) && ms <= nowMs ? ms : NaN;
+		return Number.isFinite(ms) && ms <= horizonMs ? ms : NaN;
 	};
 
 	// Cached dates are free, so they are applied to every row before the walk
 	// starts rather than only to the rows it reaches — a date the walk would
-	// have stopped short of is still a date the row can show.
+	// have stopped short of is still a date the row can show. A cached date gets
+	// the same horizon check as a fetched one: a clock corrected backwards since
+	// it was written would otherwise leave a future date on the row, winning the
+	// pill and never being re-read, because a dated row is one the walk skips.
 	for (const pr of prs) {
 		const cached = known instanceof Map ? known.get(pr.number) : null;
 		if (!cached || !cached.commitDate || !cached.updatedAt) continue;
 		if (cached.updatedAt !== pr.updatedAt) continue;
-		pr.commitDate = cached.commitDate;
 		const cachedMs = usable(cached.commitDate);
-		if (Number.isFinite(cachedMs) && cachedMs > bestMs) bestMs = cachedMs;
+		if (!Number.isFinite(cachedMs)) continue;
+		pr.commitDate = cached.commitDate;
+		if (cachedMs > bestMs) bestMs = cachedMs;
 	}
 
 	for (const pr of prs) {

--- a/src/github-prs.js
+++ b/src/github-prs.js
@@ -29,14 +29,18 @@ const { httpGet } = require('./github-http.cjs');
 const REPO = 'WordPress/wordpress-develop';
 
 /**
- * How many pull requests may have their commit date looked up for one ticket.
+ * How many requests the commit-date walk may spend on one ticket.
  *
- * Each lookup is one request against the shared unauthenticated 60/hour, so the
+ * Each is one request against the shared unauthenticated 60/hour, so the
  * ranking below spends them only while they can still change the answer and
  * stops at this cap regardless. Four covers every ticket seen in practice
  * except one caught inside a fresh upstream force-push sweep, where no number
- * of lookups is obviously right and admitting the ranking is incomplete is
- * better than emptying the quota.
+ * is obviously right and admitting the ranking is incomplete is better than
+ * emptying the quota.
+ *
+ * It counts requests rather than pull requests because that is what the quota
+ * counts: a pull request over 100 commits costs two, and four rows of those
+ * would be eight requests under a cap that reads like four.
  */
 const MAX_COMMIT_LOOKUPS = 4;
 
@@ -141,16 +145,50 @@ function lastPageNumber(link) {
  * the cap or on a failed lookup. The caller shows no "Latest" pill on an
  * incomplete ranking, because an unread row could be the real winner.
  *
- * @param {Array}    prs Sorted by `updatedAt` descending; mutated in place.
+ * A date already known from the cache is reused rather than fetched again, on
+ * the same bound that makes the walk cheap: `updated_at` moves when a branch is
+ * pushed, so a row whose stamp has not changed since it was cached has not had
+ * new code pushed to it either. Without this a Refresh on a rate-limited
+ * quota would replace a ranking the contributor could already read with an
+ * unranked list, and the request that failed would have destroyed the evidence
+ * rather than merely failed to add to it.
+ *
+ * @param {Array}    prs   Sorted by `updatedAt` descending; mutated in place.
  * @param {Function} get
+ * @param {Map}      known PR number → `{updatedAt, commitDate}` last seen.
  * @return {Promise<boolean>} Whether the ranking is complete.
  */
-async function resolveCommitDates(prs, get) {
+async function resolveCommitDates(prs, get, known) {
 	const spent = { count: 0 };
 	let bestMs = -Infinity;
 	let complete = true;
 
+	// A commit dated ahead of now is a contributor's clock, not a fresher fix.
+	// It has to be discarded rather than merely ignored for the pill: as
+	// `bestMs` it would clear every remaining bound at once, ending the walk and
+	// reporting the whole ranking complete on the strength of the one date that
+	// is wrong.
+	const nowMs = Date.now();
+	const usable = (date) => {
+		const ms = date ? Date.parse(date) : NaN;
+		return Number.isFinite(ms) && ms <= nowMs ? ms : NaN;
+	};
+
+	// Cached dates are free, so they are applied to every row before the walk
+	// starts rather than only to the rows it reaches — a date the walk would
+	// have stopped short of is still a date the row can show.
 	for (const pr of prs) {
+		const cached = known instanceof Map ? known.get(pr.number) : null;
+		if (!cached || !cached.commitDate || !cached.updatedAt) continue;
+		if (cached.updatedAt !== pr.updatedAt) continue;
+		pr.commitDate = cached.commitDate;
+		const cachedMs = usable(cached.commitDate);
+		if (Number.isFinite(cachedMs) && cachedMs > bestMs) bestMs = cachedMs;
+	}
+
+	for (const pr of prs) {
+		if (pr.commitDate) continue;
+
 		const boundMs = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;
 		// Nothing from here down can beat what is already resolved.
 		if (Number.isFinite(boundMs) && bestMs >= boundMs) break;
@@ -162,8 +200,8 @@ async function resolveCommitDates(prs, get) {
 		// diff they are about to apply.
 		if (!res.ok) { complete = false; break; }
 
-		pr.commitDate = res.date;
-		const ms = res.date ? Date.parse(res.date) : NaN;
+		const ms = usable(res.date);
+		pr.commitDate = Number.isFinite(ms) ? res.date : null;
 		if (Number.isFinite(ms) && ms > bestMs) bestMs = ms;
 	}
 
@@ -173,12 +211,23 @@ async function resolveCommitDates(prs, get) {
 /**
  * The pull requests that cite a ticket, newest first.
  *
+ * `deps.known` is the last-seen list for this ticket, if the caller kept one.
+ * Its commit dates are reused for rows whose `updatedAt` has not moved since,
+ * which is what stops a Refresh from re-spending the walk — and, on a spent
+ * quota, from replacing a ranking the contributor could already read.
+ *
  * @param {number|string} ticketId
  * @param {Object}        [deps]
+ * @param {Function}      [deps.httpGet]
+ * @param {Array}         [deps.known]
  * @return {Promise<{status: 'ok'|'rate-limited'|'error'|'offline', items: Array, rankComplete?: boolean, error?: string}>}
  */
 async function fetchLinkedPrs(ticketId, deps = {}) {
 	const get = deps.httpGet || httpGet;
+	const known = new Map();
+	for (const pr of Array.isArray(deps.known) ? deps.known : []) {
+		if (pr && typeof pr.number === 'number') known.set(pr.number, { updatedAt: pr.updatedAt, commitDate: pr.commitDate });
+	}
 	const id = String(ticketId).replace(/[^0-9]/g, '');
 	if (!id) return { status: 'error', items: [], error: 'No ticket number' };
 
@@ -217,7 +266,7 @@ async function fetchLinkedPrs(ticketId, deps = {}) {
 	// The list arrives ordered by `updatedAt`, which is the bound the walk needs
 	// and not an ordering worth showing (#281). Rank it by real commit dates,
 	// then reorder for display.
-	const rankComplete = await resolveCommitDates(items, get);
+	const rankComplete = await resolveCommitDates(items, get, known);
 	return { status: 'ok', items: orderByCommitDate(items), rankComplete };
 }
 

--- a/src/latest-patch.cjs
+++ b/src/latest-patch.cjs
@@ -26,10 +26,10 @@
  * github-prs.js, and an unresolved one does not compete at all — falling back
  * to `updatedAt` would be falling back to the bug.
  *
- * Which leaves two cases where the honest answer is no pill rather than a
- * guess, both handled in pickLatest: a ranking that could not be completed, and
- * a margin too small to mean anything. The dates stay on every row either way,
- * so the contributor can still read them.
+ * Which leaves the cases where the honest answer is no pill rather than a
+ * guess, all handled in pickLatest by the same comparison: a row that has not
+ * been ruled out, and a margin too small to mean anything. The dates stay on
+ * every row either way, so the contributor can still read them.
  */
 
 /**
@@ -97,11 +97,24 @@ function prDateMs(pr) {
  * sends a contributor into an apply that cannot succeed, which costs far more
  * than the pill was ever worth.
  *
- * A PR list is treated as incomplete whenever any PR lacks a resolved commit
- * date, whatever `prRankComplete` says. That covers a caller that does not pass
- * the flag and a list restored from a cache written before commit dates
- * existed: an undated PR is not old, it is unknown, and an unknown row could be
- * the real winner.
+ * An undated PR does not disqualify the answer; it competes as an upper bound.
+ * That single rule replaces what used to be a special case, and it is worth
+ * spelling out because getting it wrong cost this feature its pill on the
+ * ordinary ticket:
+ *
+ * - A PR the walk *ruled out* is undated on purpose — the walk stopped early
+ *   precisely because its `updatedAt` was already below a resolved date. Its
+ *   bound therefore sits far below the winner, and the pill shows. Treating it
+ *   as "unknown, so no answer" threw away the pill in exactly the cheap,
+ *   one-lookup case the walk exists to produce.
+ * - A PR the walk never *reached* — the cap, a failed lookup, a cache written
+ *   before commit dates existed — carries the stamp that has not been ruled
+ *   out, which in a force-push sweep sits at or above the winner. The near-tie
+ *   check then suppresses the pill on its own.
+ *
+ * So both cases fall out of the same comparison, with no flag distinguishing
+ * them. A PR with neither a date nor a usable stamp is unbounded, and takes the
+ * answer with it.
  *
  * @param {Object}  root0
  * @param {Array}   [root0.prs]
@@ -121,15 +134,21 @@ function pickLatest({ prs, attachments, prRankComplete } = {}) {
 		}
 		runnerUpMs = Math.max(runnerUpMs, whenMs);
 	};
+	// A bound can only ever argue that the answer is too close to call. It never
+	// becomes the answer: `updatedAt` is not a date this app is willing to put a
+	// pill on, which is the whole of #281.
+	const considerBound = (whenMs) => {
+		runnerUpMs = Number.isFinite(whenMs) ? Math.max(runnerUpMs, whenMs) : Infinity;
+	};
 
-	const prList = Array.isArray(prs) ? prs : [];
-	let ranked = prRankComplete !== false;
-	for (const pr of prList) {
+	for (const pr of Array.isArray(prs) ? prs : []) {
 		const whenMs = prDateMs(pr);
-		if (!Number.isFinite(whenMs)) ranked = false;
-		consider('pr', pr.number, whenMs);
+		if (Number.isFinite(whenMs)) consider('pr', pr.number, whenMs);
+		else considerBound(pr && pr.updatedAt ? Date.parse(pr.updatedAt) : NaN);
 	}
-	if (!ranked) return null;
+	// A walk that broke on a failed lookup may not have left a usable bound on
+	// the row it died at, so the flag still gets the last word.
+	if (prRankComplete === false) return null;
 
 	for (const att of Array.isArray(attachments) ? attachments : []) {
 		if (!att.applyable) continue;

--- a/src/latest-patch.cjs
+++ b/src/latest-patch.cjs
@@ -16,11 +16,28 @@
  * the renderer imports it, `node --test` requires it directly (same convention
  * as patch-plan.cjs / patch-sources.cjs).
  *
- * Caveat, deliberate: a PR is dated by `updatedAt`, which also bumps on
- * comments, so "latest" means "most recently touched", not "newest commit".
- * That matches the common case (an active PR is usually the freshest thing) and
- * is the only date the list already carries.
+ * A PR used to be dated by `updatedAt`, on the reasoning that "most recently
+ * touched" is usually also "newest code" — a fair trade for a comment. It does
+ * not survive an event that touches every PR at once: an upstream force-push of
+ * trunk restamped thousands of open PRs inside one window, and on #62064 the
+ * nineteen seconds between two of those restamps were the entire basis on which
+ * a patch from 2024 that no longer applies was crowned over one from 2026 that
+ * does (#281). So a PR is now dated by its newest commit, resolved by
+ * github-prs.js, and an unresolved one does not compete at all — falling back
+ * to `updatedAt` would be falling back to the bug.
+ *
+ * Which leaves two cases where the honest answer is no pill rather than a
+ * guess, both handled in pickLatest: a ranking that could not be completed, and
+ * a margin too small to mean anything. The dates stay on every row either way,
+ * so the contributor can still read them.
  */
+
+/**
+ * How close two patches have to be before "which is later" stops being an
+ * answer worth putting a pill on. Two commits within the hour are one piece of
+ * work, not a newer and an older fix.
+ */
+const NEAR_TIE_MS = 60 * 60 * 1000;
 
 /**
  * Milliseconds for an attachment's upload time, or NaN when it cannot be known.
@@ -53,43 +70,75 @@ function attachmentDateMs(attachment) {
 }
 
 /**
- * Milliseconds for a PR's last activity, or NaN when absent.
+ * Milliseconds for a PR's newest commit, or NaN when it was never resolved.
+ *
+ * NaN keeps that PR out of the comparison entirely. `updatedAt` is still on the
+ * object and is still the wrong answer; see the note at the top of this file.
  *
  * @param {Object} pr
  * @return {number}
  */
 function prDateMs(pr) {
-	const text = pr && typeof pr.updatedAt === 'string' ? pr.updatedAt : '';
+	const text = pr && typeof pr.commitDate === 'string' ? pr.commitDate : '';
 	return text ? Date.parse(text) : NaN;
 }
 
 /**
- * The most recent patch across the loaded sources, or null if none is datable.
+ * The most recent patch across the loaded sources, or null when there is no
+ * answer worth showing.
  *
  * Only applyable attachments (patch files) compete — a .txt is context, not a
  * fix. `attachments` being undefined means they have not been loaded yet, so
  * the answer is drawn from PRs alone; that is the normal, pre-attachment state.
  *
- * @param {Object} root0
- * @param {Array}  [root0.prs]
- * @param {Array}  [root0.attachments]
+ * Null means "show nothing", and it covers three cases, not one: nothing is
+ * datable, the PR ranking is incomplete, or the top two are too close to
+ * separate. The last two are the point — a pill is a claim, and a wrong claim
+ * sends a contributor into an apply that cannot succeed, which costs far more
+ * than the pill was ever worth.
+ *
+ * A PR list is treated as incomplete whenever any PR lacks a resolved commit
+ * date, whatever `prRankComplete` says. That covers a caller that does not pass
+ * the flag and a list restored from a cache written before commit dates
+ * existed: an undated PR is not old, it is unknown, and an unknown row could be
+ * the real winner.
+ *
+ * @param {Object}  root0
+ * @param {Array}   [root0.prs]
+ * @param {Array}   [root0.attachments]
+ * @param {boolean} [root0.prRankComplete] False when the lookup walk stopped early.
  * @return {{kind: 'pr'|'attachment', key: (number|string), whenMs: number}|null}
  */
-function pickLatest({ prs, attachments } = {}) {
+function pickLatest({ prs, attachments, prRankComplete } = {}) {
 	let best = null;
+	let runnerUpMs = -Infinity;
 	const consider = (kind, key, whenMs) => {
 		if (!Number.isFinite(whenMs)) return;
-		if (!best || whenMs > best.whenMs) best = { kind, key, whenMs };
+		if (!best || whenMs > best.whenMs) {
+			if (best) runnerUpMs = Math.max(runnerUpMs, best.whenMs);
+			best = { kind, key, whenMs };
+			return;
+		}
+		runnerUpMs = Math.max(runnerUpMs, whenMs);
 	};
 
-	for (const pr of Array.isArray(prs) ? prs : []) {
-		consider('pr', pr.number, prDateMs(pr));
+	const prList = Array.isArray(prs) ? prs : [];
+	let ranked = prRankComplete !== false;
+	for (const pr of prList) {
+		const whenMs = prDateMs(pr);
+		if (!Number.isFinite(whenMs)) ranked = false;
+		consider('pr', pr.number, whenMs);
 	}
+	if (!ranked) return null;
+
 	for (const att of Array.isArray(attachments) ? attachments : []) {
 		if (!att.applyable) continue;
 		consider('attachment', att.url || att.filename, attachmentDateMs(att));
 	}
+
+	if (!best) return null;
+	if (best.whenMs - runnerUpMs < NEAR_TIE_MS) return null;
 	return best;
 }
 
-module.exports = { attachmentDateMs, prDateMs, pickLatest };
+module.exports = { NEAR_TIE_MS, attachmentDateMs, prDateMs, pickLatest };

--- a/src/main.js
+++ b/src/main.js
@@ -1324,8 +1324,12 @@ ipcMain.handle('git:list-ticket-patches', async (_e, sitePath) => {
 
         const result = await fetchLinkedPrs(ticketId);
         if (result.status === 'ok') {
-            s.set(patchCacheKey(ticketId), { checkedAt: new Date().toISOString(), items: result.items });
-            return { ok: true, ticket: ticketId, prs: { status: 'ok', items: result.items } };
+            // `rankComplete` is cached with the items and handed back with them:
+            // a list whose commit-date ranking was cut short must not come back
+            // from the cache looking complete, or the "Latest" pill returns
+            // without the evidence for it (#281).
+            s.set(patchCacheKey(ticketId), { checkedAt: new Date().toISOString(), items: result.items, rankComplete: result.rankComplete });
+            return { ok: true, ticket: ticketId, prs: { status: 'ok', items: result.items, rankComplete: result.rankComplete } };
         }
 
         // Could not read GitHub. Fall back to whatever was last seen for this
@@ -1335,7 +1339,13 @@ ipcMain.handle('git:list-ticket-patches', async (_e, sitePath) => {
         return {
             ok: true,
             ticket: ticketId,
-            prs: { status: result.status, items: cached ? cached.items : [], cachedAt: cached ? cached.checkedAt : null, error: result.error }
+            prs: {
+                status: result.status,
+                items: cached ? cached.items : [],
+                rankComplete: cached ? cached.rankComplete === true : false,
+                cachedAt: cached ? cached.checkedAt : null,
+                error: result.error
+            }
         };
     } catch (e) {
         return { ok: false, error: String(e) };

--- a/src/main.js
+++ b/src/main.js
@@ -1322,7 +1322,13 @@ ipcMain.handle('git:list-ticket-patches', async (_e, sitePath) => {
         const ticketId = meta.tracTicket;
         if (!ticketId) return { ok: true, ticket: null, prs: { status: 'no-ticket', items: [] } };
 
-        const result = await fetchLinkedPrs(ticketId);
+        // The cached list is passed back in, not just fallen back to: its commit
+        // dates are still valid for any pull request GitHub reports with the
+        // same `updatedAt`, so a Refresh does not re-spend the ranking, and a
+        // Refresh on a spent quota cannot replace a ranking the contributor
+        // could already read with an unranked one (#281).
+        const cachedBefore = s.get(patchCacheKey(ticketId)) || null;
+        const result = await fetchLinkedPrs(ticketId, { known: cachedBefore ? cachedBefore.items : null });
         if (result.status === 'ok') {
             // `rankComplete` is cached with the items and handed back with them:
             // a list whose commit-date ranking was cut short must not come back
@@ -1335,7 +1341,7 @@ ipcMain.handle('git:list-ticket-patches', async (_e, sitePath) => {
         // Could not read GitHub. Fall back to whatever was last seen for this
         // ticket, labelled with when — a stale-but-shown list beats a short one
         // presented as complete.
-        const cached = s.get(patchCacheKey(ticketId)) || null;
+        const cached = cachedBefore;
         return {
             ok: true,
             ticket: ticketId,

--- a/src/patch-sources.cjs
+++ b/src/patch-sources.cjs
@@ -130,11 +130,17 @@ function parseLinkedPrs(searchJson, ticketId) {
  * The order a contributor reads: newest code first (issue #281).
  *
  * Pull requests whose commit date was resolved come first, freshest first. The
- * rest follow in `updatedAt` order — not because that says anything about
- * their freshness, but because the alternative is an arbitrary shuffle, and
- * they are either provably older than everything above them (the walk stopped
- * on its bound) or explicitly unranked (it stopped on its cap), which the
- * caller reflects by showing no "Latest" pill at all.
+ * rest follow in `updatedAt` order, which is not a claim about them — it is
+ * simply better than an arbitrary shuffle.
+ *
+ * Worth being exact about what the tail does and does not mean, because the
+ * walk that produced it stops on a bound: an unresolved row is known to be
+ * older than the *newest* resolved one, which is what the "Latest" pill needs,
+ * but not older than every resolved row above it. So a 2020 commit can sit
+ * above an unresolved row whose real commit is last month. The pill is still
+ * correct; the ordering below the top is a best effort, and the row's own date
+ * — blank where it is unknown — is what a contributor should read rather than
+ * the position.
  *
  * @param {Array} prs
  * @return {Array}

--- a/src/patch-sources.cjs
+++ b/src/patch-sources.cjs
@@ -85,8 +85,14 @@ function prState(item) {
 
 /**
  * Reduces a GitHub `search/issues` response to the PRs that cite the ticket.
- * Returns newest-first — for a moving target like a PR the freshest is the one
- * a contributor most likely wants.
+ *
+ * Returns sorted by `updatedAt` descending. That is deliberately *not* the
+ * order shown to a contributor: `updatedAt` moves on a comment, a label or an
+ * upstream force-push, so as a claim about freshness it is worthless (#281).
+ * What it is worth is a bound — it never sits earlier than the last commit —
+ * so this ordering is the one the commit-date walk in github-prs.js needs to
+ * decide how few lookups it can get away with. The display order comes from
+ * orderByCommitDate below, once those lookups have happened.
  *
  * @param {Object}        searchJson
  * @param {number|string} ticketId
@@ -121,6 +127,36 @@ function parseLinkedPrs(searchJson, ticketId) {
 }
 
 /**
+ * The order a contributor reads: newest code first (issue #281).
+ *
+ * Pull requests whose commit date was resolved come first, freshest first. The
+ * rest follow in `updatedAt` order — not because that says anything about
+ * their freshness, but because the alternative is an arbitrary shuffle, and
+ * they are either provably older than everything above them (the walk stopped
+ * on its bound) or explicitly unranked (it stopped on its cap), which the
+ * caller reflects by showing no "Latest" pill at all.
+ *
+ * @param {Array} prs
+ * @return {Array}
+ */
+function orderByCommitDate(prs) {
+	const list = Array.isArray(prs) ? prs.slice() : [];
+	const ms = (pr) => {
+		const parsed = pr && typeof pr.commitDate === 'string' && pr.commitDate ? Date.parse(pr.commitDate) : NaN;
+		return Number.isFinite(parsed) ? parsed : null;
+	};
+	list.sort((a, b) => {
+		const x = ms(a);
+		const y = ms(b);
+		if (x !== null && y !== null) return y - x;
+		if (x !== null) return -1;
+		if (y !== null) return 1;
+		return (b.updatedAt || '').localeCompare(a.updatedAt || '');
+	});
+	return list;
+}
+
+/**
  * Classifies a non-2xx GitHub response so the UI can tell "nothing on this
  * ticket" apart from "we could not read it". A rate-limited answer is not an
  * empty ticket: on a shared Contributor-Day IP the unauthenticated 60/hour is
@@ -145,6 +181,7 @@ module.exports = {
 	TICKET_HOST,
 	bodyCitesTicket,
 	parseLinkedPrs,
+	orderByCommitDate,
 	classifyHttpFailure,
 	parsePrRef
 };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -34,6 +34,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { prStateBadge } from './pr-state.cjs';
+import { prDateLabel } from './pr-date-label.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
@@ -4083,12 +4084,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2, fontSize: 11, color: '#6c6f72' }}>
                           {prStatePill(pr.state)}
-                          {/* The commit date when it is known, so the row agrees
-                              with the pill above it. "updated" is the fallback
-                              and says only that something was touched — a
-                              comment, a label, a force-push upstream (#281). */}
-                          {pr.commitDate ? <span>last commit {new Date(pr.commitDate).toLocaleDateString()}</span> : null}
-                          {!pr.commitDate && pr.updatedAt ? <span>updated {new Date(pr.updatedAt).toLocaleDateString()}</span> : null}
+                          {(() => {
+                            const dated = prDateLabel(pr);
+                            return dated ? <span>{dated.prefix} {new Date(dated.when).toLocaleDateString()}</span> : null;
+                          })()}
                         </div>
                       </div>
                       <Button

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2560,7 +2560,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // The single most recent patch across whatever is loaded — PRs always, Trac
   // attachments once the contributor has opened them (#11). Drives the "Latest"
   // pill and the "latest is a patch file" note.
-  const latestPatch = pickLatest({ prs: ticketPatches?.items, attachments: tracAttachments?.items });
+  // `rankComplete` travels with the list: when the commit-date walk stopped
+  // early there is no pill, because an unranked row could be the newer fix
+  // (#281).
+  const latestPatch = pickLatest({
+    prs: ticketPatches?.items,
+    attachments: tracAttachments?.items,
+    prRankComplete: ticketPatches?.rankComplete
+  });
   const latestIsAttachment = latestPatch?.kind === 'attachment';
   // The panel lists only what can be applied — screenshots and other non-patch
   // attachments are noise here. The parser still returns them (pickLatest and
@@ -4076,7 +4083,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </div>
                         <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2, fontSize: 11, color: '#6c6f72' }}>
                           {prStatePill(pr.state)}
-                          {pr.updatedAt ? <span>updated {new Date(pr.updatedAt).toLocaleDateString()}</span> : null}
+                          {/* The commit date when it is known, so the row agrees
+                              with the pill above it. "updated" is the fallback
+                              and says only that something was touched — a
+                              comment, a label, a force-push upstream (#281). */}
+                          {pr.commitDate ? <span>last commit {new Date(pr.commitDate).toLocaleDateString()}</span> : null}
+                          {!pr.commitDate && pr.updatedAt ? <span>updated {new Date(pr.updatedAt).toLocaleDateString()}</span> : null}
                         </div>
                       </div>
                       <Button

--- a/src/renderer/pr-date-label.cjs
+++ b/src/renderer/pr-date-label.cjs
@@ -1,0 +1,41 @@
+// The date shown under a linked pull request (#281).
+//
+// The row used to read "updated 6 Jul 2026", and on the ticket that produced
+// #281 that was the one number a contributor should not have been reading: an
+// upstream force-push had restamped both pull requests on the ticket inside the
+// same second, so the row was reporting the sweep, not the work.
+//
+// So the row prefers the date of the newest commit, and says which date it is
+// showing rather than leaving the reader to assume. "updated" survives as the
+// fallback, for a pull request whose commit date could not be resolved — that
+// row is genuinely unknown, and a blank line would read as "nothing here".
+//
+// The asymmetry is deliberate and is the reason this is a module with a test
+// rather than two lines of JSX: latest-patch.cjs must NEVER fall back to
+// `updatedAt` — a pull request without a resolved commit date does not compete
+// for the "Latest" pill at all — while the row shows it, clearly labelled,
+// because a contributor reading a date they can see beats a contributor reading
+// nothing.
+'use strict';
+
+/**
+ * What the date line under a pull request row says, or null when the row has no
+ * date to show at all.
+ *
+ * Returns the field to read rather than a formatted string: the formatting is
+ * `toLocaleDateString`, which belongs where the locale does.
+ *
+ * @param {Object} pr
+ * @return {{prefix: string, when: string}|null}
+ */
+function prDateLabel(pr) {
+	const commitDate = pr && typeof pr.commitDate === 'string' ? pr.commitDate : '';
+	if (commitDate) return { prefix: 'last commit', when: commitDate };
+
+	const updatedAt = pr && typeof pr.updatedAt === 'string' ? pr.updatedAt : '';
+	if (updatedAt) return { prefix: 'updated', when: updatedAt };
+
+	return null;
+}
+
+module.exports = { prDateLabel };

--- a/test/github-prs.test.cjs
+++ b/test/github-prs.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
 const { httpGet, fetchLinkedPrs, MAX_COMMIT_LOOKUPS } = require('../src/github-prs');
+const { pickLatest } = require('../src/latest-patch.cjs');
 
 // A stand-in for Electron's `net`: request() hands back an EventEmitter whose
 // end() lets the test drive the response (or an error) the way the real client
@@ -256,6 +257,81 @@ test('fetchLinkedPrs discards a commit dated in the future rather than crowning 
 	const byNumber = Object.fromEntries(res.items.map((p) => [p.number, p.commitDate]));
 	assert.strictEqual(byNumber[1], null, 'a date ahead of now is not a date');
 	assert.strictEqual(byNumber[2], '2026-04-12T11:30:00Z');
+});
+
+// --- the seam: what the walk produces, fed to what decides the pill ---------
+//
+// Both halves were green in isolation while the feature was broken between
+// them: the walk correctly reported a complete ranking with rows left undated,
+// and pickLatest correctly refused to rank a list with undated rows. Nothing
+// drove one into the other, so the headline behaviour — a pill on the ticket
+// this issue is about — was the one thing untested. These run the real modules
+// end to end, no doubles beyond the network.
+
+test('the pill lands on the winner of a one-lookup ticket (issue #281)', async () => {
+	// The cheap path the bound exists to produce: PR 8455 is fetched, its commit
+	// date is already past PR 7382's stamp, so 7382 is never fetched and stays
+	// undated. That must not cost the ticket its pill.
+	const gh = ghDouble(
+		[searchItem(8455, '2026-07-20T00:00:00Z'), searchItem(7382, '2024-11-19T00:00:00Z')],
+		{ 8455: ['2026-07-19T00:00:00Z'] }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, 1);
+
+	const latest = pickLatest({ prs: res.items, prRankComplete: res.rankComplete });
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 8455 });
+});
+
+test('the pill is withheld when the sweep left the ranking unfinished (issue #281)', async () => {
+	// #62064's shape widened past the cap: every stamp identical, so no row can
+	// be ruled out and the rows past the cap are genuinely unknown.
+	const stamp = '2026-07-06T03:10:00Z';
+	const numbers = [1, 2, 3, 4, 5, 6];
+	const commits = {};
+	for (const n of numbers) commits[n] = [`2026-0${n}-01T00:00:00Z`];
+	const gh = ghDouble(numbers.map((n) => searchItem(n, stamp)), commits);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+
+	assert.strictEqual(res.rankComplete, false);
+	assert.strictEqual(pickLatest({ prs: res.items, prRankComplete: res.rankComplete }), null);
+});
+
+test('the pill survives a Refresh that could not reach GitHub at all (issue #281)', async () => {
+	// The spent-quota Refresh: the search answers from cache-backed reuse, every
+	// commit lookup would fail, and the contributor keeps the pill they had.
+	const known = [
+		{ number: 8455, updatedAt: '2026-07-20T00:00:00Z', commitDate: '2026-07-19T00:00:00Z' },
+		{ number: 7382, updatedAt: '2024-11-19T00:00:00Z', commitDate: '2024-11-19T00:00:00Z' }
+	];
+	const gh = ghDouble(
+		[searchItem(8455, '2026-07-20T00:00:00Z'), searchItem(7382, '2024-11-19T00:00:00Z')],
+		{ 8455: () => { throw new Error('quota'); }, 7382: () => { throw new Error('quota'); } }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet, known });
+	const latest = pickLatest({ prs: res.items, prRankComplete: res.rankComplete });
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 8455 });
+});
+
+test('a paginated PR cannot push the walk past the request cap (issue #281)', async () => {
+	// Every row paginated and every stamp identical: without the cap check on
+	// the second page, four admitted rows would spend eight requests.
+	const stamp = '2026-07-06T03:10:00Z';
+	const numbers = [1, 2, 3, 4, 5, 6];
+	const commits = {};
+	for (const n of numbers) {
+		commits[n] = (url) => (url.includes('page=2')
+			? { status: 200, headers: {}, body: JSON.stringify([{ commit: { committer: { date: `2026-0${n}-01T00:00:00Z` } } }]) }
+			: {
+				status: 200,
+				headers: { link: `<https://api.github.com/repos/WordPress/wordpress-develop/pulls/${n}/commits?per_page=100&page=2>; rel="last"` },
+				body: JSON.stringify([{ commit: { committer: { date: '2020-01-01T00:00:00Z' } } }])
+			});
+	}
+	const gh = ghDouble(numbers.map((n) => searchItem(n, stamp)), commits);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, MAX_COMMIT_LOOKUPS, 'the cap counts requests, and pagination spends two');
+	assert.strictEqual(res.rankComplete, false);
 });
 
 test('fetchLinkedPrs falls back to the author date when a commit has no committer date (issue #281)', async () => {

--- a/test/github-prs.test.cjs
+++ b/test/github-prs.test.cjs
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
-const { httpGet, fetchLinkedPrs } = require('../src/github-prs');
+const { httpGet, fetchLinkedPrs, MAX_COMMIT_LOOKUPS } = require('../src/github-prs');
 
 // A stand-in for Electron's `net`: request() hands back an EventEmitter whose
 // end() lets the test drive the response (or an error) the way the real client
@@ -83,16 +83,136 @@ test('httpGet settles once: a timeout after a successful response is a no-op', a
 
 const CITE = (id) => `Trac: https://core.trac.wordpress.org/ticket/${id}`;
 
+const searchItem = (number, updatedAt) => ({
+	number,
+	pull_request: { url: 'x' },
+	title: `PR ${number}`,
+	state: 'open',
+	updated_at: updatedAt,
+	html_url: `https://github.com/WordPress/wordpress-develop/pull/${number}`,
+	body: CITE(123)
+});
+
+/**
+ * An httpGet that answers the search once and each `pulls/N/commits` from a
+ * table, recording every URL it was asked for. The request count is the point
+ * of most of the tests below: this feature spends a shared 60/hour quota, so
+ * "does it get the right answer" and "how many requests did that take" are the
+ * same question.
+ *
+ * @param {Array}  items     `search/issues` items the one search request answers with.
+ * @param {Object} [commits] PR number → an array of commit dates, or a function
+ *                           of the URL for the pagination and failure cases.
+ * @return {Object}
+ */
+function ghDouble(items, commits = {}) {
+	const calls = [];
+	const searchBody = JSON.stringify({ total_count: items.length, incomplete_results: false, items });
+	const httpGetImpl = async (url) => {
+		calls.push(url);
+		if (url.includes('/search/issues')) return { status: 200, headers: {}, body: searchBody };
+		const n = Number(/\/pulls\/(\d+)\/commits/.exec(url)[1]);
+		const entry = commits[n];
+		if (typeof entry === 'function') return entry(url);
+		const dates = Array.isArray(entry) ? entry : [];
+		return { status: 200, headers: {}, body: JSON.stringify(dates.map((d) => ({ commit: { committer: { date: d } } }))) };
+	};
+	return { httpGet: httpGetImpl, calls, commitCalls: () => calls.filter((u) => u.includes('/commits')) };
+}
+
 test('fetchLinkedPrs returns ok with the citing PRs when the result is complete', async () => {
-	const body = JSON.stringify({
-		total_count: 1,
-		incomplete_results: false,
-		items: [{ number: 42, pull_request: { url: 'x' }, title: 'Fix', state: 'open', updated_at: '2026-01-01T00:00:00Z', html_url: 'u', body: CITE(123) }]
-	});
-	const res = await fetchLinkedPrs('123', { httpGet: async () => ({ status: 200, headers: {}, body }) });
+	const gh = ghDouble([searchItem(42, '2026-01-01T00:00:00Z')], { 42: ['2025-12-30T10:00:00Z'] });
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
 	assert.strictEqual(res.status, 'ok');
 	assert.strictEqual(res.items.length, 1);
 	assert.strictEqual(res.items[0].number, 42);
+	assert.strictEqual(res.items[0].commitDate, '2025-12-30T10:00:00Z');
+	assert.strictEqual(res.rankComplete, true);
+	assert.strictEqual(gh.commitCalls().length, 1, 'one PR, one lookup');
+});
+
+// --- ranking by commit date (issue #281) ---------------------------------
+
+// The bug, in the shape it actually shipped: an upstream force-push restamped
+// both PRs 19 seconds apart, so updatedAt crowned the November 2024 patch that
+// no longer applies over the April 2026 one that does.
+test('fetchLinkedPrs ranks by newest commit, not by an upstream force-push stamp (issue #281)', async () => {
+	const gh = ghDouble(
+		[searchItem(7382, '2026-07-06T03:10:47Z'), searchItem(8455, '2026-07-06T03:10:28Z')],
+		{ 7382: ['2024-11-19T09:00:00Z'], 8455: ['2026-01-02T08:00:00Z', '2026-04-12T11:30:00Z'] }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.deepStrictEqual(res.items.map((p) => p.number), [8455, 7382]);
+	assert.strictEqual(res.items[0].commitDate, '2026-04-12T11:30:00Z', 'newest commit on the PR, not its first');
+	assert.strictEqual(res.rankComplete, true);
+});
+
+// The saving that makes the extra requests affordable: updatedAt is never
+// earlier than the last commit, so it bounds every row below.
+test('fetchLinkedPrs stops looking up once no remaining PR can win (issue #281)', async () => {
+	const gh = ghDouble(
+		[searchItem(1, '2026-08-01T00:00:00Z'), searchItem(2, '2026-02-01T00:00:00Z'), searchItem(3, '2026-01-01T00:00:00Z')],
+		{ 1: ['2026-07-01T00:00:00Z'], 2: ['2026-01-15T00:00:00Z'], 3: ['2025-01-01T00:00:00Z'] }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, 1, 'PR 1 beats the bound on PR 2, so 2 and 3 are never fetched');
+	assert.strictEqual(res.rankComplete, true, 'the tail was ruled out, not merely unread');
+	assert.deepStrictEqual(res.items.map((p) => p.number), [1, 2, 3]);
+});
+
+test('fetchLinkedPrs stops at the lookup cap and says the ranking is incomplete (issue #281)', async () => {
+	// Every bound identical — a force-push sweep — so the walk cannot rule
+	// anything out and would otherwise fetch the lot.
+	const stamp = '2026-07-06T03:10:00Z';
+	const numbers = [1, 2, 3, 4, 5, 6];
+	const commits = {};
+	for (const n of numbers) commits[n] = [`2026-0${n}-01T00:00:00Z`];
+	const gh = ghDouble(numbers.map((n) => searchItem(n, stamp)), commits);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, MAX_COMMIT_LOOKUPS);
+	assert.strictEqual(res.rankComplete, false);
+});
+
+test('fetchLinkedPrs stops looking up after a failed lookup rather than spending the rest (issue #281)', async () => {
+	const stamp = '2026-07-06T03:10:00Z';
+	const gh = ghDouble(
+		[searchItem(1, stamp), searchItem(2, stamp), searchItem(3, stamp)],
+		{
+			1: ['2026-01-01T00:00:00Z'],
+			2: () => ({ status: 403, headers: { 'x-ratelimit-remaining': '0' }, body: '' }),
+			3: ['2026-06-01T00:00:00Z']
+		}
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, 2, 'PR 3 is not attempted against a spent quota');
+	assert.strictEqual(res.rankComplete, false);
+	// The list itself still came back — a ranking we could not finish is not a
+	// reason to hide the work that exists.
+	assert.strictEqual(res.status, 'ok');
+	assert.strictEqual(res.items.length, 3);
+});
+
+test('fetchLinkedPrs follows Link rel="last" once for a long PR, and takes the newest there (issue #281)', async () => {
+	const gh = ghDouble([searchItem(9, '2026-08-01T00:00:00Z')], {
+		9: (url) => (url.includes('page=3')
+			? { status: 200, headers: {}, body: JSON.stringify([{ commit: { committer: { date: '2026-07-30T12:00:00Z' } } }]) }
+			: {
+				status: 200,
+				headers: { link: '<https://api.github.com/repos/WordPress/wordpress-develop/pulls/9/commits?per_page=100&page=3>; rel="last"' },
+				body: JSON.stringify([{ commit: { committer: { date: '2024-01-01T00:00:00Z' } } }])
+			})
+	});
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, 2, 'the last page, not a walk through the middle');
+	assert.strictEqual(res.items[0].commitDate, '2026-07-30T12:00:00Z');
+});
+
+test('fetchLinkedPrs falls back to the author date when a commit has no committer date (issue #281)', async () => {
+	const gh = ghDouble([searchItem(4, '2026-08-01T00:00:00Z')], {
+		4: () => ({ status: 200, headers: {}, body: JSON.stringify([{ commit: { author: { date: '2026-05-05T00:00:00Z' } } }]) })
+	});
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(res.items[0].commitDate, '2026-05-05T00:00:00Z');
 });
 
 test('fetchLinkedPrs refuses to cache a truncated result, so the cache is used instead', async () => {

--- a/test/github-prs.test.cjs
+++ b/test/github-prs.test.cjs
@@ -207,6 +207,57 @@ test('fetchLinkedPrs follows Link rel="last" once for a long PR, and takes the n
 	assert.strictEqual(res.items[0].commitDate, '2026-07-30T12:00:00Z');
 });
 
+// The failure the cache reuse exists to prevent: `search/issues` and the core
+// API have separate unauthenticated allowances, so "the search works, the
+// commit lookups are 403" is the ordinary state on a shared Contributor Day IP.
+// Without reuse, that Refresh would replace a ranking the contributor could
+// already read with an unranked list — the failed request destroying the
+// evidence rather than merely failing to add to it.
+test('fetchLinkedPrs reuses cached commit dates, so a spent quota cannot downgrade a ranking (issue #281)', async () => {
+	const known = [
+		{ number: 7382, updatedAt: '2026-07-06T03:10:47Z', commitDate: '2024-11-19T09:00:00Z' },
+		{ number: 8455, updatedAt: '2026-07-06T03:10:28Z', commitDate: '2026-04-12T11:30:00Z' }
+	];
+	const gh = ghDouble(
+		[searchItem(7382, '2026-07-06T03:10:47Z'), searchItem(8455, '2026-07-06T03:10:28Z')],
+		{ 7382: () => { throw new Error('must not be fetched'); }, 8455: () => { throw new Error('must not be fetched'); } }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet, known });
+	assert.strictEqual(gh.commitCalls().length, 0, 'nothing moved, so nothing is re-fetched');
+	assert.strictEqual(res.rankComplete, true);
+	assert.deepStrictEqual(res.items.map((p) => p.number), [8455, 7382]);
+});
+
+test('fetchLinkedPrs re-fetches a PR whose updatedAt moved since it was cached (issue #281)', async () => {
+	// A push moves `updated_at`, so a changed stamp is the signal that the
+	// cached commit date may be stale. It is only a signal in one direction —
+	// a comment moves it too — so this costs a request it sometimes did not
+	// need to, which is the safe side of that trade.
+	const known = [{ number: 42, updatedAt: '2026-01-01T00:00:00Z', commitDate: '2025-12-30T10:00:00Z' }];
+	const gh = ghDouble([searchItem(42, '2026-08-01T00:00:00Z')], { 42: ['2026-07-31T10:00:00Z'] });
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet, known });
+	assert.strictEqual(gh.commitCalls().length, 1);
+	assert.strictEqual(res.items[0].commitDate, '2026-07-31T10:00:00Z');
+});
+
+// A commit date is written by whoever made the commit, so it can be ahead of
+// now. Left alone it would be the worst possible input to the walk: as the
+// running best it clears every remaining bound at once, ending the walk and
+// declaring the ranking complete on the strength of the one date that is wrong.
+test('fetchLinkedPrs discards a commit dated in the future rather than crowning it (issue #281)', async () => {
+	const future = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+	const stamp = '2026-07-06T03:10:00Z';
+	const gh = ghDouble(
+		[searchItem(1, stamp), searchItem(2, stamp)],
+		{ 1: [future], 2: ['2026-04-12T11:30:00Z'] }
+	);
+	const res = await fetchLinkedPrs('123', { httpGet: gh.httpGet });
+	assert.strictEqual(gh.commitCalls().length, 2, 'the bad date must not end the walk');
+	const byNumber = Object.fromEntries(res.items.map((p) => [p.number, p.commitDate]));
+	assert.strictEqual(byNumber[1], null, 'a date ahead of now is not a date');
+	assert.strictEqual(byNumber[2], '2026-04-12T11:30:00Z');
+});
+
 test('fetchLinkedPrs falls back to the author date when a commit has no committer date (issue #281)', async () => {
 	const gh = ghDouble([searchItem(4, '2026-08-01T00:00:00Z')], {
 		4: () => ({ status: 200, headers: {}, body: JSON.stringify([{ commit: { author: { date: '2026-05-05T00:00:00Z' } } }]) })

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1894,11 +1894,29 @@ test('git:list-ticket-patches fetches the linked PRs for the stored ticket', asy
 
 	const result = await main.invoke('git:list-ticket-patches', '/sites/wp');
 
-	assert.deepEqual(fetchLinkedPrs.calls, [[62281]]);
+	assert.deepEqual(fetchLinkedPrs.calls, [[62281, { known: null }]], 'nothing cached yet, so no dates to reuse');
 	assert.equal(result.ok, true);
 	assert.equal(result.ticket, 62281);
 	assert.equal(result.prs.status, 'ok');
 	assert.deepEqual(result.prs.items, [{ number: 7, title: 'x' }]);
+});
+
+// The commit dates behind the "Latest" pill cost a request each against a
+// shared quota, so a Refresh hands the last-seen list back to the fetcher to
+// reuse rather than re-spending the walk — and, on a spent quota, so that a
+// failed lookup cannot replace a ranking the contributor could already read
+// (issue #281).
+test('git:list-ticket-patches hands the cached list back so commit dates are not re-fetched', async () => {
+	const cachedItems = [{ number: 7, updatedAt: '2026-07-06T03:10:28Z', commitDate: '2026-04-12T11:30:00Z' }];
+	const fetchLinkedPrs = spy(async () => ({ status: 'ok', items: cachedItems, rankComplete: true }));
+	const settings = fakeSettingsStore({ sites: ['/sites/wp'], siteMeta: { '/sites/wp': { tracTicket: 62281 } } });
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs, './github-prs': { fetchLinkedPrs } } });
+
+	await main.invoke('git:list-ticket-patches', '/sites/wp'); // populates the cache
+	const result = await main.invoke('git:list-ticket-patches', '/sites/wp');
+
+	assert.deepEqual(fetchLinkedPrs.calls[1], [62281, { known: cachedItems }]);
+	assert.equal(result.prs.rankComplete, true, 'the completeness of the ranking survives the cache');
 });
 
 test('git:list-ticket-patches falls back to the cached list when GitHub cannot be read', async () => {

--- a/test/latest-patch.test.cjs
+++ b/test/latest-patch.test.cjs
@@ -4,7 +4,10 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { attachmentDateMs, pickLatest } = require('../src/latest-patch.cjs');
 
-const pr = (number, updatedAt) => ({ number, updatedAt });
+// A PR is dated by its newest commit (#281). `updatedAt` rides along because
+// the real object carries it and the row falls back to it, but nothing here may
+// rank by it.
+const pr = (number, commitDate, updatedAt = '2026-07-06T03:10:00Z') => ({ number, commitDate, updatedAt });
 const att = (filename, dateText, applyable = true) => ({ filename, url: `https://core.trac.wordpress.org/raw-attachment/ticket/1/${filename}`, dateText, applyable });
 
 test('attachmentDateMs: a US-format absolute date parses, a relative one does not (issue #11)', () => {
@@ -24,7 +27,7 @@ test('attachmentDateMs: parses to a fixed UTC instant, timezone-independent (iss
 });
 
 // The common case: attachments not loaded yet, so the newest PR is the latest.
-test('pickLatest: with only PRs, the most recently updated PR wins (issue #11)', () => {
+test('pickLatest: with only PRs, the one with the newest commit wins (issue #11)', () => {
 	const latest = pickLatest({ prs: [pr(1, '2026-01-01T00:00:00Z'), pr(2, '2026-08-06T00:00:00Z')] });
 	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 2 });
 });
@@ -79,4 +82,74 @@ test('pickLatest: attachments-only (no PRs cite the ticket) still picks the newe
 	});
 	assert.strictEqual(latest.kind, 'attachment');
 	assert.ok(String(latest.key).endsWith('b.diff'));
+});
+
+// --- ranking by commit, and refusing to guess (issue #281) ---------------
+
+// Trac #62064, as it shipped: one force-push upstream restamped both PRs 19
+// seconds apart, and the app crowned the November 2024 patch — which no longer
+// applies — over the April 2026 one, which does.
+test('pickLatest: the force-push stamps do not decide it; the newest commit does (issue #281)', () => {
+	const latest = pickLatest({
+		prs: [
+			pr(7382, '2024-11-19T09:00:00Z', '2026-07-06T03:10:47Z'),
+			pr(8455, '2026-04-12T11:30:00Z', '2026-07-06T03:10:28Z')
+		],
+		prRankComplete: true
+	});
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 8455 });
+});
+
+test('pickLatest: an incomplete ranking shows nothing rather than a guess (issue #281)', () => {
+	const prs = [pr(1, '2026-04-12T11:30:00Z'), pr(2, '2024-11-19T09:00:00Z')];
+	assert.strictEqual(pickLatest({ prs, prRankComplete: false }), null);
+	assert.ok(pickLatest({ prs, prRankComplete: true }), 'the same list ranks fine once the walk finished');
+});
+
+// A PR whose commit date was never resolved is unknown, not old — so it makes
+// the whole answer unknown, whatever the flag says. This is also what a list
+// restored from a cache written before commit dates existed looks like.
+test('pickLatest: an undated PR suppresses the pill, never falling back to updatedAt (issue #281)', () => {
+	const prs = [pr(1, '2020-01-01T00:00:00Z'), { number: 2, updatedAt: '2026-08-01T00:00:00Z' }];
+	assert.strictEqual(pickLatest({ prs, prRankComplete: true }), null);
+	assert.strictEqual(pickLatest({ prs }), null, 'a caller that passes no flag gets the same answer');
+});
+
+// An undated PR is also unknown next to an attachment: it could be the newer
+// fix, so the attachment cannot be crowned either.
+test('pickLatest: an undated PR blocks an attachment from winning too (issue #281)', () => {
+	const latest = pickLatest({
+		prs: [{ number: 2, updatedAt: '2026-08-01T00:00:00Z' }],
+		attachments: [att('fix.diff', '05/16/2025 11:00:00 AM')]
+	});
+	assert.strictEqual(latest, null);
+});
+
+test('pickLatest: two patches within the hour are not a ranking (issue #281)', () => {
+	const near = pickLatest({
+		prs: [pr(1, '2026-04-12T11:30:00Z'), pr(2, '2026-04-12T11:55:00Z')],
+		prRankComplete: true
+	});
+	assert.strictEqual(near, null, '25 minutes apart is one piece of work, not a newer and an older fix');
+
+	const clear = pickLatest({
+		prs: [pr(1, '2026-04-12T11:30:00Z'), pr(2, '2026-04-12T14:30:00Z')],
+		prRankComplete: true
+	});
+	assert.deepStrictEqual({ kind: clear.kind, key: clear.key }, { kind: 'pr', key: 2 });
+});
+
+// The near-tie rule reads the runner-up wherever it is, not just the previous
+// winner: three candidates must not let an early loser hide a close second.
+test('pickLatest: the near-tie is measured against the true runner-up (issue #281)', () => {
+	const latest = pickLatest({
+		prs: [pr(1, '2020-01-01T00:00:00Z'), pr(2, '2026-04-12T14:30:00Z'), pr(3, '2026-04-12T14:20:00Z')],
+		prRankComplete: true
+	});
+	assert.strictEqual(latest, null);
+});
+
+test('pickLatest: a single PR still gets the pill (issue #281)', () => {
+	const latest = pickLatest({ prs: [pr(9026, '2026-04-12T11:30:00Z')], prRankComplete: true });
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 9026 });
 });

--- a/test/latest-patch.test.cjs
+++ b/test/latest-patch.test.cjs
@@ -100,29 +100,57 @@ test('pickLatest: the force-push stamps do not decide it; the newest commit does
 	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 8455 });
 });
 
-test('pickLatest: an incomplete ranking shows nothing rather than a guess (issue #281)', () => {
+test('pickLatest: a walk that broke shows nothing rather than a guess (issue #281)', () => {
 	const prs = [pr(1, '2026-04-12T11:30:00Z'), pr(2, '2024-11-19T09:00:00Z')];
 	assert.strictEqual(pickLatest({ prs, prRankComplete: false }), null);
 	assert.ok(pickLatest({ prs, prRankComplete: true }), 'the same list ranks fine once the walk finished');
 });
 
-// A PR whose commit date was never resolved is unknown, not old — so it makes
-// the whole answer unknown, whatever the flag says. This is also what a list
-// restored from a cache written before commit dates existed looks like.
-test('pickLatest: an undated PR suppresses the pill, never falling back to updatedAt (issue #281)', () => {
-	const prs = [pr(1, '2020-01-01T00:00:00Z'), { number: 2, updatedAt: '2026-08-01T00:00:00Z' }];
+// The regression this rule was rewritten for: the walk leaves a ruled-out row
+// undated on purpose, and treating that as "unknown, so no answer" removed the
+// pill from the ordinary one-lookup ticket the walk exists to serve.
+test('pickLatest: a PR the walk ruled out does not cost the pill (issue #281)', () => {
+	const latest = pickLatest({
+		prs: [pr(8455, '2026-07-19T00:00:00Z', '2026-07-20T00:00:00Z'), { number: 7382, updatedAt: '2024-11-19T00:00:00Z' }],
+		prRankComplete: true
+	});
+	assert.deepStrictEqual({ kind: latest.kind, key: latest.key }, { kind: 'pr', key: 8455 });
+});
+
+// The other side of the same comparison: a row the walk never reached carries
+// the stamp that has not been ruled out, and in a force-push sweep that stamp
+// sits at or above the winner — so it suppresses the pill on its own, with no
+// flag needed. This is the shape of a cache written before commit dates existed.
+test('pickLatest: an unreached PR whose stamp beats the winner suppresses the pill (issue #281)', () => {
+	const prs = [pr(1, '2026-04-12T11:30:00Z', '2026-07-06T03:10:47Z'), { number: 2, updatedAt: '2026-07-06T03:10:28Z' }];
 	assert.strictEqual(pickLatest({ prs, prRankComplete: true }), null);
 	assert.strictEqual(pickLatest({ prs }), null, 'a caller that passes no flag gets the same answer');
 });
 
-// An undated PR is also unknown next to an attachment: it could be the newer
+// A PR with neither a commit date nor a usable stamp is unbounded — nothing
+// says it is not the newest fix on the ticket, so nothing can be crowned.
+test('pickLatest: a PR with no date at all takes the answer with it (issue #281)', () => {
+	assert.strictEqual(pickLatest({ prs: [pr(1, '2026-04-12T11:30:00Z'), { number: 2 }], prRankComplete: true }), null);
+});
+
+// An unreached PR is unknown next to an attachment too: it could be the newer
 // fix, so the attachment cannot be crowned either.
-test('pickLatest: an undated PR blocks an attachment from winning too (issue #281)', () => {
+test('pickLatest: an unreached PR blocks an attachment from winning too (issue #281)', () => {
 	const latest = pickLatest({
 		prs: [{ number: 2, updatedAt: '2026-08-01T00:00:00Z' }],
 		attachments: [att('fix.diff', '05/16/2025 11:00:00 AM')]
 	});
 	assert.strictEqual(latest, null);
+});
+
+// And the mirror: an attachment genuinely newer than a ruled-out PR's stamp
+// still wins, so the bound does not become a blanket veto.
+test('pickLatest: an attachment beats a PR whose stamp is older than it (issue #281)', () => {
+	const latest = pickLatest({
+		prs: [{ number: 2, updatedAt: '2020-01-01T00:00:00Z' }],
+		attachments: [att('fix.diff', '05/16/2025 11:00:00 AM')]
+	});
+	assert.strictEqual(latest.kind, 'attachment');
 });
 
 test('pickLatest: two patches within the hour are not a ranking (issue #281)', () => {

--- a/test/patch-sources.test.cjs
+++ b/test/patch-sources.test.cjs
@@ -2,7 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { bodyCitesTicket, parseLinkedPrs, classifyHttpFailure } = require('../src/patch-sources.cjs');
+const { bodyCitesTicket, parseLinkedPrs, orderByCommitDate, classifyHttpFailure } = require('../src/patch-sources.cjs');
 
 // Shaped like a real search/issues item, trimmed to the fields the parser reads.
 function item(number, overrides = {}) {
@@ -44,7 +44,10 @@ test('parseLinkedPrs: keeps only PRs whose body cites the ticket (issue #11)', (
 	assert.deepStrictEqual(prs.map((p) => p.number), [101], 'only the verified PR survives; the issue and the passing mention drop');
 });
 
-test('parseLinkedPrs: newest first, and duplicates collapse (issue #11)', () => {
+// The order parseLinkedPrs returns is the bound the commit-date walk needs, not
+// the order a contributor sees. Naming it here so a later reader does not
+// "simplify" one into the other (#281).
+test('parseLinkedPrs: sorted by updatedAt, and duplicates collapse (issue #11)', () => {
 	const json = { items: [
 		item(1, { updated_at: '2026-01-01T00:00:00Z' }),
 		item(2, { updated_at: '2026-08-06T00:00:00Z' }),
@@ -52,6 +55,37 @@ test('parseLinkedPrs: newest first, and duplicates collapse (issue #11)', () => 
 	] };
 	const prs = parseLinkedPrs(json, 62281);
 	assert.deepStrictEqual(prs.map((p) => p.number), [2, 1]);
+});
+
+// --- display order (issue #281) ------------------------------------------
+
+// The #62064 shape: the force-push sweep left the older PR with the later
+// `updatedAt`, so ordering by it puts the dead patch on top.
+test('orderByCommitDate: newest commit first, whatever updatedAt says (issue #281)', () => {
+	const ordered = orderByCommitDate([
+		{ number: 7382, updatedAt: '2026-07-06T03:10:47Z', commitDate: '2024-11-19T09:00:00Z' },
+		{ number: 8455, updatedAt: '2026-07-06T03:10:28Z', commitDate: '2026-04-12T11:30:00Z' }
+	]);
+	assert.deepStrictEqual(ordered.map((p) => p.number), [8455, 7382]);
+});
+
+test('orderByCommitDate: unresolved PRs sink below every dated one (issue #281)', () => {
+	const ordered = orderByCommitDate([
+		{ number: 1, updatedAt: '2026-08-01T00:00:00Z', commitDate: null },
+		{ number: 2, updatedAt: '2026-07-01T00:00:00Z', commitDate: '2020-01-01T00:00:00Z' },
+		{ number: 3, updatedAt: '2026-06-01T00:00:00Z' }
+	]);
+	assert.deepStrictEqual(ordered.map((p) => p.number), [2, 1, 3],
+		'even a 2020 commit outranks an unknown one: unknown is not a date, and the row order must not imply it is');
+});
+
+test('orderByCommitDate: does not mutate its input (issue #281)', () => {
+	const input = [
+		{ number: 1, updatedAt: '2026-01-01T00:00:00Z', commitDate: '2024-01-01T00:00:00Z' },
+		{ number: 2, updatedAt: '2026-01-02T00:00:00Z', commitDate: '2026-01-01T00:00:00Z' }
+	];
+	orderByCommitDate(input);
+	assert.deepStrictEqual(input.map((p) => p.number), [1, 2]);
 });
 
 test('parseLinkedPrs: a closed PR is marked closed, not dropped (issue #11)', () => {

--- a/test/pr-date-label.test.cjs
+++ b/test/pr-date-label.test.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { prDateLabel } = require('../src/renderer/pr-date-label.cjs');
+
+test('prDateLabel: a resolved commit date is what the row shows (issue #281)', () => {
+	assert.deepStrictEqual(
+		prDateLabel({ commitDate: '2026-04-12T11:30:00Z', updatedAt: '2026-07-06T03:10:28Z' }),
+		{ prefix: 'last commit', when: '2026-04-12T11:30:00Z' },
+		'the force-push stamp is on the object and must not be the one shown'
+	);
+});
+
+test('prDateLabel: without a commit date the row says "updated", not nothing (issue #281)', () => {
+	assert.deepStrictEqual(
+		prDateLabel({ commitDate: null, updatedAt: '2026-07-06T03:10:28Z' }),
+		{ prefix: 'updated', when: '2026-07-06T03:10:28Z' }
+	);
+	// The deliberate asymmetry with latest-patch.cjs: that module must never
+	// fall back to `updatedAt`, because an undated PR does not compete for the
+	// pill. The row shows it, labelled, because a date a contributor can read
+	// beats a blank line.
+	assert.strictEqual(prDateLabel({ updatedAt: '2026-07-06T03:10:28Z' }).prefix, 'updated');
+});
+
+test('prDateLabel: a row with no dates at all yields null, not a broken label (issue #281)', () => {
+	assert.strictEqual(prDateLabel({}), null);
+	assert.strictEqual(prDateLabel(null), null);
+	assert.strictEqual(prDateLabel({ commitDate: '', updatedAt: '' }), null);
+});


### PR DESCRIPTION
## Why

The **Latest** pill is meant to point a contributor at the freshest fix so they can try that one first. It was ranked by GitHub's `updated_at`, which a comment, a label change or a bot sweep bumps just as hard as a push.

On Trac #62064 that broke outright. An upstream force-push of trunk restamped roughly 2,580 open pull requests inside one window; the two on that ticket landed 19 seconds apart in that sweep, and the app crowned the one whose newest code is from November 2024 — which no longer applies — over the one from April 2026, which does. The contributor followed the pill into an apply that could not succeed.

It is not an edge case needing a tie-break. Any ticket with more than one open pull request had its pill decided by the internal ordering of an unrelated bulk event upstream. See #281.

## What changes

**Root cause:** `updated_at` is a "most recently touched" stamp, and the ranking treated it as "newest code". The caveat was written down when the ranking was built and accepted as a fair trade for a comment. It does not survive an event that touches every pull request at once — that does not nudge the ordering, it replaces it with noise.

Pull requests are now dated by their **most recent commit**. An unresolved one does not compete at all: falling back to `updated_at` would be falling back to the bug.

**The cost, and what keeps it small.** `search/issues` — the one request the list is built from — carries no commit date, so this costs a request per pull request against the shared unauthenticated quota. Three things bound it:

- **A bound, not a fixed top-N.** `updated_at` is never *earlier* than the last commit, so on the list already sorted by it, it is a per-row upper bound. The walk stops as soon as a resolved commit date beats the next row's bound. A ticket with one pull request, or with a clear winner, costs **one** extra request. Only a ticket caught inside a fresh force-push sweep — every bound identical — walks further.
- **A cap of four requests**, after which the ranking is reported incomplete rather than the quota emptied.
- **Cached dates are reused.** A push moves `updated_at`, so a row whose stamp has not changed since it was cached has not had new code pushed to it either. A Refresh re-spends nothing.

**Where it stays quiet.** No pill when the walk could not finish, and none when the top two commits are within an hour of each other — that margin is a coin flip, and the rows carry their dates for the contributor to read. Each row now says `last commit 12 Apr 2026` rather than `updated 6 Jul 2026`, so the row and the pill stop contradicting each other.

**Deliberately not in this PR:** authenticating the lookups to get a larger quota, and pre-resolving dates in the background. Both are real options if the cap turns out to bite; neither is needed to fix the bug.

## How to test this

Platforms: any — no paths, spawning or line endings are touched.

**Starting state:** a site with **Trac #62064** linked, and the patch panel open. Run the app from a terminal with `WP_DEV_ENV_HTTP_LOG=1` set so the GitHub requests are visible.

1. Open the pull request list on the ticket. **Expected:** the **Latest** pill sits on the pull request whose row reads `last commit` with an April 2026 date — three rows below where the pill used to be. Every row reads `last commit …`, not `updated …`.
2. Click **Apply…** on the pill's pull request. **Expected:** the patch applies. On `trunk` today the pill points at the November 2024 one, whose apply fails because the file it touches has moved on (#226).
3. Count the `/pulls/*/commits` lines in the terminal. **Expected:** at most four, and on a ticket with an obvious winner exactly one.
4. Click **Refresh**. **Expected:** no new `/pulls/*/commits` requests at all — the dates come back from the cache — and the list and pill are unchanged.
5. Open a ticket with a single pull request. **Expected:** the pill is on it, and it cost one extra request.
6. Open a ticket with no pull requests. **Expected:** unchanged from before, and no extra requests.

**What must not have happened:**

- The pill must not silently stay on the November 2024 pull request while the row beneath it reads an April 2026 date — the two must agree or the pill must be absent.
- The list must not vanish, shrink, or lose its rows when the commit lookups fail. A failed ranking hides the pill; it must never hide the work that exists.
- Refreshing on a spent quota must not *remove* a pill that was there a minute ago. This was a self-review finding, now fixed by the cache reuse: the cached dates survive the failed lookup.
- The quota must not be drained. If step 3 shows a request per row on a busy ticket, the bound is broken.

Covered by `test/latest-patch.test.cjs` — `pickLatest: the force-push stamps do not decide it; the newest commit does (issue #281)` reproduces #62064's exact two stamps and commit dates, and fails on the old code. So does `fetchLinkedPrs ranks by newest commit, not by an upstream force-push stamp` in `test/github-prs.test.cjs`. Both checked against `trunk`.

## Risks and limitations

Self-review, two rounds: **5 findings then 4** — all `[fix here]` items fixed in both, one follow-up deferred. The second round caught a 🔴 that would have shipped this PR **removing** the pill from the ordinary ticket; detail in the collapsed block below.

- **I have not driven this in the app.** The suite covers the ranking, the walk and its failure paths; the pill on a real #62064 with a real quota is untested by hand, and steps 1–4 above are exactly what I could not run.
- **An attachment's Trac date is anchored to UTC by hand** and can be off by the real Trac offset, so a pull-request-versus-attachment comparison inside a few hours is fuzzier than a pull-request-versus-pull-request one. The one-hour near-tie rule narrows that window; it does not close it.
- **The cap of four is a judgement call**, not a measured number. On a ticket with five or more pull requests all caught in the same sweep, the honest outcome is no pill — which is the intended behaviour, but it is a pill a contributor used to see.
- **The near-tie window is also a judgement call.** An hour was chosen so that two commits from one working session do not get ranked against each other. There is no data behind the exact figure.
- **Reuse trusts one direction of a signal.** A cached date is kept when `updated_at` has not moved. A comment moves it too, so this sometimes re-fetches a date it did not need to — the safe side of the trade.

## Related

Closes #281
Fixes the failed apply described in #226
Follow-up to #109, where the pill and the pull request list came from

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why `pulls/{n}/commits` and not something cheaper.** `GET /repos/…/pulls/{n}` carries no commit date. `head.repo.pushed_at` is the fork's last push to *any* branch, so it is wrong for this. Resolving `head.sha` and then `commits/{sha}` is two requests, not one. A ref trick — asking `commits/refs%2Fpull%2FN%2Fhead` — might be one request, but it is undocumented, and this file already refuses undocumented GitHub behaviour on the `.diff` routes for the same reason.

**Why a bound rather than "resolve the top three".** A fixed top-N is simpler and predictable, but it spends requests on tickets with an obvious winner and still misses the true winner on a ticket with four or more pull requests — the exact shape of the bug. The bound is exact where it terminates and costs less in the common case. The cap is what keeps the pathological case survivable.

**Why no pill instead of a tie-break rule.** A tie-break on noise is still noise, wearing a more confident face. The rows carry their dates; a contributor reading two dates is better served than one following a pill into a dead end.

**What was deliberately left alone.** The `updatedAt` sort in `parseLinkedPrs` stays — it is the ordering the bound needs. It is now documented as such, so it does not get "simplified" into the display order later.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Run twice per `.github/instructions/code-review.instructions.md`, each time with the judgement pass dispatched to a subagent given only the diff and the standard. `npm run lint` clean, `npm test` 853 pass / 0 fail.

### Round two — 3 [fix here] · 1 [follow-up]

All five round-one findings verified resolved. Three new, all fixed:

- **correctness · 🔴 · [fix here] · `src/latest-patch.cjs`** — **the pill disappeared from the ordinary ticket.** The walk leaves a row undated on purpose once its stamp falls below a resolved commit date — that is how it gets away with one lookup — and reports the ranking complete, correctly. `pickLatest` then read any undated row as unknown and refused to answer, so the cheap path the walk exists to produce was exactly the path that showed no pill, and the "latest is a patch file" note went with it. Reproduced end to end before fixing: a two-PR ticket with an unambiguous winner and `rankComplete: true` returned `null`.

  The blanket rule was mine, added so a pre-change cache would degrade safely. Replaced by one comparison: an undated pull request competes as an **upper bound on the runner-up** rather than disqualifying the answer. A ruled-out row's stamp sits far below the winner, so the pill shows; an unreached row's stamp sits at or above it in a force-push sweep, so the near-tie check withholds the pill on its own. No flag distinguishes them.

  The test finding matters as much: both halves were green in isolation while the feature was broken between them, because nothing drove `fetchLinkedPrs` output into `pickLatest`. Four seam tests now do.

- **correctness · 🔵 · [fix here] · `src/github-prs.js`** — the horizon check from round one covered fetched dates but not cached ones, so a backwards clock correction could leave a future date on a row where it would win the pill and never be re-read (a dated row is one the walk skips). It also gained ten minutes of tolerance, so a machine a few minutes out does not discard a legitimately just-pushed commit.
- **performance · 🔵 · [fix here] · `src/github-prs.js`** — the cap was checked before a lookup, but a paginated pull request spends two requests inside one, so the real ceiling was five against a comment that argues at length that it counts requests. The second page is now checked too, and refuses rather than falling back to the first page — whose newest commit is the oldest part of the pull request.

Deferred: **architecture · 🔵 · [follow-up] · `src/main.js`** — if a pull request's `updatedAt` moves for a non-code reason while the commits quota is spent, its cached date is dropped, the refetch fails, and the store is overwritten with that row undated. The good date is gone from disk rather than merely unused. The fix is a policy choice — keep the last-known date, marked stale — rather than a bug in what shipped, so it is a follow-up.

### Round one — 2 [fix here] · 3 [follow-up]

Both `[fix here]` fixed, 2 of 3 follow-ups also fixed:

- **architecture · 🟡 · [fix here] · `src/main.js`** — a partially-ranked result overwrote a complete cached ranking. `search/issues` and the core API have separate unauthenticated allowances, so "search works, commit lookups 403" is the ordinary state on a shared Contributor Day IP; the failed request destroyed the evidence rather than merely failing to add to it. Fixed by passing the cached list back into `fetchLinkedPrs` and reusing dates for rows whose `updatedAt` has not moved — which also resolves the re-spend follow-up below.
- **architecture · 🟡 · [fix here] · `src/renderer/index.jsx`** — the date label became a two-branch decision inside `index.jsx`, unreachable by the suite. Moved to `src/renderer/pr-date-label.cjs` with `test/pr-date-label.test.cjs`, per the §1 invariant.
- **architecture · 🔵 · [follow-up] · `src/github-prs.js`** — a future-dated commit both won the pill and silently truncated the walk, since as the running best it clears every remaining bound at once. Fixed here rather than deferred: it reported the highest confidence exactly where it had the least. A date ahead of now is now discarded.
- **performance · 🔵 · [follow-up]** — commit dates were never reused, so every Refresh re-spent the walk. Fixed by the same cache reuse as the first finding.
- **tests · 🔵 · [follow-up] · `src/patch-sources.cjs`** — a comment claimed unresolved rows were "provably older than everything above them"; the walk only proves they are older than the *newest* resolved one. Comment corrected to state what the code actually establishes. The ordering itself is unchanged, and the pill is unaffected either way.

Round one raised no style or process notes beyond these: the ones it did — `MAX_COMMIT_LOOKUPS` counting requests rather than pull requests, and `item.number` interpolated into a URL path without the digit-stripping `fetchPrDiff` uses — were both addressed in the doc comment and judged consistency-not-exposure respectively (the source is api.github.com over TLS).

</details>

<details>
<summary>Implementation notes</summary>

- `src/github-prs.js` — `fetchPrCommitDate` (one page of 100, following `Link rel="last"` once for a longer pull request; a failed second page discards the first page's stale answer rather than using it) and `resolveCommitDates` (the cache pre-pass, then the bounded walk). GitHub truncates the commit list at 250, so a pull request longer than that resolves to the newest of the 250 it lists.
- `src/patch-sources.cjs` — `orderByCommitDate` for display order. Resolved rows first by commit date; the rest follow in `updatedAt` order, which is not a claim about them.
- `src/latest-patch.cjs` — `prDateMs` reads `commitDate`; `pickLatest` gained `prRankComplete` and the near-tie rule. An undated pull request contributes its `updatedAt` as an upper bound on the runner-up and never as the answer, which is also what makes a list restored from a pre-change cache degrade safely rather than needing a migration.
- `src/main.js` — `rankComplete` is stored with the items and returned on both the fresh and the fallback path. The store shape change is purely additive.
- A failed lookup stops the walk rather than throwing more requests at a spent quota.

</details>

<details>
<summary>Screenshots or recording</summary>

Not captured — see the first limitation above. The visible change is small and stated precisely in **How to test this**: the pill moves to the April 2026 pull request, and each row's date line reads `last commit …` instead of `updated …`. Worth a reviewer confirming on a real #62064 rather than taking a still frame from me.

</details>
