### PR TITLE
Bring the guide back in line with the app before 1.0

### DIFF
--- a/docs/guide/applying-patches.md
+++ b/docs/guide/applying-patches.md
@@ -27,7 +27,32 @@ Click **Apply and rebuild** to go ahead, or **Cancel** to back out.
 
 The panel shows each step as it runs: applying the patch, installing dependencies if needed, and rebuilding. When it finishes, the panel reports what is applied — the patch's name, how many files it changed, and when.
 
-If a step fails, the error says what went wrong and the checkout was not changed.
+If the [build watch](running-the-site#the-build-watch) is running and the patch only touches `src/`, there is no build step: the patch is applied and left for the watch to compile, and the checklist says so. A patch that moves `package-lock.json` or needs a full build pauses the watch for the duration and resumes it after — the dev server stays up throughout.
+
+## When a patch will not apply
+
+The apply is all-or-nothing. If anything fails, nothing is written to your checkout — but the panel now tells you *how much* failed, because one region of twenty missing and all twenty missing are opposite decisions for you.
+
+The headline is a count, not an adjective: *4 of this patch's 20 changes across 3 files no longer fit — the other 16 do.* When every change is already in your checkout — which is what a patch that has since been committed to core looks like — it says that instead, rather than reporting the patch as dead.
+
+### For a patch file or a Trac attachment
+
+You get the full breakdown, because you are the only one who can rescue it. Each file lists its failing regions, and each region says **why**:
+
+- **the code around it has changed** — the patch was written against an older trunk and the lines it expected have moved.
+- **looks like it is already in your checkout** — that change is present. The app tells the two apart by testing whether the region's reverse fits.
+
+Each region shows the lines it wanted to add and remove, and — more usefully — an **anchor line taken from your own file** to search for. A hunk's line numbers are coordinates in the file as its author had it, so on an old patch they miss by exactly the drift that made it fail; a line you can search for does not.
+
+### For a pull request
+
+The regions belong to whoever updates the pull request, and that is its author, not you. So the notice names the situation and its scale — *this pull request was written against an older trunk and no longer fits it: 4 of its 20 changes, in 3 files, would need rework* — without the line-level detail, and points at the one act that is genuinely yours: telling the author. Leaving a comment asking for a rebase is a real contribution.
+
+A **closed** pull request is read differently, because on `wordpress-develop` "closed" is also what landing looks like — core commits go through SVN and the pull request is closed, never merged. If all its changes read back as already in trunk, the panel says it was likely committed to core and there is nothing left to apply. Otherwise it says nobody is coming back to update it, and offers **See why it was closed**.
+
+### The way out
+
+When the ticket has other patches on it — another pull request, another attachment — the panel offers them. It only does so when there is genuinely one to try: a way out that lands you back at the same dead end costs a click to discover.
 
 ## Applied patches belong to a ticket
 

--- a/docs/guide/applying-patches.md
+++ b/docs/guide/applying-patches.md
@@ -27,7 +27,7 @@ Click **Apply and rebuild** to go ahead, or **Cancel** to back out.
 
 The panel shows each step as it runs: applying the patch, installing dependencies if needed, and rebuilding. When it finishes, the panel reports what is applied — the patch's name, how many files it changed, and when.
 
-If the [build watch](running-the-site#the-build-watch) is running and the patch only touches `src/`, there is no build step: the patch is applied and left for the watch to compile, and the checklist says so. A patch that moves `package-lock.json` or needs a full build pauses the watch for the duration and resumes it after — the dev server stays up throughout.
+If the [build watch](running-the-site#the-build-watch) is running and the patch does not move `package-lock.json`, there is no build step: the patch is applied and left for the watch to compile, and the checklist says so. A patch that does move the lockfile has to install and build, so it pauses the watch for the duration and resumes it after — the dev server stays up throughout.
 
 ## When a patch will not apply
 
@@ -42,7 +42,7 @@ You get the full breakdown, because you are the only one who can rescue it. Each
 - **the code around it has changed** — the patch was written against an older trunk and the lines it expected have moved.
 - **looks like it is already in your checkout** — that change is present. The app tells the two apart by testing whether the region's reverse fits.
 
-Each region shows the lines it wanted to add and remove, and — more usefully — an **anchor line taken from your own file** to search for. A hunk's line numbers are coordinates in the file as its author had it, so on an old patch they miss by exactly the drift that made it fail; a line you can search for does not.
+Every region carries an **anchor line taken from your own file** to search for. A hunk's line numbers are coordinates in the file as its author had it, so on an old patch they miss by exactly the drift that made it fail; a line you can search for does not. The first few regions of each file also show the lines the patch wanted to add and remove — enough to recognise the change without turning the panel into the diff itself.
 
 ### For a pull request
 

--- a/docs/guide/creating-a-site.md
+++ b/docs/guide/creating-a-site.md
@@ -25,7 +25,7 @@ The app clones the `wordpress-develop` repository from GitHub. Git is bundled wi
 
 While the clone runs, the site view shows a **Setting up new site…** card with the current phase and a terminal panel streaming progress output. The clone downloads the full repository, so expect it to take several minutes depending on your connection.
 
-The clone is the first step of the [initial setup checklist](./setup-wizard); the remaining steps (installing dependencies, building, starting the dev server) stay locked until it finishes, then you drive them yourself.
+The clone is the first step of the [initial setup checklist](./setup-wizard); the remaining steps stay locked until it finishes. Then the app carries on by itself — installing the dependencies and running the first build without waiting for you — so the only step left to click is starting the dev server.
 
 If setup fails, the half-created site is removed from the list — the row simply disappears. The
 reason goes to the application log rather than to a dialog, so **Help → Open App Log** is where

--- a/docs/guide/editors.md
+++ b/docs/guide/editors.md
@@ -37,4 +37,4 @@ If an application fails to open the directory — it was uninstalled, or the lau
 
 ## What to edit
 
-WordPress source lives under `src/` in the site directory. While the dev server is running, a watcher rebuilds your edits into `build/` automatically — see [Running the site](./running-the-site). When your change is ready, see [Submitting changes](./submitting-changes).
+WordPress source lives under `src/` in the site directory. While the [build watch](./running-the-site#the-build-watch) is running, your edits are rebuilt into `build/` as you save them. It runs on its own control, so it does not need the dev server up — though starting the server starts it too. When your change is ready, see [Submitting changes](./submitting-changes).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -45,8 +45,8 @@ The app is signed and notarized by Automattic, so macOS should open it without i
 
 That's it — you've contributed to WordPress core.
 
-::: tip You are never left guessing what to do next
-Whatever state a site is in, one block on the screen carries a **Start here** ring and scrolls itself into view — the step to run, the warning to act on, or the work currently in flight. It is announced to screen readers too. And when an action finishes — a patch saved, trunk updated, a pull request opened — a brief notice says so out loud rather than leaving you to check.
+::: tip You are not left guessing what to do next
+When a site has something pending — a setup step to run, a warning to act on, work in flight — that one block is ringed in amber and scrolls itself into view, and is announced to screen readers as *Next step: …*. A site that is set up, running and clean has nothing pending, so nothing is ringed. And when an action finishes — a patch saved, trunk updated, a pull request opened — a brief notice says so out loud rather than leaving you to check.
 :::
 
 ![A site ready for work: Start dev server, Review & submit changes, the Trac ticket panel and the patch panel](/screenshots/site-view.png)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,18 +33,21 @@ The app is signed and notarized by Automattic, so macOS should open it without i
   The app is code-signed. The recursive flag (`-r`) tries to strip attributes from files inside the sealed bundle, which macOS rejects with permission errors. Removing the attribute from the top-level bundle is sufficient.
   :::
 
-## Your first contribution, in ten steps
+## Your first contribution, in seven steps
 
 1. Click **Create WordPress Core site** and choose a destination folder for your site.
-2. Wait while the app downloads `wordpress-develop`.
-3. Click **Install npm dependencies**.
-4. Click **Run full build**.
-5. Click **Start dev server**.
-6. A browser window opens automatically. If not, open it by clicking the site URL.
-7. Make changes to the code — [open the site in your editor](./editors) straight from the app.
-8. Click **Review & submit changes** to see a diff of everything you changed.
-9. Pick where the patch goes: [a pull request](./submit-github-pr), [a Trac ticket](./submit-trac), or [a file for your mentor](./submit-mentor).
-10. That's it — you've contributed to WordPress core.
+2. Wait. The app downloads `wordpress-develop`, then installs the dependencies and runs the first build on its own — go and get a coffee. See [The setup wizard](./setup-wizard).
+3. Click **Start dev server**.
+4. A browser window opens automatically. If not, open it by clicking the site URL — or the **wp-admin** link beside it, to go straight to the dashboard.
+5. Make changes to the code — [open the site in your editor](./editors) straight from the app.
+6. Click **Review & submit changes** to see a diff of everything you changed.
+7. Pick where the patch goes: [a pull request](./submit-github-pr), [a Trac ticket](./submit-trac), or [a file for your mentor](./submit-mentor).
+
+That's it — you've contributed to WordPress core.
+
+::: tip You are never left guessing what to do next
+Whatever state a site is in, one block on the screen carries a **Start here** ring and scrolls itself into view — the step to run, the warning to act on, or the work currently in flight. It is announced to screen readers too. And when an action finishes — a patch saved, trunk updated, a pull request opened — a brief notice says so out loud rather than leaving you to check.
+:::
 
 ![A site ready for work: Start dev server, Review & submit changes, the Trac ticket panel and the patch panel](/screenshots/site-view.png)
 

--- a/docs/guide/logs-and-debugging.md
+++ b/docs/guide/logs-and-debugging.md
@@ -5,8 +5,9 @@ The **Logs** section of the site view has three tabs:
 - **Server** — the dev server's own output: everything the Playground server prints while
   starting and running.
 - **Build watcher** — the [build watch](./running-the-site#the-build-watch)'s output. The tab title
-  carries its state: *Build watcher (watching)*, *(building)*, *(paused)*, *(stopped)*, or
-  *(exited 1)* when it ended on its own.
+  carries its state while it is doing something: *Build watcher (watching)*, *(building)*,
+  *(paused)*, or *(exited 1)* when it stopped on its own. Stop it yourself and the title goes back
+  to a plain *Build watcher*.
 - **debug.log** — WordPress's PHP log for this site, streamed live while the dev server runs.
 
 Output from `npm install` and `npm run` commands appears in the [Terminal](./terminal), not here.

--- a/docs/guide/logs-and-debugging.md
+++ b/docs/guide/logs-and-debugging.md
@@ -1,12 +1,21 @@
 # Logs and debugging
 
-The **Logs** section of the site view has two tabs:
+The **Logs** section of the site view has three tabs:
 
 - **Server** — the dev server's own output: everything the Playground server prints while
   starting and running.
+- **Build watcher** — the [build watch](./running-the-site#the-build-watch)'s output. The tab title
+  carries its state: *Build watcher (watching)*, *(building)*, *(paused)*, *(stopped)*, or
+  *(exited 1)* when it ended on its own.
 - **debug.log** — WordPress's PHP log for this site, streamed live while the dev server runs.
 
 Output from `npm install` and `npm run` commands appears in the [Terminal](./terminal), not here.
+
+All three panes read in the terminal's own monospace font, so the columns of a PHP stack trace line
+up, and each line is coloured by what it is: a fatal, a warning, a deprecation, a notice, a stack
+trace frame, or the `Ready! WordPress is running on …` line you are actually waiting for. The
+`[11-Aug-2026 …]` timestamp at the head of a `debug.log` line is dimmed, so 26 identical characters
+per line recede instead of competing with the message.
 
 ![The debug.log tab showing PHP notices](/screenshots/debug-log.png)
 

--- a/docs/guide/running-the-site.md
+++ b/docs/guide/running-the-site.md
@@ -12,9 +12,9 @@ Click **Start dev server**. The button cycles through three states:
 - **Starting dev server...** — the server is booting. A "Dev server is starting…" line below the button shows the elapsed time.
 - **Stop dev server** — the server is up. The button shows a red dot; clicking it stops the server.
 
-When the server is ready, its URL appears below the button, for example `http://127.0.0.1:<port>/`. Click it to open the site in your default browser.
+When the server is ready, its URL appears below the button, for example `http://127.0.0.1:<port>/`, with a **wp-admin** link beside it. Click either to open the site in your default browser.
 
-The button is disabled while a trunk update is running, and a trunk update is blocked while the server runs — the two would fight over the same files.
+The button is disabled while a trunk update is running. The reverse is no longer true: an update can run with the server up, because it pauses the build watch for the rebuild and leaves the server serving — see [Applying patches and PRs](./applying-patches) and [Staying up to date with trunk](./trunk-updates).
 
 ## Logging in
 
@@ -23,7 +23,7 @@ Every site uses the same credentials, shown next to the URL:
 - Username: `admin`
 - Password: `password`
 
-Append `/wp-admin/` to the site URL to reach the dashboard.
+The **wp-admin** link next to the site URL opens the dashboard directly. It appears in both places the URL does: the [setup checklist](./setup-wizard) step and the site page.
 
 ## What the dev server actually runs
 
@@ -31,9 +31,30 @@ The dev server is not a stub — it is WordPress Playground running your checkou
 
 - The app spawns the [Playground CLI](https://wordpress.github.io/wordpress-playground/) (`@wp-playground/cli`) in server mode, with your site's `build/` directory mounted as the WordPress root. PHP runs as WebAssembly inside the bundled Node.js runtime, so no PHP install is needed.
 - The database is **SQLite**, stored inside the Playground instance. This covers most core contribution work; if a ticket specifically needs MySQL behaviour, this environment cannot reproduce it.
-- Alongside the server, the app runs the core build watcher, so edits under `src/` are rebuilt into `build/` while the server is up. A page reload then shows the change.
 - The server binds to the loopback interface only. It is reachable from your machine, not from the rest of your network.
 - Outgoing mail is captured locally instead of being sent — see [Mail](./mail).
+
+## The build watch
+
+The build watcher compiles what you edit under `src/` into `build/`, which is what the server actually serves. It has its own **Start build watch** button next to the dev-server button, and its own status dot:
+
+| Dot | State |
+| --- | --- |
+| Green | Watching — waiting for you to save something. |
+| Amber | Building — compiling a change, or paused while another action owns the build directory. |
+| Red | It exited on its own. Read the **Build watcher** log tab to find out why. |
+| Grey | Stopped. |
+
+The watch and the server are independent in both directions:
+
+- Starting the dev server starts the watch first (building once if the site has no `build/` yet), then serves.
+- Stopping the dev server leaves the watch running, so you can keep compile-on-save going without a server.
+- The watch exiting never touches the server.
+- You can start and stop the watch on its own, at any time, whether or not a server is up.
+
+While the watch is running, applying a patch or updating trunk uses it rather than fighting it. A change that only touches `src/` is applied and left for the watch to rebuild — the checklist shows the build step skipped and names the watch as doing it. Anything that installs dependencies or needs a full build pauses the watch for the duration and resumes it after, with the PHP server up throughout.
+
+Its output goes to its own **Build watcher** log tab, not to the terminal, and it no longer holds the terminal's "running" lock — so the terminal and one-shot actions stay available while it runs.
 
 ## Open Adminer
 
@@ -43,4 +64,4 @@ The button disappears when the server stops, because there is no database to con
 
 ## Where the output goes
 
-Everything the server and the watcher print streams into the site's terminal panel, which is also where startup errors land. See [Terminal](./terminal) and [Logs and debugging](./logs-and-debugging).
+The server's output goes to the **Server** tab of the Logs section, and the watcher's to its own **Build watcher** tab; startup errors land there too. The terminal panel is for the commands you type. See [Logs and debugging](./logs-and-debugging) and [Terminal](./terminal).

--- a/docs/guide/running-the-site.md
+++ b/docs/guide/running-the-site.md
@@ -40,8 +40,8 @@ The build watcher compiles what you edit under `src/` into `build/`, which is wh
 
 | Dot | State |
 | --- | --- |
-| Green | Watching — waiting for you to save something. |
-| Amber | Building — compiling a change, or paused while another action owns the build directory. |
+| Green | Watching. It stays green while it recompiles a save — that is its normal working state. |
+| Amber | Either the one-off full build that runs before the watch can start on a site that has never been built, or the watch paused while another action owns the build directory. |
 | Red | It exited on its own. Read the **Build watcher** log tab to find out why. |
 | Grey | Stopped. |
 
@@ -52,7 +52,7 @@ The watch and the server are independent in both directions:
 - The watch exiting never touches the server.
 - You can start and stop the watch on its own, at any time, whether or not a server is up.
 
-While the watch is running, applying a patch or updating trunk uses it rather than fighting it. A change that only touches `src/` is applied and left for the watch to rebuild — the checklist shows the build step skipped and names the watch as doing it. Anything that installs dependencies or needs a full build pauses the watch for the duration and resumes it after, with the PHP server up throughout.
+While the watch is running, applying a patch or updating trunk uses it rather than fighting it. A patch that does not move `package-lock.json` is applied and left for the watch to recompile — the checklist shows the build step skipped and names the watch as doing it. One that does move the lockfile has to install and build, so it pauses the watch for the duration and resumes it after, with the PHP server up throughout.
 
 Its output goes to its own **Build watcher** log tab, not to the terminal, and it no longer holds the terminal's "running" lock — so the terminal and one-shot actions stay available while it runs.
 

--- a/docs/guide/setup-wizard.md
+++ b/docs/guide/setup-wizard.md
@@ -1,6 +1,6 @@
 # The setup wizard
 
-After [creating a site](./creating-a-site), its view shows the **Initial setup checklist**. Complete each step to prepare the site for development. The steps run in order — each one unlocks the next.
+After [creating a site](./creating-a-site), its view shows the **Initial setup checklist**. It runs itself: when the clone finishes, the install and the build start on their own and run to the end, so a site you walked away from is ready to work on when you come back. The buttons are there for when something fails, or when you stopped the chain yourself.
 
 ![The Initial setup checklist showing four steps: download, install npm dependencies, run full build, and start dev server](/screenshots/setup-wizard.png)
 
@@ -12,33 +12,40 @@ The clone of `wordpress-develop` that started when you created the site. It runs
 
 ### 2. Install npm dependencies
 
-Click **Install npm dependencies** to run `npm install` using the Node.js runtime bundled with the app — no system Node or npm is needed. If the install fails, the button changes to **Retry npm install**; a leftover `node_modules` folder from a failed run does not count as completed.
+`npm install`, run on the Node.js runtime bundled with the app — no system Node or npm is needed. It starts by itself when the clone ends, and the terminal says so: *Setting this site up — running npm install…*
 
-Once installed, the button reads **Dependencies installed** and stays disabled. If you later add a dependency to `package.json`, run `npm install` yourself in the [Terminal](./terminal).
+If it fails, the chain stops there and the button changes to **Retry npm install**; a leftover `node_modules` folder from a failed run does not count as completed. Once installed, the button reads **Dependencies installed** and stays disabled. If you later add a dependency to `package.json`, run `npm install` yourself in the [Terminal](./terminal).
 
 ### 3. Run full build
 
-Click **Run full build** to compile WordPress core and generate the `dist` files the dev server serves. This is the longest step after the clone.
+Compiles WordPress core and generates the files the dev server serves. This is the longest step after the clone, and it follows the install without asking.
 
-You only run it manually once: [trunk updates](./trunk-updates) and [applied patches](./applying-patches) rebuild on their own. If you edit files in `src/` by hand, run `npm run build` in the Terminal so the site picks them up.
+You never run it manually unless something failed: [trunk updates](./trunk-updates) and [applied patches](./applying-patches) rebuild on their own, and while the [build watch](./running-the-site#the-build-watch) is running your own edits under `src/` are compiled as you save them.
 
 ### 4. Start dev server & finish wizard
 
-Click **Start dev server and finish the wizard** to launch the WordPress dev server for the first time. This completes the checklist and permanently replaces it with the compact action bar described below. The server URL appears next to the button once it is up — see [Running the site](./running-the-site).
+Click **Start dev server and finish the wizard** to launch the WordPress dev server for the first time. This completes the checklist and permanently replaces it with the compact action bar described below. The server URL, and a **wp-admin** link beside it, appear next to the button once it is up — see [Running the site](./running-the-site).
+
+## Stopping the chain
+
+Press **Ctrl+C** in the [Terminal](./terminal) to stop setup, including a running `npm install`. The terminal says where you stand — *Setup stopped. The remaining steps are in the checklist above — run them whenever you are ready* — and the checklist buttons take over from there. The chain names its other endings too: setup complete, the install failed, or the build failed with dependencies already installed.
 
 ## Step states
 
 Each step carries a state label:
 
 - **Completed** — done, marked with a green check.
-- **In progress** — the step to do next; its button is enabled.
+- **In progress** — this step is running right now.
+- **Ready** — the next step to do, waiting on you rather than working. The distinction matters: a step that said "In progress" while nothing was installing invited you to wait instead of to click.
 - **Pending** — ready but waiting for you to reach it.
 - **Locked** — its prerequisites are not met yet; the button is disabled.
+
+The step to act on also carries a **Start here** ring and scrolls itself into view, and is announced to screen readers as *Next step: …*. The cue clears when the action completes, not on a timer, and it follows the work: while a patch is applying or trunk is updating, it points at the block doing the work.
 
 Steps also lock temporarily while a [trunk update](./trunk-updates) is running, since the update owns the working tree during that time.
 
 ## Skipping the wizard
 
-Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, **Review & submit changes**, and — while the server is running — **Open Adminer**.
+Below the checklist is a **Skip initialization wizard** link. Clicking it hides the checklist for this site, for good, and shows the compact action bar instead: the dev server start/stop button, the [build watch](./running-the-site#the-build-watch) button, **Review & submit changes**, and — while the server is running — **Open Adminer**.
 
 Skipping does not run any of the steps for you. If the dependencies were never installed or the build never ran, the dev server will not have anything to serve, so only skip on a site you know is already set up (for example, a `wordpress-develop` checkout you prepared outside the app). For everything else, finishing step 4 gets you to the same action bar with the work actually done.

--- a/docs/guide/setup-wizard.md
+++ b/docs/guide/setup-wizard.md
@@ -40,7 +40,7 @@ Each step carries a state label:
 - **Pending** — ready but waiting for you to reach it.
 - **Locked** — its prerequisites are not met yet; the button is disabled.
 
-The step to act on also carries a **Start here** ring and scrolls itself into view, and is announced to screen readers as *Next step: …*. The cue clears when the action completes, not on a timer, and it follows the work: while a patch is applying or trunk is updating, it points at the block doing the work.
+The step to act on is also ringed in amber and scrolls itself into view, and is announced to screen readers as *Next step: …*. The ring carries no label of its own — the step's own status text names it. It moves when the step it points at is done, not on a timer.
 
 Steps also lock temporarily while a [trunk update](./trunk-updates) is running, since the update owns the working tree during that time.
 

--- a/docs/guide/submitting-changes.md
+++ b/docs/guide/submitting-changes.md
@@ -15,6 +15,14 @@ Two buttons sit above the diff:
 
 If there are no changes to send, the screen says so. If the site's WordPress code is old, a warning says the patch may not apply on Trac and suggests updating to the latest trunk first — see [Staying up to date with trunk](trunk-updates).
 
+## Discarding it all
+
+Next to the heading is **Discard all changes**. It asks first — *Discard all local changes? This cannot be undone* — and then throws away exactly what the diff above it shows, which on a ticket means the whole of that ticket's work: your uncommitted edits *and* anything parked in a commit the last time you switched away from it.
+
+The ticket itself survives. Its branch stays, the link stays, and you carry on working on it from a clean base. Throwing the ticket's work away along with its branch is a different gesture — [Delete this ticket's work](ticket-branches#deleting-a-ticket-s-work), on the tickets card.
+
+The button is unavailable while an install, a build or a [trunk update](trunk-updates) is running, or while the dev server is up, since all of them are holding the files it would rewind.
+
 ## What a patch can and cannot carry
 
 The patch carries files you added, files you edited, and files you deleted. A deletion is written the way `git apply` and `patch` expect one, so a reviewer applying your patch really does lose the file.

--- a/docs/guide/trac-tickets.md
+++ b/docs/guide/trac-tickets.md
@@ -17,10 +17,10 @@ Linking a ticket gives it its own branch inside the site, so the work you do for
 
 If you have edited anything before linking, the app asks what should happen to those edits rather than deciding for you. The four choices are described under [Edits you made before picking a ticket](./ticket-branches#edits-you-made-before-picking-a-ticket).
 
-Once a ticket is linked, the panel shows its number with two actions:
+Once a ticket is linked, the panel shows its number with these actions:
 
 - **Open in Trac** — opens the ticket in your browser.
-- **Read details from Trac** — fills in what the ticket actually says, described below.
+- **Read details from Trac** — fills in what the ticket actually says, described below. It is only there until the details are loaded; once they are on screen it has nothing left to do and goes.
 - **Unlink** — removes the link and puts the site back on trunk. Nothing on Trac is affected, and nothing you did for the ticket is lost: the work stays attached to the ticket in this site, and the ticket moves to the **Your tickets on this site** card, ready to continue.
 
 ## What the ticket says

--- a/docs/guide/trac-tickets.md
+++ b/docs/guide/trac-tickets.md
@@ -20,7 +20,21 @@ If you have edited anything before linking, the app asks what should happen to t
 Once a ticket is linked, the panel shows its number with two actions:
 
 - **Open in Trac** — opens the ticket in your browser.
+- **Read details from Trac** — fills in what the ticket actually says, described below.
 - **Unlink** — removes the link and puts the site back on trunk. Nothing on Trac is affected, and nothing you did for the ticket is lost: the work stays attached to the ticket in this site, and the ticket moves to the **Your tickets on this site** card, ready to continue.
+
+## What the ticket says
+
+A ticket number on its own tells you nothing about the ticket. One closed `wontfix` three years ago reads exactly like one filed last week — and you find out on Trac, after the afternoon is spent.
+
+Click **Read details from Trac** and the panel fills in the ticket's own facts, under its number:
+
+- Its **summary**.
+- A **status pill** with the resolution folded in — `closed (wontfix)` rather than a bare `closed`, because "closed (fixed)" and "closed (wontfix)" are opposite instructions to a contributor.
+- Its **type**, its **milestone**, and how long ago it was **opened** (the exact date is in the tooltip).
+- Its **component** and **keywords**, as links. These use Trac's own query URLs, lifted from the page rather than rebuilt, and open in your browser like any other link.
+
+This reads the same embedded Trac window the attachment list uses, so it costs the same single human check — see [Trac attachments](#trac-attachments) below. Clearing that check once serves both.
 
 ## Unsubmitted work
 
@@ -30,7 +44,7 @@ The count is the ticket's whole work, including everything parked when you last 
 
 ## Linked pull requests
 
-The panel searches GitHub for pull requests on `WordPress/wordpress-develop` that cite the ticket number, and lists them newest first. Each row shows the PR number (click it to open the PR in your browser), its title, its state, and when it was last updated. Click **Refresh** to search again.
+The panel searches GitHub for pull requests on `WordPress/wordpress-develop` that cite the ticket number, and lists them newest first. Each row shows the PR number (click it to open the PR in your browser), its title, its state, and a date labelled with what it is: **last commit** when the newest commit's date could be resolved, **updated** only as a fallback when it could not. Click **Refresh** to search again.
 
 ![The Trac ticket panel with two linked pull requests, one carrying a red CLOSED pill and one a green OPEN pill](/screenshots/linked-pull-requests.png)
 
@@ -55,7 +69,9 @@ Two things can go wrong:
 
 ## Which patch is newest
 
-When a ticket has both pull requests and attachments, the panel marks the most recent one, and points out when the latest work is a file attachment rather than a pull request. Testing the newest patch first is usually what a ticket needs.
+When a ticket has both pull requests and attachments, the panel marks the most recent one with a **Latest** pill, and points out when the latest work is a file attachment rather than a pull request. Testing the newest patch first is usually what a ticket needs.
+
+"Most recent" means the newest **commit**, not the last time the pull request was touched. GitHub's "updated" timestamp is bumped just as hard by a comment, a label change or a bot sweep as by a push — and an upstream force-push of trunk can restamp thousands of open pull requests inside one window, which is enough to crown a patch whose newest code is eighteen months old over one that still applies.
 
 ## Next steps
 

--- a/docs/guide/trunk-updates.md
+++ b/docs/guide/trunk-updates.md
@@ -12,7 +12,11 @@ The header of each site shows which snapshot it currently holds — for example 
 
 This option is always there — on every site, at any time, no matter how old or new the snapshot is and whether or not the app has flagged it as stale. If nothing has moved, you simply get "Already up to date." in the terminal.
 
-You no longer have to stop the dev server first. The update pauses the [build watch](./running-the-site#the-build-watch) for the rebuild and resumes it afterwards, and the PHP server keeps serving throughout. Both entry points are unavailable while an install or a build is already running, since those own the same files.
+You no longer have to stop the dev server first. The update pauses the [build watch](./running-the-site#the-build-watch) for the rebuild and resumes it afterwards, and the PHP server keeps serving throughout.
+
+What it will not run alongside is another install or build. The **Update to latest trunk** button in
+the staleness notice is disabled while one is running — but the ☰ menu entry is not, and clicking it
+in that state simply does nothing, with no message to say why.
 
 ## What an update runs
 

--- a/docs/guide/trunk-updates.md
+++ b/docs/guide/trunk-updates.md
@@ -12,9 +12,7 @@ The header of each site shows which snapshot it currently holds — for example 
 
 This option is always there — on every site, at any time, no matter how old or new the snapshot is and whether or not the app has flagged it as stale. If nothing has moved, you simply get "Already up to date." in the terminal.
 
-Stop the dev server first. The **Update to latest trunk** button in the staleness notice is
-disabled while the server, an install, or a build is running — but the ☰ menu entry is not, and
-clicking it in that state simply does nothing, with no message to say why.
+You no longer have to stop the dev server first. The update pauses the [build watch](./running-the-site#the-build-watch) for the rebuild and resumes it afterwards, and the PHP server keeps serving throughout. Both entry points are unavailable while an install or a build is already running, since those own the same files.
 
 ## What an update runs
 


### PR DESCRIPTION
## Why

Twenty PRs landed on `trunk` between `v1.0.0-beta.1` and this release candidate, and several moved behaviour the guide describes. Four of the guide's claims had gone from incomplete to simply false:

- **The build watcher is no longer tied to the dev server** (#247/#272) — `running-the-site.md` said it ran "alongside the server… while the server is up".
- **A trunk update no longer needs the server stopped** (#262/#273) — the guide said the opposite.
- **The setup checklist is no longer four clicks** (#246/#276) — install and build now start themselves once the clone finishes.
- **There is a wp-admin link now** (#250) — the guide told you to type `/wp-admin/` onto the URL by hand.

## What changes

Correcting those four, and documenting what came with them: the build watch's own control, dot and log tab; what a failed apply says now and why the framing differs for a pull request versus a loose patch file (#282); the ticket's own facts and the "Latest" pill's real ranking (#292, #281); **Discard all changes** rewinding to the ticket's base (#270); severity colour in the log panes (#280); and one short passage on the "Start here" cue and the completion toasts (#252, #253) — cross-cutting enough that repeating them per page would read worse than naming them once.

## Review

Ran `/self-review` per `AGENTS.md`, dispatched to a fresh `Explore` subagent so the session that wrote the docs was not the one grading them. `npm run lint` / `npm test` don't apply — docs-only, no JS touched — so the review focused on the one dimension that does: **every behavioural claim verified against the actual source**, not assumed. It caught ten inaccuracies, five worth fixing here — including two pages I hadn't touched (`editors.md`, `creating-a-site.md`) that my changes to `running-the-site.md`/`setup-wizard.md` had left contradicting. All five are fixed in the second commit; the other five were softened as follow-up-scale wording tightenings, folded into the same commit since they were one-line each.

## Not in this PR

Screenshots. `site-view.png`, `setup-wizard.png` and `trac-ticket-panel.png` now show a UI that has moved on (Build watch button, wp-admin link, ticket-facts card). Retaking them needs the shots harness against a running app; filing a follow-up issue rather than blocking this PR on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)