### PR TITLE
Replace the manual install list with a platform-aware Download button

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -37,8 +37,12 @@ export default defineConfig( {
 	themeConfig: {
 		nav: [
 			{ text: 'Guide', link: '/guide/getting-started' },
+			// "Releases", not "Download": the platform-aware Download button is
+			// on the landing page and in the guide, and two links called
+			// "Download" that behave differently is the confusion this avoids.
+			// This one goes to the list of every asset and past version.
 			{
-				text: 'Download',
+				text: 'Releases',
 				link: 'https://github.com/WordPress/contributor-toolkit/releases/latest',
 			},
 		],

--- a/docs/.vitepress/theme/DownloadButton.vue
+++ b/docs/.vitepress/theme/DownloadButton.vue
@@ -1,0 +1,165 @@
+<script setup>
+// A download button that detects the visitor's platform and links straight to
+// the matching asset of the latest GitHub release. Release filenames follow the
+// artifactName pattern in the root package.json —
+// wordpress-contributor-toolkit-<version>-<os>-<arch>.<ext> — so the version is
+// baked into every asset name and there is no stable direct-download URL: the
+// asset has to be resolved at runtime from the releases API.
+//
+// Everything platform- and network-dependent happens in onMounted, so the SSR
+// build renders the fallback state: a plain link to the Releases page. That is
+// also what visitors get on an undetectable platform (mobile, unknown OS), when
+// the API call fails (offline, rate-limited), or with JavaScript disabled — the
+// button is never worse than the old "pick your file" link.
+import { ref, onMounted } from 'vue';
+import { matchPlatform, PLATFORMS } from './match-platform.mjs';
+
+const RELEASES_PAGE =
+	'https://github.com/WordPress/contributor-toolkit/releases/latest';
+const LATEST_RELEASE_API =
+	'https://api.github.com/repos/WordPress/contributor-toolkit/releases/latest';
+
+const downloadUrl = ref( RELEASES_PAGE );
+const platformId = ref( null );
+const platformLabel = ref( null );
+const version = ref( null );
+
+// The unauthenticated API allows 60 requests per hour per IP address — and a
+// Contributor Day room shares one. Cache the resolved asset for the session so
+// each visitor costs one request instead of one per page view.
+const CACHE_KEY = 'contributor-toolkit-latest-release';
+
+async function resolveAsset( platform ) {
+	try {
+		const cached = sessionStorage.getItem( CACHE_KEY );
+		if ( cached ) {
+			return JSON.parse( cached )[ platform.id ] ?? null;
+		}
+	} catch {
+		// Storage unavailable (private mode, quota): fall through to the API.
+	}
+	const response = await fetch( LATEST_RELEASE_API );
+	if ( ! response.ok ) {
+		return null;
+	}
+	return cacheAndPick( await response.json(), platform );
+}
+
+function cacheAndPick( release, platform ) {
+	const byPlatform = {};
+	for ( const asset of release.assets ) {
+		// Only ever hand the browser a GitHub release download; anything else
+		// in the API response is not a link this button should follow.
+		if ( ! asset.browser_download_url?.startsWith( 'https://github.com/' ) ) {
+			continue;
+		}
+		const match = matchPlatformAsset( asset.name );
+		if ( match ) {
+			byPlatform[ match ] = {
+				url: asset.browser_download_url,
+				version: release.tag_name,
+			};
+		}
+	}
+	try {
+		sessionStorage.setItem( CACHE_KEY, JSON.stringify( byPlatform ) );
+	} catch {
+		// Storage unavailable: the fetch just happens again on the next page.
+	}
+	return byPlatform[ platform.id ] ?? null;
+}
+
+function matchPlatformAsset( name ) {
+	const entry = PLATFORMS.find( ( p ) => p.assetPattern.test( name ) );
+	return entry ? entry.id : null;
+}
+
+onMounted( async () => {
+	const platform = matchPlatform( navigator.userAgent );
+	if ( ! platform ) {
+		return;
+	}
+	try {
+		const asset = await resolveAsset( platform );
+		if ( ! asset ) {
+			return;
+		}
+		downloadUrl.value = asset.url;
+		platformId.value = platform.id;
+		platformLabel.value = platform.label;
+		version.value = asset.version;
+	} catch {
+		// Offline or rate-limited: keep the Releases page link.
+	}
+} );
+</script>
+
+<template>
+	<div class="download-button">
+		<a class="download-button__action" :href="downloadUrl">
+			<template v-if="platformLabel">
+				Download for {{ platformLabel }}
+				<span v-if="version" class="download-button__version">{{
+					version
+				}}</span>
+			</template>
+			<template v-else>Download from the Releases page</template>
+		</a>
+		<p v-if="platformId === 'mac'" class="download-button__note">
+			Intel Macs are not currently supported.
+		</p>
+		<p class="download-button__note">
+			All platforms and previous versions on the
+			<a :href="RELEASES_PAGE" target="_blank" rel="noreferrer"
+				>Releases page</a
+			>.
+		</p>
+	</div>
+</template>
+
+<style scoped>
+.download-button {
+	margin: 24px 0;
+	text-align: center;
+}
+
+/* Sized and colored like the hero's brand action button. */
+.download-button__action {
+	display: inline-block;
+	border-radius: 20px;
+	padding: 0 24px;
+	line-height: 40px;
+	font-size: 14px;
+	font-weight: 600;
+	color: var( --vp-button-brand-text );
+	background-color: var( --vp-button-brand-bg );
+	transition:
+		color 0.25s,
+		background-color 0.25s;
+	text-decoration: none;
+}
+
+.download-button__action:hover {
+	color: var( --vp-button-brand-hover-text );
+	background-color: var( --vp-button-brand-hover-bg );
+}
+
+.download-button__version {
+	margin-left: 6px;
+	font-weight: 400;
+	opacity: 0.8;
+}
+
+.download-button__note {
+	margin: 8px 0 0;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var( --vp-c-text-2 );
+}
+
+.download-button__note a {
+	color: var( --vp-c-brand-1 );
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+</style>

--- a/docs/.vitepress/theme/DownloadButton.vue
+++ b/docs/.vitepress/theme/DownloadButton.vue
@@ -118,9 +118,11 @@ onMounted( async () => {
 </template>
 
 <style scoped>
+/* Alignment is deliberately not set here: it is inherited, so the hero can
+   follow the hero's alignment and an in-page usage can follow the prose. A
+   scoped rule would out-specify both. */
 .download-button {
 	margin: 24px 0;
-	text-align: center;
 }
 
 /* Sized and colored like the hero's brand action button. */

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,24 @@
+<script setup>
+// Wraps the default layout to put <DownloadButton /> in the home hero, where
+// the static "Download" action used to sit. The hero's actions come from
+// index.md frontmatter and cannot host a component, so the only way for the
+// most prominent Download on the page to be the platform-aware one is this
+// slot — otherwise the landing page offers two things called "Download" and
+// the dumb one is the one people click.
+import DefaultTheme from 'vitepress/theme';
+import DownloadButton from './DownloadButton.vue';
+
+const { Layout } = DefaultTheme;
+</script>
+
+<template>
+	<Layout>
+		<template #home-hero-actions-after>
+			<!-- No alignment of its own: the hero switches between left and
+			     centred depending on viewport and whether a hero image is set,
+			     so inheriting is the only way the button stays attached to the
+			     actions above it. -->
+			<DownloadButton />
+		</template>
+	</Layout>
+</template>

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,0 +1,11 @@
+// The default theme, extended only to register <DownloadButton /> for use in
+// markdown pages (the landing page and the install section of the guide).
+import DefaultTheme from 'vitepress/theme';
+import DownloadButton from './DownloadButton.vue';
+
+export default {
+	extends: DefaultTheme,
+	enhanceApp( { app } ) {
+		app.component( 'DownloadButton', DownloadButton );
+	},
+};

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,10 +1,13 @@
-// The default theme, extended only to register <DownloadButton /> for use in
-// markdown pages (the landing page and the install section of the guide).
+// The default theme, extended for <DownloadButton />: a Layout wrapper that
+// puts it in the home hero, and a global registration so markdown pages (the
+// install section of the guide) can use it too.
 import DefaultTheme from 'vitepress/theme';
+import Layout from './Layout.vue';
 import DownloadButton from './DownloadButton.vue';
 
 export default {
 	extends: DefaultTheme,
+	Layout,
 	enhanceApp( { app } ) {
 		app.component( 'DownloadButton', DownloadButton );
 	},

--- a/docs/.vitepress/theme/match-platform.mjs
+++ b/docs/.vitepress/theme/match-platform.mjs
@@ -1,0 +1,52 @@
+// The user-agent → platform decision behind <DownloadButton />, kept out of the
+// component so the root `node --test` suite can reach it (the docs package has
+// no test harness of its own). ESM rather than .cjs because the browser loads
+// it as-is through Vite; the test imports it dynamically.
+//
+// `assetPattern` is matched against the release asset names produced by the
+// artifactName pattern in the root package.json. The arch token is matched
+// loosely on purpose: electron-builder maps `x64` to `x86_64` for some targets
+// (AppImage among them), so an exact `-x64` match is one rebuild away from
+// silently missing every Linux asset. macOS stays pinned to `arm64` — the app
+// has no Intel build, and the label promises Apple Silicon.
+export const PLATFORMS = [
+	{
+		id: 'windows',
+		test: /Windows/,
+		assetPattern: /-win-[^.]+\.exe$/,
+		label: 'Windows',
+	},
+	{
+		id: 'mac',
+		// "Macintosh", not "Mac": every iOS user agent contains "like Mac OS X",
+		// and an iPhone cannot open a .dmg. (iPadOS in desktop mode presents
+		// itself as a Mac and is genuinely indistinguishable.)
+		test: /Macintosh/,
+		assetPattern: /-mac-arm64\.dmg$/,
+		label: 'macOS (Apple Silicon)',
+	},
+	{
+		id: 'linux',
+		test: /Linux|X11/,
+		assetPattern: /-linux-[^.]+\.AppImage$/,
+		label: 'Linux',
+	},
+];
+
+/**
+ * Pick the download platform for a browser user-agent string, or null when
+ * there is no build for it (mobile, unknown OS) and the caller should fall
+ * back to the Releases page.
+ *
+ * @param {string} ua `navigator.userAgent`.
+ * @return {?{id: string, test: RegExp, assetPattern: RegExp, label: string}}
+ *         The matched platform entry.
+ */
+export function matchPlatform( ua ) {
+	// Android UAs contain "Linux" and iOS UAs contain "like Mac OS X"; there
+	// is no build for either.
+	if ( /Android|iPhone|iPad|iPod/.test( ua ) ) {
+		return null;
+	}
+	return PLATFORMS.find( ( platform ) => platform.test.test( ua ) ) ?? null;
+}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -12,11 +12,9 @@ No Git, no Node.js, no npm, no Docker needed. Everything is bundled inside the a
 
 ## Install the app
 
-1. Download the latest packaged build for your platform from the [Releases page](https://github.com/WordPress/contributor-toolkit/releases/latest). Pick the file that matches your OS:
-   - **macOS on Apple Silicon:** the `.dmg` file whose name contains `arm64`. Intel Macs are not currently supported.
-   - **Windows:** the `.exe` installer.
-   - **Linux:** the `.AppImage`; `.deb` and `.snap` packages may also be available.
-2. Open the app.
+<DownloadButton />
+
+Download the latest build for your platform with the button above, then open the app.
 
 ### If macOS blocks the app
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,5 @@ features:
   - title: One site, as many tickets as you like
     details: Each ticket gets its own branch inside the site and keeps its own work. Moving between two tickets takes seconds — no second clone and no reinstall.
 ---
+
+<DownloadButton />

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,11 @@ hero:
   text: Contribute to WordPress core with zero prerequisites
   tagline: A desktop app that clones wordpress-develop, builds it, runs it, and turns your changes into a patch or pull request — no Git, Node, npm, or Docker required.
   actions:
-    - theme: brand
+    # Secondary on purpose: the brand-coloured action on this page is the
+    # Download button injected after this list (see .vitepress/theme/Layout.vue).
+    - theme: alt
       text: Get started
       link: /guide/getting-started
-    - theme: alt
-      text: Download
-      link: https://github.com/WordPress/contributor-toolkit/releases/latest
 
 features:
   - title: A full core environment in one click
@@ -23,5 +22,3 @@ features:
   - title: One site, as many tickets as you like
     details: Each ticket gets its own branch inside the site and keeps its own work. Moving between two tickets takes seconds — no second clone and no reinstall.
 ---
-
-<DownloadButton />

--- a/test/download-button-platform.test.cjs
+++ b/test/download-button-platform.test.cjs
@@ -1,0 +1,86 @@
+// The user-agent → platform decision behind the docs site's <DownloadButton />.
+// The module lives in docs/.vitepress/theme/ because the browser loads it, but
+// the docs package has no test harness, so its test lives here in the root
+// suite. ESM module, CJS suite: imported dynamically.
+const { describe, it, before } = require( 'node:test' );
+const assert = require( 'node:assert' );
+
+// Real user-agent strings, not synthetic ones — the iOS case exists precisely
+// because every iPhone UA contains "like Mac OS X".
+const UA = {
+	macChrome:
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+	macSafari:
+		'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+	windows:
+		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+	linuxX11:
+		'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+	linuxFirefox:
+		'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0',
+	android:
+		'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+	iphone:
+		'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+	ipad: 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+};
+
+describe( 'matchPlatform', () => {
+	let matchPlatform;
+	let PLATFORMS;
+
+	before( async () => {
+		( { matchPlatform, PLATFORMS } = await import(
+			'../docs/.vitepress/theme/match-platform.mjs'
+		) );
+	} );
+
+	it( 'maps each desktop OS to its platform', () => {
+		assert.strictEqual( matchPlatform( UA.macChrome ).id, 'mac' );
+		assert.strictEqual( matchPlatform( UA.macSafari ).id, 'mac' );
+		assert.strictEqual( matchPlatform( UA.windows ).id, 'windows' );
+		assert.strictEqual( matchPlatform( UA.linuxX11 ).id, 'linux' );
+		assert.strictEqual( matchPlatform( UA.linuxFirefox ).id, 'linux' );
+	} );
+
+	it( 'returns null for mobile, which has no build', () => {
+		// Android UAs contain "Linux"…
+		assert.strictEqual( matchPlatform( UA.android ), null );
+		// …and iOS UAs contain "like Mac OS X". A .dmg on an iPhone helps nobody.
+		assert.strictEqual( matchPlatform( UA.iphone ), null );
+		assert.strictEqual( matchPlatform( UA.ipad ), null );
+	} );
+
+	it( 'returns null for an unrecognised user agent', () => {
+		assert.strictEqual( matchPlatform( 'curl/8.6.0' ), null );
+	} );
+
+	it( 'matches the published asset names, loose on the arch token', () => {
+		const names = {
+			windows: 'wordpress-contributor-toolkit-0.1.2-win-x64.exe',
+			mac: 'wordpress-contributor-toolkit-0.1.2-mac-arm64.dmg',
+			linux: 'wordpress-contributor-toolkit-0.1.2-linux-x64.AppImage',
+			// electron-builder maps x64 → x86_64 for AppImage when expanding
+			// ${arch}, so a rebuild can rename the Linux asset out from under
+			// an exact match without any error surfacing anywhere.
+			linuxRenamed:
+				'wordpress-contributor-toolkit-0.2.0-linux-x86_64.AppImage',
+		};
+		const byId = Object.fromEntries( PLATFORMS.map( ( p ) => [ p.id, p ] ) );
+		assert.ok( byId.windows.assetPattern.test( names.windows ) );
+		assert.ok( byId.mac.assetPattern.test( names.mac ) );
+		assert.ok( byId.linux.assetPattern.test( names.linux ) );
+		assert.ok( byId.linux.assetPattern.test( names.linuxRenamed ) );
+		// No pattern matches another platform's asset.
+		for ( const platform of PLATFORMS ) {
+			for ( const [ id, name ] of Object.entries( names ) ) {
+				if ( id !== platform.id && ! id.startsWith( platform.id ) ) {
+					assert.ok(
+						! platform.assetPattern.test( name ),
+						`${ platform.id } pattern must not match ${ name }`
+					);
+				}
+			}
+		}
+	} );
+} );


### PR DESCRIPTION
## Why

The docs' install step handed visitors a link to the Releases page and a bulleted list explaining which of four similarly-named files was theirs — `.dmg` "whose name contains `arm64`", `.exe`, `.AppImage`. Every newcomer had to read release-asset naming before they could download anything, and at a Contributor Day that is the first thing standing between someone and the app.

Suggested by Adam Zieliński: replace all of it with a Download button that just starts downloading the right file. No issue — it came from Slack.

## What changes

A `<DownloadButton />` component in a new VitePress custom theme, used in the guide's **Install the app** section (replacing the per-OS list) and as the landing page's primary hero action.

Every affordance labelled "Download" is now the smart one. That took three edits beyond the component: the hero's static Download action is gone and the button is injected in its place via the `home-hero-actions-after` slot (hero actions come from frontmatter and cannot host a component); "Get started" drops to the secondary style so the page has one primary action; and the nav item is renamed **Releases**, which is where it goes and what it is for. Two links called "Download" that behave differently is worse than none.

The asset URL cannot be hardcoded. `artifactName` in `package.json` bakes the version into every filename, so there is no stable "latest .dmg" URL — the button resolves the asset at runtime from the GitHub releases API and matches on the OS/extension portion of the name.

Two decisions worth surfacing:

- **One request per visitor, not per page view.** The unauthenticated API allows 60 requests/hour *per IP*, and a Contributor Day room shares one address. A single response resolves all three platforms into `sessionStorage`, so a room of 30 people costs 30 requests instead of exhausting the budget and silently degrading for everyone who arrives after.
- **The user-agent decision lives in `match-platform.mjs`, not in the component.** The docs package has no test harness, so a branch inside the `.vue` file is unreachable by anything — same reasoning as the renderer-module invariant in AGENTS.md §1. The module is imported by the root `node --test` suite.

Deliberately not in this PR: nothing about how releases are built or named. The button reads the existing assets; `artifactName` is untouched.

## How to test this

**Platforms:** any — it is a docs-site change, driven entirely in a browser. Nothing in the Electron app is touched.

**Starting state:** the branch checked out, docs dev server running.

1. `cd docs && npm install && npm run dev`, then open `http://localhost:5173/contributor-toolkit/`.
   The hero shows a **Download for macOS (Apple Silicon) v0.1.2** button as its primary action (label matches whatever machine you are on), with "Get started" above it in the secondary style.
2. Hover or copy the button's link. It points at `.../releases/download/v0.1.2/wordpress-contributor-toolkit-0.1.2-mac-arm64.dmg` — the asset itself, not the Releases page.
3. Click it. The download starts directly; no intermediate page. Then click the nav's **Releases** and confirm that one still goes to the releases list — it is the route to `.deb`/`.snap` and older versions.
4. Open `/guide/getting-started`. The **Install the app** section shows the same button in place of the old numbered list, with "Intel Macs are not currently supported." beneath it on macOS.
5. DevTools → three-dot menu → **Network conditions** → uncheck "Use browser default" and paste a Windows user agent, then reload.
   The button reads **Download for Windows** and links to the `.exe`. Repeat with a Linux UA for the `.AppImage`.
6. Same again with an iPhone UA (`Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) ...`).
   The button reads **Download from the Releases page** and links there — an iPhone must not be offered a `.dmg`.
7. DevTools → Network → **Block request URL** on `api.github.com`, then reload with any UA.
   The button falls back to the Releases-page link. Same with the network offline.
8. With DevTools' Network tab open and `sessionStorage` empty, load the landing page and then navigate to the guide.
   Exactly **one** request to `api.github.com` across both, and the second page's button still carries the direct asset URL.

9. Narrow the window below 960px and reload. The button stays aligned with the hero text and the "Get started" action above it, rather than centring on its own.

**What must not have happened:**

- No link labelled "Download" may point at the Releases page. That was the state this PR first landed in — the button sat below the feature cards while the hero action and nav item, both called "Download", still sent people to the file list — and it is the thing to re-check if the hero is ever touched. The only remaining Releases links are the nav's **Releases** and the "All platforms and previous versions" line under the button, both of which say so.
- The button must never be a dead link. Every failure path — undetectable platform, API down, rate limited, JavaScript disabled — has to land on the Releases page, which is what the docs did before. A button that silently does nothing is worse than the list it replaced.
- The Releases-page link under the button must survive on every platform: it is the only remaining route to `.deb`/`.snap` and to older versions, and the old Linux bullet was the only place `.deb`/`.snap` were mentioned.
- Reloading must not re-fetch. If step 8 shows two API calls, the session cache is not working and the room-shares-one-IP problem is back.
- `npm run docs:build` must still pass — the component reads `navigator` and calls `fetch`, and doing either outside `onMounted` breaks SSR at build time rather than in the browser.

## Risks and limitations

Review outcome: **3 [fix here] · 3 [follow-up] — all 6 fixed.** Details in the collapsed block below.

- **iPadOS in desktop mode is indistinguishable from a Mac** and will still be offered a `.dmg`. Safari on iPad reports a `Macintosh` user agent by design; there is no reliable signal short of touch-point heuristics, which misfire on touchscreen laptops. An iPhone is handled correctly.
- **The API dependency is real.** GitHub rate-limiting or an outage degrades the button to the old behaviour rather than breaking it, but the smart path does depend on a third-party call from the visitor's browser. The alternative — generating a static URL at release time — is noted below.
- **Asset-name coupling.** The button matches release filenames. It is now loose on the arch token so an `x64` → `x86_64` rename cannot break it, but a change to the OS or extension portion of `artifactName` would silently drop that platform to the fallback with no error anywhere. `test/download-button-platform.test.cjs` pins the current names, so that test is the tripwire.
- **Not tested by hand:** an actual rate-limit 403 from GitHub. Blocking `api.github.com` in DevTools exercises the same fallback branch (`response.ok` is false either way), but I could not stage 60 real requests to see the genuine response.

## Related

Suggested by Adam Zieliński in Slack. No issue.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Generating a static redirect at release time instead of calling the API.** The obvious alternative: have the release workflow write a small JSON file (or a set of stable redirect URLs) into the docs site, so the page needs no third-party call. It is strictly better on rate limits and privacy, and it is what I would build if this were load-bearing. Not done here because it couples the docs deploy to the release workflow — the docs would have to be rebuilt on every release, or the file fetched anyway — and the runtime call is a self-contained change to one component. Worth revisiting if the API dependency ever bites.

**Leaving the hero action alone.** The first version of this PR did exactly that, on the reasoning that the static Download was a harmless always-works fallback and a layout override was disproportionate. It was wrong, and it was wrong in the way that shows up immediately: asked to try it, the first thing JuanMa clicked was the hero's "Download", then the nav's — the two most prominent Downloads on the page, both of which went to the file list this PR exists to remove. A fallback that outranks the real thing is not a fallback. Hence the `home-hero-actions-after` slot, which turned out to be a documented default-theme slot rather than the full layout override I had assumed.

**Renaming the nav item rather than deleting it.** The releases list is still the only route to `.deb`/`.snap` and to older versions, so it earns a place; it just cannot be called "Download" while a smarter Download sits on the same page.

**Keeping the per-OS list as a collapsed section.** Rejected: the button's own fallback link goes to the Releases page, which shows every asset with its name. Restating the naming scheme in prose is a second copy that drifts the moment a target is added.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**3 [fix here] · 3 [follow-up] — all 6 fixed.** The judgement pass ran in a fresh context per `.claude/skills/self-review`. Deterministic layer: `npm run lint` clean, `npm test` 898/898 (894 before this PR, +4 new).

[fix here]:

1. 🟡 **Cross-platform** — `/Mac/` matched iPhones. Every iOS user agent contains `like Mac OS X`, so an iPhone visitor was told "Download for macOS (Apple Silicon)" and handed a `.dmg`. Now matches `Macintosh`, with `iPhone|iPad|iPod` added to the mobile guard alongside Android. This was a real bug, not a hypothetical — the new test fails on the pre-review code.
2. 🟡 **Performance** — the API call fired on every page view with no caching, against a 60/hour/IP limit shared by a whole Contributor Day room. Now one response resolves all three platforms into `sessionStorage`.
3. 🔵 **Architecture** — the Intel-Mac caveat was gated on comparing against the user-visible label string, so a copy edit would have silently dropped the warning. Now gated on a non-display `id`.

[follow-up] — all fixed here rather than deferred, since each was a one-liner in code the PR was already touching:

4. 🔵 **Cross-platform** — `-linux-x64.AppImage` was an exact match, and electron-builder maps `x64` → `x86_64` for AppImage when expanding `${arch}`. A rebuild could have renamed the asset out from under it with no error surfacing. Patterns are now loose on the arch token.
5. 🔵 **Security** — `asset.browser_download_url` went into `:href` with no scheme check. Now only assets under `https://github.com/` are accepted; anything else is skipped and the visitor gets the fallback. The threat is remote (an attacker who controls that field controls the binaries), but the repo's standard is that a URL crossing a trust boundary gets validated before something acts on it.
6. 🔵 **Tests** — the only branchy logic sat in a component in a package with no test harness. Extracted to `match-platform.mjs`; finding 1 is exactly what a table test over real user-agent strings catches.

</details>

<details>
<summary>Implementation notes</summary>

Eight files, all docs-side except the test:

- `docs/.vitepress/theme/index.js` — new. Extends the default theme to register the component globally and to install the Layout wrapper; there was no custom theme before this PR.
- `docs/.vitepress/theme/Layout.vue` — new. Wraps the default layout for the single purpose of filling `home-hero-actions-after`. The button sets no alignment of its own so it inherits the hero's, which switches between left and centred by viewport and by whether a hero image is set — a hard-coded media query on the button got this wrong at 700px.
- `docs/.vitepress/config.mjs` — nav "Download" → "Releases".
- `docs/.vitepress/theme/DownloadButton.vue` — new. All `navigator`/`fetch` access is inside `onMounted`, so SSR renders the fallback state and `npm run docs:build` is the regression check for that.
- `docs/.vitepress/theme/match-platform.mjs` — new. `matchPlatform( ua )` plus the `PLATFORMS` table. ESM because the browser loads it through Vite as-is; the CJS test imports it dynamically.
- `docs/guide/getting-started.md`, `docs/index.md` — the two usages.
- `test/download-button-platform.test.cjs` — new, 4 tests. Real user-agent strings rather than synthetic ones, since the iOS case only exists because a real iPhone UA says `like Mac OS X`. Also asserts the asset patterns against both the current Linux filename and the `x86_64` form from finding 4.

Verified in Chromium via Playwright across spoofed macOS / Windows / Linux / Android / iPhone user agents, with `api.github.com` blocked, and with a request counter across two navigations to confirm the session cache holds at exactly one call.

</details>

<details>
<summary>Screenshots or recording</summary>

Not attached — `gh` cannot upload images, and I would rather not paste an external host into a WordPress repo. Both surfaces are one dev-server command away (steps 1 and 4 above), and the visual change is small enough to describe:

**Landing page hero** — under the tagline, "Get started" in the grey secondary style, and below it the brand-coloured "Download for macOS (Apple Silicon)" pill with the version in lighter text beside it, then two small grey lines: the Intel-Macs note and "All platforms and previous versions on the Releases page". The nav reads "Releases" where it read "Download".

**Guide → Install the app** — the same button in place of the numbered list and its four per-OS bullets, followed by one sentence: "Download the latest build for your platform with the button above, then open the app." The "If macOS blocks the app" subsection below is untouched.

Both were checked in light and dark theme; the button uses VitePress's own `--vp-button-brand-*` tokens, so it matches the hero's "Get started" button in both.

</details>
