### PR TITLE
Measure the patch conflict warning against the ticket's base, not its last save

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1134,9 +1134,10 @@ async function collectUnsubmittedFiles(sitePath) {
 
 // Two questions, deliberately two channels (#239). This one asks "are there
 // edits not written down yet" — the narrow reading the checkout guards need:
-// the trunk-update dirty dialog and the patch-apply collision scan protect
-// exactly the files a force checkout would overwrite, and parked work is not
-// among them. The card's note asks `git:unsubmitted-work` instead.
+// the trunk-update dirty dialog protects exactly the files a force checkout
+// would overwrite, and parked work is not among them. Everything that asks
+// what this ticket has done — the card's note, and the patch-apply collision
+// scan (#301) — asks `git:unsubmitted-work`'s question instead.
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
         const files = await collectDirtyFiles(sitePath);
@@ -1433,18 +1434,26 @@ const REVERTABLE_PATCH_LIMIT = 512 * 1024;
 // Reading a patch without touching the checkout, so the contributor sees which
 // files it would change — and which of their own edits it collides with —
 // before deciding.
+//
+// Measured from the ticket's base, not from HEAD (#301). Under the
+// ticket-as-branch model a ticket's work lives in its parked WIP commit, so a
+// ticket that has been left and resumed has a worktree matching HEAD exactly:
+// HEAD-relative, the warning goes silent on precisely the tree it exists to
+// protect, and speaks up about files edited back to what the base holds. This
+// is the same measurement the patch itself is taken with, so what the warning
+// calls "your own edits" is what the patch modal would show.
 ipcMain.handle('git:preview-patch', async (_e, sitePath, patchText) => {
     try {
         const parsed = parsePatchFiles(patchText);
         if (!parsed.ok) return { ok: false, error: parsed.error };
         let dirtyPaths;
         try {
-            dirtyPaths = await collectDirtyFiles(sitePath);
+            dirtyPaths = await collectUnsubmittedFiles(sitePath);
         } catch (e) {
             // Failing open here would promise "no collisions" precisely when the
             // app could not look — surface the failure instead.
             logError('git:preview-patch', String(e && e.stack ? e.stack : e));
-            return { ok: false, error: 'Could not check your working tree for conflicts, so the preview was not shown.' };
+            return { ok: false, error: 'Could not check your work for conflicts, so the preview was not shown.' };
         }
         const plan = planApply({ files: parsed.files, dirtyPaths });
         return { ok: true, ...plan, files: parsed.files.map((f) => ({ kind: f.kind, path: f.path })) };

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -465,24 +465,31 @@ test('git:discard-changes resets through trunk-update and clears the applied-pat
 // A site the way the ticket-as-branch model leaves it: the contributor's work
 // parked in the branch's single WIP commit, the worktree clean. `git status`
 // says nothing; the patch says +1 line. The note has to side with the patch.
-async function parkedTicketRepo(t) {
+// `workFile` is where the parked edit lands. The default keeps this repo as the
+// note's tests have always had it; the patch-preview tests below ask for the
+// `src/` layout instead, because a patch's paths are read through
+// `mapToSrcLayout` and a collision is a string match on the result.
+async function parkedTicketRepo(t, { workFile = 'wp-login.php' } = {}) {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-parked-'));
 	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
 	await git.init({ fs, dir, defaultBranch: 'trunk' });
 	const author = { name: 'test', email: 'test@example.com' };
-	fs.writeFileSync(path.join(dir, 'wp-login.php'), '<?php // login\n');
-	await git.add({ fs, dir, filepath: 'wp-login.php' });
+	const abs = path.join(dir, workFile);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	const baseText = '<?php // login\n';
+	fs.writeFileSync(abs, baseText);
+	await git.add({ fs, dir, filepath: workFile });
 	const baseOid = await git.commit({ fs, dir, message: 'trunk snapshot', author });
 	await git.branch({ fs, dir, ref: 'ticket/62281', object: 'trunk', checkout: true });
-	fs.writeFileSync(path.join(dir, 'wp-login.php'), '<?php // login\n// the ticket work\n');
-	await git.add({ fs, dir, filepath: 'wp-login.php' });
+	fs.writeFileSync(abs, `${baseText}// the ticket work\n`);
+	await git.add({ fs, dir, filepath: workFile });
 	await git.commit({
 		fs, dir,
 		message: 'Work in progress (WordPress Contributor Toolkit)',
 		author,
 		parent: [baseOid]
 	});
-	return { dir, baseOid };
+	return { dir, baseOid, workFile, baseText };
 }
 
 function parkedTicketMain(dir, baseOid) {
@@ -1750,6 +1757,68 @@ test('git:preview-patch reads the patch through patch-plan', async () => {
 
 	assert.deepEqual(parsePatchFiles.calls, [['PATCH TEXT']]);
 	assert.deepEqual(result, { ok: false, error: 'unreadable' });
+});
+
+// --- what the collision warning is measured against (#301) ----------------
+
+// A patch against `src/wp-login.php`, the file the parked repo's ticket work is
+// in. Written the way the app's own reader expects to read it back.
+const LOGIN_DIFF = `diff --git a/src/wp-login.php b/src/wp-login.php
+index 384bf9e..dbfa038 100644
+--- a/src/wp-login.php
++++ b/src/wp-login.php
+@@ -1,2 +1,2 @@
+ <?php // login
+-// the ticket work
++// somebody else's change
+`;
+
+// The silence #301 is about, end to end. A resumed ticket has its work in the
+// WIP commit and a worktree that matches it exactly, so the narrow question
+// answers "clean" — correctly, and it must keep doing so for the checkout
+// guards. The warning cannot be built on that answer: measured from HEAD it
+// says nothing at all, and the patch lands on top of the contributor's work
+// with no warning.
+test('git:preview-patch warns about work parked in the WIP commit (#301)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const main = parkedTicketMain(dir, baseOid);
+
+	const narrow = await main.invoke('git:worktree-dirty', dir);
+	assert.equal(narrow.dirty, false, 'nothing is uncommitted — the guards keep their answer');
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+});
+
+// The other direction: a file edited back to what the base holds carries none
+// of the contributor's work, whatever HEAD says about it. Announcing it sends
+// someone looking for changes they never made.
+test('git:preview-patch does not warn about a file that matches the base (#301)', async (t) => {
+	const { dir, baseOid, workFile, baseText } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	// Differs from HEAD (the parked commit), identical to the branch point.
+	fs.writeFileSync(path.join(dir, workFile), baseText);
+	const main = parkedTicketMain(dir, baseOid);
+
+	const narrow = await main.invoke('git:worktree-dirty', dir);
+	assert.equal(narrow.dirty, true, 'HEAD-relative this file reads as edited');
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.conflicts, []);
+});
+
+// And a patch that touches nothing the ticket has worked on still warns about
+// nothing — the wider baseline widens what counts as the contributor's work,
+// it does not warn about every file in the patch.
+test('git:preview-patch stays quiet about files the ticket never touched (#301)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const main = parkedTicketMain(dir, baseOid);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF.replace(/wp-login\.php/g, 'wp-signup.php'));
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.paths, ['src/wp-signup.php']);
+	assert.deepEqual(preview.conflicts, []);
 });
 
 // git:apply-patch reads the store for its guard before delegating, which is the


### PR DESCRIPTION
## Why

Before a patch or PR is applied, the app warns which incoming files collide with work the
contributor already did. That warning was measured against HEAD, and under the ticket-as-branch
model (#108) HEAD is the ticket's *last saved state* — the parked WIP commit — not the ticket's
base. Switching tickets parks the current work automatically, so the two baselines separate the
moment a ticket has been left and resumed.

From then on the warning is wrong in both directions, and the silent one is the reason to fix it:
a resumed ticket has a worktree matching HEAD exactly, which reads as a clean tree, so a PR
applied at that point lands on top of the contributor's own work with no warning at all. That is
not an edge case — it is the ordinary shape of a ticket someone has come back to.

Fixes #301.

## What changes

Root cause: `git:preview-patch` fed `planApply` with `collectDirtyFiles(sitePath)`, a
`git.statusMatrix` walk with no `ref` — i.e. "what differs from the last commit".

It now asks `collectUnsubmittedFiles(sitePath)`, the base-relative measurement everything else in
the patch flow already uses (`patchBaseOid` → `collectChangedFiles` → drop the rows the patch
would not speak about). No new measurement code: the two questions and their two channels already
exist from #239, and this check was simply on the wrong one.

`collectDirtyFiles` is unchanged and keeps its callers: `git:worktree-dirty` and the trunk-update
guards still need the narrow "what a force checkout would overwrite" answer, where parked work
correctly does not count.

On trunk `patchBaseOid` answers `null` and the walk falls back to HEAD, so a site that never
linked a ticket keeps exactly the answer it had.

## How to test this

Platforms: any — no paths, spawning or line endings involved.

**Starting state:** a site with a linked ticket, and a second ticket to switch to.

1. On ticket A, edit a file the incoming patch also touches (e.g. `src/wp-login.php`).
2. Switch to ticket B, then back to ticket A. The work is parked; the tree now looks clean.
3. Apply a patch or a PR that touches that same file — Trac attachment, PR diff, or a `.patch`
   file, all three go through the same preview.
   **Expected:** the amber block appears — "You have your own edits to `src/wp-login.php`…".
   Before this change it did not appear at all.
4. Apply a patch touching a file the ticket never touched.
   **Expected:** no such block.
5. Optional, the other direction: edit a file back to its original content, then preview a patch
   touching it. **Expected:** no warning — that file holds none of your work, whatever `git status`
   thinks.

**What must not have happened:**

- The trunk-update dirty dialog must not start firing on a clean-but-parked tree — it deliberately
  keeps the narrow reading. Run "Update to latest trunk" on a resumed ticket and confirm it does
  not now claim uncommitted changes.
- No preview should fail with "Could not check your work for conflicts" on a healthy site; that
  path is the fail-closed branch, not a normal outcome.
- The preview must still list every file the patch touches, warning or not.

Covered by three new tests in `test/ipc-wiring.test.cjs`, built on the existing real-repo
`parkedTicketRepo` harness. Verified the first two fail on the old code — one with `conflicts: []`
where the warning should fire, the other with a spurious `['src/wp-login.php']` — and pass after.

## Risks and limitations

Self-review: **0 [fix here] · 1 [follow-up]**, and the follow-up predates this PR.

- **More warnings than before, by design.** A resumed ticket now warns where it used to stay
  quiet. The existing copy already reads correctly for parked work.
- **A slightly wider scan per preview.** `collectChangedFiles` reads both sides of each changed
  file, where `collectDirtyFiles` only walked status. It is the same cost the card's
  unsubmitted-work note already pays on the same repo, on an action that is already a file read.
- **Not tested by hand yet** — I have not driven the app through the steps above; the coverage
  here is the suite plus the reasoning about the two baselines.

## Related

Fixes #301. Builds on #300 — this PR targets its branch, so review that one first.
Follow-up: #303 — the post-failure narration blames the pull request's author for a collision
with the contributor's own work, using the same fact this PR puts at hand.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why not a union of both readings** (dirty-vs-HEAD ∪ changed-vs-base)? The base-relative walk
already contains everything the HEAD-relative one reports on a ticket branch — uncommitted edits
differ from the base too. A union would only re-import the false alarm: a file edited back to the
base still differs from HEAD, and that is exactly the row #301 says should not be announced.

**Why not compute the overlap inside `patch-plan.cjs`?** `planApply` is deliberately
baseline-agnostic — it takes `dirtyPaths` and intersects. The bug was in what the handler passed
it, so that is where the fix belongs; `test/patch-plan.test.cjs` needed no change at all.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`/self-review` per AGENTS.md, judgement pass dispatched to a fresh-context subagent:
**0 [fix here] · 1 [follow-up]**. `npm run lint` clean; `npm test` 941/941 pass.

The follow-up (🔵, architecture): `patchBaseOid` has two silent fallbacks that this warning now
becomes a second consumer of — a ticket branch with no recorded `baseOid` falls back to live
`refs/heads/trunk`, which an "Update to latest trunk" can have moved ahead of the branch point
(over-warning); and any throw inside it returns `null`, routing the walk back to HEAD with no
signal to the renderer. Both predate this PR — `git:unsubmitted-work` and the card's note have
ridden on them since #239 — so fixing them is a change to `patchBaseOid`'s contract, not to this
handler. Deferred rather than widened into this diff; happy to file it as its own issue.

</details>

<details>
<summary>Implementation notes</summary>

- `src/main.js` — `git:preview-patch` swaps its source and says which baseline it reads and why.
  The fail-closed `catch` stays (failing open would promise "no collisions" precisely when the app
  could not look); its message moves from "your working tree" to "your work", which is what it now
  failed to read.
- `src/main.js` — the comment above `git:worktree-dirty` listed the patch-apply collision scan as
  a caller of the narrow reading. It was documenting the bug; it now names the checkout guards
  only.
- `test/ipc-wiring.test.cjs` — `parkedTicketRepo` takes an optional `workFile` so the same harness
  can build the `src/` layout a patch's paths are mapped into by `mapToSrcLayout`. The default is
  unchanged, so the #239 tests are untouched.

</details>

<details>
<summary>Screenshots or recording</summary>

Nothing on screen changed: the amber "You have your own edits to …" block at
`src/renderer/index.jsx:4722` renders exactly as before. What changed is when it appears.

</details>
