### PR TITLE
Discard all changes rewinds the ticket to its base

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ const {
 const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
-const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, updateToLatestTrunk } = require('./trunk-update');
+const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
 const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
@@ -1150,6 +1150,32 @@ ipcMain.handle('git:unsubmitted-work', async (_e, sitePath) => {
     try {
         const files = await collectUnsubmittedFiles(sitePath);
         return { ok: true, dirty: files.length > 0, changedCount: files.length, files };
+    } catch (e) {
+        return { ok: false, error: String(e) };
+    }
+});
+
+// "Discard all changes" in the review-and-submit modal: throws away everything
+// the modal shows, which on a ticket branch is measured from the branch point
+// (#108/#239) and so includes the parked WIP commit. Rewinds to `patchBaseOid`
+// — the same base the diff was taken against — so the modal ends on "No
+// changes". The branch survives and the ticket stays linked; only its work is
+// gone. On trunk (or a branch with no recorded base) there is nothing past
+// HEAD to rewind, so it falls back to the uncommitted-only reset.
+ipcMain.handle('git:discard-to-base', async (_e, sitePath) => {
+    try {
+        const baseOid = await patchBaseOid(sitePath);
+        if (baseOid) {
+            await discardToBase(sitePath, baseOid);
+        } else {
+            await discardChanges(sitePath);
+        }
+        await writeWorkMeta(sitePath, { appliedPatch: null });
+        let files = null;
+        try { files = await collectUnsubmittedFiles(sitePath); } catch {}
+        return files
+            ? { ok: true, dirty: files.length > 0, changedCount: files.length }
+            : { ok: true };
     } catch (e) {
         return { ok: false, error: String(e) };
     }

--- a/src/preload.js
+++ b/src/preload.js
@@ -180,6 +180,8 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	discardChanges: (sitePath) => ipcRenderer.invoke('git:discard-changes', sitePath)
 ,
+	discardToBase: (sitePath) => ipcRenderer.invoke('git:discard-to-base', sitePath)
+,
 	markUpdateComplete: (sitePath) => ipcRenderer.invoke('sites:mark-update-complete', sitePath)
 ,
 	choosePatchFile: () => ipcRenderer.invoke('dialog:choose-patch-file')

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2882,6 +2882,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     applyDiscardToNote(discardOutcome(d));
     setDirtyModalOpen(false);
     writeToTerminal('\nDiscarded local changes.\n');
+    confirm('Local changes discarded.');
     beginTrunkUpdate();
   });
 
@@ -2953,7 +2954,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     try {
       let outcome;
       try {
-        outcome = discardOutcome(await window.api.discardChanges(sitePath));
+        outcome = discardOutcome(await window.api.discardToBase(sitePath));
       } catch (e) {
         // A rejected invoke never returns a reply object; shape it into one so
         // the failure reaches the same red line instead of vanishing.
@@ -2966,6 +2967,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       applyDiscardToNote(outcome);
       setAppliedPatch(null);
       writeToTerminal('\nDiscarded local changes.\n');
+      confirm('All changes discarded.');
       if (isPatchOpen) await loadPatchText();
     } finally {
       setDiscarding(false);
@@ -4522,7 +4524,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:12, flexWrap:'wrap' }}>
                   <div>
                     <div style={{ fontWeight:600, fontSize:14, color:'#1d2327', display:'flex', alignItems:'baseline', gap:4, flexWrap:'wrap' }}>
-                      Your changes
+                      {tracTicket ? `Your changes for ticket #${tracTicket}` : 'Your changes'}
                       <span style={{ fontWeight:400 }}>
                         {'('}
                         <Button

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -138,6 +138,55 @@ async function discardChanges(dir) {
 }
 
 /**
+ * Discards everything the patch modal shows — the whole diff against `baseOid`,
+ * not just the uncommitted edits `discardChanges` rewinds. On a ticket branch
+ * the modal measures from the branch point (#108/#239), so its "your changes"
+ * includes the parked WIP commit; rewinding the branch ref to `baseOid` before
+ * the forced checkout throws that commit away too, leaving the tree at the base
+ * with "No changes" to show.
+ *
+ * Kept separate from `discardChanges` on purpose: the trunk-update dirty flow
+ * and the switch-off-trunk flow must reset only uncommitted edits and preserve
+ * parked ticket work, so they stay on `discardChanges`. This one is the modal's
+ * "Discard all changes", where the contributor has asked for the whole thing to
+ * go. The branch is not deleted and the ticket stays linked — the substrate
+ * survives, only its work is rewound; deleting the branch is what "Delete this
+ * ticket's work" is for.
+ *
+ * @param {string} dir
+ * @param {string} baseOid The commit the modal diffed against — the branch point.
+ */
+async function discardToBase(dir, baseOid) {
+	await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs, dir });
+	for (const [filepath, head, workdir] of matrix) {
+		if (head === 0) {
+			try { await git.remove({ fs, dir, filepath }); } catch {}
+			if (workdir !== 0) {
+				try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
+			}
+		}
+	}
+	const ref = (await git.currentBranch({ fs, dir, fullname: false })) || 'trunk';
+	// Only rewind the ref when baseOid really is this branch's own history — its
+	// point off trunk. patchBaseOid falls back to the live `trunk` tip for a
+	// branch with no recorded base (hand-created, or a hand-edited registry);
+	// that tip need not be an ancestor of HEAD, and moving the ref onto it would
+	// orphan the branch's commits and re-point it at unrelated work. When it is
+	// not an ancestor, leave the ref alone and just reset the worktree to HEAD —
+	// the uncommitted-only discard, which never throws away committed work.
+	const head = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+	let rewind = false;
+	if (baseOid !== head) {
+		try { rewind = await git.isDescendent({ fs, dir, oid: head, ancestor: baseOid }); } catch { rewind = false; }
+	}
+	if (rewind) {
+		await git.writeRef({ fs, dir, ref: `refs/heads/${ref}`, value: baseOid, force: true });
+	}
+	await git.checkout({ fs, dir, ref, force: true });
+}
+
+/**
  * Step 1 of the update chain: fetch the latest remote trunk and hard-reset
  * the site to it. Returns { upToDate, oldOid, newOid, lockfileChanged,
  * trunkDate }; throws with `error.stage` set to 'fetch' (nothing moved —
@@ -226,5 +275,6 @@ module.exports = {
 	readTrunkInfo,
 	collectDirtyFiles,
 	discardChanges,
+	discardToBase,
 	updateToLatestTrunk
 };

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -589,6 +589,35 @@ test('git:discard-changes reports the parked work that survives it (#239)', asyn
 	assert.equal(res.changedCount, 1);
 });
 
+// The submit modal's "Discard all changes" is the opposite promise (#270): it
+// throws away the whole diff the modal shows — measured from the branch point,
+// so parked WIP included — by rewinding the branch ref to its base. The branch
+// survives and the ticket stays linked; only its work is gone, so the reply is
+// clean.
+test('git:discard-to-base rewinds the branch to its base, parked work included (#270)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t);
+	fs.writeFileSync(path.join(dir, 'loose.php'), '<?php // uncommitted\n');
+	const main = parkedTicketMain(dir, baseOid);
+
+	const res = await main.invoke('git:discard-to-base', dir);
+
+	assert.equal(res.ok, true);
+	assert.equal(fs.existsSync(path.join(dir, 'loose.php')), false, 'the uncommitted edit is gone');
+	assert.doesNotMatch(
+		fs.readFileSync(path.join(dir, 'wp-login.php'), 'utf8'),
+		/the ticket work/,
+		'the parked work is rewound too, unlike a plain discard'
+	);
+	assert.equal(await git.resolveRef({ fs, dir, ref: 'HEAD' }), baseOid, 'HEAD is the branch base');
+	assert.equal(
+		await git.currentBranch({ fs, dir, fullname: false }),
+		'ticket/62281',
+		'still on the ticket branch — the ticket stays linked'
+	);
+	assert.equal(res.dirty, false, 'nothing survives, so the note goes clean');
+	assert.equal(res.changedCount, 0);
+});
+
 test('git:update-trunk hands the update to trunk-update and streams its log back', async () => {
 	let called;
 	const started = new Promise((resolve) => { called = resolve; });
@@ -3396,6 +3425,7 @@ const WIRED = new Set([
 	'git:worktree-dirty',
 	'git:unsubmitted-work',
 	'git:discard-changes',
+	'git:discard-to-base',
 	'git:update-trunk',
 	'git:get-patch',
 	'git:create-patch',

--- a/test/trunk-update.integration.test.cjs
+++ b/test/trunk-update.integration.test.cjs
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const git = require('isomorphic-git');
-const { collectDirtyFiles, discardChanges, readTrunkInfo } = require('../src/trunk-update.js');
+const { collectDirtyFiles, discardChanges, discardToBase, readTrunkInfo } = require('../src/trunk-update.js');
 
 const AUTHOR = { name: 'test', email: 'test@example.com' };
 
@@ -63,6 +63,58 @@ test('discardChanges: restores tracked files and deletes untracked ones, even st
 	assert.strictEqual(fs.existsSync(path.join(dir, 'untracked.txt')), false);
 	assert.strictEqual(fs.existsSync(path.join(dir, 'staged-untracked.txt')), false);
 	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+test('discardToBase: rewinds the branch to base, dropping parked WIP and edits (issue #270)', async (t) => {
+	const dir = await makeRepo(t);
+	const baseOid = await git.resolveRef({ fs, dir, ref: 'refs/heads/trunk' });
+	await git.branch({ fs, dir, ref: 'ticket/36259', object: 'trunk', checkout: true });
+
+	// Parked work: a committed WIP on top of the branch point — what the patch
+	// modal measures as "your changes" but a plain discard would keep (#108).
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'parked work\n');
+	await git.add({ fs, dir, filepath: 'text.txt' });
+	await git.commit({ fs, dir, message: 'WIP', author: AUTHOR, parent: [baseOid] });
+	// Uncommitted edits and an untracked file on top of the parked commit.
+	fs.appendFileSync(path.join(dir, 'text.txt'), 'unsaved scribble\n');
+	fs.writeFileSync(path.join(dir, 'untracked.txt'), 'new\n');
+
+	await discardToBase(dir, baseOid);
+
+	// The whole diff is gone: tree is the base tree, HEAD is the base commit
+	// (parked WIP orphaned), still on the ticket branch, untracked file removed.
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'text.txt'), 'utf8'), 'line1\nline2\n');
+	assert.strictEqual(fs.existsSync(path.join(dir, 'untracked.txt')), false);
+	assert.strictEqual(await git.resolveRef({ fs, dir, ref: 'HEAD' }), baseOid);
+	assert.strictEqual(await git.currentBranch({ fs, dir, fullname: false }), 'ticket/36259');
+	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+test('discardToBase: a base that is not an ancestor of HEAD does not rewind the branch (issue #270)', async (t) => {
+	const dir = await makeRepo(t);
+	const trunkStart = await git.resolveRef({ fs, dir, ref: 'refs/heads/trunk' });
+	// A ticket branch with a committed WIP off the original trunk point.
+	await git.branch({ fs, dir, ref: 'ticket/36259', object: 'trunk', checkout: true });
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'committed ticket work\n');
+	await git.add({ fs, dir, filepath: 'text.txt' });
+	const wip = await git.commit({ fs, dir, message: 'WIP', author: AUTHOR, parent: [trunkStart] });
+	// Trunk advances to a commit that is a sibling of the ticket HEAD, not an
+	// ancestor — the shape patchBaseOid's fallback would hand a branch with no
+	// recorded base once trunk has moved on.
+	await git.checkout({ fs, dir, ref: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'other.txt'), 'unrelated trunk work\n');
+	await git.add({ fs, dir, filepath: 'other.txt' });
+	const trunkTip = await git.commit({ fs, dir, message: 'trunk moves on', author: AUTHOR, parent: [trunkStart] });
+	await git.checkout({ fs, dir, ref: 'ticket/36259' });
+	fs.appendFileSync(path.join(dir, 'text.txt'), 'unsaved scribble\n');
+
+	await discardToBase(dir, trunkTip);
+
+	// The non-ancestor base is refused: the branch is not rewound onto it, the
+	// committed work survives, and only the uncommitted scribble is cleared.
+	assert.strictEqual(await git.resolveRef({ fs, dir, ref: 'HEAD' }), wip, 'the ref is left at the WIP commit');
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'text.txt'), 'utf8'), 'committed ticket work\n');
+	assert.strictEqual(await git.currentBranch({ fs, dir, fullname: false }), 'ticket/36259');
 });
 
 test('readTrunkInfo: returns the HEAD oid and its committer date (issue #94)', async (t) => {


### PR DESCRIPTION
## What & why

In **Review & submit changes**, clicking **Discard all changes** appeared to do nothing on a ticket-linked site (issue #270). The modal shows the working tree diffed against the ticket branch's **base** (its point off trunk), so "your changes" includes the **parked WIP commit** — but `discardChanges` only reset the tree to the branch **HEAD**, keeping that commit. When the shown changes were the parked commit, discard removed nothing the modal measures, so it reloaded identically.

## Approach

- **`discardToBase(dir, baseOid)`** (`src/trunk-update.js`) — rewinds the branch ref to the same base the diff is taken against (`git.writeRef` → `git.checkout({ force })`) before materialising the tree, so the *whole* diff — parked WIP included — is discarded. The branch survives and the ticket stays linked; only its work is rewound. Deleting the branch remains what "Delete this ticket's work" is for.
- **`git:discard-to-base`** IPC (`src/main.js`) picks the baseline via `patchBaseOid` (on trunk there's no base past HEAD, so it falls back to the uncommitted-only `discardChanges`). `discardChanges` itself is **untouched**, so the trunk-update dirty flow and switch-off-trunk flow still preserve parked work.
- The submit modal's discard points at the new channel; the update-flow discard stays HEAD-relative.
- Header now names the ticket: **"Your changes for ticket #N"**.
- A completed discard is confirmed through the accessible toast (#253) from both the modal and the update flow.

## Decision

"Discard all changes" now discards *everything the modal shows* while keeping the ticket linked (empties it to base) — chosen over deleting the branch outright.

## Tests

- `discardToBase` integration test (parked WIP + edits + untracked → tree back at base, HEAD at base, still on the ticket branch).
- `git:discard-to-base` IPC wiring test + coverage-guard entry.
- Full suite: 813 passing; lint clean; renderer bundles.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)