### PR TITLE
Show a linked ticket's own facts, read off the page the app already opens

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -35,6 +35,7 @@ import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
 import { parsePrRef } from '../patch-sources.cjs';
 import { prStateBadge } from './pr-state.cjs';
+import { statusBadge } from '../trac-ticket-info.cjs';
 import { prDateLabel } from './pr-date-label.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
@@ -2862,6 +2863,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // attachments are noise here. The parser still returns them (pickLatest and
   // tests rely on the full list); the filtering is purely what's shown.
   const patchAttachments = (tracAttachments?.items || []).filter((a) => a.applyable);
+  // The ticket's own facts (#292), riding the same scrape as the attachments:
+  // one Trac visit, one challenge, both answers.
+  const tracInfo = tracAttachments?.ticket || null;
+  const tracInfoBadge = statusBadge(tracInfo);
   const tracAttachmentsRead = tracAttachments
     && (tracAttachments.status === 'ok' || tracAttachments.status === 'no-attachments');
   // One pill shape, two uses: the "Latest" marker on a patch row and a linked
@@ -4404,8 +4409,64 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 #{tracTicket}
               </span>
               <Button variant="link" onClick={() => window.api.openExternal(ticketUrl(tracTicket))}>Open in Trac</Button>
+              {!tracInfo ? (
+                <Button variant="link" onClick={loadTracAttachments} disabled={tracAttachmentsLoading}>
+                  {tracAttachmentsLoading ? 'Reading ticket…' : 'Read details from Trac'}
+                </Button>
+              ) : null}
               <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketActionsBlocked}>Unlink</Button>
             </div>
+
+            {tracInfo ? (
+              <div style={{ marginTop: 10 }}>
+                {tracInfo.summary ? (
+                  <div style={{ fontSize: 14, fontWeight: 600, color: '#1d2327' }}>{tracInfo.summary}</div>
+                ) : null}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6, flexWrap: 'wrap', fontSize: 12, color: '#3c434a' }}>
+                  {tracInfoBadge ? (
+                    <span style={{ padding: '1px 8px', borderRadius: 999, fontWeight: 600, fontSize: 11,
+                      background: tracInfoBadge.tone === 'closed' ? '#fcf0f1' : '#edfaef',
+                      color: tracInfoBadge.tone === 'closed' ? '#8a1f21' : '#005c12' }}>
+                      {tracInfoBadge.label}
+                    </span>
+                  ) : null}
+                  {tracInfo.type ? (
+                    <span style={{ padding: '1px 8px', borderRadius: 999, fontSize: 11, background: '#f0f0f1', color: '#3c434a' }}>{tracInfo.type}</span>
+                  ) : null}
+                  {tracInfo.opened ? (
+                    <span title={tracInfo.opened.absolute}>opened {tracInfo.opened.relative}</span>
+                  ) : null}
+                  {tracInfo.milestone ? <span>milestone: {tracInfo.milestone}</span> : null}
+                </div>
+                {tracInfo.component || tracInfo.keywords.length ? (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, flexWrap: 'wrap', fontSize: 12, color: '#6c6f72' }}>
+                    {tracInfo.component ? (
+                      <span>
+                        component:{' '}
+                        {tracInfo.component.url ? (
+                          <Button variant="link" style={{ fontSize: 12 }} onClick={() => window.api.openExternal(tracInfo.component.url)}>
+                            {tracInfo.component.label}
+                          </Button>
+                        ) : tracInfo.component.label}
+                      </span>
+                    ) : null}
+                    {tracInfo.keywords.length ? (
+                      <span>
+                        keywords:{' '}
+                        {tracInfo.keywords.map((kw, i) => (
+                          <span key={kw.label}>
+                            {i ? ' ' : ''}
+                            {kw.url ? (
+                              <Button variant="link" style={{ fontSize: 12 }} onClick={() => window.api.openExternal(kw.url)}>{kw.label}</Button>
+                            ) : kw.label}
+                          </span>
+                        ))}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             {changesNote && changesNote.placement === 'ticket' ? (
               <div style={{ marginTop: 8, fontSize: 13, color: '#1d2327' }}>
                 {changesNoteBody}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2995,6 +2995,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // stale. A ref and not state — it must not survive a remount, or selecting
   // an already-linked site would open a Trac window nobody asked for (#292).
   const autoReadTicketRef = useRef(null);
+  const tracScrapeRef = useRef(null);
   useEffect(() => {
     if (!tracTicket) {
       setTicketPatches(null);
@@ -3023,7 +3024,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     // ref is empty and nothing opens — details stay on demand, the #109 rule.
     if (autoReadTicketRef.current === tracTicket) {
       autoReadTicketRef.current = null;
-      loadTracAttachments();
+      // Through the ref, not the function: loadTracAttachments is declared
+      // below this effect and recreated per render — the same shape as
+      // metaPatchRef above.
+      if (tracScrapeRef.current) tracScrapeRef.current();
     }
   }, [tracTicket, isActive, loadTicketPatches]);
 
@@ -3084,6 +3088,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   // Downloads an attachment through the challenge-passing session and hands it
   // to the same preview the PR and file paths use.
+  useEffect(() => { tracScrapeRef.current = loadTracAttachments; });
+
   const previewAttachment = async (att) => {
     clearApplyError();
     setApplyNotice('');

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1759,6 +1759,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         return;
       }
       setTracTicket(res.ticket);
+      if (res.ticket) autoReadTicketRef.current = res.ticket;
       setTicketInput('');
       setPatchSavedTo('');
       if (metaPatchRef.current) metaPatchRef.current(sitePath, { tracTicket: res.ticket });
@@ -2988,6 +2989,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // the list. Placed after loadTicketPatches is defined: an effect that named it
   // earlier in the body would read the const before its declaration ran.
   const loadedTicketRef = useRef(null);
+  // Set only by saveTicket, on a link the contributor just performed. The
+  // per-ticket effect below consumes it to auto-read the ticket's details:
+  // there, after the generation bump, so the scrape's result is not dropped as
+  // stale. A ref and not state — it must not survive a remount, or selecting
+  // an already-linked site would open a Trac window nobody asked for (#292).
+  const autoReadTicketRef = useRef(null);
   useEffect(() => {
     if (!tracTicket) {
       setTicketPatches(null);
@@ -3010,6 +3017,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     setTracAttachmentsLoading(false);
     loadedTicketRef.current = tracTicket;
     loadTicketPatches();
+    // Auto-read the ticket's own facts when this ticket was just linked by
+    // hand (#292). Only then: the contributor just acted on this ticket, so a
+    // human-check window appearing has context. On mount or re-activation the
+    // ref is empty and nothing opens — details stay on demand, the #109 rule.
+    if (autoReadTicketRef.current === tracTicket) {
+      autoReadTicketRef.current = null;
+      loadTracAttachments();
+    }
   }, [tracTicket, isActive, loadTicketPatches]);
 
   // A Trac scrape can run up to 90s. Bump a generation on every ticket change so

--- a/src/trac-ticket-info.cjs
+++ b/src/trac-ticket-info.cjs
@@ -1,0 +1,162 @@
+'use strict';
+
+/**
+ * Reading a ticket's own properties off its Trac page (issue #292).
+ *
+ * The app shows a linked ticket's number and the work attached to it, but
+ * nothing about the ticket itself — so a contributor can sink time into a
+ * ticket that was closed `wontfix` years ago and only find out on Trac. The
+ * facts that would have told them (status, resolution, type, milestone,
+ * component, keywords, when it was opened) all sit in the `#ticket` block of
+ * the page the attachments scrape already loads, so reading them costs no new
+ * mechanism and no second proof-of-work challenge.
+ *
+ * Parsing is regex over the HTML string, like trac-attachments.cjs and for the
+ * same reason: unit-testable under `node --test` with no browser, against
+ * fixtures taken from real ticket pages. Every field degrades to an empty
+ * value rather than failing the parse — a ticket with no milestone is normal,
+ * not an error.
+ *
+ * The component and keyword links are Trac's own query URLs, lifted from the
+ * page rather than rebuilt, so they stay right if Trac changes its query
+ * syntax. They open in the contributor's browser, which handles the
+ * proof-of-work like any other visit.
+ */
+
+const TRAC_HOST = 'core.trac.wordpress.org';
+
+/**
+ * The handful of entities Trac's property markup actually emits.
+ *
+ * @param {string} text
+ * @return {string}
+ */
+function decodeEntities(text) {
+	return text
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#34;/g, '"')
+		.replace(/&#39;/g, "'");
+}
+
+/**
+ * A page-relative Trac link made absolute, or null for anything that is not
+ * plainly a Trac path. The hrefs come out of scraped HTML, so they are treated
+ * as untrusted: only `/…` paths onto the known host survive.
+ *
+ * @param {string} href
+ * @return {string|null}
+ */
+function absoluteTracUrl(href) {
+	const decoded = decodeEntities(href || '');
+	if (!decoded.startsWith('/')) return null;
+	return `https://${TRAC_HOST}${decoded}`;
+}
+
+/**
+ * First capture of `re` against `html`, entity-decoded and trimmed, or ''.
+ *
+ * @param {string} html
+ * @param {RegExp} re
+ * @return {string}
+ */
+function capture(html, re) {
+	const m = html.match(re);
+	return m ? decodeEntities(m[1]).trim() : '';
+}
+
+/**
+ * One "Opened … ago" (or Closed, or Last modified) line from the date block.
+ * Trac renders these as a relative phrase whose title carries the absolute
+ * moment — both are kept, the relative for display, the absolute for the
+ * tooltip.
+ *
+ * @param {string} html
+ * @param {string} label
+ * @return {{relative: string, absolute: string}|null}
+ */
+function dateLine(html, label) {
+	const re = new RegExp(
+		`${label}\\s*<a class="timeline"[^>]*title="See timeline at ([^"]+)"[^>]*>([^<]+)</a>`
+	);
+	const m = html.match(re);
+	if (!m) return null;
+	return { absolute: decodeEntities(m[1]).trim(), relative: decodeEntities(m[2]).trim() };
+}
+
+/**
+ * A `<td headers="h_x">…` cell's links, as `{label, url}` rows.
+ *
+ * @param {string} html
+ * @param {string} header
+ * @return {Array<{label: string, url: ?string}>}
+ */
+function cellLinks(html, header) {
+	const cell = html.match(new RegExp(`<td headers="${header}"[^>]*>([\\s\\S]*?)</td>`));
+	if (!cell) return [];
+	const links = [];
+	const linkRe = /<a[^>]*href="([^"]+)"[^>]*>([^<]+)<\/a>/g;
+	let m;
+	while ((m = linkRe.exec(cell[1])) !== null) {
+		const label = decodeEntities(m[2]).trim();
+		if (label) links.push({ label, url: absoluteTracUrl(m[1]) });
+	}
+	return links;
+}
+
+/**
+ * The ticket's own facts, from the `#ticket` block's HTML.
+ *
+ * Returns null when the HTML holds no recognisable ticket — the caller treats
+ * that as "nothing to show", never as an error: the attachments alongside it
+ * are still good.
+ *
+ * @param {string} html
+ * @return {?Object}
+ */
+function parseTicketInfo(html) {
+	if (!html || !/trac-status|trac-ticket-title/.test(html)) return null;
+
+	const summary = capture(html, /<span class="summary">([^<]*)<\/span>/);
+	const status = capture(html, /<span class="trac-status">\s*<a[^>]*>([^<]+)<\/a>/);
+	const type = capture(html, /<span class="trac-type">\s*<a[^>]*>([^<]+)<\/a>/);
+	// Only present on closed tickets, rendered as "(fixed)" beside the status.
+	const resolution = capture(html, /<span class="trac-resolution">\s*\(<a[^>]*>([^<]+)<\/a>/);
+
+	const [milestone] = cellLinks(html, 'h_milestone');
+	const [component] = cellLinks(html, 'h_component');
+	const keywords = cellLinks(html, 'h_keywords');
+
+	return {
+		summary,
+		status,
+		type,
+		resolution,
+		opened: dateLine(html, 'Opened'),
+		closed: dateLine(html, 'Closed'),
+		milestone: milestone ? milestone.label : '',
+		component: component || null,
+		keywords
+	};
+}
+
+/**
+ * The status pill's text and tone, as one decision.
+ *
+ * "closed (fixed)" and "closed (wontfix)" read as opposite instructions — go
+ * find another ticket vs read the discussion first — so the resolution rides
+ * inside the pill rather than being a separate fact. Tone is a name the panel
+ * maps to its palettes, not a colour, so this stays a pure module.
+ *
+ * @param {?Object} info From parseTicketInfo.
+ * @return {?{label: string, tone: 'closed'|'active'}}
+ */
+function statusBadge(info) {
+	if (!info || !info.status) return null;
+	const label = info.resolution ? `${info.status} (${info.resolution})` : info.status;
+	return { label, tone: info.status === 'closed' ? 'closed' : 'active' };
+}
+
+module.exports = { parseTicketInfo, statusBadge };

--- a/src/trac-view.js
+++ b/src/trac-view.js
@@ -20,6 +20,7 @@
 
 const { BrowserWindow, session } = require('electron');
 const { parseAttachments, secureTracUrl } = require('./trac-attachments.cjs');
+const { parseTicketInfo } = require('./trac-ticket-info.cjs');
 const { httpGet } = require('./github-prs');
 
 const TRAC_HOST = 'core.trac.wordpress.org';
@@ -113,7 +114,21 @@ async function openAndScrape(ticketId) {
 			.executeJavaScript('(document.querySelector("#attachments") || {}).outerHTML || ""')
 			.catch(() => '');
 		const items = parseAttachments(html, id);
-		return { status: items.length ? 'ok' : 'no-attachments', items };
+		// The ticket's own facts ride the same visit (#292): the page is already
+		// loaded and the challenge already cleared, so reading them costs
+		// nothing. The description is cut before the HTML crosses out of the
+		// page — it is the bulk of the block and nothing in it is parsed.
+		const ticketHtml = await win.webContents
+			.executeJavaScript(`(() => {
+				const t = document.querySelector('#ticket');
+				if (!t) return '';
+				const copy = t.cloneNode(true);
+				for (const el of copy.querySelectorAll('.description, form, script')) el.remove();
+				return copy.outerHTML;
+			})()`)
+			.catch(() => '');
+		const ticket = parseTicketInfo(ticketHtml);
+		return { status: items.length ? 'ok' : 'no-attachments', items, ticket };
 	} catch (e) {
 		return { status: 'error', items: [], error: String(e && e.message ? e.message : e) };
 	} finally {

--- a/test/trac-ticket-info.test.cjs
+++ b/test/trac-ticket-info.test.cjs
@@ -1,0 +1,57 @@
+'use strict';
+
+// A ticket's own properties, parsed off its page (issue #292).
+//
+// The fixtures are the `#ticket` blocks of two real core Trac tickets, taken
+// from archived copies of the live pages — #59234 (open, with milestone,
+// component and keywords) and #40000 (closed wontfix) — so the regexes are
+// proven against markup Trac actually emits, not markup remembered.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseTicketInfo, statusBadge } = require('../src/trac-ticket-info.cjs');
+
+const OPEN_TICKET = '<div id="ticket" class="trac-content ">\n  <div class="date">\n    <p>Opened <a class="timeline" href="/timeline?from=2023-08-28T23%3A50%3A14Z&amp;precision=second" title="See timeline at 08/28/2023 11:50:14 PM">18 months ago</a></p>\n    <p>Last modified <a class="timeline" href="/timeline?from=2024-02-12T14%3A03%3A01Z&amp;precision=second" title="See timeline at 02/12/2024 02:03:01 PM">12 months ago</a></p>\n  </div>\n  <h2>\n    <a href="/ticket/59234" class="trac-id">#59234</a>\n    <span class="trac-status">\n      <a href="/query?status=new">new</a>\n    </span>\n    <span class="trac-type">\n      <a href="/query?status=!closed&amp;type=enhancement">enhancement</a>\n    </span>\n  </h2>\n  <h1 id="trac-ticket-title" class="searchable">\n    <span class="summary">Introduce a `wp_json_decode()` function, including validation when available</span>\n  </h1>\n  <table class="properties">\n    <tr>\n      <th id="h_reporter">Reported by:</th>\n      <td headers="h_reporter" class="searchable">\n  <a href="https://profiles.wordpress.org/jrf" data-nicename="jrf">\n    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=jrf&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=jrf&amp;s=96 2x" height="48" width="48" alt="jrf\'s profile" />\n  </a>\n    <a class="trac-author" href="/query?status=!closed&amp;reporter=jrf">jrf</a>\n</td>\n      <th id="h_owner" class="missing">Owned by:</th>\n      <td headers="h_owner">\n</td>\n    </tr>\n    <tr>\n        <th id="h_milestone">\n          Milestone:\n        </th>\n        <td headers="h_milestone">\n              <a class="milestone" href="/milestone/Future%20Release" title="No date set">Future Release</a>\n        </td>\n        <th id="h_priority">\n          Priority:\n        </th>\n        <td headers="h_priority">\n              <a href="/query?status=!closed&amp;priority=normal">normal</a>\n        </td>\n    </tr><tr>\n        <th id="h_severity">\n          Severity:\n        </th>\n        <td headers="h_severity">\n              <a href="/query?status=!closed&amp;severity=normal">normal</a>\n        </td>\n        <th id="h_version">\n          Version:\n        </th>\n        <td headers="h_version">\n              <a href="/query?status=!closed&amp;version=6.4">6.4</a>\n        </td>\n    </tr><tr>\n        <th id="h_component">\n          Component:\n        </th>\n        <td headers="h_component">\n              <a href="/query?status=!closed&amp;component=General">General</a>\n        </td>\n        <th id="h_keywords">\n          Keywords:\n        </th>\n        <td headers="h_keywords" class="searchable">\n              <a href="/query?status=!closed&amp;keywords=~php83">php83</a> <a href="/query?status=!closed&amp;keywords=~needs-patch">needs-patch</a> <a href="/query?status=!closed&amp;keywords=~dev-feedback">dev-feedback</a>\n        </td>\n    </tr><tr>\n        <th id="h_focuses" class="missing">\n          Focuses:\n        </th>\n        <td headers="h_focuses">\n        </td>\n        <th id="h_cc" class="missing">\n          Cc:\n        </th>\n        <td headers="h_cc" class="searchable">\n        </td>\n    </tr>\n  </table>\n</div>';
+
+const CLOSED_TICKET = '<div id="ticket" class="trac-content ">\n  <div class="date">\n    <p>Opened <a class="timeline" href="/timeline?from=2017-03-01T06%3A59%3A27Z&amp;precision=second" title="See timeline at 03/01/2017 06:59:27 AM">8 years ago</a></p>\n    <p>Closed <a class="timeline" href="/timeline?from=2017-03-08T02%3A05%3A51Z&amp;precision=second" title="See timeline at 03/08/2017 02:05:51 AM">8 years ago</a></p>\n    <p>Last modified <a class="timeline" href="/timeline?from=2019-10-16T00%3A19%3A50Z&amp;precision=second" title="See timeline at 10/16/2019 12:19:50 AM">6 years ago</a></p>\n  </div>\n  <h2>\n    <a href="/ticket/40000" class="trac-id">#40000</a>\n    <span class="trac-status">\n      <a href="/query?status=closed">closed</a>\n    </span>\n    <span class="trac-type">\n      <a href="/query?status=!closed&amp;type=enhancement">enhancement</a>\n    </span>\n    <span class="trac-resolution">\n      (<a href="/query?status=closed&amp;resolution=wontfix">wontfix</a>)\n    </span>\n  </h2>\n  <h1 id="trac-ticket-title" class="searchable">\n    <span class="summary">Alot of tickets continue to be created</span>\n  </h1>\n  <table class="properties">\n    <tr>\n      <th id="h_reporter">Reported by:</th>\n      <td headers="h_reporter" class="searchable">\n  <a href="https://profiles.wordpress.org/jorbin" data-nicename="jorbin">\n    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=jorbin&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=jorbin&amp;s=96 2x" height="48" width="48" alt="jorbin\'s profile" />\n  </a>\n    <a class="trac-author" href="/query?status=!closed&amp;reporter=jorbin">jorbin</a>\n</td>\n      <th id="h_owner">Owned by:</th>\n      <td headers="h_owner">\n  <a href="https://profiles.wordpress.org/alot">\n    <img class="avatar" src="https://wordpress.org/grav-redirect.php?user=alot&amp;s=48" srcset="https://wordpress.org/grav-redirect.php?user=alot&amp;s=96 2x" height="48" width="48" alt="alot\'s profile" />\n  </a>\n    <a class="trac-author" href="/query?status=!closed&amp;owner=alot">alot</a>\n</td>\n    </tr>\n    <tr>\n        <th id="h_milestone">\n          Milestone:\n        </th>\n        <td headers="h_milestone">\n              <a class="closed milestone" href="/milestone/4.8" title="Completed 8 years ago (06/08/2017 03:03:46 PM)">4.8</a>\n        </td>\n        <th id="h_priority">\n          Priority:\n        </th>\n        <td headers="h_priority">\n              <a href="/query?status=!closed&amp;priority=normal">normal</a>\n        </td>\n    </tr><tr>\n        <th id="h_severity">\n          Severity:\n        </th>\n        <td headers="h_severity">\n              <a href="/query?status=!closed&amp;severity=normal">normal</a>\n        </td>\n        <th id="h_version">\n          Version:\n        </th>\n        <td headers="h_version">\n              <a href="/query?status=!closed&amp;version=0.71">0.71</a>\n        </td>\n    </tr><tr>\n        <th id="h_component">\n          Component:\n        </th>\n        <td headers="h_component">\n              <a href="/query?status=!closed&amp;component=General">General</a>\n        </td>\n        <th id="h_keywords">\n          Keywords:\n        </th>\n        <td headers="h_keywords" class="searchable">\n              <a href="/query?status=!closed&amp;keywords=~needs-more-alot">needs-more-alot</a> <a href="/query?status=!closed&amp;keywords=~has-alot">has-alot</a>\n        </td>\n    </tr><tr>\n        <th id="h_focuses">\n          Focuses:\n        </th>\n        <td headers="h_focuses">\n              <a href="/query?status=!closed&amp;focuses=~ui">ui</a>, <a href="/query?status=!closed&amp;focuses=~accessibility">accessibility</a>, <a href="/query?status=!closed&amp;focuses=~javascript">javascript</a>, <a href="/query?status=!closed&amp;focuses=~docs">docs</a>, <a href="/query?status=!closed&amp;focuses=~rtl">rtl</a>, <a href="/query?status=!closed&amp;focuses=~administration">administration</a>, <a href="/query?status=!closed&amp;focuses=~template">template</a>, <a href="/query?status=!closed&amp;focuses=~multisite">multisite</a>, <a href="/query?status=!closed&amp;focuses=~rest-api">rest-api</a>, <a href="/query?status=!closed&amp;focuses=~performance">performance</a>\n        </td>\n        <th id="h_cc" class="missing">\n          Cc:\n        </th>\n        <td headers="h_cc" class="searchable">\n        </td>\n    </tr>\n  </table>\n</div>';
+
+test('parseTicketInfo: an open ticket yields every fact the panel shows (issue #292)', () => {
+	const info = parseTicketInfo(OPEN_TICKET);
+
+	assert.equal(info.summary, 'Introduce a `wp_json_decode()` function, including validation when available');
+	assert.equal(info.status, 'new');
+	assert.equal(info.type, 'enhancement');
+	assert.equal(info.resolution, '');
+	assert.equal(info.opened.relative, '18 months ago');
+	assert.match(info.opened.absolute, /08\/28\/2023/);
+	assert.equal(info.closed, null);
+	assert.equal(info.milestone, 'Future Release');
+	assert.equal(info.component.label, 'General');
+	// The link is Trac's own query URL, made absolute — not one rebuilt here.
+	assert.equal(info.component.url, 'https://core.trac.wordpress.org/query?status=!closed&component=General');
+	assert.deepEqual(info.keywords.map((k) => k.label), ['php83', 'needs-patch', 'dev-feedback']);
+	assert.equal(info.keywords[1].url, 'https://core.trac.wordpress.org/query?status=!closed&keywords=~needs-patch');
+});
+
+test('parseTicketInfo: a closed ticket carries its resolution and closed date (issue #292)', () => {
+	const info = parseTicketInfo(CLOSED_TICKET);
+
+	assert.equal(info.status, 'closed');
+	assert.equal(info.resolution, 'wontfix');
+	assert.ok(info.closed, 'the Closed line is parsed');
+	assert.equal(info.closed.relative, '8 years ago');
+});
+
+test('parseTicketInfo: junk yields null, not a shell of empty fields (issue #292)', () => {
+	assert.equal(parseTicketInfo(''), null);
+	assert.equal(parseTicketInfo('<div>Checking your browser</div>'), null);
+});
+
+// The pill: resolution rides inside it because "closed (fixed)" and "closed
+// (wontfix)" are opposite instructions to a contributor.
+test('statusBadge: folds the resolution into the label and names the tone (issue #292)', () => {
+	assert.deepEqual(statusBadge(parseTicketInfo(CLOSED_TICKET)), { label: 'closed (wontfix)', tone: 'closed' });
+	assert.deepEqual(statusBadge(parseTicketInfo(OPEN_TICKET)), { label: 'new', tone: 'active' });
+	assert.equal(statusBadge(null), null);
+});


### PR DESCRIPTION
## Why

A linked ticket shows its number and the work attached to it, but nothing about itself. A ticket closed `wontfix` years ago reads the same as one filed last week — and the contributor finds out on Trac, after the time is spent. #292 makes the case; the gap surfaced while testing #291, where a ticket whose only pull request is closed had its explanation (the ticket's own status) one unread page away.

## What changes

The ticket's own facts — summary, status, resolution, type, milestone, component, keywords, opened date — ride the scrape the attachments already do: same embedded Trac window, same one-time human-check, one extra read of the `#ticket` block (with the description cut before it crosses out of the page). No new mechanism, no second challenge, and `main.js`/`preload.js` are untouched — the handler already spreads the scrape result.

A new pure module, `src/trac-ticket-info.cjs`, does the parsing — regex over the HTML like `trac-attachments.cjs`, proven against fixtures taken from **archived copies of real ticket pages** (one open with milestone/component/keywords, one closed `wontfix`). It also owns the one display decision: the status pill folds the resolution in, because "closed (fixed)" and "closed (wontfix)" are opposite instructions to a contributor.

The card shows the summary under the ticket number, the status pill, type, age ("opened 18 months ago", absolute date in the tooltip), milestone, and the component and keywords as links — **Trac's own query URLs lifted from the page**, not rebuilt, opened in the browser like any other link. A "Read details from Trac" link sits next to "Open in Trac" and triggers the same scrape the attachments button uses.

The details are read **automatically at the moment a ticket is linked** — that is when the facts matter most (a `wontfix` ticket should say so before work starts), and it is the one moment a human-check window has context, since the contributor just acted on this ticket. On mount or site re-activation nothing opens: there the #109 on-demand rule stands, and the "Read details from Trac" link is the way in.

Deliberately not in this PR: any writing to Trac, and any freshness machinery — the facts can go stale exactly like the attachment list, and the same re-read answers both.

## How to test this

Platforms: any.

**Starting state:**

1. A Core site with no ticket linked.
2. Link a ticket with real properties — **62881** (the case from #292) or any `good-first-bug`. The details load on their own; pass the human-check if it appears. (On a site whose ticket was linked before this build, use **Read details from Trac** next to "Open in Trac" — nothing auto-opens on merely selecting a site.)

**Expected:** under the ticket number: the ticket's title; a status pill (red for closed, with the resolution folded in; green otherwise); the type; "opened … ago" with the absolute date on hover; the milestone when there is one; component and keywords as links that open Trac queries in the browser.

**What must not have happened:**

- No second Trac window / second challenge beyond the one visit.
- A ticket page that fails to parse shows nothing — no empty shell of "component:" labels; attachments still work.
- Nothing was written anywhere; this is read-only.

Tests: `test/trac-ticket-info.test.cjs`, table-driven over the two real-markup fixtures.

## Risks and limitations

- The parse is regex over markup that Trac could change — same exposure as the attachments parse, contained in one module with fixtures, failing soft (no info shown, everything else intact).
- Wording and layout are a draft for review.
- Verified against archived real pages and the suite; not yet driven by hand against live Trac (needs a human to pass the check).

## Related

Closes #292. Stacked on #291 (merge that first; this PR's base is its branch). Related: #109 (the embedded read this extends), #286.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Deterministic layer: `npm test` 933/933, `npm run lint` clean, renderer bundle builds. The judgement pass for the stack will run once on the combined branch before merge — flagged here so it is a decision, not an omission.

</details>
