### PR TITLE
Name the contributor's own work when a patch fails in a file they edited

### DIFF
--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -163,10 +163,9 @@ function namePaths(rows) {
  *
  * The app cannot prove the region, but it knows the file: `ownWorkPaths` is the
  * preview's own collision list, the files this ticket has work in measured from
- * its base (#301). A file on that list gets the collision named for what it is
- * and the ways out that are the contributor's own; a file off it keeps the
- * stale-pull-request framing. When both are present the notice says both, since
- * choosing one would be guessing again.
+ * its base (#301). That is evidence the contributor's work may be involved, not
+ * proof it caused the failed region. The safe route is to try the pull request
+ * on a clean ticket before asking its author to update it.
  *
  * @param {Array}    conflicts
  * @param {?string}  prState        'open' | 'merged' | 'closed' | null when unknown.
@@ -218,26 +217,24 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
 	// a copy and starting clean is a recommended way forward here, not a defeat.
 	// What must never happen is work going quietly; going on purpose, with the
 	// copy already saved, is a good outcome.
-	const YOUR_WORK_WAY_OUT = 'Save a patch of your work first to keep a copy. Then apply this on a ticket that does not have that work, or discard it here once the copy is saved.';
+	const YOUR_WORK_WAY_OUT = 'Save a patch of your work first to keep a copy, then try this pull request on a clean ticket. If it still does not fit there, open the pull request and let its author know it may need updating.';
 
-	// Every failing file is one this ticket has work in, so nothing here is the
-	// pull request being behind trunk, and there is no rebase to ask anyone for.
-	// The pull request is still worth opening — reading it is how the
-	// contributor decides whether to start a clean ticket for it — so the button
-	// stays and only the ask goes.
+	// File overlap cannot identify the failing region. Keep the pull request
+	// reachable, but make the rebase advice conditional on it also failing in a
+	// clean ticket.
 	if (!theirs.count) {
 		return {
-			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way, in ${mine.text}.`,
-			advice: `This is your work meeting the pull request, not a pull request that has gone stale, so asking its author for a rebase would not help. ${YOUR_WORK_WAY_OUT}`,
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is also in ${mine.text}, so it may be part of why the pull request does not fit.`,
+			advice: YOUR_WORK_WAY_OUT,
 			prButton: 'Open the pull request'
 		};
 	}
 
 	if (mine.count) {
 		return {
-			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way in ${mine.text}. The rest is the pull request being behind trunk: ${theirs.text}.`,
-			advice: `${REBASE_IS_THEIRS} Your own files are yours to sort out. ${YOUR_WORK_WAY_OUT}`,
-			prButton: 'Ask its author for a rebase'
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is also in ${mine.text} and may be part of the failure. Other failures are in ${theirs.text}.`,
+			advice: YOUR_WORK_WAY_OUT,
+			prButton: 'Open the pull request'
 		};
 	}
 

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -106,6 +106,33 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
 		+ attachments.filter((att) => att.filename !== failedLabel).length;
 }
 
+// How many paths a sentence will name before it starts counting instead. The
+// panel already lists every failing file underneath, so the headline's job is
+// the attribution, not the inventory — and a pull request failing in a dozen
+// files would otherwise open the notice with a paragraph of paths. Same reason
+// `REGION_DETAIL_LIMIT` exists in patch-apply.js.
+const PATH_NAME_LIMIT = 3;
+
+/**
+ * The files on one side of the failure, named for a sentence.
+ *
+ * Deduplicated because a concatenated patch can fail the same file twice — the
+ * same reason `describeApplyFailure` consumes conflicts one by one instead of
+ * keying them by path.
+ *
+ * @param {Array} rows Conflicts.
+ * @return {{count: number, text: string}}
+ */
+function namePaths(rows) {
+	const paths = [...new Set(rows.map((c) => c.path))];
+	if (paths.length <= PATH_NAME_LIMIT) return { count: paths.length, text: paths.join(', ') };
+	const rest = paths.length - PATH_NAME_LIMIT;
+	return {
+		count: paths.length,
+		text: `${paths.slice(0, PATH_NAME_LIMIT).join(', ')} and ${rest} more file${rest === 1 ? '' : 's'}`
+	};
+}
+
 /**
  * The pull-request framing: whose problem this is, and how big.
  *
@@ -127,11 +154,26 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
  * merge would settle — close enough to size the problem, not a claim GitHub
  * will show the identical number.
  *
- * @param {Array}   conflicts
- * @param {?string} prState   'open' | 'merged' | 'closed' | null when unknown.
+ * That same missing base is why `ownWorkPaths` is here (#303). Matching two-way
+ * cannot prove which side a single failed region belongs to, so the framing used
+ * to answer from the pull request's state alone: open meant stale, always. On a
+ * ticket someone has come back to, the ordinary reason a change will not fit is
+ * the contributor's own work sitting in the same file — and sending them to ask
+ * a stranger for a rebase that would not help is worse than saying nothing.
+ *
+ * The app cannot prove the region, but it knows the file: `ownWorkPaths` is the
+ * preview's own collision list, the files this ticket has work in measured from
+ * its base (#301). A file on that list gets the collision named for what it is
+ * and the ways out that are the contributor's own; a file off it keeps the
+ * stale-pull-request framing. When both are present the notice says both, since
+ * choosing one would be guessing again.
+ *
+ * @param {Array}    conflicts
+ * @param {?string}  prState        'open' | 'merged' | 'closed' | null when unknown.
+ * @param {string[]} [ownWorkPaths] Files this ticket has its own work in.
  * @return {{headline: string, advice: string, prButton: ?string}}
  */
-function prFraming(conflicts, prState) {
+function prFraming(conflicts, prState, ownWorkPaths = []) {
 	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
 	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
 	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
@@ -151,7 +193,10 @@ function prFraming(conflicts, prState) {
 		};
 	}
 
-	const files = conflicts.length;
+	// Distinct files, not conflict rows: a concatenated patch can fail the same
+	// file twice, and the sentences below go on to name the files, so counting
+	// the rows would have the count disagreeing with the list beside it.
+	const files = new Set(conflicts.map((c) => c.path)).size;
 	const scale = `${failed} of its ${total} change${total === 1 ? '' : 's'}, in ${files} file${files === 1 ? '' : 's'},`;
 
 	// A closed pull request has no author coming back to it: asking for a
@@ -165,9 +210,40 @@ function prFraming(conflicts, prState) {
 		};
 	}
 
+	const own = new Set(ownWorkPaths);
+	const mine = namePaths(conflicts.filter((c) => own.has(c.path)));
+	const theirs = namePaths(conflicts.filter((c) => !own.has(c.path)));
+	const REBASE_IS_THEIRS = 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.';
+	// A ticket's changes are cheap to redo and expensive to untangle, so keeping
+	// a copy and starting clean is a recommended way forward here, not a defeat.
+	// What must never happen is work going quietly; going on purpose, with the
+	// copy already saved, is a good outcome.
+	const YOUR_WORK_WAY_OUT = 'Save a patch of your work first to keep a copy. Then apply this on a ticket that does not have that work, or discard it here once the copy is saved.';
+
+	// Every failing file is one this ticket has work in, so nothing here is the
+	// pull request being behind trunk, and there is no rebase to ask anyone for.
+	// The pull request is still worth opening — reading it is how the
+	// contributor decides whether to start a clean ticket for it — so the button
+	// stays and only the ask goes.
+	if (!theirs.count) {
+		return {
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way, in ${mine.text}.`,
+			advice: `This is your work meeting the pull request, not a pull request that has gone stale, so asking its author for a rebase would not help. ${YOUR_WORK_WAY_OUT}`,
+			prButton: 'Open the pull request'
+		};
+	}
+
+	if (mine.count) {
+		return {
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way in ${mine.text}. The rest is the pull request being behind trunk: ${theirs.text}.`,
+			advice: `${REBASE_IS_THEIRS} Your own files are yours to sort out. ${YOUR_WORK_WAY_OUT}`,
+			prButton: 'Ask its author for a rebase'
+		};
+	}
+
 	return {
 		headline: `This pull request was written against an older trunk and no longer fits it: ${scale} would need rework.`,
-		advice: 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.',
+		advice: REBASE_IS_THEIRS,
 		prButton: 'Ask its author for a rebase'
 	};
 }
@@ -190,14 +266,16 @@ function prFraming(conflicts, prState) {
  * folder, a file to add that already exists) as well as the conflict that could
  * not be broken down.
  *
- * @param {Object}  result                    The apply payload from main.
- * @param {Object}  [options]
- * @param {number}  [options.otherPatchCount] Other patches on this ticket.
- * @param {?string} [options.prUrl]           The failing patch's pull request.
- * @param {?string} [options.prState]         Its state, when known.
+ * @param {Object}   result                    The apply payload from main.
+ * @param {Object}   [options]
+ * @param {number}   [options.otherPatchCount] Other patches on this ticket.
+ * @param {?string}  [options.prUrl]           The failing patch's pull request.
+ * @param {?string}  [options.prState]         Its state, when known.
+ * @param {string[]} [options.ownWorkPaths]    Files this ticket has work in, from
+ *                                             the preview's collision list (#303).
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [] } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -237,7 +315,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	let prButton = fromPr ? 'Open the pull request' : null;
 	if (conflicts.length) {
 		const framing = fromPr
-			? prFraming(conflicts, prState)
+			? prFraming(conflicts, prState, ownWorkPaths)
 			: { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3189,7 +3189,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               attachments: patchAttachments
             }),
             prUrl: preview?.prUrl || null,
-            prState: preview?.prState || null
+            prState: preview?.prState || null,
+            // The preview's own collision list: the files this ticket has work
+            // in, measured from its base (#301). Without it an open pull request
+            // is always narrated as stale, so a failure caused by the
+            // contributor's own edits sends them to ask a stranger for a rebase
+            // that would not help (#303).
+            ownWorkPaths: preview?.conflicts || []
           }));
           finishApply();
           return;

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -357,7 +357,8 @@ test('describeApplyFailure: a pull request already in trunk asks for nothing (is
 // change will not fit is the contributor's own work in the same file, and that
 // button asks a stranger for work that would not help. The app cannot prove
 // which side a single region belongs to — it matches without the PR's base — but
-// it knows which files this ticket has work in, and that is enough.
+// it knows which files this ticket has work in. That is enough to recommend a
+// clean-ticket check, not enough to name which side caused a failed region.
 
 test('describeApplyFailure: a failure in the contributor\'s own file is not blamed on the author (issue #303)', () => {
 	const result = describeApplyFailure({
@@ -366,21 +367,36 @@ test('describeApplyFailure: a failure in the contributor\'s own file is not blam
 		conflicts: [conflict(FOO, 4, [{ index: 0, line: 7, status: 'moved' }])]
 	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
 
-	// The culprit is named, and it is not the pull request's age.
-	assert.match(result.headline, /Your own work is in the way/);
+	// The overlap is named without turning file-level evidence into a verdict.
+	assert.match(result.headline, /Your own work is also in/);
+	assert.match(result.headline, /may be part of why/);
 	assert.doesNotMatch(result.headline, /older trunk/);
-	// No rebase to ask for, and no button offering one. The advice says the ask
-	// would not help; what it never does is hand the work to the author.
-	assert.doesNotMatch(result.advice, /author's work/);
 	// The pull request is still reachable — reading it is how the contributor
-	// decides whether to start a clean ticket for it. Only the ask is gone.
+	// decides what to do after the clean-ticket check. The ask is conditional.
 	assert.equal(result.prButton, 'Open the pull request');
 	assert.equal(result.prUrl, PR_URL);
-	// What actually moves it forward: a copy, then a clean ticket or a discard.
+	// What actually moves it forward: a copy, then a clean ticket.
 	assert.match(result.advice, /Save a patch of your work/);
-	assert.match(result.advice, /discard it here/);
+	assert.match(result.advice, /try this pull request on a clean ticket/);
+	assert.match(result.advice, /If it still does not fit/);
 	// The scale still says how much missed — that decision is unchanged.
 	assert.match(result.headline, /1 of its 4 changes, in 1 file/);
+});
+
+// File overlap is evidence that the contributor's work may matter, not proof
+// that it caused the failed region. They may have edited one function while an
+// old pull request fails against another function in the same file.
+test('describeApplyFailure: same-file overlap preserves uncertainty about the failing region (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [{ index: 2, line: 240, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	assert.match(result.headline, /may be part of why/);
+	assert.match(result.advice, /If it still does not fit/);
+	assert.doesNotMatch(result.advice, /not a pull request that has gone stale/);
+	assert.equal(result.prButton, 'Open the pull request');
 });
 
 test('describeApplyFailure: a failure in files the ticket never touched keeps the stale framing (issue #303)', () => {
@@ -406,14 +422,12 @@ test('describeApplyFailure: a failure in both kinds of file says both (issue #30
 		]
 	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
 
-	// Each file is named on the side it belongs to; neither is picked over the
-	// other, because the app has no way to know which one really failed first.
-	assert.match(result.headline, new RegExp(`Your own work is in the way in ${FOO}`));
-	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}`));
-	// The rebase ask survives, because there is a file it genuinely applies to.
-	assert.match(result.advice, /author's work/);
+	// The overlap and the other failure are both named without assigning either
+	// failed region to a side the app cannot prove.
+	assert.match(result.headline, new RegExp(`Your own work is also in ${FOO}`));
+	assert.match(result.headline, new RegExp(`Other failures are in ${BAR}`));
 	assert.match(result.advice, /Save a patch of your work/);
-	assert.equal(result.prButton, 'Ask its author for a rebase');
+	assert.equal(result.prButton, 'Open the pull request');
 	assert.equal(result.prUrl, PR_URL);
 });
 
@@ -433,7 +447,7 @@ test('describeApplyFailure: the named files are deduplicated and capped (issue #
 
 	// A concatenated patch failing the same file twice must not name it twice —
 	// nor count it twice in the same sentence that goes on to list it.
-	assert.match(twice.headline, new RegExp(`in ${FOO}\\.$`));
+	assert.match(twice.headline, new RegExp(`in ${FOO}, so it may be part`));
 	assert.match(twice.headline, /in 1 file,/);
 
 	const many = ['a', 'b', 'c', 'd', 'e'].map((n) => `src/wp-includes/${n}.php`);
@@ -461,8 +475,8 @@ test('describeApplyFailure: the mixed framing reads with several files on each s
 		]
 	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
 
-	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}, ${BAZ}\\.$`));
-	assert.equal(result.prButton, 'Ask its author for a rebase');
+	assert.match(result.headline, new RegExp(`Other failures are in ${BAR}, ${BAZ}\\.$`));
+	assert.equal(result.prButton, 'Open the pull request');
 });
 
 test('describeApplyFailure: own work does not change the closed or landed framing (issue #303)', () => {

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -350,6 +350,161 @@ test('describeApplyFailure: a pull request already in trunk asks for nothing (is
 	assert.equal(result.advice, '');
 });
 
+// --- whose work is actually in the way (#303) ----------------------------
+//
+// The framing above answers from the pull request's state alone, so an open one
+// is always "stale, ask for a rebase". On a resumed ticket the usual reason a
+// change will not fit is the contributor's own work in the same file, and that
+// button asks a stranger for work that would not help. The app cannot prove
+// which side a single region belongs to — it matches without the PR's base — but
+// it knows which files this ticket has work in, and that is enough.
+
+test('describeApplyFailure: a failure in the contributor\'s own file is not blamed on the author (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// The culprit is named, and it is not the pull request's age.
+	assert.match(result.headline, /Your own work is in the way/);
+	assert.doesNotMatch(result.headline, /older trunk/);
+	// No rebase to ask for, and no button offering one. The advice says the ask
+	// would not help; what it never does is hand the work to the author.
+	assert.doesNotMatch(result.advice, /author's work/);
+	// The pull request is still reachable — reading it is how the contributor
+	// decides whether to start a clean ticket for it. Only the ask is gone.
+	assert.equal(result.prButton, 'Open the pull request');
+	assert.equal(result.prUrl, PR_URL);
+	// What actually moves it forward: a copy, then a clean ticket or a discard.
+	assert.match(result.advice, /Save a patch of your work/);
+	assert.match(result.advice, /discard it here/);
+	// The scale still says how much missed — that decision is unchanged.
+	assert.match(result.headline, /1 of its 4 changes, in 1 file/);
+});
+
+test('describeApplyFailure: a failure in files the ticket never touched keeps the stale framing (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [BAR] });
+
+	assert.match(result.headline, /written against an older trunk/);
+	assert.doesNotMatch(result.headline, /Your own work/);
+	assert.match(result.advice, /author's work/);
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+});
+
+test('describeApplyFailure: a failure in both kinds of file says both (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${BAR} has moved on`],
+		conflicts: [
+			conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(BAR, 2, [{ index: 0, line: 11, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// Each file is named on the side it belongs to; neither is picked over the
+	// other, because the app has no way to know which one really failed first.
+	assert.match(result.headline, new RegExp(`Your own work is in the way in ${FOO}`));
+	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}`));
+	// The rebase ask survives, because there is a file it genuinely applies to.
+	assert.match(result.advice, /author's work/);
+	assert.match(result.advice, /Save a patch of your work/);
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+	assert.equal(result.prUrl, PR_URL);
+});
+
+// The headline names files, so the two things that break a list break it here:
+// a patch that fails the same file twice, and a patch that fails more files than
+// a sentence can carry. The panel prints every failing file underneath anyway,
+// so past a few the headline counts instead of listing.
+test('describeApplyFailure: the named files are deduplicated and capped (issue #303)', () => {
+	const twice = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${FOO} has moved on`],
+		conflicts: [
+			conflict(FOO, 2, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(FOO, 2, [{ index: 0, line: 40, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// A concatenated patch failing the same file twice must not name it twice —
+	// nor count it twice in the same sentence that goes on to list it.
+	assert.match(twice.headline, new RegExp(`in ${FOO}\\.$`));
+	assert.match(twice.headline, /in 1 file,/);
+
+	const many = ['a', 'b', 'c', 'd', 'e'].map((n) => `src/wp-includes/${n}.php`);
+	const wide = describeApplyFailure({
+		ok: false,
+		failures: many.map((p) => `${p} has moved on`),
+		conflicts: many.map((p) => conflict(p, 1, [{ index: 0, line: 1, status: 'moved' }]))
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: many });
+
+	assert.match(wide.headline, /a\.php, src\/wp-includes\/b\.php, src\/wp-includes\/c\.php and 2 more files/);
+	assert.doesNotMatch(wide.headline, /e\.php/);
+});
+
+// Both sides can hold several files, and the sentence has to read as English
+// either way — which is why neither list is followed by a verb agreeing with it.
+test('describeApplyFailure: the mixed framing reads with several files on each side (issue #303)', () => {
+	const BAZ = 'src/wp-includes/baz.php';
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${BAR} has moved on`, `${BAZ} has moved on`],
+		conflicts: [
+			conflict(FOO, 1, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(BAR, 1, [{ index: 0, line: 11, status: 'moved' }]),
+			conflict(BAZ, 1, [{ index: 0, line: 13, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}, ${BAZ}\\.$`));
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+});
+
+test('describeApplyFailure: own work does not change the closed or landed framing (issue #303)', () => {
+	const closed = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'closed', ownWorkPaths: [FOO] });
+
+	// Nobody is coming back to a closed pull request whatever is in the way, and
+	// its discussion is still the thing worth reading.
+	assert.match(closed.headline, /closed and was written against an older trunk/);
+	assert.equal(closed.prButton, 'See why it was closed');
+
+	const landed = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 9, status: 'already-applied' }
+		])]
+	}, { prUrl: PR_URL, prState: 'closed', ownWorkPaths: [FOO] });
+
+	assert.match(landed.headline, /likely committed to core/);
+	assert.equal(landed.prButton, null);
+});
+
+// A patch from disk or a Trac attachment has no author to misblame, so the
+// own-work list changes nothing there — the full per-region breakdown is still
+// the only way out, and it stays.
+test('describeApplyFailure: a loose patch is unaffected by the own-work list (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved', lines: ['-x', '+y'] }])]
+	}, { ownWorkPaths: [FOO] });
+
+	assert.match(result.headline, /1 of this patch's 3 changes/);
+	assert.equal(result.advice, '');
+	assert.equal(result.items[0].regions.length, 1);
+});
+
 test('describeApplyFailure: a loose patch keeps the full breakdown — there is no author to send to (issue #282)', () => {
 	const result = describeApplyFailure({
 		ok: false,


### PR DESCRIPTION
## Why

When a pull request fails in a file the ticket has changed, the app used to state that the PR was stale and tell a newcomer to ask its author for a rebase. File overlap does not prove that: the contributor and PR may have changed different regions of the same file.

## What changes

The failure copy now preserves what the app actually knows. It names the files containing ticket work, says that work may be part of the failure, and suggests saving a copy or trying from a clean ticket. It only recommends asking the author for an update when failures also occur in files the ticket did not change.

No new measurement, IPC or Git operation is introduced.

## How to test this

**Platforms:** any.

1. On a linked ticket, edit one region of a file.
2. Apply a PR that fails in a different region of that same file.
   **Expected:** the notice says your work may be part of the conflict; it does not claim either side is certainly responsible.
3. Apply a PR that fails only in files untouched by the ticket.
   **Expected:** the existing stale-PR framing and author-update action remain.
4. Try a mixed failure.
   **Expected:** both facts are named, without assigning the shared file categorically.

**What must not have happened:** a failed apply must not alter the checkout, and the link to the PR must remain available.

## Risks and limitations

Attribution remains file-level because this two-way apply path does not have the PR’s base. The copy deliberately expresses that uncertainty. The desktop flow remains to be driven from the integration artifact.

## Related

Fixes #303. Part of #309. Builds on #302.

---

<details>
<summary>Review outcome</summary>

The review found the original categorical same-file attribution unsound. Fixed with a regression covering edits in different regions of the same file. Focused tests and the full integration suite are green.

</details>

<details>
<summary>Implementation notes</summary>

The decision remains in the pure `apply-conflict.cjs` module; `index.jsx` only passes the existing collision list.

</details>

<details>
<summary>Screenshots or recording</summary>

No new component or layout; only the existing failure banner’s wording/action changes.

</details>
