### PR TITLE
Bump version to 1.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-rc.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-rc.1",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",


### PR DESCRIPTION
## Why

`v1.0.0-beta.1` shipped on 10 August. Twenty changes have landed on `trunk` since — the setup chain, the decoupled build watch, the failed-apply explanation, the ticket's own facts, the toasts. That is the release candidate for 1.0, so the version moves to `1.0.0-rc.1` before the tag is cut.

## What changes

`package.json` and `package-lock.json`, and nothing else. Written by `npm version 1.0.0-rc.1 --no-git-tag-version` rather than by hand, so the lockfile's two copies of the string move with it.

`git grep 1.0.0-beta` outside the lockfile returns nothing, so no doc, workflow or script carries the version. `electron-builder` derives the artefact names from `package.json`, so the assets become:

- `wordpress-contributor-toolkit-1.0.0-rc.1-mac-arm64.dmg`
- `wordpress-contributor-toolkit-1.0.0-rc.1-win-x64.exe`
- `wordpress-contributor-toolkit-1.0.0-rc.1-linux-x86_64.AppImage`

The `rc.1` shape (not `rc1`) keeps the same form as `beta.1`, so the filenames stay in one series.

## Scope

The open Gutenberg stack (#255 → #261 → #264 → #269 → #283) is deliberately **not** in this release candidate. An RC stabilises what is there; a feature of that size belongs in the release after it.

## Review

No behaviour changes, so the review standard has nothing to grade beyond the diff itself: two version strings, produced by npm, verified against `git grep`. Lint and unit tests run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)