### PR TITLE
Keep an empty file in the patch when it is added or deleted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -458,7 +458,13 @@ async function collectChangedFiles(dir, baseOid = null) {
 //   too is named above the diff, and counts.
 // - 'unchanged': both sides equal once line endings are normalized — the
 //   churn of a CRLF checkout (native git on Windows), which must reach
-//   neither a Trac patch nor the note's count.
+//   neither a Trac patch nor the note's count. Only a file that exists on
+//   both sides can be unchanged: whether one was added or deleted is a
+//   question about which side it is on, and the status codes are what answer
+//   it (#85), not the text. An empty file added, and an empty file deleted,
+//   both render '' on both sides and used to come out 'unchanged' — dropped
+//   from the patch and uncounted by the note, with nothing on screen to say
+//   so (#311).
 // - 'text': a real difference, normalized on both sides for the same reason.
 function classifyChangedFile(file) {
     const gone = !file.inWorkdir;
@@ -469,7 +475,7 @@ function classifyChangedFile(file) {
     }
     const a = file.base ? normalizeEol(file.base.toString('utf8')) : '';
     const b = file.work ? normalizeEol(file.work.toString('utf8')) : '';
-    if (a === b) return { kind: 'unchanged' };
+    if (file.inHead === file.inWorkdir && a === b) return { kind: 'unchanged' };
     return { kind: 'text', a, b };
 }
 
@@ -501,6 +507,15 @@ async function createMinimalPatchForDir(dir, baseOid = null) {
         // Which side exists is the walk's answer, not the buffers'.
         const oldName = file.inHead ? `a/${file.path}` : '/dev/null';
         const newName = gone ? '/dev/null' : `b/${file.path}`;
+        // An empty file added, or an empty file deleted: there is no line on
+        // either side, so jsdiff emits a section with no hunk at all — which
+        // `git apply` rejects as "no valid patches in input", taking the whole
+        // patch and every unrelated file in it. Git's own extended header is
+        // how an empty file is carried, so that is what this emits (#311).
+        if (a === b) {
+            patch += emptyFileSection(file.path, oldName, newName, gone);
+            continue;
+        }
         // No blank line between sections. jsdiff keeps consuming lines past a
         // `\ No newline at end of file` marker, so a separator becomes a
         // phantom empty context line and the section stops applying to any
@@ -512,6 +527,36 @@ async function createMinimalPatchForDir(dir, baseOid = null) {
         );
     }
     return skippedNotice(binaries, unreadable) + (patch || 'No changes.');
+}
+
+/**
+ * The section for an empty file that was added or deleted (#311).
+ *
+ * A unified diff describes a file by its lines, and an empty file has none —
+ * so what says this happened at all is the header. `git apply` reads an
+ * addition or a deletion with no hunk only from the `diff --git` line plus
+ * `new file mode` / `deleted file mode`; without them it refuses the input as
+ * garbage. The `---`/`+++` pair is kept alongside because `/dev/null` is what
+ * this app's own reader classifies from (#85), and it is what makes the
+ * section look like every other one in the patch.
+ *
+ * The mode is the plain-file default, which is what this generator carries for
+ * every file: it does not record modes, so an executable bit is not preserved
+ * here any more than it is on a non-empty addition.
+ *
+ * @param {string}  filepath Repo-relative path.
+ * @param {string}  oldName  Old side as the patch names it.
+ * @param {string}  newName  New side as the patch names it.
+ * @param {boolean} gone     True when the file is the one being deleted.
+ * @return {string} One patch section, ending in a newline.
+ */
+function emptyFileSection(filepath, oldName, newName, gone) {
+    const mode = gone ? 'deleted file mode 100644' : 'new file mode 100644';
+    return `${'='.repeat(67)}\n`
+        + `diff --git a/${filepath} b/${filepath}\n`
+        + `${mode}\n`
+        + `--- ${oldName}\n`
+        + `+++ ${newName}\n`;
 }
 
 /**

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -294,6 +294,14 @@ function resolveFile(dir, file, { diagnose = true } = {}) {
 		if (file.hunks && file.hunks.length) {
 			const text = normalizeEol(previous.toString('utf8'));
 			if (JsDiff.applyPatch(text, file.patch) === false) return conflict(file.path, text);
+		} else if (previous.length) {
+			// A deletion with no hunk is the removal of an *empty* file (#311) —
+			// there was nothing to describe, which is also the whole claim it
+			// makes about the old side. A file that has content since is not the
+			// file the patch described, and removing it would discard work no
+			// hunk ever mentioned. `git apply` refuses this outright ("removal
+			// patch leaves file contents"); so does this.
+			return conflict(file.path, normalizeEol(previous.toString('utf8')));
 		}
 		return { op: 'delete', abs: target, path: file.path, previous };
 	}

--- a/src/patch-plan.cjs
+++ b/src/patch-plan.cjs
@@ -168,6 +168,26 @@ function parsePatchFiles(text) {
 		const file = parsed[i];
 
 		if (!file.hunks || file.hunks.length === 0) {
+			// An empty file added or deleted has no line on either side, so its
+			// section is headers alone (#311). `/dev/null` still says which of
+			// the two it was — the same rule classify() applies to a hunked
+			// section — and it comes off the parsed filenames, so it does not
+			// depend on `sections` lining up with `parsed` (it does not, in a
+			// patch that mixes git-style and bare sections).
+			if (file.oldFileName === '/dev/null' || file.newFileName === '/dev/null') {
+				const empty = stripPathPrefix(file.oldFileName || '', file.newFileName || '');
+				const emptyKind = classify(file, empty.oldPath, empty.newPath);
+				const emptyTarget = emptyKind === 'delete' ? empty.oldPath : empty.newPath;
+				files.push({
+					kind: emptyKind,
+					oldPath: mapToSrcLayout(empty.oldPath),
+					newPath: mapToSrcLayout(empty.newPath),
+					path: mapToSrcLayout(emptyTarget),
+					hunks: [],
+					patch: file
+				});
+				continue;
+			}
 			// jsdiff kept nothing, so the raw section is the only evidence of
 			// what this was.
 			const section = sections[i];

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -949,6 +949,114 @@ test('a generated patch applies when the files have no trailing newline (#85)', 
 	assert.equal(fs.readFileSync(path.join(target, 'edited.php'), 'utf8'), 'line1\nline2\nline3');
 });
 
+// --- empty files added and deleted (#311) ---------------------------------
+
+// The generator used to compare the two sides' text before consulting the
+// status codes that say which side the file is on. An added empty file renders
+// '' on both sides, so it came out "unchanged" and was skipped — a contributor
+// adding a placeholder was told their ticket had no changes at all.
+test('an added empty file reaches the patch (#311)', async (t) => {
+	const dir = await patchRepo(t, { 'kept.php': '<?php // stays\n' });
+	fs.writeFileSync(path.join(dir, 'placeholder.php'), '');
+
+	const { patch } = await patchMain().invoke('git:get-patch', dir);
+
+	assert.match(patch, /^new file mode 100644$/m, 'an empty file has no line to diff, so the header is what carries it');
+	assert.match(patch, /^--- \/dev\/null$/m);
+	assert.match(patch, /^\+\+\+ b\/placeholder\.php$/m);
+	assert.doesNotMatch(patch, /No changes\./, 'the tree is not unchanged');
+});
+
+// The same on the other side: deleting a file that was already empty.
+test('a deleted empty file reaches the patch (#311)', async (t) => {
+	const dir = await patchRepo(t, { 'placeholder.php': '', 'kept.php': '<?php // stays\n' });
+	fs.rmSync(path.join(dir, 'placeholder.php'));
+
+	const { patch } = await patchMain().invoke('git:get-patch', dir);
+
+	assert.match(patch, /^deleted file mode 100644$/m);
+	assert.match(patch, /^--- a\/placeholder\.php$/m);
+	assert.match(patch, /^\+\+\+ \/dev\/null$/m);
+	assert.doesNotMatch(patch, /No changes\./);
+});
+
+// `/dev/null` has to survive the round trip for an empty file too: it is the
+// only thing this app's reader classifies an add or a delete from (#85), and a
+// section with no hunk is the shape jsdiff hands back for a rename and for
+// prose that is not a patch at all.
+test('a generated empty addition parses back as an addition (#311)', async (t) => {
+	const dir = await patchRepo(t, { 'kept.php': '<?php // stays\n' });
+	fs.writeFileSync(path.join(dir, 'placeholder.php'), '');
+
+	const { patch } = await patchMain().invoke('git:get-patch', dir);
+	const parsed = require('../src/patch-plan.cjs').parsePatchFiles(patch);
+
+	assert.equal(parsed.ok, true, parsed.error);
+	assert.deepEqual(parsed.files.map((f) => [f.kind, f.path]), [['add', 'placeholder.php']]);
+});
+
+test('a generated empty deletion parses back as a deletion (#311)', async (t) => {
+	const dir = await patchRepo(t, { 'placeholder.php': '', 'kept.php': '<?php // stays\n' });
+	fs.rmSync(path.join(dir, 'placeholder.php'));
+
+	const { patch } = await patchMain().invoke('git:get-patch', dir);
+	const parsed = require('../src/patch-plan.cjs').parsePatchFiles(patch);
+
+	assert.equal(parsed.ok, true, parsed.error);
+	assert.deepEqual(parsed.files.map((f) => [f.kind, f.path]), [['delete', 'placeholder.php']]);
+});
+
+// And it has to apply, alongside an ordinary edit in the same patch — the
+// mixed case is the one that would break everything else if the empty section
+// were malformed, since applying is all-or-nothing.
+test('a generated patch carries empty additions and deletions into another checkout (#311)', async (t) => {
+	const { applied, target } = await roundTrip(t, {
+		'was-empty.php': '',
+		'edited.php': 'line1\nline2\n'
+	}, (dir) => {
+		fs.rmSync(path.join(dir, 'was-empty.php'));
+		fs.writeFileSync(path.join(dir, 'placeholder.php'), '');
+		fs.writeFileSync(path.join(dir, 'edited.php'), 'line1\nline2\nline3\n');
+	});
+
+	assert.equal(applied.ok, true, applied.error);
+	assert.equal(fs.existsSync(path.join(target, 'was-empty.php')), false, 'the empty deletion has to actually delete');
+	assert.equal(fs.readFileSync(path.join(target, 'placeholder.php'), 'utf8'), '', 'the empty addition has to actually create');
+	assert.equal(fs.readFileSync(path.join(target, 'edited.php'), 'utf8'), 'line1\nline2\nline3\n');
+});
+
+// The card's note reads the same classification, so the omission was silent on
+// both surfaces: nothing on screen suggested a file had been dropped.
+test('git:unsubmitted-work counts empty files added and deleted (#311, #239)', async (t) => {
+	const dir = await patchRepo(t, { 'was-empty.php': '', 'kept.php': '<?php // stays\n' });
+	fs.rmSync(path.join(dir, 'was-empty.php'));
+	fs.writeFileSync(path.join(dir, 'placeholder.php'), '');
+
+	const wide = await patchMain().invoke('git:unsubmitted-work', dir);
+
+	assert.equal(wide.ok, true, wide.error);
+	assert.deepEqual(wide.files.sort(), ['placeholder.php', 'was-empty.php']);
+	assert.equal(wide.changedCount, 2);
+});
+
+// The other side of the condition #311 narrowed. A file that exists on both
+// sides and differs only in line endings — the churn a CRLF checkout produces
+// on Windows — is still nothing, and must reach neither the patch nor the note.
+// Without this, widening the existence test to cover empty adds and deletes
+// would be indistinguishable from dropping the text comparison altogether.
+test('a file that differs only in line endings is still no change (#311, #85)', async (t) => {
+	const dir = await patchRepo(t, { 'text.php': '<?php // one\n// two\n' });
+	fs.writeFileSync(path.join(dir, 'text.php'), '<?php // one\r\n// two\r\n');
+
+	const main = patchMain();
+	const { patch } = await main.invoke('git:get-patch', dir);
+	const wide = await main.invoke('git:unsubmitted-work', dir);
+
+	assert.ok(patch.endsWith('No changes.'), JSON.stringify(patch));
+	assert.deepEqual(wide.files, []);
+	assert.equal(wide.changedCount, 0);
+});
+
 // A unified diff cannot carry a binary, but dropping it without a word means a
 // contributor hands over a patch that is missing a file they changed and has no
 // way to know. Named above the diff, following the handoff header's placement,

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -496,6 +496,43 @@ deleted file mode 100644
 	assert.deepStrictEqual(snapshot(dir), before, 'the edited file must not be deleted');
 });
 
+// The same protection where there is no pre-image to match against. An empty
+// file's deletion has no hunk (#311), so the hunk check above cannot run — and
+// without a check of its own the applier would remove a file the patch only
+// ever claimed was empty, contributor's work and all. `git apply` refuses this
+// as "removal patch leaves file contents"; so must this.
+test('applyPatchToDir: an empty-file deletion refuses a file that has content (#311)', async (t) => {
+	const dir = await makeRepo(t, { 'src/placeholder.php': '' });
+	const deletePatch = `diff --git a/src/placeholder.php b/src/placeholder.php
+deleted file mode 100644
+--- a/src/placeholder.php
++++ /dev/null
+`;
+	fs.writeFileSync(path.join(dir, 'src/placeholder.php'), 'my own work\n');
+	const before = snapshot(dir);
+
+	const res = await applyPatchToDir({ dir, patchText: deletePatch });
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /moved on since the patch was written/);
+	assert.deepStrictEqual(snapshot(dir), before, 'the file that grew content must not be deleted');
+});
+
+// And it still removes the file it does describe.
+test('applyPatchToDir: an empty-file deletion removes the empty file (#311)', async (t) => {
+	const dir = await makeRepo(t, { 'src/placeholder.php': '' });
+	const deletePatch = `diff --git a/src/placeholder.php b/src/placeholder.php
+deleted file mode 100644
+--- a/src/placeholder.php
++++ /dev/null
+`;
+
+	const res = await applyPatchToDir({ dir, patchText: deletePatch });
+
+	assert.strictEqual(res.ok, true, res.error);
+	assert.strictEqual(fs.existsSync(path.join(dir, 'src/placeholder.php')), false);
+});
+
 // A rename that completes and is then undone by a later failure must restore the
 // source and remove the destination — registering each action before its
 // mutations is what lets rollback see a half-done one. (Copilot #3.)


### PR DESCRIPTION
## Why

A contributor adds a new empty file to their ticket — a placeholder, a fixture, a file they are about to fill in — and the patch modal says the ticket has no changes at all. Deleting a file that was already empty does the same. It is not merely missing from the generated `.diff`: the card's unsubmitted-work note does not count it either, so nothing on screen suggests anything was dropped.

Silent today, destructive soon. This is the same classification the planned "bring a ticket up to date" flow (#305) uses to carry a ticket's work onto newer trunk. A file the classification does not mention is a file that flow would not carry — and the force checkout it performs would delete it. A cosmetic omission now is lost work then.

## What changes

**Root cause.** `classifyChangedFile` in `src/main.js` compared the two sides' normalized text before consulting the existence flags it already held. For an added empty file `file.base` is null and `file.work` is a zero-length buffer, so both sides render `''`, compare equal, and the row is classified `unchanged` — skipped by `createMinimalPatchForDir` and filtered out of `collectUnsubmittedFiles`. Deleting an already-empty file is the mirror image.

Whether a file was added or deleted is not a question about its contents. `collectChangedFiles` already carries the answer: `inHead` and `inWorkdir` come from `statusMatrix` status codes, which is the rule #85 established for whole-file reads — the codes, not the buffers, are what say a file is gone. So `unchanged` now requires the file to exist on both sides. Nothing else about the condition moves: a file that differs only in line endings is still nothing.

Three consequences had to be handled, and they are the reason this is not a one-line diff:

1. **The patch has to be emittable.** An empty file has no line to diff, so jsdiff produces a section with no hunk at all — and `git apply` rejects that as `No valid patches in input`, taking the *whole* patch and every unrelated file in it, the same all-or-nothing failure mode the phantom `\ No newline` work was about. Git's own extended header (`diff --git` plus `new file mode` / `deleted file mode`) is how an empty file is carried, so `emptyFileSection` in `src/main.js` emits exactly that, keeping the `---`/`+++` pair because `/dev/null` is what this app's own reader classifies from. Verified against real `git apply`, mixed into a patch alongside an ordinary edit.

2. **The patch has to be readable back.** `parsePatchFiles` in `src/patch-plan.cjs` treated every zero-hunk section as a rename, a binary, or garbage. It now classifies from `/dev/null` on either parsed filename — the same rule `classify()` applies to a hunked section — before falling through to the raw-section checks. It reads the parsed filenames rather than `scanSections`' output on purpose, so it does not depend on the two arrays lining up in a patch that mixes git-style and bare sections.

3. **The applier must not become destructive.** A deletion with no hunk gives `src/patch-apply.js` no pre-image to match, so its existing "did the file move on since the preview" check could not run and the file would be removed whatever was in it. A hunkless deletion *claims* the file was empty, so `planFile` now refuses one whose target has content, routed through the same `conflict()` path as every other mismatch. `git apply` refuses the identical case as `removal patch leaves file contents`.

Deliberately not in scope: binary and unreadable handling, file modes (this generator has never recorded them, for empty files or otherwise), and reading empty add/delete sections out of patches written by *real git*, which omits the `---`/`+++` pair entirely — see Risks.

## How to test this

**Platforms: any.** Nothing here touches paths, spawning or signing. The generated section is built with `\n` like every other, and `statusMatrix` paths are forward-slash on every OS.

**Starting state:** a site with a linked Trac ticket, on its ticket branch, with no other uncommitted work. (Link a ticket from the card if the site is still on trunk.)

1. In the site's folder, create an empty file — `touch src/placeholder.php`, or save a new empty file from your editor. Do not put anything in it.
   - **Expected:** the site card's note names unsubmitted work and counts **1 file**.
2. Open **Review and submit** (the patch modal).
   - **Expected:** the diff area is not "No changes." It shows a section for `src/placeholder.php` reading `new file mode 100644`, `--- /dev/null`, `+++ b/src/placeholder.php`.
3. Save the patch to disk with **Save patch**, then in a real `wordpress-develop` clone at the same base run `git apply --check the-file.diff`.
   - **Expected:** exits 0 and prints nothing. Running `git apply the-file.diff` creates an empty `src/placeholder.php`.
4. Back in the app, edit an ordinary file too (add a line to `src/wp-login.php`) and reopen the modal.
   - **Expected:** both files are in the one patch, and step 3 still passes on it — the empty section must not break the file next to it.
5. Now the deletion side. Delete `src/placeholder.php` from disk *after* it has been carried into the ticket's parked work — or, more simply on a fresh site: pick any file that is empty in trunk, delete it, and open the modal.
   - **Expected:** a section reading `deleted file mode 100644`, `--- a/<path>`, `+++ /dev/null`, and the card's note counts it.
6. Apply a patch containing an empty addition into a second site: open the second site's **Apply a patch**, paste the `.diff` from step 3, and confirm.
   - **Expected:** the preview lists the file as **added**, not modified; applying creates it, empty.
7. The refusal. Take the step-5 deletion patch, but before applying it into the second site, put some text into the file it names.
   - **Expected:** applying fails with "moved on since the patch was written", and the file — with your text in it — is still there.

**What must not have happened:**

- No file may be deleted in step 7. A silent deletion there is work destroyed with nothing on screen to say so, and it is a path this PR opens: the applier had no pre-image check that could run on a hunkless deletion.
- `git apply` must not fail in steps 3 and 4 with `No valid patches in input` or `corrupt patch at line N`. A malformed empty section takes the whole patch down, including the unrelated file in step 4 — that is the failure this shape was chosen to avoid.
- A file whose only change is line endings must still be absent from the patch and from the note's count. Check it: on Windows, or by rewriting a file with CRLF, confirm the modal still says "No changes." Widening the existence test must not have become "stop comparing text".
- Nothing may be staged into the contributor's index by generating the patch (#85).

**The steps that used to reproduce it:** steps 1 and 2, on `trunk`, produce a card note saying nothing and a modal saying "No changes."

**Tests, and which fail on the old code.** Seven of the nine new tests fail without this change, checked by stashing the `src/` edits and re-running:

- `test/ipc-wiring.test.cjs` — `an added empty file reaches the patch (#311)`, `a deleted empty file reaches the patch (#311)`, `a generated empty addition parses back as an addition (#311)`, `a generated empty deletion parses back as a deletion (#311)`, `a generated patch carries empty additions and deletions into another checkout (#311)`, `git:unsubmitted-work counts empty files added and deleted (#311, #239)` — all six fail on the old code.
- `test/patch-apply.integration.test.cjs` — `an empty-file deletion refuses a file that has content (#311)` fails without the applier guard (checked by stashing only `src/patch-apply.js`).
- The remaining two pin the negative and the happy path: `a file that differs only in line endings is still no change (#311, #85)` and `an empty-file deletion removes the empty file (#311)`.

`npm test` 950 pass / 0 fail. `npm run lint` clean.

## Risks and limitations

Review outcome: **2 [fix here] · 1 [follow-up] — both [fix here] fixed.** One of them found a real regression this PR would have introduced (the applier deleting a file with content), so the collapsed block below is worth reading.

- **Empty add/delete sections written by real git are still not read.** `git diff` emits `diff --git` + `new file mode` + `index` and *no* `---`/`+++` pair for an empty file, so jsdiff hands back no filenames and `parsePatchFiles` still rejects — and because it returns a whole-patch error, a Trac attachment or PR `.diff` that happens to add one empty fixture is rejected entirely, unrelated files included. That is the read half of #311 and it predates this change; `scanSections` already captures the paths and would need to record the mode markers. Deferred as a follow-up rather than widened into this PR.
- **File modes are not carried.** The emitted section hardcodes `100644`. An empty file with the executable bit set loses it — as every non-empty addition already does, since this generator has never recorded modes. Applying a `deleted file mode 100644` section over a `100755` file makes `git apply` warn and then apply, which is acceptable.
- **A hunkless deletion is refused whenever the target is non-empty**, including the case where the contributor emptied the file themselves and would have been happy to see it go. That is the conservative direction, and it matches `git apply`.
- **Not tested by hand: step 5's "empty file in trunk" starting state.** `wordpress-develop` has no empty tracked file to delete, so the deletion half was driven through the suite and through real `git apply` against a synthetic repo rather than in the app against a real clone.

## Related

Fixes #311. Related to #85 (the codes, not the buffers, say a file is gone), #239 (the unsubmitted-work count reads this same classification) and #305 (the carry-forward flow that would delete anything this classification fails to mention).

Stacked on #302 — review that first; this PR targets its branch.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why not just return a new `kind` from `classifyChangedFile`?** The two consumers ask different questions of it: the generator switches on the kind, the note only asks whether it is `unchanged`. A new kind would have meant touching the note for a case it already handles correctly once the classification is right. Keeping the row as `text` with `a === b` and special-casing the emission keeps the note's filter untouched.

**Why emit `diff --git` at all, when nothing else in this generator does?** Because nothing shorter works. Tested against real `git apply`: `--- /dev/null` + `+++ b/foo` with no hunk is "no valid patches in input"; adding `@@ -0,0 +0,0 @@` or `@@ -1,0 +1,0 @@` is "corrupt patch"; `diff --git` without the mode line is "patch with only garbage". `diff --git` plus `new file mode 100644` applies cleanly, and so does the deletion form. The mode line is load-bearing, not decoration.

**Why keep the `---`/`+++` pair, which real git omits here?** Two reasons. It is what this app's own reader classifies an add or a delete from (#85) — without it, jsdiff returns a section with no filenames at all and the round trip breaks. And it makes the section look like every other one in the patch, so the renderer's diff highlighting treats its lines as meta the way it does everywhere else.

**Why classify from the parsed filenames in `patch-plan.cjs` rather than from `sections[i]`?** `scanSections` pushes an entry only for a line starting `diff --git` or `Index:`. In a patch that mixes the new git-style sections with jsdiff's bare ones — which is exactly what this generator now produces — `sections` is shorter than `parsed` and the indices do not correspond. Reading `file.oldFileName` sidesteps that entirely. The misalignment itself is pre-existing and harmless here (app-generated patches contain no renames or binaries, which are the only things the section lookup is used for), but the new branch deliberately does not depend on it.

**Why refuse a hunkless deletion over a non-empty file instead of applying it?** Symmetry with the hunked case, which exists precisely so that "an edit made after the preview fails all-or-nothing rather than being silently deleted with the contributor's changes in it". Without the guard this PR would have made the app *more* destructive than `git apply`, on a code path that did not exist before it.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**2 [fix here] · 1 [follow-up] — both [fix here] fixed, the [follow-up] deferred.**

The judgement pass ran in a fresh context (a subagent given the diff and `.github/instructions/code-review.instructions.md`), not the session that wrote the change.

**Fixed — Architecture 🟡 [fix here], `src/patch-apply.js:288`.** A zero-hunk deletion skipped the pre-image check, so an empty-file deletion removed its target whatever it contained — verified: applying the generated section over a file holding `<?php // real content` returned `ok: true` and the file was gone, where real `git apply` refuses with "removal patch leaves file contents". A new code path this PR opened, and the app was briefly more destructive than the tool the patch is destined for. Fixed with an explicit emptiness check routed through the existing `conflict()`, plus `an empty-file deletion refuses a file that has content (#311)` in `test/patch-apply.integration.test.cjs`, which fails without it.

**Fixed — Tests 🔵 [fix here], `src/main.js:478`.** The narrowed condition had no test on its negative side: nothing in the suite pinned that a CRLF-only difference must *still* be suppressed, so deleting `file.inHead === file.inWorkdir` would have broken nothing in the direction of over-reporting. Added `a file that differs only in line endings is still no change (#311, #85)` covering both the patch and the note.

**Deferred — Architecture 🟡 [follow-up], `src/patch-plan.cjs`.** Empty add/delete sections written by real git (no `---`/`+++` pair) are still unreadable, and the whole-patch error means one such section rejects an entire `.diff`. Genuinely not introduced by this PR — it is the read half of #311, reachable today from any Trac attachment — and fixing it means teaching `scanSections` the mode markers and resolving its index alignment with `parsed`. Written up in **Risks and limitations** rather than folded in, to keep this diff to the generator bug and its immediate consequences.

**Confirmed clean by the pass**, having read the surrounding files rather than the diff alone: the CRLF suppression is unaffected (every ordinary modification has `inHead === inWorkdir === true`, and `[path, 0, 0]` rows never reach the classifier); the new section shape is safe across `diff-highlight.cjs`, `patch-provenance.cjs`, `github-pr.cjs`, `pr-files.cjs` and `git:preview-patch`; `JsDiff.applyPatch('', {hunks: []})` returns `''`, so the add path writes an empty file correctly; `reverseFile` inverts both directions; the `scanSections`/`parsed` misalignment breaks no rename or binary detection; and paths containing spaces survive both readers.

</details>

<details>
<summary>Implementation notes</summary>

**`src/main.js`**
- `classifyChangedFile` — `unchanged` now additionally requires `file.inHead === file.inWorkdir`. One conjunct; the comment block above it carries the reasoning.
- `createMinimalPatchForDir` — when `a === b` on a row that reached the `text` branch (only possible for an empty add or delete), emits `emptyFileSection` instead of calling `createTwoFilesPatch`, which would produce a hunkless section.
- `emptyFileSection` — new. `===` separator (67, matching jsdiff), `diff --git a/<p> b/<p>`, the mode marker, then the `---`/`+++` pair.

**`src/patch-plan.cjs`** — `parsePatchFiles`, inside the existing `hunks.length === 0` branch, ahead of the rename and binary checks.

**`src/patch-apply.js`** — `planFile`'s delete branch gains an `else if (previous.length)` arm.

**Verification against real git**, since the suite exercises only this app's own reader: a patch combining the new deletion section, the new addition section, and an ordinary jsdiff edit section applies with `git apply` at exit 0, leaves the deleted file gone, creates the added file at 0 bytes, and updates the edited file. Each rejected alternative shape was tested the same way.

</details>

<details>
<summary>Screenshots or recording</summary>

No new UI. The visible change is entirely in surfaces that already exist and whose content is text: the patch modal shows a section where it used to say "No changes.", and the site card's note counts a file where it used to count none. Both are stated as expected results in **How to test this**, in the words that appear on screen, which is falsifiable in a way a still frame of a diff pane is not.

</details>
