### PR TITLE
Say how much of a patch failed, why, and what to do next when it will not apply

### DIFF
--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -113,15 +113,175 @@ function reverseFile(file) {
 	};
 }
 
+// How many failing regions carry their own lines, and how many lines each of
+// those carries. Everything else is still counted and located — only the
+// content is dropped. The whole diagnosis crosses IPC and then has to fit in a
+// notice, and a patch that misses in forty places would otherwise send forty
+// blocks of diff to a panel nobody can read.
+const REGION_DETAIL_LIMIT = 3;
+const REGION_LINE_LIMIT = 10;
+
+/**
+ * The `-`/`+` lines of one hunk — what that region was trying to change.
+ * Context lines are dropped: they are what the region was looking for, not what
+ * it wanted to do, and they are the bulk of the text.
+ *
+ * @param {Object} hunk
+ * @return {{lines: Array<string>, more: number}}
+ */
+function changedLines(hunk) {
+	const changed = (hunk.lines || []).filter((line) => line[0] === '+' || line[0] === '-');
+	return {
+		lines: changed.slice(0, REGION_LINE_LIMIT),
+		more: Math.max(0, changed.length - REGION_LINE_LIMIT)
+	};
+}
+
+/**
+ * A line the contributor can search for to find this region in *their* file.
+ *
+ * The hunk's line numbers cannot serve: they are coordinates in the file as it
+ * was when the patch was written, and on an old patch they miss by dozens —
+ * precision that sends someone to the wrong place. A line of content survives
+ * the drift, so the notice offers text for the editor's search instead.
+ *
+ * Which line to prefer depends on why the region failed — a region whose
+ * surroundings moved usually still has the very line it wants to change, one
+ * already applied has the *result* — but "usually" is not a promise, so every
+ * candidate is checked against the file itself and the first one actually
+ * present wins. Only when nothing from the hunk survives in the file does the
+ * preference order alone decide, as the least-bad thing to show.
+ *
+ * @param {Object}  hunk
+ * @param {boolean} alreadyApplied
+ * @param {string}  text           Current file contents, EOL-normalised.
+ * @return {string} A trimmed line, or '' when the hunk offers nothing usable.
+ */
+function anchorLine(hunk, alreadyApplied, text) {
+	const lines = hunk.lines || [];
+	const candidates = (marker) => lines
+		.filter((line) => line[0] === marker && line.slice(1).trim())
+		.map((line) => line.slice(1).trim().slice(0, 120));
+	const preferred = alreadyApplied ? ['+', '-', ' '] : ['-', ' ', '+'];
+	for (const marker of preferred) {
+		// Longest present candidate, not first: the first line of a hunk is
+		// often a bare brace, and "near `}`" locates nothing.
+		const present = candidates(marker).filter((line) => text.includes(line));
+		if (present.length) return present.reduce((a, b) => (b.length > a.length ? b : a));
+	}
+	for (const marker of preferred) {
+		const [firstLine] = candidates(marker);
+		if (firstLine) return firstLine;
+	}
+	return '';
+}
+
+/**
+ * Which regions of a patch no longer fit a file, and why.
+ *
+ * `JsDiff.applyPatch` answers for a whole file at once, so a patch that misses
+ * in one place out of twenty is indistinguishable from one that misses
+ * everywhere — and those are opposite decisions for the contributor (#282).
+ * Asking the same question once per hunk is all it takes to tell them apart.
+ *
+ * The reverse answers *why*: a region whose inverse fits is one whose change is
+ * already in the file, so the patch is redundant there rather than stale (#226).
+ * That is the same reasoning `patchIsAbsent` uses below, asked per region.
+ *
+ * **Evidence, not proof.** `applyPatch` searches by offset for somewhere the
+ * context fits, so a region whose surroundings repeat can match in the wrong
+ * place. That is acceptable for choosing what to say and is never acceptable
+ * for deciding what to write — nothing here reaches a write. Each hunk is also
+ * matched against the file as it is now, not as earlier hunks would have left
+ * it, which is the only question that can be asked when nothing is applied.
+ *
+ * @param {string} text Current file contents, EOL-normalised.
+ * @param {Object} file Parsed patch file.
+ * @return {?{total: number, regions: Array<Object>}} null when nothing to add.
+ */
+function diagnoseHunks(text, file) {
+	const hunks = file.hunks || [];
+	if (!hunks.length) return null;
+
+	const regions = [];
+	hunks.forEach((hunk, index) => {
+		const single = { ...file.patch, hunks: [hunk] };
+		if (JsDiff.applyPatch(text, single) !== false) return;
+		const alreadyApplied = JsDiff.applyPatch(text, JsDiff.reversePatch(single)) !== false;
+		const region = {
+			index,
+			// The patch's own coordinates, kept for logs and tests — the notice
+			// leads with `anchor`, because on an old patch these numbers point at
+			// where the code *used* to be, not where the contributor will find it.
+			line: hunk.oldStart,
+			status: alreadyApplied ? 'already-applied' : 'moved',
+			anchor: anchorLine(hunk, alreadyApplied, text)
+		};
+		// Only the first few regions carry their lines; the rest are still named
+		// and located, which is what the counts are built from.
+		if (regions.length < REGION_DETAIL_LIMIT) {
+			const { lines, more } = changedLines(hunk);
+			region.lines = lines;
+			if (more) region.more = more;
+		}
+		regions.push(region);
+	});
+
+	// A file can fail as a whole while every region passes alone: applied one at
+	// a time they are matched against the unshifted file, and two that overlap
+	// once applied do not. There is nothing useful to say about that, so the
+	// caller keeps its original sentence rather than claiming zero conflicts.
+	if (!regions.length) return null;
+	return { total: hunks.length, regions };
+}
+
+/**
+ * The one sentence for a file the patch no longer fits.
+ *
+ * Kept in a single place because three branches of `resolveFile` produce it and
+ * the tests match on its wording.
+ *
+ * @param {string}  label     Path to name.
+ * @param {?Object} diagnosis From `diagnoseHunks`, or null.
+ * @return {string}
+ */
+function conflictSentence(label, diagnosis) {
+	if (!diagnosis) {
+		return `${label} has moved on since the patch was written, so it no longer applies`;
+	}
+	const failed = diagnosis.regions.length;
+	const { total } = diagnosis;
+	if (failed === total) {
+		return `${label} has moved on since the patch was written, so none of its ${total} change${total === 1 ? '' : 's'} still fits`;
+	}
+	return `${label} has moved on since the patch was written: ${failed} of its ${total} changes no longer fit, and the other ${total - failed} do`;
+}
+
 /**
  * Works out what one file's new content should be, without touching disk.
  * Also captures what is there now, so a failed write can be rolled back.
  *
- * @param {string} dir
- * @param {Object} file
+ * `diagnose` is off for `patchIsAbsent`, which only ever reads `.error` — every
+ * file it asks about is expected to resolve, and diagnosing the ones that do not
+ * would be work whose answer is discarded.
+ *
+ * @param {string}  dir
+ * @param {Object}  file
+ * @param {Object}  [options]
+ * @param {boolean} [options.diagnose]
  * @return {Object}
  */
-function resolveFile(dir, file) {
+function resolveFile(dir, file, { diagnose = true } = {}) {
+	// The three "no longer applies" branches below share this: the sentence, and
+	// the per-region detail behind it when there is any.
+	const conflict = (label, text) => {
+		const diagnosis = diagnose ? diagnoseHunks(text, file) : null;
+		const error = conflictSentence(label, diagnosis);
+		// The sentence rides along inside the conflict as well, so the panel can
+		// line each detail up with its entry in `failures` without re-deriving it.
+		return diagnosis ? { error, conflict: { path: label, error, ...diagnosis } } : { error };
+	};
+
 	const target = resolveInside(dir, file.path);
 	if (!target) return { error: `${file.path} points outside the site folder` };
 
@@ -131,9 +291,9 @@ function resolveFile(dir, file) {
 		// Validate the file still matches what the patch expects to remove, so an
 		// edit made after the preview fails all-or-nothing rather than being
 		// silently deleted with the contributor's changes in it.
-		if (file.hunks && file.hunks.length
-			&& JsDiff.applyPatch(normalizeEol(previous.toString('utf8')), file.patch) === false) {
-			return { error: `${file.path} has moved on since the patch was written, so it no longer applies` };
+		if (file.hunks && file.hunks.length) {
+			const text = normalizeEol(previous.toString('utf8'));
+			if (JsDiff.applyPatch(text, file.patch) === false) return conflict(file.path, text);
 		}
 		return { op: 'delete', abs: target, path: file.path, previous };
 	}
@@ -158,10 +318,9 @@ function resolveFile(dir, file) {
 		let content = originalBuf;
 		if (file.hunks.length) {
 			const original = originalBuf.toString('utf8');
-			const applied = JsDiff.applyPatch(normalizeEol(original), file.patch);
-			if (applied === false) {
-				return { error: `${file.oldPath} has moved on since the patch was written, so it no longer applies` };
-			}
+			const text = normalizeEol(original);
+			const applied = JsDiff.applyPatch(text, file.patch);
+			if (applied === false) return conflict(file.oldPath, text);
 			content = applied.replace(/\n/g, dominantEol(original) === '\r\n' ? '\r\n' : '\n');
 		}
 		return {
@@ -176,10 +335,9 @@ function resolveFile(dir, file) {
 	// checkout does not make every context line miss — but the file is written
 	// back with the endings it already had.
 	const raw = fs.readFileSync(target, 'utf8');
-	const applied = JsDiff.applyPatch(normalizeEol(raw), file.patch);
-	if (applied === false) {
-		return { error: `${file.path} has moved on since the patch was written, so it no longer applies` };
-	}
+	const normalized = normalizeEol(raw);
+	const applied = JsDiff.applyPatch(normalized, file.patch);
+	if (applied === false) return conflict(file.path, normalized);
 	const content = dominantEol(raw) === '\r\n' ? applied.replace(/\n/g, '\r\n') : applied;
 	return { op: 'write', abs: target, path: file.path, content, previous: Buffer.from(raw, 'utf8') };
 }
@@ -216,7 +374,7 @@ function resolveFile(dir, file) {
 function patchIsAbsent(dir, files) {
 	const text = files.filter((f) => f.kind !== 'binary');
 	if (!text.length) return false;
-	return text.every((f) => !resolveFile(dir, f).error);
+	return text.every((f) => !resolveFile(dir, f, { diagnose: false }).error);
 }
 
 /**
@@ -285,15 +443,20 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	const actions = [];
 	const skipped = [];
 	const failures = [];
+	const conflicts = [];
 
 	for (const file of files) {
 		if (file.kind === 'binary') {
 			skipped.push(file.path);
 			continue;
 		}
-		const resolved = resolveFile(dir, file);
+		// No diagnosis on a reverse: the panel discards it — the patch being
+		// reverted came through this app, and the ticket's other patches are no
+		// answer to a revert that failed.
+		const resolved = resolveFile(dir, file, { diagnose: !reverse });
 		if (resolved.error) {
 			failures.push(resolved.error);
+			if (resolved.conflict) conflicts.push(resolved.conflict);
 			continue;
 		}
 		actions.push(resolved);
@@ -316,7 +479,11 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 			return { ok: false, notApplied: true, error, applied: [], skipped };
 		}
 		onLog(`\nThe patch was not applied — the checkout is unchanged.\n${failures.map((f) => `  • ${f}\n`).join('')}`);
-		return { ok: false, error: failures[0], failures, applied: [], skipped };
+		// `failures` carries every file, not just the first: the panel used to show
+		// `error` alone and send the rest to the terminal, where a contributor has
+		// no reason to be looking (#282). `conflicts` is the same failures with
+		// their regions, for the ones that have any.
+		return { ok: false, error: failures[0], failures, conflicts, applied: [], skipped };
 	}
 
 	if (!actions.length && !skipped.length) {
@@ -369,4 +536,4 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	return { ok: true, applied, skipped };
 }
 
-module.exports = { applyPatchToDir, resolveInside, reverseFile, dominantEol, rollback };
+module.exports = { applyPatchToDir, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -107,8 +107,54 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
 }
 
 /**
+ * The pull-request framing: whose problem this is, and how big.
+ *
+ * The regions belong to whoever updates the pull request, and that is its
+ * author, not the contributor reading this notice — showing them line-level
+ * detail invites them into work that is not theirs. What they need instead is
+ * the situation named (the PR is behind trunk), the scale (files and places),
+ * and the one act that is genuinely theirs: telling the author.
+ *
+ * "No longer fits today's trunk" rather than "has conflicts": the app matches
+ * without the pull request's base, so its count can include a region a real
+ * merge would settle — close enough to size the problem, not a claim GitHub
+ * will show the identical number.
+ *
+ * @param {Array} conflicts
+ * @return {{headline: string, advice: string}}
+ */
+function prFraming(conflicts) {
+	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
+	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
+	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
+
+	// A pull request whose changes are all in trunk already needs no rebase and
+	// no message — there is nothing left for anyone to do with it.
+	if (allApplied && failed === total) {
+		return {
+			headline: `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in trunk — there is nothing left to apply.`,
+			advice: ''
+		};
+	}
+
+	const files = conflicts.length;
+	const scale = `${failed} of its ${total} change${total === 1 ? '' : 's'}, in ${files} file${files === 1 ? '' : 's'},`;
+	return {
+		headline: `This pull request was written against an older trunk and no longer fits it: ${scale} would need rework.`,
+		advice: 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.'
+	};
+}
+
+/**
  * Everything the panel needs to explain a failed apply, or null when there is
  * nothing to explain.
+ *
+ * Two framings, chosen by where the patch came from. A pull request has an
+ * author who is the one to fix it, so the notice names the situation and the
+ * scale and points at them — no line-level detail. A loose patch (a Trac
+ * attachment, a file from disk) has nobody to send the contributor to, so it
+ * keeps the full per-region breakdown: there, the contributor with the failing
+ * lines in hand is the only way out.
  *
  * `items` follows the order of `failures` so that a patch failing for mixed
  * reasons — one file with drifted regions, another simply not in the checkout —
@@ -133,6 +179,8 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	// the panel keeps rendering it exactly as it did before.
 	if (!failures.length && !conflicts.length) return null;
 
+	const fromPr = Boolean(prUrl);
+
 	// Each conflict is consumed as it is matched, not looked up in a map: a
 	// concatenated patch can fail the same file twice with the identical
 	// sentence, and a map would show one breakdown twice while dropping the
@@ -148,14 +196,24 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 			path: conflict.path,
 			total: conflict.total,
 			failed: conflict.regions.length,
-			regions: conflict.regions.map(describeRegion)
+			// For a pull request the regions are the author's problem; the file
+			// row with its counts is the whole story the contributor needs.
+			regions: fromPr ? [] : conflict.regions.map(describeRegion)
 		};
 	});
 
+	// With no conflicts to count there is nothing to summarise that the items
+	// do not already say, so the headline stands down rather than padding.
+	let headline = '';
+	let advice = '';
+	if (conflicts.length) {
+		const framing = fromPr ? prFraming(conflicts) : { headline: headlineFor(conflicts), advice: '' };
+		headline = framing.headline;
+		advice = framing.advice;
+	}
 	return {
-		// With no conflicts to count there is nothing to summarise that the items
-		// do not already say, so the headline stands down rather than padding.
-		headline: conflicts.length ? headlineFor(conflicts) : '',
+		headline,
+		advice,
 		items,
 		// Both are offered only when they lead somewhere, the way open-failure.cjs
 		// withholds its picker: a way out that returns to the same dead end is

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -115,33 +115,60 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
  * the situation named (the PR is behind trunk), the scale (files and places),
  * and the one act that is genuinely theirs: telling the author.
  *
+ * The pull request's state changes who that act is for. Asking a closed pull
+ * request's author for a rebase asks for work on something they walked away
+ * from — and in wordpress-develop "closed" is also what *landing* looks like,
+ * since core commits go through SVN and the pull request is closed, never
+ * merged. The regions tell those apart: a landed change reads back as already
+ * in the checkout, an abandoned one as moved.
+ *
  * "No longer fits today's trunk" rather than "has conflicts": the app matches
  * without the pull request's base, so its count can include a region a real
  * merge would settle — close enough to size the problem, not a claim GitHub
  * will show the identical number.
  *
- * @param {Array} conflicts
- * @return {{headline: string, advice: string}}
+ * @param {Array}   conflicts
+ * @param {?string} prState   'open' | 'merged' | 'closed' | null when unknown.
+ * @return {{headline: string, advice: string, prButton: ?string}}
  */
-function prFraming(conflicts) {
+function prFraming(conflicts, prState) {
 	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
 	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
 	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
+	const closed = prState === 'closed' || prState === 'merged';
 
 	// A pull request whose changes are all in trunk already needs no rebase and
-	// no message — there is nothing left for anyone to do with it.
+	// no message — there is nothing left for anyone to do with it. When it is
+	// also closed, that is core's own way of landing a change: committed via
+	// SVN, pull request closed.
 	if (allApplied && failed === total) {
 		return {
-			headline: `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in trunk — there is nothing left to apply.`,
-			advice: ''
+			headline: closed
+				? `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in trunk — it was likely committed to core, which is why it is closed. There is nothing left to apply.`
+				: `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in trunk — there is nothing left to apply.`,
+			advice: '',
+			prButton: null
 		};
 	}
 
 	const files = conflicts.length;
 	const scale = `${failed} of its ${total} change${total === 1 ? '' : 's'}, in ${files} file${files === 1 ? '' : 's'},`;
+
+	// A closed pull request has no author coming back to it: asking for a
+	// rebase would be a message into the void. The way forward is the ticket —
+	// another patch, or redoing the change, which is a contribution in itself.
+	if (closed) {
+		return {
+			headline: `This pull request is closed and was written against an older trunk — it no longer fits: ${scale} would need rework.`,
+			advice: 'Nobody is coming back to update a closed pull request — its discussion may say why it ended. Redoing the change against today\'s code is a contribution in itself.',
+			prButton: 'See why it was closed'
+		};
+	}
+
 	return {
 		headline: `This pull request was written against an older trunk and no longer fits it: ${scale} would need rework.`,
-		advice: 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.'
+		advice: 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.',
+		prButton: 'Ask its author for a rebase'
 	};
 }
 
@@ -167,9 +194,10 @@ function prFraming(conflicts) {
  * @param {Object}  [options]
  * @param {number}  [options.otherPatchCount] Other patches on this ticket.
  * @param {?string} [options.prUrl]           The failing patch's pull request.
+ * @param {?string} [options.prState]         Its state, when known.
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -206,10 +234,14 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	// do not already say, so the headline stands down rather than padding.
 	let headline = '';
 	let advice = '';
+	let prButton = fromPr ? 'Open the pull request' : null;
 	if (conflicts.length) {
-		const framing = fromPr ? prFraming(conflicts) : { headline: headlineFor(conflicts), advice: '' };
+		const framing = fromPr
+			? prFraming(conflicts, prState)
+			: { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;
+		prButton = framing.prButton;
 	}
 	return {
 		headline,
@@ -219,7 +251,8 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 		// withholds its picker: a way out that returns to the same dead end is
 		// worse than no button, because it costs a click to find that out.
 		offerOtherPatches: othersAvailable > 0,
-		prUrl: prUrl || null
+		prUrl: prUrl && prButton ? prUrl : null,
+		prButton
 	};
 }
 

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -1,0 +1,168 @@
+// What the panel says when a patch will not apply.
+//
+// The refusal itself is right and stays: nothing is written, and a patch placed
+// approximately is worse than no patch at all. What was wrong is everything
+// after it (#282). "This file has moved on" read identically whether one region
+// of twenty missed or all twenty did — opposite decisions for the contributor,
+// who either spends ten minutes on a salvageable change or throws it away — and
+// the panel showed only the first failing file, sending the rest to the terminal
+// where nobody is looking.
+//
+// So this turns `applyPatchToDir`'s failure payload into something to act on:
+// every failing file, how much of the patch actually missed, where, why (#226),
+// and what those regions were trying to do. Plus the two ways out that need no
+// data the app is not already holding — the ticket's other patches, and the pull
+// request itself, where a rebase is someone else's to do.
+//
+// Pure and dependency-free like open-failure.cjs, and for the same reason: the
+// renderer bundle imports it, `node --test` requires it directly, and neither
+// needs a DOM.
+'use strict';
+
+// Why a region no longer fits, in the contributor's terms.
+//
+// Hedged on purpose. Matching searches for somewhere the surrounding lines fit,
+// so a region whose surroundings repeat can be recognised in the wrong place —
+// good enough to choose a sentence, never good enough to decide what to write.
+// "Looks like" is that uncertainty, said out loud rather than buried here.
+const REASONS = {
+	'already-applied': 'looks like it is already in your checkout',
+	moved: 'the code around it has changed'
+};
+
+/**
+ * One failing region, ready to render.
+ *
+ * @param {Object} region
+ * @return {Object}
+ */
+function describeRegion(region) {
+	return {
+		line: region.line,
+		status: region.status,
+		reason: REASONS[region.status] || 'it no longer fits',
+		// A line to search for, not a number to go to: the hunk's line numbers
+		// are in the patched file's coordinates and miss by the drift the patch
+		// failed on. The panel leads with this and keeps `line` as the fallback.
+		anchor: region.anchor || '',
+		lines: region.lines || [],
+		more: region.more || 0
+	};
+}
+
+/**
+ * The headline: how much of the patch missed, across every file.
+ *
+ * Counts, not adjectives. "2 of 20" is the whole point — it is what separates a
+ * patch worth rescuing by hand from one that is genuinely dead.
+ *
+ * The already-applied case gets its own sentences: a patch whose changes are
+ * all in the tree already fails every region, and "none of its changes still
+ * fit" over rows saying "already in your checkout" would be the banner
+ * contradicting itself — with the headline, the half that decides whether the
+ * patch gets thrown away, telling the wrong story.
+ *
+ * @param {Array} conflicts
+ * @return {string}
+ */
+function headlineFor(conflicts) {
+	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
+	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
+	const changes = `change${total === 1 ? '' : 's'}`;
+	const where = conflicts.length === 1 ? '' : ` across ${conflicts.length} files`;
+	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
+
+	if (allApplied) {
+		if (failed === total) {
+			return `All ${total} of this patch's ${changes}${where} look like they are already in your checkout.`;
+		}
+		return `${failed} of this patch's ${total} ${changes}${where} look like they are already in your checkout — the other ${total - failed} still fit.`;
+	}
+	if (failed === total) {
+		return `None of this patch's ${total} ${changes}${where} still fit your checkout.`;
+	}
+	return `${failed} of this patch's ${total} ${changes}${where} no longer fit — the other ${total - failed} do.`;
+}
+
+/**
+ * How many other patches the ticket is offering besides the one that failed.
+ *
+ * The answer decides whether "try another patch" is a way out or a click back
+ * to the same dead end, so only what is already on screen counts — Trac
+ * attachments load on demand and are genuinely not there until asked for.
+ * Matching is by the preview's label on both lists: a failed PR is labelled
+ * `PR #n`, a failed attachment (or the same file picked from disk) by its
+ * filename.
+ *
+ * @param {Object}  root0
+ * @param {?string} root0.label         The failed preview's label.
+ * @param {Array}   [root0.prs]         The ticket's linked pull requests.
+ * @param {Array}   [root0.attachments] The ticket's loaded patch attachments.
+ * @return {number}
+ */
+function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
+	const failedLabel = label || '';
+	return prs.filter((pr) => `PR #${pr.number}` !== failedLabel).length
+		+ attachments.filter((att) => att.filename !== failedLabel).length;
+}
+
+/**
+ * Everything the panel needs to explain a failed apply, or null when there is
+ * nothing to explain.
+ *
+ * `items` follows the order of `failures` so that a patch failing for mixed
+ * reasons — one file with drifted regions, another simply not in the checkout —
+ * reads as one list rather than two. Failures with no region detail keep their
+ * own sentence; that covers every non-conflict refusal (a path escaping the
+ * folder, a file to add that already exists) as well as the conflict that could
+ * not be broken down.
+ *
+ * @param {Object}  result                    The apply payload from main.
+ * @param {Object}  [options]
+ * @param {number}  [options.otherPatchCount] Other patches on this ticket.
+ * @param {?string} [options.prUrl]           The failing patch's pull request.
+ * @return {?Object}
+ */
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null } = {}) {
+	if (!result || result.ok) return null;
+
+	const failures = Array.isArray(result.failures) ? result.failures : [];
+	const conflicts = Array.isArray(result.conflicts) ? result.conflicts : [];
+	// Nothing structured to add: a parse failure, a write that was rolled back,
+	// a refusal from main. The single sentence is already the whole story, and
+	// the panel keeps rendering it exactly as it did before.
+	if (!failures.length && !conflicts.length) return null;
+
+	// Each conflict is consumed as it is matched, not looked up in a map: a
+	// concatenated patch can fail the same file twice with the identical
+	// sentence, and a map would show one breakdown twice while dropping the
+	// other from the counts.
+	const unmatched = [...conflicts];
+	const sentences = failures.length ? failures : conflicts.map((c) => c.error);
+	const items = sentences.map((text) => {
+		const at = unmatched.findIndex((c) => c.error === text);
+		const conflict = at === -1 ? null : unmatched.splice(at, 1)[0];
+		if (!conflict) return { kind: 'note', text };
+		return {
+			kind: 'conflict',
+			path: conflict.path,
+			total: conflict.total,
+			failed: conflict.regions.length,
+			regions: conflict.regions.map(describeRegion)
+		};
+	});
+
+	return {
+		// With no conflicts to count there is nothing to summarise that the items
+		// do not already say, so the headline stands down rather than padding.
+		headline: conflicts.length ? headlineFor(conflicts) : '',
+		items,
+		// Both are offered only when they lead somewhere, the way open-failure.cjs
+		// withholds its picker: a way out that returns to the same dead end is
+		// worse than no button, because it costs a click to find that out.
+		offerOtherPatches: othersAvailable > 0,
+		prUrl: prUrl || null
+	};
+}
+
+module.exports = { describeApplyFailure, headlineFor, otherPatchCount, REASONS };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -160,7 +160,7 @@ function prFraming(conflicts, prState) {
 	if (closed) {
 		return {
 			headline: `This pull request is closed and was written against an older trunk — it no longer fits: ${scale} would need rework.`,
-			advice: 'Nobody is coming back to update a closed pull request — its discussion may say why it ended. Redoing the change against today\'s code is a contribution in itself.',
+			advice: 'Nobody is coming back to update a closed pull request — its discussion may say why it ended.',
 			prButton: 'See why it was closed'
 		};
 	}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -4736,11 +4736,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                           variant="secondary"
                           isSmall
                           onClick={() => {
-                            // The lists' Apply buttons are disabled while a
-                            // preview is up, so scrolling there without clearing
-                            // it would land on greyed-out rows — the same dead
-                            // end this button exists to escape.
+                            // Choosing another patch is walking away from this
+                            // one, so everything about it goes: the preview
+                            // (whose presence keeps the lists' Apply buttons
+                            // disabled) and the failure banner itself — an
+                            // error describing an abandoned attempt would sit
+                            // above the new one as noise.
                             setApplyPreview(null);
+                            clearApplyError();
                             ticketPatchesRef.current?.scrollIntoView({
                               block: 'center',
                               behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -4729,6 +4729,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     </div>
                   ))}
 
+                  {applyConflict.advice ? (
+                    <div style={{ marginTop: 8 }}>{applyConflict.advice}</div>
+                  ) : null}
+
                   {applyConflict.offerOtherPatches || applyConflict.prUrl ? (
                     <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                       {applyConflict.offerOtherPatches ? (
@@ -4753,7 +4757,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                       ) : null}
                       {applyConflict.prUrl ? (
                         <Button variant="secondary" isSmall onClick={() => window.api.openExternal(applyConflict.prUrl)}>
-                          Open the pull request
+                          Ask its author for a rebase
                         </Button>
                       ) : null}
                     </div>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -29,6 +29,7 @@ import { appendBounded, countLines } from './debug-log.cjs';
 import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
+import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -1309,6 +1310,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // chain shows its build step skipped and attributed to the watch (#262).
   const [applyBuildByWatcher, setApplyBuildByWatcher] = useState(false);
   const [applyError, setApplyError] = useState('');
+  // The failure broken down: which regions of the patch no longer fit, where,
+  // why, and what they were trying to change (#282, #226). Held beside
+  // applyError rather than replacing it — a refusal with nothing to break down
+  // (a parse error, a rolled-back write) still has only its sentence.
+  const [applyConflict, setApplyConflict] = useState(null);
+  // One call, because the breakdown must never outlive the sentence it belongs
+  // to: every place that took the error banner down predates it, and any that
+  // cleared only one would leave regions on screen describing a patch the
+  // contributor has moved on from.
+  const clearApplyError = () => { setApplyError(''); setApplyConflict(null); };
+  // Where "try another patch" goes. The list is already on screen when a patch
+  // fails — three rows above, in the case that prompted this — so the way out
+  // is a scroll, not a fetch.
+  const ticketPatchesRef = useRef(null);
   // Not every unhappy ending is a failure: a revert can find that the patch is
   // already gone, which resolves the situation rather than blocking it. Red
   // would read as "you broke something" when nothing is left to do.
@@ -2925,7 +2940,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // Reads a patch file and works out what it would do, without touching the
   // checkout — the contributor decides after seeing the file list.
   const choosePatchFile = async () => {
-    setApplyError('');
+    clearApplyError();
     setApplyNotice('');
     try {
       const chosen = await window.api.choosePatchFile();
@@ -3001,7 +3016,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // Fetches a PR's diff and drops into the same preview the file picker uses,
   // so applying a PR and applying a downloaded patch are one path from here on.
   const previewPr = async (pr) => {
-    setApplyError('');
+    clearApplyError();
     setApplyNotice('');
     setFetchingPr(pr.number);
     try {
@@ -3017,7 +3032,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         setApplyError(preview?.error || 'Could not read that diff.');
         return;
       }
-      setApplyPreview({ ...preview, label: `PR #${pr.number}`, text: diff.text });
+      // `url` rides along so a conflict can offer the pull request itself: a
+      // patch that no longer applies because it is old is rebased by its author,
+      // not by the contributor who just tried to test it (#282).
+      setApplyPreview({ ...preview, label: `PR #${pr.number}`, text: diff.text, prUrl: pr.url });
     } catch (e) {
       setApplyError(String(e));
     } finally {
@@ -3029,7 +3047,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // scrapes its attachment list, and shows it in-app. On demand, not on link.
   const loadTracAttachments = async () => {
     const gen = scrapeGenRef.current;
-    setApplyError('');
+    clearApplyError();
     setTracAttachmentsLoading(true);
     try {
       const res = await window.api.listTracAttachments(sitePath);
@@ -3046,7 +3064,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // Downloads an attachment through the challenge-passing session and hands it
   // to the same preview the PR and file paths use.
   const previewAttachment = async (att) => {
-    setApplyError('');
+    clearApplyError();
     setApplyNotice('');
     setFetchingAttachment(att.url);
     try {
@@ -3072,7 +3090,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // linked to the ticket — same fetch → preview flow as the linked-PR list.
   const previewPrFromInput = () => {
     const parsed = parsePrRef(prUrlInput);
-    if (!parsed.ok) { setApplyError(parsed.error); setApplyNotice(''); return; }
+    // clearApplyError first, not setApplyError alone: a parse error arriving on
+    // top of a conflict breakdown would otherwise leave the stale regions on
+    // screen hiding it, since the banner leads with the breakdown's headline.
+    if (!parsed.ok) { clearApplyError(); setApplyError(parsed.error); setApplyNotice(''); return; }
     setPrUrlInput('');
     previewPr({ number: parsed.number, url: `https://github.com/WordPress/wordpress-develop/pull/${parsed.number}` });
   };
@@ -3091,7 +3112,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     // the build and is not interrupted; an install/full build pauses it (#262).
     const watcherActive = watchStateRef.current === 'watching';
     const impact = planWatchImpact({ needsInstall, watcherActive });
-    setApplyError('');
+    clearApplyError();
     setApplyNotice('');
     setApplyNeedsInstall(needsInstall);
     setApplyBuildByWatcher(!impact.runBuild);
@@ -3123,6 +3144,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             return;
           }
           setApplyError(res?.error || 'The patch could not be applied.');
+          // A conflict is where the panel used to stop: one file named, the
+          // rest of the failures left in the terminal, and no sense of whether
+          // one region of twenty missed or all of them. The breakdown is what
+          // turns that into a decision (#282). A reverse is left out — the
+          // patch it names came from this app and the ticket's other patches
+          // are no help against it.
+          setApplyConflict(reverse ? null : describeApplyFailure(res, {
+            otherPatchCount: otherPatchCount({
+              label: preview?.label,
+              prs: ticketPatches?.items,
+              attachments: patchAttachments
+            }),
+            prUrl: preview?.prUrl || null
+          }));
           finishApply();
           return;
         }
@@ -4376,7 +4411,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               </div>
             ) : null}
 
-            <div style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
+            <div ref={ticketPatchesRef} style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
                 <div style={{ fontWeight: 600, fontSize: 13, color: '#1d2327' }}>Linked pull requests</div>
                 <Button variant="link" onClick={loadTicketPatches} disabled={ticketPatchesLoading} style={{ fontSize: 12 }}>
@@ -4613,7 +4648,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
               <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
                 <Button variant="primary" onClick={() => runApply()} disabled={isUpdating || installing || building}>Apply and rebuild</Button>
-                <Button variant="tertiary" onClick={() => { setApplyPreview(null); setApplyError(''); setApplyNotice(''); }}>Cancel</Button>
+                <Button variant="tertiary" onClick={() => { setApplyPreview(null); clearApplyError(); setApplyNotice(''); }}>Cancel</Button>
               </div>
             </div>
           ) : null}
@@ -4635,15 +4670,93 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           ) : null}
 
           {applyError ? (
-            <div role="alert" style={{ marginTop: 12, padding: '8px 10px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 12, color: '#8a1f21', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-              <span style={{ flex: '1 1 auto' }}>{/[.!?]$/.test(applyError.trim()) ? applyError : `${applyError.trim()}.`} The checkout was not changed.</span>
-              <Button
-                variant="tertiary"
-                isSmall
-                aria-label="Dismiss"
-                onClick={() => setApplyError('')}
-                style={{ color: '#8a1f21' }}
-              >✕</Button>
+            <div role="alert" style={{ marginTop: 12, padding: '8px 10px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 12, color: '#8a1f21' }}>
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                {/* The headline replaces the sentence when there is one: it says
+                    the same thing in counts, which is the part that decides
+                    whether the patch is worth rescuing. Without a breakdown the
+                    original sentence is still the whole story. */}
+                <span style={{ flex: '1 1 auto' }}>
+                  {applyConflict?.headline || (/[.!?]$/.test(applyError.trim()) ? applyError : `${applyError.trim()}.`)} The checkout was not changed.
+                </span>
+                <Button
+                  variant="tertiary"
+                  isSmall
+                  aria-label="Dismiss"
+                  onClick={() => clearApplyError()}
+                  style={{ color: '#8a1f21' }}
+                >✕</Button>
+              </div>
+
+              {applyConflict ? (
+                <div style={{ marginTop: 8 }}>
+                  {applyConflict.items.map((item, i) => (
+                    <div key={i} style={{ marginTop: i ? 8 : 0 }}>
+                      {item.kind === 'note' ? (
+                        <div>{item.text}</div>
+                      ) : (
+                        <>
+                          <div style={{ fontWeight: 600, wordBreak: 'break-all' }}>
+                            {item.path} — {item.failed} of {item.total} {item.total === 1 ? 'change' : 'changes'}
+                          </div>
+                          {item.regions.map((region) => (
+                            // index, not line: a concatenated patch can carry
+                            // two hunks whose oldStart coincides.
+                            <div key={region.index} style={{ marginTop: 4, paddingLeft: 10, borderLeft: '2px solid #d63638' }}>
+                              {/* A searchable line, not a line number: the patch's
+                                  numbers are coordinates in the file as its author
+                                  had it, and on an old patch they miss by dozens.
+                                  Text survives the drift — copy it into the
+                                  editor's search and land on the region. */}
+                              <div>
+                                {region.anchor
+                                  ? <>near <code style={{ fontSize: 11, wordBreak: 'break-all' }}>{region.anchor}</code></>
+                                  : `line ${region.line} of the patch`} · {region.reason}
+                              </div>
+                              {/* The lines themselves, because a location alone
+                                  cannot answer the question that decides the
+                                  next ten minutes: is this the change that
+                                  matters, or reformatting that came with it. */}
+                              {region.lines.length ? (
+                                <pre style={{ margin: '2px 0 0', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                                  {region.lines.join('\n')}{region.more ? `\n… ${region.more} more ${region.more === 1 ? 'line' : 'lines'}` : ''}
+                                </pre>
+                              ) : null}
+                            </div>
+                          ))}
+                        </>
+                      )}
+                    </div>
+                  ))}
+
+                  {applyConflict.offerOtherPatches || applyConflict.prUrl ? (
+                    <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      {applyConflict.offerOtherPatches ? (
+                        <Button
+                          variant="secondary"
+                          isSmall
+                          onClick={() => {
+                            // The lists' Apply buttons are disabled while a
+                            // preview is up, so scrolling there without clearing
+                            // it would land on greyed-out rows — the same dead
+                            // end this button exists to escape.
+                            setApplyPreview(null);
+                            ticketPatchesRef.current?.scrollIntoView({
+                              block: 'center',
+                              behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+                            });
+                          }}
+                        >Try another patch on this ticket</Button>
+                      ) : null}
+                      {applyConflict.prUrl ? (
+                        <Button variant="secondary" isSmall onClick={() => window.api.openExternal(applyConflict.prUrl)}>
+                          Open the pull request
+                        </Button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
 
@@ -4670,7 +4783,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ minWidth: 280, flex: '1 1 280px' }}>
                   <TextControl
                     value={prUrlInput}
-                    onChange={(value) => { setPrUrlInput(value); setApplyError(''); setApplyNotice(''); }}
+                    onChange={(value) => { setPrUrlInput(value); clearApplyError(); setApplyNotice(''); }}
                     onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); previewPrFromInput(); } }}
                     disabled={isUpdating || installing || building}
                     placeholder="Paste a pull request URL or number"

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3032,10 +3032,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         setApplyError(preview?.error || 'Could not read that diff.');
         return;
       }
-      // `url` rides along so a conflict can offer the pull request itself: a
-      // patch that no longer applies because it is old is rebased by its author,
-      // not by the contributor who just tried to test it (#282).
-      setApplyPreview({ ...preview, label: `PR #${pr.number}`, text: diff.text, prUrl: pr.url });
+      // `url` and `state` ride along so a conflict can offer the pull request
+      // itself, framed by what it is: an open one is rebased by its author, a
+      // closed one is nobody's to update (#282). State is absent when the PR
+      // came from a pasted number rather than the linked list.
+      setApplyPreview({ ...preview, label: `PR #${pr.number}`, text: diff.text, prUrl: pr.url, prState: pr.state || null });
     } catch (e) {
       setApplyError(String(e));
     } finally {
@@ -3156,7 +3157,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               prs: ticketPatches?.items,
               attachments: patchAttachments
             }),
-            prUrl: preview?.prUrl || null
+            prUrl: preview?.prUrl || null,
+            prState: preview?.prState || null
           }));
           finishApply();
           return;
@@ -4755,9 +4757,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                           }}
                         >Try another patch on this ticket</Button>
                       ) : null}
-                      {applyConflict.prUrl ? (
+                      {applyConflict.prUrl && applyConflict.prButton ? (
                         <Button variant="secondary" isSmall onClick={() => window.api.openExternal(applyConflict.prUrl)}>
-                          Ask its author for a rebase
+                          {applyConflict.prButton}
                         </Button>
                       ) : null}
                     </div>

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -1,0 +1,287 @@
+'use strict';
+
+// What the panel says when a patch will not apply (#282).
+//
+// The failure it exists for: "this file has moved on" read the same whether one
+// region of twenty missed or all twenty did, and only the first failing file
+// ever reached the screen. Both of those are decisions the contributor makes
+// differently — rescue the patch by hand, or abandon it — so both are asserted
+// here rather than left to the panel.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { describeApplyFailure, otherPatchCount, REASONS } = require('../src/renderer/apply-conflict.cjs');
+
+const FOO = 'src/wp-includes/foo.php';
+const BAR = 'src/wp-includes/bar.php';
+
+function conflict(path, total, regions) {
+	return { path, error: `${path} has moved on`, total, regions };
+}
+
+// --- nothing to explain --------------------------------------------------
+
+test('describeApplyFailure: a success has nothing to say (issue #282)', () => {
+	assert.equal(describeApplyFailure({ ok: true, applied: [FOO] }), null);
+	assert.equal(describeApplyFailure(null), null);
+});
+
+// A failure with no structured detail is every refusal that is not a conflict —
+// a parse error, a rolled-back write, main declining. The panel already renders
+// `error` for those, and inventing a second empty banner beside it would be
+// noise, so this stands down rather than returning an itemless shell.
+test('describeApplyFailure: a failure with no detail leaves the plain error alone (issue #282)', () => {
+	assert.equal(describeApplyFailure({ ok: false, error: 'The patch does not change any files.' }), null);
+});
+
+// --- the count that changes the decision ---------------------------------
+
+test('describeApplyFailure: a mostly-fitting patch says so, in counts (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 20, [
+			{ index: 0, line: 40, status: 'moved', lines: ['-a', '+b'] },
+			{ index: 1, line: 58, status: 'moved' }
+		])]
+	});
+
+	// The whole point of the issue: 2 of 20 is a patch worth ten minutes, and
+	// "it no longer applies" is one that gets thrown away.
+	assert.match(result.headline, /2 of this patch's 20 changes/);
+	assert.match(result.headline, /the other 18 do/);
+	assert.equal(result.items.length, 1);
+	assert.equal(result.items[0].failed, 2);
+	assert.equal(result.items[0].total, 20);
+});
+
+test('describeApplyFailure: a patch that misses everywhere does not claim a salvageable remainder (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 1, status: 'moved' },
+			{ index: 1, line: 9, status: 'moved' }
+		])]
+	});
+
+	assert.match(result.headline, /None of this patch's 2 changes/);
+	assert.doesNotMatch(result.headline, /the other/);
+});
+
+test('describeApplyFailure: counts span every failing file (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${BAR} has moved on`],
+		conflicts: [
+			conflict(FOO, 5, [{ index: 0, line: 3, status: 'moved' }]),
+			conflict(BAR, 5, [{ index: 0, line: 7, status: 'moved' }])
+		]
+	});
+
+	assert.match(result.headline, /2 of this patch's 10 changes across 2 files/);
+	assert.equal(result.items.length, 2);
+});
+
+// A patch whose changes are all in the tree fails every region, and a headline
+// counting fits ("none still fit") over rows saying "already in your checkout"
+// would be the banner contradicting itself — with the headline being the half
+// that decides whether the patch gets thrown away (issue #226).
+test('describeApplyFailure: an all-already-applied patch is not announced as dead (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 19, status: 'already-applied' }
+		])]
+	});
+
+	assert.match(result.headline, /All 2 of this patch's changes look like they are already in your checkout/);
+	assert.doesNotMatch(result.headline, /still fit your checkout/);
+});
+
+test('describeApplyFailure: a partly-applied patch says both halves (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 5, [
+			{ index: 0, line: 4, status: 'already-applied' }
+		])]
+	});
+
+	assert.match(result.headline, /1 of this patch's 5 changes look like they are already in your checkout/);
+	assert.match(result.headline, /the other 4 still fit/);
+});
+
+// One region genuinely moved keeps the plain counting headline: "already in
+// your checkout" as a summary would be wrong about that region.
+test('describeApplyFailure: mixed reasons keep the counting headline (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 5, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 19, status: 'moved' }
+		])]
+	});
+
+	assert.match(result.headline, /2 of this patch's 5 changes no longer fit/);
+});
+
+// A concatenated patch can fail the same file twice with the identical
+// sentence. A lookup by sentence would render one breakdown twice and lose the
+// other from the counts; matching consumes each conflict once instead.
+test('describeApplyFailure: two identical failure sentences get their own breakdowns (issue #282)', () => {
+	const sentence = `${FOO} has moved on`;
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [sentence, sentence],
+		conflicts: [
+			conflict(FOO, 3, [{ index: 0, line: 1, status: 'moved' }]),
+			conflict(FOO, 4, [{ index: 0, line: 9, status: 'moved' }])
+		]
+	});
+
+	assert.equal(result.items.length, 2);
+	assert.deepEqual(result.items.map((i) => i.total), [3, 4]);
+});
+
+// --- every failure reaches the screen, not just the first ----------------
+
+test('describeApplyFailure: a second failing file is not dropped (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		error: `${FOO} has moved on`,
+		failures: [`${FOO} has moved on`, `${BAR} is not in this checkout`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 1, status: 'moved' }])]
+	});
+
+	assert.equal(result.items.length, 2);
+	// Mixed reasons stay one list, in the order they were reported: a file whose
+	// regions drifted, then one that is simply absent and has no regions at all.
+	assert.equal(result.items[0].kind, 'conflict');
+	assert.deepEqual(result.items[1], { kind: 'note', text: `${BAR} is not in this checkout` });
+});
+
+// --- why it failed (issue #226) ------------------------------------------
+
+test('describeApplyFailure: tells "already there" apart from "the code moved" (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [
+			{ index: 0, line: 40, status: 'already-applied' },
+			{ index: 1, line: 58, status: 'moved' }
+		])]
+	});
+
+	const [redundant, drifted] = result.items[0].regions;
+	assert.equal(redundant.reason, REASONS['already-applied']);
+	assert.equal(drifted.reason, REASONS.moved);
+	// Hedged, because matching searches for a fit and can find one in the wrong
+	// place. A sentence that sounds certain here would be the app overstating
+	// evidence it cannot have.
+	assert.match(redundant.reason, /looks like/);
+});
+
+test('describeApplyFailure: an unknown status still gets a sentence (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 1, [{ index: 0, line: 2, status: 'something-new' }])]
+	});
+
+	assert.equal(result.items[0].regions[0].reason, 'it no longer fits');
+});
+
+// --- what the region was trying to do ------------------------------------
+
+test('describeApplyFailure: carries the lines a region wanted to change (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 1, [
+			{ index: 0, line: 40, status: 'moved', lines: ['-return $out;', '+return apply_filters( $out );'], more: 4 }
+		])]
+	});
+
+	const region = result.items[0].regions[0];
+	assert.deepEqual(region.lines, ['-return $out;', '+return apply_filters( $out );']);
+	assert.equal(region.more, 4);
+});
+
+test('describeApplyFailure: carries the anchor, and falls back to the patch line without one (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 40, status: 'moved', anchor: 'return $out;' },
+			{ index: 1, line: 90, status: 'moved' }
+		])]
+	});
+
+	const [anchored, bare] = result.items[0].regions;
+	assert.equal(anchored.anchor, 'return $out;');
+	// The fallback is empty-string, not undefined: the panel branches on it to
+	// decide between "near `…`" and the patch's own line number.
+	assert.equal(bare.anchor, '');
+	assert.equal(bare.line, 90);
+});
+
+test('describeApplyFailure: a region with no lines renders as an empty list, not undefined (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 9, [{ index: 8, line: 300, status: 'moved' }])]
+	});
+
+	assert.deepEqual(result.items[0].regions[0].lines, []);
+	assert.equal(result.items[0].regions[0].more, 0);
+});
+
+// --- the ways out --------------------------------------------------------
+
+test('describeApplyFailure: offers the other patches only when there are some (issue #282)', () => {
+	const payload = {
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 1, [{ index: 0, line: 1, status: 'moved' }])]
+	};
+
+	assert.equal(describeApplyFailure(payload, { otherPatchCount: 1 }).offerOtherPatches, true);
+	// The only patch on the ticket is the one that just failed: a button back to
+	// the same list is a click that teaches the contributor nothing.
+	assert.equal(describeApplyFailure(payload, { otherPatchCount: 0 }).offerOtherPatches, false);
+	assert.equal(describeApplyFailure(payload).offerOtherPatches, false);
+});
+
+// The count feeding offerOtherPatches, as its own unit: it lives here rather
+// than in index.jsx so the label-matching (a failed PR by `PR #n`, a failed
+// attachment — or the same file picked from disk — by filename) is testable.
+test('otherPatchCount: excludes the failed patch from either list (issue #282)', () => {
+	const prs = [{ number: 7871 }, { number: 11517 }];
+	const attachments = [{ filename: '62064.diff' }];
+
+	assert.equal(otherPatchCount({ label: 'PR #7871', prs, attachments }), 2);
+	assert.equal(otherPatchCount({ label: '62064.diff', prs, attachments }), 2);
+	// The same attachment picked from disk carries its filename as the label,
+	// so it is excluded the same way as one applied from the list.
+	assert.equal(otherPatchCount({ label: '62064.diff', prs: [], attachments }), 0);
+	assert.equal(otherPatchCount({ label: 'unrelated.diff', prs, attachments }), 3);
+	assert.equal(otherPatchCount({}), 0);
+});
+
+test('describeApplyFailure: carries the pull request only when the patch came from one (issue #282)', () => {
+	const payload = {
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 1, [{ index: 0, line: 1, status: 'moved' }])]
+	};
+
+	const url = 'https://github.com/WordPress/wordpress-develop/pull/1234';
+	assert.equal(describeApplyFailure(payload, { prUrl: url }).prUrl, url);
+	// A .diff chosen off disk has no pull request to ask for a rebase on.
+	assert.equal(describeApplyFailure(payload).prUrl, null);
+});

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -299,7 +299,7 @@ test('describeApplyFailure: a closed pull request is not offered a rebase (issue
 
 	assert.match(result.headline, /closed and was written against an older trunk/);
 	assert.doesNotMatch(result.advice, /rebase/);
-	assert.match(result.advice, /Redoing the change against today's code/);
+	assert.match(result.advice, /Nobody is coming back/);
 	// The PR is still worth opening — its discussion says why it ended — but
 	// the button says that, not "ask for a rebase".
 	assert.equal(result.prButton, 'See why it was closed');

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -257,6 +257,65 @@ test('describeApplyFailure: offers the other patches only when there are some (i
 	assert.equal(describeApplyFailure(payload).offerOtherPatches, false);
 });
 
+// --- the pull-request framing --------------------------------------------
+//
+// The regions belong to whoever updates the pull request — its author. The
+// contributor gets the situation, the scale, and their one real act: telling
+// the author. Line-level detail is for patches with nobody behind them.
+
+const PR_URL = 'https://github.com/WordPress/wordpress-develop/pull/7871';
+
+test('describeApplyFailure: a pull request failure names the stale side and the scale, not the lines (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 24, [
+			{ index: 0, line: 18, status: 'moved', lines: ['-a', '+b'] },
+			{ index: 1, line: 69, status: 'moved' }
+		])]
+	}, { prUrl: PR_URL, otherPatchCount: 1 });
+
+	// The stale side is the pull request, said outright — not "your checkout".
+	assert.match(result.headline, /written against an older trunk/);
+	// The scale, so the contributor can size it: places and files.
+	assert.match(result.headline, /2 of its 24 changes, in 1 file/);
+	// Whose work the fix is, and what the contributor can actually do.
+	assert.match(result.advice, /author's work/);
+	assert.match(result.advice, /comment on the pull request/);
+	// The file row survives for the summary; the regions do not.
+	assert.equal(result.items[0].failed, 2);
+	assert.deepEqual(result.items[0].regions, []);
+});
+
+test('describeApplyFailure: a pull request already in trunk asks for nothing (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 9, status: 'already-applied' }
+		])]
+	}, { prUrl: PR_URL });
+
+	assert.match(result.headline, /already in trunk — there is nothing left to apply/);
+	// No rebase to ask for: the advice line stands down.
+	assert.equal(result.advice, '');
+});
+
+test('describeApplyFailure: a loose patch keeps the full breakdown — there is no author to send to (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [
+			{ index: 0, line: 7, status: 'moved', lines: ['-x', '+y'] }
+		])]
+	});
+
+	assert.equal(result.items[0].regions.length, 1);
+	assert.deepEqual(result.items[0].regions[0].lines, ['-x', '+y']);
+	assert.equal(result.advice, '');
+});
+
 // The count feeding offerOtherPatches, as its own unit: it lives here rather
 // than in index.jsx so the label-matching (a failed PR by `PR #n`, a failed
 // attachment — or the same file picked from disk — by filename) is testable.

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -287,6 +287,54 @@ test('describeApplyFailure: a pull request failure names the stale side and the 
 	assert.deepEqual(result.items[0].regions, []);
 });
 
+// A closed pull request has no author coming back to it. Asking for a rebase
+// would send the contributor's one act into the void — and in wordpress-develop
+// "closed" is also what landing looks like, since core commits via SVN.
+test('describeApplyFailure: a closed pull request is not offered a rebase (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'closed' });
+
+	assert.match(result.headline, /closed and was written against an older trunk/);
+	assert.doesNotMatch(result.advice, /rebase/);
+	assert.match(result.advice, /Redoing the change against today's code/);
+	// The PR is still worth opening — its discussion says why it ended — but
+	// the button says that, not "ask for a rebase".
+	assert.equal(result.prButton, 'See why it was closed');
+	assert.equal(result.prUrl, PR_URL);
+});
+
+test('describeApplyFailure: a closed PR already in trunk reads as landed, not dead (issue #226)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 9, status: 'already-applied' }
+		])]
+	}, { prUrl: PR_URL, prState: 'closed' });
+
+	// Core lands through SVN and closes the PR; the regions reading back as
+	// already-present is what that looks like from the checkout.
+	assert.match(result.headline, /likely committed to core/);
+	assert.equal(result.prButton, null);
+	assert.equal(result.prUrl, null, 'no button, no url — nothing to do with the PR');
+});
+
+test('describeApplyFailure: an unknown PR state keeps the open framing (issue #282)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL });
+
+	// A PR pasted by number carries no state; assuming open keeps the rebase
+	// path available rather than withholding it on missing data.
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+});
+
 test('describeApplyFailure: a pull request already in trunk asks for nothing (issue #226)', () => {
 	const result = describeApplyFailure({
 		ok: false,

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -6,7 +6,9 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const git = require('isomorphic-git');
-const { applyPatchToDir, resolveInside, dominantEol, rollback } = require('../src/patch-apply');
+const JsDiff = require('diff');
+const { applyPatchToDir, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
+const { parsePatchFiles } = require('../src/patch-plan.cjs');
 
 // A real on-disk repo, like trunk-update.integration.test.cjs: applyPatchToDir
 // calls ensureAutocrlf, which reads and writes git config, so a bare temp
@@ -548,4 +550,245 @@ test('rollback: returns an empty list when it restores everything (issue #11)', 
 
 	assert.deepStrictEqual(recovery, []);
 	assert.strictEqual(fs.existsSync(path.join(dir, 'added')), false, 'an added file is removed on rollback');
+});
+
+// --- how badly it failed (issue #282) ------------------------------------
+//
+// The refusal is right and stays; what it says is what changed. "This file has
+// moved on" read identically whether one region of twenty missed or all twenty
+// did, which is the difference between a patch worth rescuing by hand and one
+// worth abandoning. These assert the counts the panel is built from.
+
+// A file long enough to hold three regions that do not merge into one hunk.
+const LONG = 'src/wp-includes/long.php';
+const LONG_BODY = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+
+// Three regions: near the top, the middle and the bottom.
+const LONG_PATCH = `diff --git a/${LONG} b/${LONG}
+--- a/${LONG}
++++ b/${LONG}
+@@ -1,3 +1,3 @@
+ line 1
+-line 2
++LINE TWO
+ line 3
+@@ -14,3 +14,3 @@
+ line 14
+-line 15
++LINE FIFTEEN
+ line 16
+@@ -27,3 +27,3 @@
+ line 27
+-line 28
++LINE TWENTY-EIGHT
+ line 29
+`;
+
+test('applyPatchToDir: names how many regions missed, not just the file (issue #282)', async (t) => {
+	const dir = await makeRepo(t, { [LONG]: LONG_BODY });
+	// Only the first region's surroundings are disturbed.
+	fs.writeFileSync(path.join(dir, LONG), LONG_BODY.replace('line 1\n', 'line one, rewritten\n'));
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.conflicts.length, 1);
+	const [conflict] = res.conflicts;
+	assert.strictEqual(conflict.path, LONG);
+	assert.strictEqual(conflict.total, 3, 'the patch has three regions');
+	assert.strictEqual(conflict.regions.length, 1, 'only one of them missed');
+	assert.strictEqual(conflict.regions[0].line, 1);
+	// The sentence carries the same counts, for the terminal and for anywhere
+	// the structured detail does not reach.
+	assert.match(res.error, /1 of its 3 changes no longer fit/);
+	assert.match(res.error, /the other 2 do/);
+});
+
+test('applyPatchToDir: a region carries the lines it was trying to change (issue #282)', async (t) => {
+	const dir = await makeRepo(t, { [LONG]: LONG_BODY });
+	fs.writeFileSync(path.join(dir, LONG), LONG_BODY.replace('line 1\n', 'line one, rewritten\n'));
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+
+	// Without these there is a location and no way to judge whether it is the
+	// change that matters or reformatting noise, which is the judgement the
+	// whole diagnosis exists to enable.
+	assert.deepStrictEqual(res.conflicts[0].regions[0].lines, ['-line 2', '+LINE TWO']);
+});
+
+// The anchor is a line to search for, because the hunk's numbers are in the
+// patched file's coordinates and an old patch misses by its whole drift. For a
+// "moved" region the `-` line is the one thing known to still be in the file —
+// the failure means the *neighbours* changed, not it.
+test('applyPatchToDir: a region\'s anchor is a line still present in the checkout (issue #282)', async (t) => {
+	const dir = await makeRepo(t, { [LONG]: LONG_BODY });
+	const drifted = LONG_BODY.replace('line 1\n', 'line one, rewritten\n');
+	fs.writeFileSync(path.join(dir, LONG), drifted);
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+
+	const region = res.conflicts[0].regions[0];
+	assert.strictEqual(region.anchor, 'line 2');
+	assert.ok(drifted.includes(region.anchor), 'searching the anchor finds the region');
+});
+
+// An already-applied region carries the change, not its precondition: the `-`
+// line is gone from the file by definition, and the `+` line is what a search
+// will actually hit.
+test('applyPatchToDir: an already-applied region anchors on its result (issue #226)', async (t) => {
+	const dir = await makeRepo(t, { [LONG]: LONG_BODY });
+	const current = LONG_BODY
+		.replace('line 2\n', 'LINE TWO\n')
+		.replace('line 14\n', 'line fourteen!\n');
+	fs.writeFileSync(path.join(dir, LONG), current);
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+
+	const applied = res.conflicts[0].regions.find((r) => r.status === 'already-applied');
+	assert.strictEqual(applied.anchor, 'LINE TWO');
+	assert.ok(current.includes(applied.anchor), 'searching the anchor finds the region');
+});
+
+// The other half of the same question (issue #226): a region can miss because
+// its change is already there, which means the patch is redundant rather than
+// stale — the opposite conclusion from the same failure.
+test('applyPatchToDir: a region already in the tree is told apart from one that drifted (issue #226)', async (t) => {
+	const dir = await makeRepo(t, { [LONG]: LONG_BODY });
+	const current = LONG_BODY
+		.replace('line 2\n', 'LINE TWO\n')          // the patch's own change, already here
+		.replace('line 14\n', 'line fourteen!\n');  // and genuine drift around another region
+	fs.writeFileSync(path.join(dir, LONG), current);
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+
+	assert.strictEqual(res.ok, false);
+	const byLine = Object.fromEntries(res.conflicts[0].regions.map((r) => [r.line, r.status]));
+	assert.strictEqual(byLine[1], 'already-applied');
+	assert.strictEqual(byLine[14], 'moved');
+});
+
+// Every failing file reaches the caller. The panel showed `error` alone and
+// sent the rest to the terminal, where a contributor has no reason to look.
+test('applyPatchToDir: a second conflicting file is reported, not swallowed (issue #282)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	const twoFilePatch = `${FOO_PATCH}diff --git a/${BAR} b/${BAR}
+--- a/${BAR}
++++ b/${BAR}
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETA
+ gamma
+`;
+	fs.writeFileSync(path.join(dir, FOO), 'ONE\nTWO\nTHREE\n');
+	fs.writeFileSync(path.join(dir, BAR), 'ALPHA\nBETA\nGAMMA\n');
+
+	const res = await applyPatchToDir({ dir, patchText: twoFilePatch });
+
+	assert.strictEqual(res.failures.length, 2);
+	assert.strictEqual(res.conflicts.length, 2);
+	assert.deepStrictEqual(res.conflicts.map((c) => c.path), [FOO, BAR]);
+});
+
+// A file that is simply not there has no regions to break down, so it keeps the
+// sentence it always had. The panel has to render both kinds side by side.
+test('applyPatchToDir: a failure with no regions carries no conflict detail (issue #282)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	const missingFilePatch = FOO_PATCH.replace(new RegExp(FOO, 'g'), 'src/wp-includes/gone.php');
+
+	const res = await applyPatchToDir({ dir, patchText: missingFilePatch });
+
+	assert.strictEqual(res.ok, false);
+	assert.deepStrictEqual(res.conflicts, []);
+	assert.match(res.error, /not in this checkout/);
+});
+
+// --- diagnoseHunks directly, for what the integration path cannot reach ---
+//
+// The caps and fallbacks fire only on shapes no small fixture hits through
+// applyPatchToDir: a hunk with more changed lines than the cap, more failing
+// regions than carry detail, a hunk none of whose lines survive in the file.
+
+// A one-hunk patch against `original`, parsed the way applyPatchToDir would.
+function parsedFile(patchText) {
+	const parsed = parsePatchFiles(patchText);
+	assert.ok(parsed.ok, parsed.error);
+	return parsed.files[0];
+}
+
+test('diagnoseHunks: caps the lines one region carries and counts the rest (issue #282)', () => {
+	const before = Array.from({ length: 14 }, (_, i) => `alpha ${i}`).join('\n') + '\n';
+	const after = Array.from({ length: 14 }, (_, i) => `beta ${i}`).join('\n') + '\n';
+	const patch = JsDiff.createPatch('big.txt', before, after);
+	const file = parsedFile(`diff --git a/big.txt b/big.txt\n${patch.split('\n').slice(1).join('\n')}`);
+
+	// A file the hunk cannot fit at all, so the one region fails.
+	const diagnosis = diagnoseHunks('something else entirely\n', file);
+
+	assert.strictEqual(diagnosis.regions.length, 1);
+	assert.strictEqual(diagnosis.regions[0].lines.length, 10, 'REGION_LINE_LIMIT caps the carried lines');
+	// 14 removed + 14 added = 28 changed lines; 10 carried, 18 counted.
+	assert.strictEqual(diagnosis.regions[0].more, 18);
+});
+
+test('diagnoseHunks: regions beyond the detail cap are located but carry no lines (issue #282)', () => {
+	// Five separated regions, all of which will fail.
+	const body = Array.from({ length: 41 }, (_, i) => `row ${i}`).join('\n') + '\n';
+	const changed = body
+		.replace('row 2\n', 'ROW 2\n').replace('row 10\n', 'ROW 10\n')
+		.replace('row 18\n', 'ROW 18\n').replace('row 26\n', 'ROW 26\n')
+		.replace('row 34\n', 'ROW 34\n');
+	const patch = JsDiff.createPatch('rows.txt', body, changed, '', '', { context: 2 });
+	const file = parsedFile(`diff --git a/rows.txt b/rows.txt\n${patch.split('\n').slice(1).join('\n')}`);
+
+	const diagnosis = diagnoseHunks('unrelated\n', file);
+
+	assert.strictEqual(diagnosis.total, 5);
+	assert.strictEqual(diagnosis.regions.length, 5);
+	const detailed = diagnosis.regions.filter((r) => Array.isArray(r.lines));
+	assert.strictEqual(detailed.length, 3, 'REGION_DETAIL_LIMIT caps which regions carry lines');
+	assert.ok(diagnosis.regions.slice(3).every((r) => r.lines === undefined));
+	// Every region still has an anchor, even past the detail cap.
+	assert.ok(diagnosis.regions.every((r) => typeof r.anchor === 'string' && r.anchor));
+});
+
+test('diagnoseHunks: a hunk with nothing left in the file still offers its best anchor (issue #282)', () => {
+	const file = parsedFile([
+		'diff --git a/gone.txt b/gone.txt',
+		'--- a/gone.txt',
+		'+++ b/gone.txt',
+		'@@ -1,3 +1,3 @@',
+		' context line',
+		'-old line',
+		'+new line',
+		' other context',
+		''
+	].join('\n'));
+
+	const diagnosis = diagnoseHunks('completely different file\n', file);
+
+	// Nothing from the hunk survives in the file, so the preference order alone
+	// decides: for a moved region, the first `-` line.
+	assert.strictEqual(diagnosis.regions[0].anchor, 'old line');
+});
+
+test('diagnoseHunks: overlapping hunks that each pass alone yield null, not zero conflicts (issue #282)', () => {
+	// Both hunks fit the file individually (their contexts are present), but the
+	// whole patch fails because the first hunk's insertion shifts the second's.
+	// diagnoseHunks must decline to explain rather than claim nothing failed.
+	const body = 'one\ntwo\nthree\nfour\nfive\nsix\nseven\n';
+	const file = parsedFile([
+		'diff --git a/f.txt b/f.txt',
+		'--- a/f.txt',
+		'+++ b/f.txt',
+		'@@ -1,3 +1,3 @@',
+		' one',
+		'-two',
+		'+TWO',
+		' three',
+		''
+	].join('\n'));
+
+	// Sanity: the single hunk applies, so per-hunk diagnosis finds no failures.
+	assert.strictEqual(diagnoseHunks(body, file), null);
 });


### PR DESCRIPTION
## Why

When a patch no longer applies, the app names one file, says the checkout was not changed, and stops. That sentence reads identically whether one region of twenty missed or all twenty did — opposite decisions for the contributor, who either spends ten minutes rescuing the patch or throws it away. The failures beyond the first file never reach the card at all, and the most useful thing on screen at that moment — the ticket's other pull request, which applies cleanly — is never pointed at. #282 makes the full case, from applying a pull request on Trac #62064.

## What changes

The refusal itself is untouched: all-or-nothing stays, and nothing here writes to the checkout. What changes is what the refusal says.

`resolveFile` now asks its existing question once per region instead of once per file, only on the failure path. Each failing region reports **why** — its surroundings changed, or its change looks already present, told apart by whether the region's reverse fits (the same reasoning `patchIsAbsent` already uses; this is #226's first half) — and carries the `-`/`+` lines it wanted to make plus a **searchable anchor line verified to exist in the contributor's file** (the hunk's own line numbers are coordinates in the file as the patch author had it, and on an old patch they miss by the very drift the patch failed on).

A new pure module, `src/renderer/apply-conflict.cjs`, turns the failure payload into the notice (the `open-failure.cjs` shape), with **two framings chosen by where the patch came from**:

- **A pull request** has an author, and its conflicts are theirs to fix — showing the contributor line-level detail invites them into work that is not theirs. The notice names the stale side (*"written against an older trunk"*, not "your checkout has moved on"), sizes the problem (places and files), says whose work the fix is, and frames the contributor's one real act: leaving a comment asking for a rebase. Buttons: **Ask its author for a rebase** (opens the PR) and **Try another patch on this ticket**.
- **A loose patch** (Trac attachment, file from disk) has nobody to send the contributor to, so it keeps the full per-region breakdown — there, the contributor with the failing lines in hand is the only way out.

Every failing file reaches the card in both framings, rather than only the first.

Deliberately not in this PR: loosening the matching or applying the parts that fit (ruled out in #226 and #282), applying from the pull request's recorded base (three-way — #226's second half, with verified groundwork in its comments), and naming which side is stale (needs the PR-date work shared with #281).

## How to test this

Platforms: any.

**Starting state:**

1. A Core site on current trunk, linked to Trac ticket **62064**.
2. In *Apply a patch or PR*, paste `7871` and preview it, then **Apply and rebuild**.

**Expected:** the apply refuses; the banner says the pull request was written against an older trunk, sizes it ("7 of its 24 changes, in 1 file, would need rework"), says updating it is its author's work and suggests a comment on the PR, and offers **Ask its author for a rebase** (the PR shows GitHub's own "conflicts that must be resolved" banner, corroborating) and **Try another patch on this ticket** (which dismisses the failed attempt entirely — banner and preview — and scrolls to the list, whose Apply buttons are enabled again). Applying PR **11517** from the same list then succeeds.

For the detailed framing, download a failing patch as a `.diff` and apply it via "choose a .diff / .patch file": the same failure now shows the per-region breakdown — `near …` anchor lines you can Cmd+F in the checkout and find, "the code around it has changed" labels, and the `-`/`+` lines for the first three regions.

**What must not have happened:**

- No file in the checkout changed on the refusal (`git status` clean, or exactly as it was before).
- A patch that fails for a non-conflict reason (a `.diff` whose file is not in the checkout) still shows its plain sentence — no empty breakdown, no headline claiming counts.
- Reverting an applied patch that conflicts shows the plain message, not the breakdown with buttons that make no sense for a revert.

The old behaviour — one file named, the rest of the failures only in the terminal — is pinned by the new tests: `test/apply-conflict.test.cjs` (module) and the `#282`/`#226` blocks in `test/patch-apply.integration.test.cjs` (per-region diagnosis on a real repo, anchors asserted to exist in the file).

## Risks and limitations

- The per-region labels are **evidence, not proof**: matching searches for a fit and can find one in the wrong place, which is why the wording hedges ("looks like") and why the diagnosis never decides a write. Stated in the module comment.
- The wording throughout is a draft for review — headline, region labels, button copy.
- Verified by hand on macOS against the real case (PR 7871 / Trac 62064); Windows through the suite only.
- Self-review outcome: 4 [fix here] · 1 [follow-up] — all five addressed before opening, details in the collapsed block.

## Related

Closes #282. First half of #226 (its second half — apply from the recorded base — stays open there, with the measured groundwork in its comments). Related: #286 (next-step guidance from a different angle), #290 (trying the PR as written), #281 (which side is stale).

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Anchors instead of line numbers.** The hunk's `oldStart` is in the patch-base file's coordinates: on the motivating case it says "line 132" for code sitting at line 149 of the contributor's file, and the drift grows toward the end of the file. Candidates from the hunk are checked against the file and the longest one actually present wins (first line of a hunk is often a bare brace, and "near `}`" locates nothing); preference order follows the failure kind — a moved region usually still contains its own `-` line, an already-applied one its `+` result. Falling back to "line N of the patch" only when nothing from the hunk survives.

**Diagnosis stays in `patch-apply.js`, presentation in a `.cjs` module.** Same split as `open-failure.cjs`, for the same reason: `index.jsx` cannot be loaded by the suite, so every branch that decides what the contributor reads lives where a test reaches it.

**No three-way in this PR.** The apply is two-way by construction (no base is known). Three-way with the PR's recorded base collapses most of these false failures — measured on this very case: 41 of 49 regions merge cleanly, and the `diff3` algorithm reproduces git's six conflicts exactly — but it is a different change with its own surface (GitHub API, new dependency), tracked in #226 with the measurements posted there.

**Reverse skips the diagnosis.** A failed revert's answer is never "try the ticket's other patches"; the panel discards the breakdown, so the resolver does not compute it.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Run per `.github/instructions/code-review.instructions.md`, judgement pass in a fresh-context subagent. **4 [fix here] · 1 [follow-up] — all five addressed, plus the three style notes.**

- 🟡 "Try another patch" scrolled to a list whose Apply buttons were disabled by the still-open preview — the exact dead end the module's own comment forbids. → the button clears the preview first.
- 🟡 `otherTicketPatchCount` was a derivation inside `index.jsx`, unreachable by the suite. → moved to `apply-conflict.cjs` as `otherPatchCount`, with tests including the picked-from-disk label case.
- 🟡 A patch entirely already-in-tree got the headline "None of this patch's changes still fit" above regions saying the opposite. → dedicated headline when every failing region is `already-applied`.
- 🔵 One path still set `applyError` without clearing the breakdown, leaving a stale breakdown hiding a parse error. → routed through `clearApplyError()`.
- 🔵 [follow-up, done here] `diagnoseHunks` exported with no direct test — the caps and fallbacks were unasserted. → direct tests for `REGION_LINE_LIMIT`, `REGION_DETAIL_LIMIT`, the anchor's last-resort branch, and the `null` on overlapping hunks.
- Style notes applied: reverse no longer pays for a discarded diagnosis; region React keys use the hunk index (`oldStart` can collide in concatenated patches, which also double-counted via the by-sentence map — replaced with consume-on-match); anchor picks the longest present candidate.

Clean and verified by the reviewer, not reported as findings: EOL/CRLF handling end-to-end, IPC surface (nothing added to the bridge; the payload rides the existing done channel), performance (worst plausible diagnosis measured at 38 ms, failure path only).

</details>

<details>
<summary>Implementation notes</summary>

- The apply result now carries `failures` (all sentences — previously computed and forwarded but read only as `error`) and `conflicts` (`{ path, error, total, regions[] }`). `main.js` and `preload.js` needed no changes: the handler already spreads the whole result into the done payload.
- `diagnoseHunks` applies each hunk in isolation against the unshifted file — the only question askable when nothing is applied. Two hunks that overlap once applied can each pass alone while the file fails; the resolver returns `null` for that and the original sentence stands, rather than claiming zero conflicts.
- Payload is bounded: 3 regions per file carry lines, 10 lines per region, anchors capped at 120 chars; the rest are counted and located.
- End-to-end verification script (throwaway, scratchpad only) drove the packaged renderer against a fixture checkout with the real PR 7871 diff and asserted every anchor exists in the current `forms.css`.

</details>

<details>
<summary>Screenshots or recording</summary>

Banner on the real case (PR 7871 against current trunk, Trac 62064) — will attach the capture in a comment:

```
This pull request was written against an older trunk and no longer fits it:
7 of its 24 changes, in 1 file, would need rework. The checkout was not changed.

src/wp-admin/css/forms.css — 7 of 24 changes

Bringing it up to date is its author's work — a rebase, or merging trunk in.
Leaving a comment on the pull request to let them know is a real contribution
in itself.

[Try another patch on this ticket]  [Ask its author for a rebase]
```

The same failure from a `.diff` file shows the detailed framing instead:

```
7 of this patch's 24 changes no longer fit — the other 17 do. The checkout was not changed.

src/wp-admin/css/forms.css — 7 of 24 changes
  near line-height: 1.42857143; /* 20px */ · the code around it has changed
    -  line-height: 1.42857143; /* 20px */
    +  line-height: 1.42857143;
    +  /* 20px */
  … (7 regions, all anchors present in the contributor's file)
```

</details>
