### PR TITLE
Treat an applied patch as a named layer, not an undo blob

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
 const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
-const { applyPatchToDir } = require('./patch-apply');
+const { applyPatchToDir, diagnoseRemoval } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
 const { getClientId: getGithubClientId, requestDeviceCode, pollForToken, fetchViewer } = require('./github-auth.cjs');
@@ -1719,12 +1719,41 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 
 		// Summarised rather than passed through: the stored patch text is only
 		// needed by the main process to reverse it, and this is polled.
+		//
+		// `revertable` used to mean "we kept the text". It now means what the
+		// banner actually asks — can this layer still be lifted out, right now
+		// (#306) — which is a fact about the tree and has to be measured here,
+		// because the text does not cross IPC and the renderer cannot ask.
+		// The measurement is in-memory: it reads the patch's own files (one to a
+		// handful, on a call that already stats the checkout and reads a git
+		// object) and matches hunks against them. Nothing is written. It is
+		// bounded twice over — a patch bigger than REVERTABLE_PATCH_LIMIT has no
+		// stored text to check, and this handler is called on mount and after
+		// long operations, not on a timer. The costly shape is a large absorbed
+		// patch, which pays its per-hunk diagnosis on every one of those reads;
+		// if that is ever felt, a ceiling belongs in diagnoseRemoval, not here.
+		//
+		// Guarded, and it fails towards offering Revert: a check that could not
+		// run must not hide the exit. Pressing Revert then gives the real answer
+		// from the apply path, with its own explanation.
+		let absorbed = [];
+		if (work.appliedPatch && work.appliedPatch.text) {
+			try {
+				absorbed = diagnoseRemoval({ dir: sitePath, patchText: work.appliedPatch.text }).absorbed;
+			} catch (e) {
+				logError('site:status', `could not check whether ${describeRefused(work.appliedPatch.label)} still comes out of ${describeRefused(sitePath)}: ${String(e && e.stack ? e.stack : e)}`);
+			}
+		}
 		const appliedPatch = work.appliedPatch
 			? {
 				label: work.appliedPatch.label,
 				appliedAt: work.appliedPatch.appliedAt,
 				files: work.appliedPatch.files || [],
-				revertable: Boolean(work.appliedPatch.text)
+				// Whether a text was kept at all — the separate reason a patch
+				// cannot be reverted, and a different sentence from absorption.
+				kept: Boolean(work.appliedPatch.text),
+				absorbed,
+				revertable: Boolean(work.appliedPatch.text) && absorbed.length === 0
 			}
 			: null;
 

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
 const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
-const { applyPatchToDir, diagnoseRemoval } = require('./patch-apply');
+const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
 const { getClientId: getGithubClientId, requestDeviceCode, pollForToken, fetchViewer } = require('./github-auth.cjs');
@@ -1720,30 +1720,10 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		// Summarised rather than passed through: the stored patch text is only
 		// needed by the main process to reverse it, and this is polled.
 		//
-		// `revertable` used to mean "we kept the text". It now means what the
-		// banner actually asks — can this layer still be lifted out, right now
-		// (#306) — which is a fact about the tree and has to be measured here,
-		// because the text does not cross IPC and the renderer cannot ask.
-		// The measurement is in-memory: it reads the patch's own files (one to a
-		// handful, on a call that already stats the checkout and reads a git
-		// object) and matches hunks against them. Nothing is written. It is
-		// bounded twice over — a patch bigger than REVERTABLE_PATCH_LIMIT has no
-		// stored text to check, and this handler is called on mount and after
-		// long operations, not on a timer. The costly shape is a large absorbed
-		// patch, which pays its per-hunk diagnosis on every one of those reads;
-		// if that is ever felt, a ceiling belongs in diagnoseRemoval, not here.
-		//
-		// Guarded, and it fails towards offering Revert: a check that could not
-		// run must not hide the exit. Pressing Revert then gives the real answer
-		// from the apply path, with its own explanation.
-		let absorbed = [];
-		if (work.appliedPatch && work.appliedPatch.text) {
-			try {
-				absorbed = diagnoseRemoval({ dir: sitePath, patchText: work.appliedPatch.text }).absorbed;
-			} catch (e) {
-				logError('site:status', `could not check whether ${describeRefused(work.appliedPatch.label)} still comes out of ${describeRefused(sitePath)}: ${String(e && e.stack ? e.stack : e)}`);
-			}
-		}
+		// A routine status read does not open and diff the patch's files. Revert
+		// performs that check when the contributor asks for it, and its existing
+		// failure payload explains overlapping edits without freezing every
+		// status refresh in the main process (#306).
 		const appliedPatch = work.appliedPatch
 			? {
 				label: work.appliedPatch.label,
@@ -1752,8 +1732,7 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 				// Whether a text was kept at all — the separate reason a patch
 				// cannot be reverted, and a different sentence from absorption.
 				kept: Boolean(work.appliedPatch.text),
-				absorbed,
-				revertable: Boolean(work.appliedPatch.text) && absorbed.length === 0
+				revertable: Boolean(work.appliedPatch.text)
 			}
 			: null;
 

--- a/src/main.js
+++ b/src/main.js
@@ -1579,7 +1579,7 @@ ipcMain.handle('git:apply-patch', async (event, sitePath, options = {}) => {
                     // site is still stuck, and telling the contributor it is
                     // sorted would send them back to a button that still refuses.
                     try {
-                        await mergeSiteMeta(sitePath, { appliedPatch: null });
+                        await writeWorkMeta(sitePath, { appliedPatch: null });
                         recordCleared = true;
                     } catch (e) {
                         logError('git:apply-patch', `clearing stale applied-patch record failed: ${String(e && e.stack ? e.stack : e)}`);

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -386,6 +386,74 @@ function patchIsAbsent(dir, files) {
 }
 
 /**
+ * Whether the patch the app applied could still be taken back out of this
+ * checkout, asked right now rather than remembered (#306).
+ *
+ * The record the app keeps says only that a patch text was stored. That is not
+ * the question the banner needs answering: once the contributor's own edits sit
+ * on the patch's lines it has been **absorbed** — it has become their changes,
+ * and no revert can separate the two again. Undoing those edits makes it
+ * removable again, which is why this is measured on demand and never tracked as
+ * a flag.
+ *
+ * Nothing here writes. `resolveFile` reads each file and works out what a
+ * reverse *would* produce, and `diagnoseHunks` behind it says how much of the
+ * patch the file no longer holds — the same machinery the apply path uses, so
+ * there is no second way to ask whether a patch still fits. The resolved
+ * contents are discarded.
+ *
+ * A patch that is simply gone — a trunk update or a discard reset the tree — is
+ * not absorbed, and gets the same two-part guard the revert itself uses: not one
+ * file reversed, *and* the whole patch resolves forwards. Its record is stale,
+ * and Revert stays offered because pressing it is what clears it.
+ *
+ * @param {Object} root0
+ * @param {string} root0.dir       Site working directory.
+ * @param {string} root0.patchText The stored patch, forward as it was applied.
+ * @return {{absorbed: Array<{path: string, editedOver: boolean, failed: number, total: number}>, missing: boolean, error?: string}}
+ */
+function diagnoseRemoval({ dir, patchText }) {
+	const parsed = parsePatchFiles(String(patchText || ''));
+	if (!parsed.ok) return { absorbed: [], missing: false, error: parsed.error };
+
+	const absorbed = [];
+	let intact = 0;
+	for (const file of parsed.files) {
+		// Binary files were never applied, so they cannot be in the way of a
+		// removal either — the apply path skips them the same way.
+		if (file.kind === 'binary') continue;
+		const reversed = reverseFile(file);
+		const resolved = resolveFile(dir, reversed);
+		if (!resolved.error) {
+			intact += 1;
+			continue;
+		}
+		const conflict = resolved.conflict;
+		absorbed.push({
+			// The forward path, not the reversed one: a rename's reverse names the
+			// file it moves *back* to, while the record of what was applied holds
+			// the name the patch moved it to. Keyed on the reversed name, the
+			// caller's attribution could never match its own record.
+			path: file.path,
+			// Not every refusal is an edit over the patch's lines: a file the
+			// contributor deleted outright, or one a reversed add can no longer
+			// find, blocks the removal without anything having been written over.
+			// Withholding Revert is right either way — the revert is all or
+			// nothing — but the sentence about it is not, so the two are told
+			// apart here rather than guessed at by the caller.
+			editedOver: Boolean(conflict),
+			failed: conflict ? conflict.regions.length : 0,
+			total: conflict ? conflict.total : 0
+		});
+	}
+
+	if (absorbed.length && !intact && patchIsAbsent(dir, parsed.files)) {
+		return { absorbed: [], missing: true };
+	}
+	return { absorbed, missing: false };
+}
+
+/**
  * Puts back everything a failed run had already written.
  *
  * Returns the paths it could not restore. The same full-disk, lock, or
@@ -458,10 +526,12 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 			skipped.push(file.path);
 			continue;
 		}
-		// No diagnosis on a reverse: the panel discards it — the patch being
-		// reverted came through this app, and the ticket's other patches are no
-		// answer to a revert that failed.
-		const resolved = resolveFile(dir, file, { diagnose: !reverse });
+		// Diagnosed on a reverse too (#306). The ticket's other patches are still
+		// no answer to a revert that failed, but the *reason* it failed is: a
+		// revert only fails because the contributor's own edits are on the
+		// patch's lines, and naming how many of them, and where, is the whole
+		// difference between an explanation and a generic error.
+		const resolved = resolveFile(dir, file);
 		if (resolved.error) {
 			failures.push(resolved.error);
 			if (resolved.conflict) conflicts.push(resolved.conflict);
@@ -544,4 +614,4 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	return { ok: true, applied, skipped };
 }
 
-module.exports = { applyPatchToDir, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };
+module.exports = { applyPatchToDir, diagnoseRemoval, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -386,74 +386,6 @@ function patchIsAbsent(dir, files) {
 }
 
 /**
- * Whether the patch the app applied could still be taken back out of this
- * checkout, asked right now rather than remembered (#306).
- *
- * The record the app keeps says only that a patch text was stored. That is not
- * the question the banner needs answering: once the contributor's own edits sit
- * on the patch's lines it has been **absorbed** — it has become their changes,
- * and no revert can separate the two again. Undoing those edits makes it
- * removable again, which is why this is measured on demand and never tracked as
- * a flag.
- *
- * Nothing here writes. `resolveFile` reads each file and works out what a
- * reverse *would* produce, and `diagnoseHunks` behind it says how much of the
- * patch the file no longer holds — the same machinery the apply path uses, so
- * there is no second way to ask whether a patch still fits. The resolved
- * contents are discarded.
- *
- * A patch that is simply gone — a trunk update or a discard reset the tree — is
- * not absorbed, and gets the same two-part guard the revert itself uses: not one
- * file reversed, *and* the whole patch resolves forwards. Its record is stale,
- * and Revert stays offered because pressing it is what clears it.
- *
- * @param {Object} root0
- * @param {string} root0.dir       Site working directory.
- * @param {string} root0.patchText The stored patch, forward as it was applied.
- * @return {{absorbed: Array<{path: string, editedOver: boolean, failed: number, total: number}>, missing: boolean, error?: string}}
- */
-function diagnoseRemoval({ dir, patchText }) {
-	const parsed = parsePatchFiles(String(patchText || ''));
-	if (!parsed.ok) return { absorbed: [], missing: false, error: parsed.error };
-
-	const absorbed = [];
-	let intact = 0;
-	for (const file of parsed.files) {
-		// Binary files were never applied, so they cannot be in the way of a
-		// removal either — the apply path skips them the same way.
-		if (file.kind === 'binary') continue;
-		const reversed = reverseFile(file);
-		const resolved = resolveFile(dir, reversed);
-		if (!resolved.error) {
-			intact += 1;
-			continue;
-		}
-		const conflict = resolved.conflict;
-		absorbed.push({
-			// The forward path, not the reversed one: a rename's reverse names the
-			// file it moves *back* to, while the record of what was applied holds
-			// the name the patch moved it to. Keyed on the reversed name, the
-			// caller's attribution could never match its own record.
-			path: file.path,
-			// Not every refusal is an edit over the patch's lines: a file the
-			// contributor deleted outright, or one a reversed add can no longer
-			// find, blocks the removal without anything having been written over.
-			// Withholding Revert is right either way — the revert is all or
-			// nothing — but the sentence about it is not, so the two are told
-			// apart here rather than guessed at by the caller.
-			editedOver: Boolean(conflict),
-			failed: conflict ? conflict.regions.length : 0,
-			total: conflict ? conflict.total : 0
-		});
-	}
-
-	if (absorbed.length && !intact && patchIsAbsent(dir, parsed.files)) {
-		return { absorbed: [], missing: true };
-	}
-	return { absorbed, missing: false };
-}
-
-/**
  * Puts back everything a failed run had already written.
  *
  * Returns the paths it could not restore. The same full-disk, lock, or
@@ -614,4 +546,4 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	return { ok: true, applied, skipped };
 }
 
-module.exports = { applyPatchToDir, diagnoseRemoval, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };
+module.exports = { applyPatchToDir, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };

--- a/src/renderer/applied-layer.cjs
+++ b/src/renderer/applied-layer.cjs
@@ -1,0 +1,203 @@
+// What the app says about the one patch a ticket has applied (#306).
+//
+// A ticket is a branch (#108): trunk, plus at most one applied patch or pull
+// request, plus the contributor's own edits. The branch holds that faithfully.
+// What the app *said* about it did not — the applied patch was remembered as an
+// undo blob, so every file it brought was announced as the contributor's own
+// writing, and "can this be reverted" meant no more than "we kept the text".
+//
+// Two answers live here, both pure:
+//
+//   - `attributeConflicts` — whose changes are the ones a new patch would land
+//     on. A file only the applied layer touched is named as the layer's; a file
+//     the contributor has also edited over keeps naming their work, because that
+//     is the one that decides what they do next.
+//   - `describeAppliedLayer` — the banner's two faces. While the layer still
+//     comes out cleanly, Revert is offered. Once the contributor's edits sit on
+//     its lines it is **absorbed**: it has become their changes, and the honest
+//     exits are saving a copy and discarding the ticket to its base.
+//
+// Absorption is measured, never tracked — the main process re-answers it on
+// every status read, so undoing the overlapping edit brings Revert back on its
+// own. And it never frees the one-patch slot: the record survives as provenance.
+//
+// Pure and dependency-free like update-plan.cjs and apply-conflict.cjs, for the
+// same reason: the renderer bundle imports it, `node --test` requires it
+// directly, and neither needs a DOM.
+'use strict';
+
+// Saving a copy and then discarding is a recommendable way forward on this
+// project, not a defeat: a ticket's changes are one afternoon's work on a
+// checkout that gets thrown away, and redoing them is cheaper than untangling
+// them. Said once, here, so both faces that offer it say it the same way.
+const DISPOSABLE_EXIT = 'Save a copy of your work first and the ticket is safe to discard back to its base — on this project that is a normal way forward, not a lost afternoon.';
+
+// The slot does not open when a patch is absorbed. Saying so is what stops the
+// contributor reading "it is part of your changes now" as "so I can apply
+// another one".
+const SLOT_HELD = 'It still counts as this ticket\'s one applied patch, so another cannot be applied until this ticket is reverted or discarded.';
+
+/**
+ * `a`, `a and b`, `a, b and c` — a list a person reads rather than a join.
+ *
+ * @param {string[]} items
+ * @return {string}
+ */
+function listOf(items) {
+	if (items.length <= 1) return items[0] || '';
+	return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
+/**
+ * The paths of an applied layer whose lines the contributor has edited over.
+ *
+ * @param {?Object} appliedPatch
+ * @return {string[]}
+ */
+function absorbedPaths(appliedPatch) {
+	const list = appliedPatch && Array.isArray(appliedPatch.absorbed) ? appliedPatch.absorbed : [];
+	return list.map((entry) => (typeof entry === 'string' ? entry : entry && entry.path)).filter(Boolean);
+}
+
+/**
+ * Who owns each file a patch about to be applied would land on.
+ *
+ * The pre-apply warning exists to say "your work is here, and this could fail
+ * without touching it". Counting the applied layer's files as the contributor's
+ * own writing is the kind of wrong that teaches people to ignore the warning —
+ * so both are named, separately, and neither is dropped.
+ *
+ * The measurement behind `absorbed` is per-region: a file is the layer's when
+ * the layer's own lines are untouched. A contributor edit *elsewhere* in the
+ * same file therefore reads as the layer's rather than as theirs. The file is
+ * still named and the "fails without touching anything" caveat still covers it,
+ * so the warning does not go quiet — it is the attribution that is coarse, and
+ * only in that direction.
+ *
+ * @param {Object}   root0
+ * @param {string[]} [root0.conflicts]    Paths from the preview's plan.
+ * @param {?Object}  [root0.appliedPatch] The status record, or null.
+ * @return {{yours: string[], fromLayer: string[], sentences: string[]}}
+ */
+function attributeConflicts({ conflicts = [], appliedPatch = null } = {}) {
+	const paths = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
+	const layerFiles = new Set(appliedPatch && Array.isArray(appliedPatch.files) ? appliedPatch.files : []);
+	const editedOver = new Set(absorbedPaths(appliedPatch));
+
+	const fromLayer = appliedPatch ? paths.filter((p) => layerFiles.has(p) && !editedOver.has(p)) : [];
+	const claimed = new Set(fromLayer);
+	const yours = paths.filter((p) => !claimed.has(p));
+
+	const sentences = [];
+	if (yours.length) {
+		sentences.push(`You have your own edits to ${listOf(yours)}. Save a patch of your work first if you want a copy.`);
+	}
+	if (fromLayer.length) {
+		const label = appliedPatch.label || 'the patch you applied';
+		sentences.push(`${listOf(fromLayer)} ${fromLayer.length === 1 ? 'was' : 'were'} changed by ${label}, which you applied — not by you.`);
+	}
+	if (sentences.length) {
+		sentences.push('The patch is applied on top of those changes: it succeeds if they do not overlap, and fails without touching anything if they do.');
+	}
+	return { yours, fromLayer, sentences };
+}
+
+/**
+ * The applied-layer banner, in whichever face the checkout has earned.
+ *
+ * Three, not two, because "cannot be reverted" has two different causes and
+ * they need different sentences: a patch too large to keep a copy of was never
+ * revertable, and a patch whose lines have been edited over stopped being.
+ *
+ * `when` is passed in already formatted — the locale-dependent part is the
+ * component's, and keeping it out of here is what lets this be asserted on.
+ *
+ * @param {?Object} appliedPatch   The `site:status` record, or null.
+ * @param {Object}  [options]
+ * @param {string}  [options.when] Formatted apply time, or '' when unknown.
+ * @return {?Object}
+ */
+function describeAppliedLayer(appliedPatch, { when = '' } = {}) {
+	if (!appliedPatch) return null;
+
+	const label = appliedPatch.label || 'A patch';
+	const files = Array.isArray(appliedPatch.files) ? appliedPatch.files : [];
+	const absorbed = absorbedPaths(appliedPatch);
+	const kept = appliedPatch.kept === undefined ? Boolean(appliedPatch.revertable) : Boolean(appliedPatch.kept);
+
+	const summary = `is applied — ${files.length} file${files.length === 1 ? '' : 's'}${when ? `, ${when}` : ''}.`;
+
+	if (kept && !absorbed.length) {
+		return { label, summary, canRevert: true, absorbed: false, explanation: '', detail: [], note: '', offerCopy: false };
+	}
+
+	// Too large to have kept a copy of. Nothing about the tree changes this one,
+	// so it says so plainly and goes straight to the exit that always works.
+	if (!kept) {
+		return {
+			label,
+			summary,
+			canRevert: false,
+			absorbed: false,
+			explanation: `${label} was too large to keep a copy of for an undo, so it cannot be lifted back out on its own.`,
+			detail: [],
+			note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
+			offerCopy: true
+		};
+	}
+
+	// Absorbed: the contributor's edits are on the patch's own lines, so there
+	// is no longer a patch and an edit — there is one body of changes. Said as a
+	// state of the work rather than as a failure, and with the way back named,
+	// because undoing the overlapping edit really does bring Revert back.
+	//
+	// Not every file in the way was written over, though. One the contributor
+	// deleted outright blocks the removal just as firmly, and calling that "your
+	// edits are on its lines" would send them looking at lines that are not
+	// there — so the two get their own sentence, and either alone is enough for
+	// the revert to be off, because a revert is all or nothing.
+	const entries = (appliedPatch.absorbed || []).filter((entry) => entry && entry.path);
+	const written = entries.filter((entry) => entry.editedOver !== false).map((entry) => entry.path);
+	const gone = entries.filter((entry) => entry.editedOver === false).map((entry) => entry.path);
+
+	const reasons = [];
+	if (written.length) reasons.push(`your own edits are on the lines it brought to ${listOf(written)}`);
+	if (gone.length) reasons.push(`${listOf(gone)} ${gone.length === 1 ? 'is' : 'are'} no longer where it left ${gone.length === 1 ? 'it' : 'them'}`);
+
+	return {
+		label,
+		summary,
+		canRevert: false,
+		absorbed: true,
+		explanation: `${label} is part of your changes now and cannot be lifted back out on its own: ${listOf(reasons)}. Undo those edits and Revert comes back on its own.`,
+		detail: entries
+			.filter((entry) => entry.total)
+			.map((entry) => `${entry.path} — you have edited ${entry.failed} of the ${entry.total} change${entry.total === 1 ? '' : 's'} it brought`),
+		note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
+		offerCopy: true
+	};
+}
+
+/**
+ * Whichever of the two absorbed exits failed, said where they were offered.
+ *
+ * Both report through state that belongs to somewhere else on screen — the
+ * changes note and the patch modal — and the absorbed banner is neither. A
+ * refusal that lands there is a button that did nothing, on the one way out
+ * this banner recommends, so it is repeated here rather than left behind.
+ *
+ * The save goes first: it is the step that makes discarding safe, and its
+ * failure is the one that must not be missed.
+ *
+ * @param {Object} root0
+ * @param {string} [root0.patchSaveError]
+ * @param {string} [root0.discardError]
+ * @return {{message: string}}
+ */
+function absorbedExitFailure({ patchSaveError = '', discardError = '' } = {}) {
+	if (patchSaveError) return { message: `The copy could not be saved: ${patchSaveError}` };
+	if (discardError) return { message: discardError };
+	return { message: '' };
+}
+
+module.exports = { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };

--- a/src/renderer/applied-layer.cjs
+++ b/src/renderer/applied-layer.cjs
@@ -8,18 +8,10 @@
 //
 // Two answers live here, both pure:
 //
-//   - `attributeConflicts` — whose changes are the ones a new patch would land
-//     on. A file only the applied layer touched is named as the layer's; a file
-//     the contributor has also edited over keeps naming their work, because that
-//     is the one that decides what they do next.
-//   - `describeAppliedLayer` — the banner's two faces. While the layer still
-//     comes out cleanly, Revert is offered. Once the contributor's edits sit on
-//     its lines it is **absorbed**: it has become their changes, and the honest
-//     exits are saving a copy and discarding the ticket to its base.
-//
-// Absorption is measured, never tracked — the main process re-answers it on
-// every status read, so undoing the overlapping edit brings Revert back on its
-// own. And it never frees the one-patch slot: the record survives as provenance.
+//   - `attributeConflicts` names files that include the applied layer without
+//     claiming the contributor could not also have edited them.
+//   - `describeAppliedLayer` offers Revert when the text was retained, and the
+//     copy-and-discard exit when it was too large to keep.
 //
 // Pure and dependency-free like update-plan.cjs and apply-conflict.cjs, for the
 // same reason: the renderer bundle imports it, `node --test` requires it
@@ -32,9 +24,8 @@
 // them. Said once, here, so both faces that offer it say it the same way.
 const DISPOSABLE_EXIT = 'Save a copy of your work first and the ticket is safe to discard back to its base — on this project that is a normal way forward, not a lost afternoon.';
 
-// The slot does not open when a patch is absorbed. Saying so is what stops the
-// contributor reading "it is part of your changes now" as "so I can apply
-// another one".
+// A patch that cannot be reverted still holds the slot until the ticket is
+// discarded; keeping that explicit prevents the banner implying otherwise.
 const SLOT_HELD = 'It still counts as this ticket\'s one applied patch, so another cannot be applied until this ticket is reverted or discarded.';
 
 /**
@@ -49,17 +40,6 @@ function listOf(items) {
 }
 
 /**
- * The paths of an applied layer whose lines the contributor has edited over.
- *
- * @param {?Object} appliedPatch
- * @return {string[]}
- */
-function absorbedPaths(appliedPatch) {
-	const list = appliedPatch && Array.isArray(appliedPatch.absorbed) ? appliedPatch.absorbed : [];
-	return list.map((entry) => (typeof entry === 'string' ? entry : entry && entry.path)).filter(Boolean);
-}
-
-/**
  * Who owns each file a patch about to be applied would land on.
  *
  * The pre-apply warning exists to say "your work is here, and this could fail
@@ -67,12 +47,9 @@ function absorbedPaths(appliedPatch) {
  * own writing is the kind of wrong that teaches people to ignore the warning —
  * so both are named, separately, and neither is dropped.
  *
- * The measurement behind `absorbed` is per-region: a file is the layer's when
- * the layer's own lines are untouched. A contributor edit *elsewhere* in the
- * same file therefore reads as the layer's rather than as theirs. The file is
- * still named and the "fails without touching anything" caveat still covers it,
- * so the warning does not go quiet — it is the attribution that is coarse, and
- * only in that direction.
+ * This is provenance, not exclusive ownership. A routine status read does not
+ * inspect every line, so a layer file may also contain contributor edits and
+ * the copy says that explicitly.
  *
  * @param {Object}   root0
  * @param {string[]} [root0.conflicts]    Paths from the preview's plan.
@@ -82,9 +59,7 @@ function absorbedPaths(appliedPatch) {
 function attributeConflicts({ conflicts = [], appliedPatch = null } = {}) {
 	const paths = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
 	const layerFiles = new Set(appliedPatch && Array.isArray(appliedPatch.files) ? appliedPatch.files : []);
-	const editedOver = new Set(absorbedPaths(appliedPatch));
-
-	const fromLayer = appliedPatch ? paths.filter((p) => layerFiles.has(p) && !editedOver.has(p)) : [];
+	const fromLayer = appliedPatch ? paths.filter((p) => layerFiles.has(p)) : [];
 	const claimed = new Set(fromLayer);
 	const yours = paths.filter((p) => !claimed.has(p));
 
@@ -94,7 +69,7 @@ function attributeConflicts({ conflicts = [], appliedPatch = null } = {}) {
 	}
 	if (fromLayer.length) {
 		const label = appliedPatch.label || 'the patch you applied';
-		sentences.push(`${listOf(fromLayer)} ${fromLayer.length === 1 ? 'was' : 'were'} changed by ${label}, which you applied — not by you.`);
+		sentences.push(`${listOf(fromLayer)} ${fromLayer.length === 1 ? 'includes' : 'include'} changes from ${label}, which you applied. The ${fromLayer.length === 1 ? 'file may' : 'files may'} also contain your own edits.`);
 	}
 	if (sentences.length) {
 		sentences.push('The patch is applied on top of those changes: it succeeds if they do not overlap, and fails without touching anything if they do.');
@@ -105,9 +80,7 @@ function attributeConflicts({ conflicts = [], appliedPatch = null } = {}) {
 /**
  * The applied-layer banner, in whichever face the checkout has earned.
  *
- * Three, not two, because "cannot be reverted" has two different causes and
- * they need different sentences: a patch too large to keep a copy of was never
- * revertable, and a patch whose lines have been edited over stopped being.
+ * The banner only promises an undo when the app retained the patch text.
  *
  * `when` is passed in already formatted — the locale-dependent part is the
  * component's, and keeping it out of here is what lets this be asserted on.
@@ -122,67 +95,32 @@ function describeAppliedLayer(appliedPatch, { when = '' } = {}) {
 
 	const label = appliedPatch.label || 'A patch';
 	const files = Array.isArray(appliedPatch.files) ? appliedPatch.files : [];
-	const absorbed = absorbedPaths(appliedPatch);
 	const kept = appliedPatch.kept === undefined ? Boolean(appliedPatch.revertable) : Boolean(appliedPatch.kept);
 
 	const summary = `is applied — ${files.length} file${files.length === 1 ? '' : 's'}${when ? `, ${when}` : ''}.`;
 
-	if (kept && !absorbed.length) {
-		return { label, summary, canRevert: true, absorbed: false, explanation: '', detail: [], note: '', offerCopy: false };
+	if (kept) {
+		return { label, summary, canRevert: true, explanation: '', detail: [], note: '', offerCopy: false };
 	}
 
 	// Too large to have kept a copy of. Nothing about the tree changes this one,
 	// so it says so plainly and goes straight to the exit that always works.
-	if (!kept) {
-		return {
-			label,
-			summary,
-			canRevert: false,
-			absorbed: false,
-			explanation: `${label} was too large to keep a copy of for an undo, so it cannot be lifted back out on its own.`,
-			detail: [],
-			note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
-			offerCopy: true
-		};
-	}
-
-	// Absorbed: the contributor's edits are on the patch's own lines, so there
-	// is no longer a patch and an edit — there is one body of changes. Said as a
-	// state of the work rather than as a failure, and with the way back named,
-	// because undoing the overlapping edit really does bring Revert back.
-	//
-	// Not every file in the way was written over, though. One the contributor
-	// deleted outright blocks the removal just as firmly, and calling that "your
-	// edits are on its lines" would send them looking at lines that are not
-	// there — so the two get their own sentence, and either alone is enough for
-	// the revert to be off, because a revert is all or nothing.
-	const entries = (appliedPatch.absorbed || []).filter((entry) => entry && entry.path);
-	const written = entries.filter((entry) => entry.editedOver !== false).map((entry) => entry.path);
-	const gone = entries.filter((entry) => entry.editedOver === false).map((entry) => entry.path);
-
-	const reasons = [];
-	if (written.length) reasons.push(`your own edits are on the lines it brought to ${listOf(written)}`);
-	if (gone.length) reasons.push(`${listOf(gone)} ${gone.length === 1 ? 'is' : 'are'} no longer where it left ${gone.length === 1 ? 'it' : 'them'}`);
-
 	return {
 		label,
 		summary,
 		canRevert: false,
-		absorbed: true,
-		explanation: `${label} is part of your changes now and cannot be lifted back out on its own: ${listOf(reasons)}. Undo those edits and Revert comes back on its own.`,
-		detail: entries
-			.filter((entry) => entry.total)
-			.map((entry) => `${entry.path} — you have edited ${entry.failed} of the ${entry.total} change${entry.total === 1 ? '' : 's'} it brought`),
+		explanation: `${label} was too large to keep a copy of for an undo, so it cannot be lifted back out on its own.`,
+		detail: [],
 		note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
 		offerCopy: true
 	};
 }
 
 /**
- * Whichever of the two absorbed exits failed, said where they were offered.
+ * Whichever of the layer's two safe exits failed, said where they were offered.
  *
  * Both report through state that belongs to somewhere else on screen — the
- * changes note and the patch modal — and the absorbed banner is neither. A
+ * changes note and the patch modal — and the layer banner is neither. A
  * refusal that lands there is a button that did nothing, on the one way out
  * this banner recommends, so it is repeated here rather than left behind.
  *
@@ -194,10 +132,10 @@ function describeAppliedLayer(appliedPatch, { when = '' } = {}) {
  * @param {string} [root0.discardError]
  * @return {{message: string}}
  */
-function absorbedExitFailure({ patchSaveError = '', discardError = '' } = {}) {
+function layerExitFailure({ patchSaveError = '', discardError = '' } = {}) {
 	if (patchSaveError) return { message: `The copy could not be saved: ${patchSaveError}` };
 	if (discardError) return { message: discardError };
 	return { message: '' };
 }
 
-module.exports = { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };
+module.exports = { attributeConflicts, describeAppliedLayer, layerExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -190,12 +190,24 @@ function prFraming(conflicts, prState, ownWorkPaths = [], appliedPatch = null) {
 	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
 	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
 	const closed = prState === 'closed' || prState === 'merged';
+	const ticketWork = new Set(ownWorkPaths);
+	const alreadyPresentInTicketWork = conflicts.some((c) => ticketWork.has(c.path));
 
 	// A pull request whose changes are all in trunk already needs no rebase and
 	// no message — there is nothing left for anyone to do with it. When it is
 	// also closed, that is core's own way of landing a change: committed via
 	// SVN, pull request closed.
 	if (allApplied && failed === total) {
+		// Two-way matching only proves that these lines are in the checkout. If
+		// the ticket also has work in the file, they may come from that work or
+		// its named layer; claiming trunk would erase the provenance (#306).
+		if (alreadyPresentInTicketWork) {
+			return {
+				headline: `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in your checkout — there is nothing left to apply.`,
+				advice: '',
+				prButton: 'Open the pull request'
+			};
+		}
 		return {
 			headline: closed
 				? `All ${total} of this pull request's change${total === 1 ? '' : 's'} look like they are already in trunk — it was likely committed to core, which is why it is closed. There is nothing left to apply.`

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -182,9 +182,10 @@ function namePaths(rows) {
  * @param {Array}    conflicts
  * @param {?string}  prState        'open' | 'merged' | 'closed' | null when unknown.
  * @param {string[]} [ownWorkPaths] Files this ticket has its own work in.
+ * @param {?Object}  [appliedPatch] Named layer whose files are part of that work.
  * @return {{headline: string, advice: string, prButton: ?string}}
  */
-function prFraming(conflicts, prState, ownWorkPaths = []) {
+function prFraming(conflicts, prState, ownWorkPaths = [], appliedPatch = null) {
 	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
 	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
 	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
@@ -222,7 +223,9 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
 	}
 
 	const own = new Set(ownWorkPaths);
-	const mine = namePaths(conflicts.filter((c) => own.has(c.path)));
+	const layerFiles = new Set(appliedPatch && Array.isArray(appliedPatch.files) ? appliedPatch.files : []);
+	const layered = namePaths(conflicts.filter((c) => own.has(c.path) && layerFiles.has(c.path)));
+	const mine = namePaths(conflicts.filter((c) => own.has(c.path) && !layerFiles.has(c.path)));
 	const theirs = namePaths(conflicts.filter((c) => !own.has(c.path)));
 	const REBASE_IS_THEIRS = 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.';
 	// A ticket's changes are cheap to redo and expensive to untangle, so keeping
@@ -230,6 +233,23 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
 	// What must never happen is work going quietly; going on purpose, with the
 	// copy already saved, is a good outcome.
 	const YOUR_WORK_WAY_OUT = 'Save a patch of your work first to keep a copy, then try this pull request on a clean ticket. If it still does not fit there, open the pull request and let its author know it may need updating.';
+
+	// The ticket-base scan sees the named layer as ticket work too. It cannot
+	// prove whether the contributor edited those files afterwards, so name the
+	// provenance and preserve the same uncertainty as the preview (#306).
+	if (layered.count) {
+		const label = appliedPatch.label || 'the patch you applied';
+		const parts = [
+			`${layered.text} ${layered.count === 1 ? 'includes' : 'include'} changes from ${label} and may also contain your own edits.`
+		];
+		if (mine.count) parts.push(`Your own work is also in ${mine.text} and may be part of the failure.`);
+		if (theirs.count) parts.push(`Other failures are in ${theirs.text}.`);
+		return {
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. ${parts.join(' ')}`,
+			advice: YOUR_WORK_WAY_OUT,
+			prButton: 'Open the pull request'
+		};
+	}
 
 	// File overlap cannot identify the failing region. Keep the pull request
 	// reachable, but make the rebase advice conditional on it also failing in a
@@ -312,10 +332,11 @@ function revertFraming(conflicts, label) {
  * @param {?string}  [options.prState]         Its state, when known.
  * @param {string[]} [options.ownWorkPaths]    Files this ticket has work in, from
  *                                             the preview's collision list (#303).
+ * @param {?Object}  [options.appliedPatch]    Named layer within that work (#306).
  * @param {?string}  [options.reverting]       Label of the layer being reverted.
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [], reverting = null } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [], appliedPatch = null, reverting = null } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -362,7 +383,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 		// contributor's own work sitting on its lines (#306).
 		let framing;
 		if (reverting) framing = revertFraming(conflicts, reverting);
-		else if (fromPr) framing = prFraming(conflicts, prState, ownWorkPaths);
+		else if (fromPr) framing = prFraming(conflicts, prState, ownWorkPaths, appliedPatch);
 		else framing = { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -30,17 +30,29 @@ const REASONS = {
 	moved: 'the code around it has changed'
 };
 
+// The same two statuses read backwards, for a revert (#306). `already-applied`
+// is derived by testing the inverse of what is being applied, so on a reverse it
+// means the *forward* hunk fits — that region's change is not in the checkout
+// any more. Rendering the forward wording there would put "already in your
+// checkout" under a headline saying the contributor has edited over it.
+const REVERT_REASONS = {
+	'already-applied': 'looks like that change is not in your checkout any more',
+	moved: 'the code around it has changed'
+};
+
 /**
  * One failing region, ready to render.
  *
- * @param {Object} region
+ * @param {Object}  region
+ * @param {boolean} [reversing] Whether the failed run was a revert.
  * @return {Object}
  */
-function describeRegion(region) {
+function describeRegion(region, reversing = false) {
+	const reasons = reversing ? REVERT_REASONS : REASONS;
 	return {
 		line: region.line,
 		status: region.status,
-		reason: REASONS[region.status] || 'it no longer fits',
+		reason: reasons[region.status] || 'it no longer fits',
 		// A line to search for, not a number to go to: the hunk's line numbers
 		// are in the patched file's coordinates and miss by the drift the patch
 		// failed on. The panel leads with this and keeps `line` as the fallback.
@@ -246,6 +258,36 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
 }
 
 /**
+ * The framing for a revert that would not come back out (#306).
+ *
+ * A revert fails for one reason: the contributor's own edits are on the lines
+ * the patch brought. There is no third party here and no rebase to ask anyone
+ * for — the patch and the edits are one body of work now, which is what
+ * absorption means. So the sentence names that, and the two ways forward are
+ * undoing the overlapping edits, or saving a copy and discarding the ticket to
+ * its base, which on this project is a normal step rather than a defeat.
+ *
+ * Regions are kept, unlike the pull-request framing: these lines are the
+ * contributor's own, so pointing at them is pointing at their work.
+ *
+ * @param {Array}  conflicts
+ * @param {string} label
+ * @return {{headline: string, advice: string, prButton: ?string}}
+ */
+function revertFraming(conflicts, label) {
+	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
+	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
+	const files = conflicts.length;
+	const where = files === 1 ? '' : `, across ${files} files`;
+
+	return {
+		headline: `${label} cannot be lifted back out on its own: your own edits are on ${failed} of its ${total} change${total === 1 ? '' : 's'}${where}.`,
+		advice: 'It is part of your changes now. Undoing your edits on those lines brings Revert back; otherwise save a copy of your work and discard the ticket to its base — on this project that is a normal way forward, not a lost afternoon.',
+		prButton: null
+	};
+}
+
+/**
  * Everything the panel needs to explain a failed apply, or null when there is
  * nothing to explain.
  *
@@ -270,9 +312,10 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
  * @param {?string}  [options.prState]         Its state, when known.
  * @param {string[]} [options.ownWorkPaths]    Files this ticket has work in, from
  *                                             the preview's collision list (#303).
+ * @param {?string}  [options.reverting]       Label of the layer being reverted.
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [] } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [], reverting = null } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -282,7 +325,10 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	// the panel keeps rendering it exactly as it did before.
 	if (!failures.length && !conflicts.length) return null;
 
-	const fromPr = Boolean(prUrl);
+	// A revert is never "someone else's patch does not fit": it is the
+	// contributor's own edits sitting on lines they applied. The pull-request
+	// framing would send them to an author who has nothing to do with it.
+	const fromPr = Boolean(prUrl) && !reverting;
 
 	// Each conflict is consumed as it is matched, not looked up in a map: a
 	// concatenated patch can fail the same file twice with the identical
@@ -301,7 +347,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 			failed: conflict.regions.length,
 			// For a pull request the regions are the author's problem; the file
 			// row with its counts is the whole story the contributor needs.
-			regions: fromPr ? [] : conflict.regions.map(describeRegion)
+			regions: fromPr ? [] : conflict.regions.map((region) => describeRegion(region, Boolean(reverting)))
 		};
 	});
 
@@ -311,9 +357,13 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	let advice = '';
 	let prButton = fromPr ? 'Open the pull request' : null;
 	if (conflicts.length) {
-		const framing = fromPr
-			? prFraming(conflicts, prState, ownWorkPaths)
-			: { headline: headlineFor(conflicts), advice: '', prButton: null };
+		// A failed revert is never the pull request having gone stale, so it is
+		// asked first: the only thing that stops a layer coming back out is the
+		// contributor's own work sitting on its lines (#306).
+		let framing;
+		if (reverting) framing = revertFraming(conflicts, reverting);
+		else if (fromPr) framing = prFraming(conflicts, prState, ownWorkPaths);
+		else framing = { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;
 		prButton = framing.prButton;
@@ -322,13 +372,17 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 		headline,
 		advice,
 		items,
+		// The absorbed exit, for the panel to offer alongside the sentence. Only
+		// a revert has one: every other failure left the checkout untouched, so
+		// there is nothing to save a copy of that is not already safe.
+		offerDiscardToBase: Boolean(reverting) && conflicts.length > 0,
 		// Both are offered only when they lead somewhere, the way open-failure.cjs
 		// withholds its picker: a way out that returns to the same dead end is
 		// worse than no button, because it costs a click to find that out.
-		offerOtherPatches: othersAvailable > 0,
+		offerOtherPatches: !reverting && othersAvailable > 0,
 		prUrl: prUrl && prButton ? prUrl : null,
 		prButton
 	};
 }
 
-module.exports = { describeApplyFailure, headlineFor, otherPatchCount, REASONS };
+module.exports = { describeApplyFailure, headlineFor, otherPatchCount, revertFraming, REASONS, REVERT_REASONS };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -372,7 +372,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 		headline,
 		advice,
 		items,
-		// The absorbed exit, for the panel to offer alongside the sentence. Only
+		// The safe exit, for the panel to offer alongside the sentence. Only
 		// a revert has one: every other failure left the checkout untouched, so
 		// there is nothing to save a copy of that is not already safe.
 		offerDiscardToBase: Boolean(reverting) && conflicts.length > 0,

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,7 +30,7 @@ import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
-import { describeAppliedLayer, attributeConflicts, absorbedExitFailure } from './applied-layer.cjs';
+import { describeAppliedLayer, attributeConflicts, layerExitFailure } from './applied-layer.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -2738,12 +2738,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     when: appliedPatch?.appliedAt ? new Date(appliedPatch.appliedAt).toLocaleString() : ''
   });
   const previewAttribution = attributeConflicts({ conflicts: applyPreview?.conflicts, appliedPatch });
-  // The absorbed exits reach the same two operations the changes note does, so
+  // The layer exits reach the same two operations the changes note does, so
   // they go through the same guard: a discard is a force checkout, and running
   // it under a live dev server or a half-finished install rewrites the tree
   // from under it. Not re-derived here — that is how a second answer starts.
-  const absorbedExitBlocked = discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding });
-  const absorbedExit = absorbedExitFailure({ patchSaveError, discardError });
+  const layerExitBlocked = discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding });
+  const layerExit = layerExitFailure({ patchSaveError, discardError });
 
   // --- Initial setup, as one chain (#246) ---
   // The third chain, and the only one nobody starts: between the clone, the
@@ -4740,8 +4740,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 ) : null}
                 {appliedLayer.offerCopy ? (
                   <>
-                    <Button variant="secondary" onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
-                    <Button variant="tertiary" onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                    <Button variant="secondary" onClick={savePatch} disabled={layerExitBlocked}>Save a copy of your work</Button>
+                    <Button variant="tertiary" onClick={discardAllChanges} disabled={layerExitBlocked}>Discard this ticket to its base</Button>
                   </>
                 ) : null}
               </div>
@@ -4749,8 +4749,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   patch modal own, and neither is on screen here — so a save that
                   could not write, or a discard that refused, would be a button
                   that did nothing on the one way out this banner recommends. */}
-              {absorbedExit.message ? (
-                <div role="alert" style={{ marginTop: 8, fontSize: 12, color: '#d63638' }}>{absorbedExit.message}</div>
+              {layerExit.message ? (
+                <div role="alert" style={{ marginTop: 8, fontSize: 12, color: '#d63638' }}>{layerExit.message}</div>
               ) : null}
             </div>
           ) : null}
@@ -4868,8 +4868,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                       {applyConflict.offerDiscardToBase ? (
                         <>
-                          <Button variant="secondary" isSmall onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
-                          <Button variant="secondary" isSmall onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                          <Button variant="secondary" isSmall onClick={savePatch} disabled={layerExitBlocked}>Save a copy of your work</Button>
+                          <Button variant="secondary" isSmall onClick={discardAllChanges} disabled={layerExitBlocked}>Discard this ticket to its base</Button>
                         </>
                       ) : null}
                       {applyConflict.offerOtherPatches ? (
@@ -4900,8 +4900,8 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     </div>
                   ) : null}
 
-                  {applyConflict.offerDiscardToBase && absorbedExit.message ? (
-                    <div style={{ marginTop: 8 }}>{absorbedExit.message}</div>
+                  {applyConflict.offerDiscardToBase && layerExit.message ? (
+                    <div style={{ marginTop: 8 }}>{layerExit.message}</div>
                   ) : null}
                 </div>
               ) : null}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,6 +30,7 @@ import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
+import { describeAppliedLayer, attributeConflicts, absorbedExitFailure } from './applied-layer.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -2729,6 +2730,21 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const applySteps = planApplySteps({ needsInstall: applyNeedsInstall, buildByWatcher: applyBuildByWatcher });
   const applyStepStates = updateStepStatuses(applySteps, applyState, APPLY_STATE_TO_STEP);
 
+  // The applied patch as a layer with a name (#306), not an undo blob. Both
+  // answers come from the same record: whether it can still be lifted out —
+  // measured in main on every status read, so it comes back on its own when the
+  // overlapping edit is undone — and whose changes the next patch would land on.
+  const appliedLayer = describeAppliedLayer(appliedPatch, {
+    when: appliedPatch?.appliedAt ? new Date(appliedPatch.appliedAt).toLocaleString() : ''
+  });
+  const previewAttribution = attributeConflicts({ conflicts: applyPreview?.conflicts, appliedPatch });
+  // The absorbed exits reach the same two operations the changes note does, so
+  // they go through the same guard: a discard is a force checkout, and running
+  // it under a live dev server or a half-finished install rewrites the tree
+  // from under it. Not re-derived here — that is how a second answer starts.
+  const absorbedExitBlocked = discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding });
+  const absorbedExit = absorbedExitFailure({ patchSaveError, discardError });
+
   // --- Initial setup, as one chain (#246) ---
   // The third chain, and the only one nobody starts: between the clone, the
   // install and the build there is no decision to make, so making the
@@ -3179,24 +3195,27 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           // A conflict is where the panel used to stop: one file named, the
           // rest of the failures left in the terminal, and no sense of whether
           // one region of twenty missed or all of them. The breakdown is what
-          // turns that into a decision (#282). A reverse is left out — the
-          // patch it names came from this app and the ticket's other patches
-          // are no help against it.
-          setApplyConflict(reverse ? null : describeApplyFailure(res, {
-            otherPatchCount: otherPatchCount({
-              label: preview?.label,
-              prs: ticketPatches?.items,
-              attachments: patchAttachments
-            }),
-            prUrl: preview?.prUrl || null,
-            prState: preview?.prState || null,
-            // The preview's own collision list: the files this ticket has work
-            // in, measured from its base (#301). Without it an open pull request
-            // is always narrated as stale, so a failure caused by the
-            // contributor's own edits sends them to ask a stranger for a rebase
-            // that would not help (#303).
-            ownWorkPaths: preview?.conflicts || []
-          }));
+          // turns that into a decision (#282). A reverse gets its own framing
+          // (#306): it fails only because the contributor's own edits are on the
+          // patch's lines, so the ticket's other patches and the pull request's
+          // author are both the wrong place to send them.
+          setApplyConflict(describeApplyFailure(res, reverse
+            ? { reverting: appliedPatch?.label || 'That patch' }
+            : {
+              otherPatchCount: otherPatchCount({
+                label: preview?.label,
+                prs: ticketPatches?.items,
+                attachments: patchAttachments
+              }),
+              prUrl: preview?.prUrl || null,
+              prState: preview?.prState || null,
+              // The preview's own collision list: the files this ticket has work
+              // in, measured from its base (#301). Without it an open pull
+              // request is always narrated as stale, so a failure caused by the
+              // contributor's own edits sends them to ask a stranger for a
+              // rebase that would not help (#303).
+              ownWorkPaths: preview?.conflicts || []
+            }));
           finishApply();
           return;
         }
@@ -4701,19 +4720,38 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             </div>
           ) : null}
 
-          {appliedPatch && !isApplying ? (
-            <div style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #94d3ae', background: '#f4fbf4', borderRadius: 8 }}>
-              <div style={{ fontSize: 13, color: '#0f5132' }}>
-                <strong>{appliedPatch.label}</strong> is applied — {appliedPatch.files.length} file{appliedPatch.files.length === 1 ? '' : 's'}
-                {appliedPatch.appliedAt ? `, ${new Date(appliedPatch.appliedAt).toLocaleString()}` : ''}.
+          {appliedLayer && !isApplying ? (
+            <div style={{ marginTop: 12, padding: '14px 16px', border: `1px solid ${appliedLayer.canRevert ? '#94d3ae' : '#dba617'}`, background: appliedLayer.canRevert ? '#f4fbf4' : '#fcf9e8', borderRadius: 8 }}>
+              <div style={{ fontSize: 13, color: appliedLayer.canRevert ? '#0f5132' : '#6e5406' }}>
+                <strong>{appliedLayer.label}</strong> {appliedLayer.summary}
               </div>
+              {appliedLayer.explanation ? (
+                <div style={{ marginTop: 8, fontSize: 12, color: '#6e5406' }}>{appliedLayer.explanation}</div>
+              ) : null}
+              {appliedLayer.detail.map((line) => (
+                <div key={line} style={{ marginTop: 4, fontSize: 12, color: '#6e5406', wordBreak: 'break-all' }}>{line}</div>
+              ))}
+              {appliedLayer.note ? (
+                <div style={{ marginTop: 8, fontSize: 12, color: '#6c6f72' }}>{appliedLayer.note}</div>
+              ) : null}
               <div style={{ marginTop: 10, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                {appliedPatch.revertable ? (
+                {appliedLayer.canRevert ? (
                   <Button variant="secondary" onClick={() => runApply({ reverse: true })} disabled={isUpdating || installing || building}>Revert this patch</Button>
-                ) : (
-                  <span style={{ fontSize: 12, color: '#6c6f72' }}>Too large to undo automatically — use Update to latest trunk to reset.</span>
-                )}
+                ) : null}
+                {appliedLayer.offerCopy ? (
+                  <>
+                    <Button variant="secondary" onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
+                    <Button variant="tertiary" onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                  </>
+                ) : null}
               </div>
+              {/* Both exits report failure through state the changes note and the
+                  patch modal own, and neither is on screen here — so a save that
+                  could not write, or a discard that refused, would be a button
+                  that did nothing on the one way out this banner recommends. */}
+              {absorbedExit.message ? (
+                <div role="alert" style={{ marginTop: 8, fontSize: 12, color: '#d63638' }}>{absorbedExit.message}</div>
+              ) : null}
             </div>
           ) : null}
 
@@ -4725,9 +4763,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div style={{ marginTop: 8, fontFamily: 'monospace', fontSize: 12, color: '#3c434a', lineHeight: 1.7, overflowWrap: 'anywhere', maxHeight: 140, overflowY: 'auto' }}>
                 {applyPreview.paths.map((p) => <div key={p}>{p}</div>)}
               </div>
-              {applyPreview.conflicts.length ? (
+              {/* Who the colliding work belongs to (#306) is the sentence. */}
+              {previewAttribution.sentences.length ? (
                 <div role="alert" style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
-                  You have your own edits to {applyPreview.conflicts.join(', ')}. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.
+                  {previewAttribution.sentences.map((sentence) => <div key={sentence} style={{ marginTop: 2 }}>{sentence}</div>)}
                 </div>
               ) : null}
               {applyPreview.unsupported.length ? (
@@ -4825,8 +4864,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     <div style={{ marginTop: 8 }}>{applyConflict.advice}</div>
                   ) : null}
 
-                  {applyConflict.offerOtherPatches || applyConflict.prUrl ? (
+                  {applyConflict.offerOtherPatches || applyConflict.prUrl || applyConflict.offerDiscardToBase ? (
                     <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      {applyConflict.offerDiscardToBase ? (
+                        <>
+                          <Button variant="secondary" isSmall onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
+                          <Button variant="secondary" isSmall onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                        </>
+                      ) : null}
                       {applyConflict.offerOtherPatches ? (
                         <Button
                           variant="secondary"
@@ -4853,6 +4898,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </Button>
                       ) : null}
                     </div>
+                  ) : null}
+
+                  {applyConflict.offerDiscardToBase && absorbedExit.message ? (
+                    <div style={{ marginTop: 8 }}>{absorbedExit.message}</div>
                   ) : null}
                 </div>
               ) : null}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3209,6 +3209,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               }),
               prUrl: preview?.prUrl || null,
               prState: preview?.prState || null,
+              appliedPatch,
               // The preview's own collision list: the files this ticket has work
               // in, measured from its base (#301). Without it an open pull
               // request is always narrated as stale, so a failure caused by the

--- a/test/applied-layer.test.cjs
+++ b/test/applied-layer.test.cjs
@@ -81,6 +81,23 @@ test('describeApplyFailure: an applied-layer-only conflict keeps ownership uncer
 	assert.doesNotMatch(notice.headline, /Your own work is also in/);
 });
 
+test('describeApplyFailure: already-present layer changes are not claimed as trunk (#306)', () => {
+	const notice = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} looks already applied`],
+		conflicts: [{ path: FOO, total: 1, regions: [{ index: 0, line: 7, status: 'already-applied' }] }]
+	}, {
+		prUrl: 'https://example.invalid/pr/456',
+		prState: 'open',
+		ownWorkPaths: [FOO],
+		appliedPatch: layer()
+	});
+
+	assert.match(notice.headline, /already in your checkout/);
+	assert.doesNotMatch(notice.headline, /already in trunk/);
+	assert.equal(notice.prButton, 'Open the pull request');
+});
+
 test('listOf: reads as a sentence rather than a join (#306)', () => {
 	assert.strictEqual(listOf([]), '');
 	assert.strictEqual(listOf(['a']), 'a');

--- a/test/applied-layer.test.cjs
+++ b/test/applied-layer.test.cjs
@@ -64,6 +64,23 @@ test('attributeConflicts: a clean tree says nothing at all (#306)', () => {
 	assert.deepStrictEqual(attributeConflicts().sentences, []);
 });
 
+test('describeApplyFailure: an applied-layer-only conflict keeps ownership uncertain (#306)', () => {
+	const notice = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [{ path: FOO, total: 1, regions: [{ index: 0, line: 7, status: 'moved' }] }]
+	}, {
+		prUrl: 'https://example.invalid/pr/456',
+		prState: 'open',
+		ownWorkPaths: [FOO],
+		appliedPatch: layer()
+	});
+
+	assert.match(notice.headline, /includes changes from PR #123/);
+	assert.match(notice.headline, /may also contain your own edits/);
+	assert.doesNotMatch(notice.headline, /Your own work is also in/);
+});
+
 test('listOf: reads as a sentence rather than a join (#306)', () => {
 	assert.strictEqual(listOf([]), '');
 	assert.strictEqual(listOf(['a']), 'a');

--- a/test/applied-layer.test.cjs
+++ b/test/applied-layer.test.cjs
@@ -6,7 +6,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf } = require('../src/renderer/applied-layer.cjs');
+const { attributeConflicts, describeAppliedLayer, layerExitFailure, listOf } = require('../src/renderer/applied-layer.cjs');
 const { describeApplyFailure } = require('../src/renderer/apply-conflict.cjs');
 
 const FOO = 'src/wp-login.php';
@@ -17,14 +17,13 @@ const layer = (over = {}) => ({
 	appliedAt: '2026-08-12T10:00:00.000Z',
 	files: [FOO],
 	kept: true,
-	absorbed: [],
 	revertable: true,
 	...over
 });
 
 // --- attribution ----------------------------------------------------------
 
-test('attributeConflicts: a file only the applied patch touched is not called your work (#306)', () => {
+test('attributeConflicts: a layer file is named without excluding later contributor edits (#306)', () => {
 	const { yours, fromLayer, sentences } = attributeConflicts({
 		conflicts: [FOO],
 		appliedPatch: layer()
@@ -34,18 +33,9 @@ test('attributeConflicts: a file only the applied patch touched is not called yo
 	assert.deepStrictEqual(fromLayer, [FOO]);
 	// The warning does not go quiet — the file is still named, just attributed.
 	assert.ok(sentences.some((s) => s.includes(FOO) && s.includes('PR #123')));
+	assert.ok(sentences.some((s) => /includes changes from/.test(s)));
+	assert.ok(!sentences.some((s) => /not by you/.test(s)));
 	assert.ok(!sentences.some((s) => s.startsWith('You have your own edits')));
-});
-
-test('attributeConflicts: a file the contributor also edited keeps naming their work (#306)', () => {
-	const { yours, fromLayer, sentences } = attributeConflicts({
-		conflicts: [FOO],
-		appliedPatch: layer({ absorbed: [{ path: FOO, failed: 1, total: 3 }], revertable: false })
-	});
-
-	assert.deepStrictEqual(yours, [FOO]);
-	assert.deepStrictEqual(fromLayer, []);
-	assert.ok(sentences[0].startsWith('You have your own edits'));
 });
 
 test('attributeConflicts: the two owners are named separately, not merged (#306)', () => {
@@ -91,51 +81,24 @@ test('describeAppliedLayer: while it still comes out, Revert is the only offer (
 	const face = describeAppliedLayer(layer(), { when: '12/08/2026' });
 
 	assert.strictEqual(face.canRevert, true);
-	assert.strictEqual(face.absorbed, false);
 	assert.strictEqual(face.offerCopy, false);
 	assert.strictEqual(face.explanation, '');
 	assert.strictEqual(face.summary, 'is applied — 1 file, 12/08/2026.');
 });
 
-test('describeAppliedLayer: absorbed drops Revert and offers the copy-and-discard exit (#306)', () => {
-	const face = describeAppliedLayer(layer({
-		revertable: false,
-		absorbed: [{ path: FOO, failed: 2, total: 5 }]
-	}));
-
-	assert.strictEqual(face.canRevert, false);
-	assert.strictEqual(face.absorbed, true);
-	assert.strictEqual(face.offerCopy, true);
-	assert.ok(face.explanation.includes(FOO));
-	assert.ok(face.explanation.includes('part of your changes now'));
-	// Not a one-way door, and the banner has to say so.
-	assert.ok(/Undo those edits and Revert comes back/.test(face.explanation));
-	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 2 of the 5 changes it brought`]);
-});
-
-// The constraint the whole design rests on: absorption is not a way to apply a
-// second patch. The banner has to say the slot is still taken.
-test('describeAppliedLayer: absorption does not free the one-patch slot (#306)', () => {
-	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
-
-	assert.ok(/one applied patch/.test(face.note));
-	assert.ok(/reverted or discarded/.test(face.note));
-});
-
 // Discarding is a recommendable step here, not an admission of failure — the
 // wording is the point, so it is asserted rather than left to drift.
 test('describeAppliedLayer: the exit is worded as a normal way forward (#306)', () => {
-	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
+	const face = describeAppliedLayer(layer({ kept: false, revertable: false }));
 
 	assert.ok(/not a lost afternoon/.test(face.note));
 	assert.ok(/Save a copy of your work/.test(face.note));
 });
 
-test('describeAppliedLayer: a patch too large to keep is a different sentence from absorption (#306)', () => {
+test('describeAppliedLayer: a patch too large to keep offers the disposable-ticket exit (#306)', () => {
 	const face = describeAppliedLayer(layer({ kept: false, revertable: false }));
 
 	assert.strictEqual(face.canRevert, false);
-	assert.strictEqual(face.absorbed, false);
 	assert.strictEqual(face.offerCopy, true);
 	assert.ok(/too large to keep a copy of/.test(face.explanation));
 	assert.deepStrictEqual(face.detail, []);
@@ -195,37 +158,6 @@ test('describeApplyFailure: a forward apply is unaffected by the revert framing 
 	assert.ok(/author/.test(notice.advice));
 });
 
-// A file blocked for a reason that is not an edit over the patch's lines — the
-// contributor deleted it outright — must not be described as one. Withholding
-// Revert is still right; the sentence about it is what changes.
-test('describeAppliedLayer: a file that is simply gone gets its own sentence (#306)', () => {
-	const face = describeAppliedLayer(layer({
-		revertable: false,
-		absorbed: [{ path: FOO, editedOver: false, failed: 0, total: 0 }]
-	}));
-
-	assert.strictEqual(face.canRevert, false);
-	assert.ok(!/your own edits are on the lines/.test(face.explanation));
-	assert.ok(/no longer where it left it/.test(face.explanation));
-	// Nothing to count, so nothing is counted.
-	assert.deepStrictEqual(face.detail, []);
-});
-
-test('describeAppliedLayer: both reasons at once read as one sentence (#306)', () => {
-	const face = describeAppliedLayer(layer({
-		files: [FOO, BAR],
-		revertable: false,
-		absorbed: [
-			{ path: FOO, editedOver: true, failed: 1, total: 2 },
-			{ path: BAR, editedOver: false, failed: 0, total: 0 }
-		]
-	}));
-
-	assert.ok(face.explanation.includes(`your own edits are on the lines it brought to ${FOO}`));
-	assert.ok(face.explanation.includes(`${BAR} is no longer where it left it`));
-	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 1 of the 2 changes it brought`]);
-});
-
 // `already-applied` is derived by testing the inverse of what is being applied,
 // so on a revert it means the opposite of what it means going forwards. Reading
 // the forward wording out loud there contradicts the headline above it.
@@ -244,15 +176,15 @@ test('describeApplyFailure: a revert reads `already-applied` backwards (#306)', 
 
 // --- the exits' own failures ---------------------------------------------
 
-test('absorbedExitFailure: silence when neither exit has failed (#306)', () => {
-	assert.strictEqual(absorbedExitFailure().message, '');
-	assert.strictEqual(absorbedExitFailure({ patchSaveError: '', discardError: '' }).message, '');
+test('layerExitFailure: silence when neither exit has failed (#306)', () => {
+	assert.strictEqual(layerExitFailure().message, '');
+	assert.strictEqual(layerExitFailure({ patchSaveError: '', discardError: '' }).message, '');
 });
 
-test('absorbedExitFailure: the save is the failure that must not be missed (#306)', () => {
-	const both = absorbedExitFailure({ patchSaveError: 'EACCES', discardError: 'could not reset' });
+test('layerExitFailure: the save is the failure that must not be missed (#306)', () => {
+	const both = layerExitFailure({ patchSaveError: 'EACCES', discardError: 'could not reset' });
 	assert.ok(both.message.includes('EACCES'));
 	assert.ok(!both.message.includes('could not reset'));
 
-	assert.strictEqual(absorbedExitFailure({ discardError: 'could not reset' }).message, 'could not reset');
+	assert.strictEqual(layerExitFailure({ discardError: 'could not reset' }).message, 'could not reset');
 });

--- a/test/applied-layer.test.cjs
+++ b/test/applied-layer.test.cjs
@@ -1,0 +1,258 @@
+'use strict';
+
+// The applied patch as a layer with a name (#306): who owns which file, and
+// which of the banner's faces the checkout has earned. Pure — the module holds
+// the branching so the component does not, which is what makes this reachable.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf } = require('../src/renderer/applied-layer.cjs');
+const { describeApplyFailure } = require('../src/renderer/apply-conflict.cjs');
+
+const FOO = 'src/wp-login.php';
+const BAR = 'src/wp-admin/edit.php';
+
+const layer = (over = {}) => ({
+	label: 'PR #123',
+	appliedAt: '2026-08-12T10:00:00.000Z',
+	files: [FOO],
+	kept: true,
+	absorbed: [],
+	revertable: true,
+	...over
+});
+
+// --- attribution ----------------------------------------------------------
+
+test('attributeConflicts: a file only the applied patch touched is not called your work (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO],
+		appliedPatch: layer()
+	});
+
+	assert.deepStrictEqual(yours, []);
+	assert.deepStrictEqual(fromLayer, [FOO]);
+	// The warning does not go quiet — the file is still named, just attributed.
+	assert.ok(sentences.some((s) => s.includes(FOO) && s.includes('PR #123')));
+	assert.ok(!sentences.some((s) => s.startsWith('You have your own edits')));
+});
+
+test('attributeConflicts: a file the contributor also edited keeps naming their work (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO],
+		appliedPatch: layer({ absorbed: [{ path: FOO, failed: 1, total: 3 }], revertable: false })
+	});
+
+	assert.deepStrictEqual(yours, [FOO]);
+	assert.deepStrictEqual(fromLayer, []);
+	assert.ok(sentences[0].startsWith('You have your own edits'));
+});
+
+test('attributeConflicts: the two owners are named separately, not merged (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO, BAR],
+		appliedPatch: layer()
+	});
+
+	assert.deepStrictEqual(yours, [BAR]);
+	assert.deepStrictEqual(fromLayer, [FOO]);
+	assert.strictEqual(sentences.length, 3);
+	assert.ok(sentences[0].includes(BAR) && !sentences[0].includes(FOO));
+	assert.ok(sentences[1].includes(FOO) && !sentences[1].includes(BAR));
+});
+
+test('attributeConflicts: with no patch applied every file is the contributor\'s (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({ conflicts: [FOO, BAR], appliedPatch: null });
+
+	assert.deepStrictEqual(yours, [FOO, BAR]);
+	assert.deepStrictEqual(fromLayer, []);
+	assert.ok(sentences[0].startsWith('You have your own edits'));
+});
+
+test('attributeConflicts: a clean tree says nothing at all (#306)', () => {
+	assert.deepStrictEqual(attributeConflicts({ conflicts: [], appliedPatch: layer() }).sentences, []);
+	assert.deepStrictEqual(attributeConflicts().sentences, []);
+});
+
+test('listOf: reads as a sentence rather than a join (#306)', () => {
+	assert.strictEqual(listOf([]), '');
+	assert.strictEqual(listOf(['a']), 'a');
+	assert.strictEqual(listOf(['a', 'b']), 'a and b');
+	assert.strictEqual(listOf(['a', 'b', 'c']), 'a, b and c');
+});
+
+// --- the banner's faces ---------------------------------------------------
+
+test('describeAppliedLayer: nothing applied, nothing to say (#306)', () => {
+	assert.strictEqual(describeAppliedLayer(null), null);
+});
+
+test('describeAppliedLayer: while it still comes out, Revert is the only offer (#306)', () => {
+	const face = describeAppliedLayer(layer(), { when: '12/08/2026' });
+
+	assert.strictEqual(face.canRevert, true);
+	assert.strictEqual(face.absorbed, false);
+	assert.strictEqual(face.offerCopy, false);
+	assert.strictEqual(face.explanation, '');
+	assert.strictEqual(face.summary, 'is applied — 1 file, 12/08/2026.');
+});
+
+test('describeAppliedLayer: absorbed drops Revert and offers the copy-and-discard exit (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		revertable: false,
+		absorbed: [{ path: FOO, failed: 2, total: 5 }]
+	}));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.strictEqual(face.absorbed, true);
+	assert.strictEqual(face.offerCopy, true);
+	assert.ok(face.explanation.includes(FOO));
+	assert.ok(face.explanation.includes('part of your changes now'));
+	// Not a one-way door, and the banner has to say so.
+	assert.ok(/Undo those edits and Revert comes back/.test(face.explanation));
+	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 2 of the 5 changes it brought`]);
+});
+
+// The constraint the whole design rests on: absorption is not a way to apply a
+// second patch. The banner has to say the slot is still taken.
+test('describeAppliedLayer: absorption does not free the one-patch slot (#306)', () => {
+	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
+
+	assert.ok(/one applied patch/.test(face.note));
+	assert.ok(/reverted or discarded/.test(face.note));
+});
+
+// Discarding is a recommendable step here, not an admission of failure — the
+// wording is the point, so it is asserted rather than left to drift.
+test('describeAppliedLayer: the exit is worded as a normal way forward (#306)', () => {
+	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
+
+	assert.ok(/not a lost afternoon/.test(face.note));
+	assert.ok(/Save a copy of your work/.test(face.note));
+});
+
+test('describeAppliedLayer: a patch too large to keep is a different sentence from absorption (#306)', () => {
+	const face = describeAppliedLayer(layer({ kept: false, revertable: false }));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.strictEqual(face.absorbed, false);
+	assert.strictEqual(face.offerCopy, true);
+	assert.ok(/too large to keep a copy of/.test(face.explanation));
+	assert.deepStrictEqual(face.detail, []);
+});
+
+// A record written before this change carries `revertable` and no `kept`.
+test('describeAppliedLayer: an older record without `kept` still reads correctly (#306)', () => {
+	assert.strictEqual(describeAppliedLayer({ label: 'x', files: [FOO], revertable: true }).canRevert, true);
+	assert.strictEqual(describeAppliedLayer({ label: 'x', files: [FOO], revertable: false }).canRevert, false);
+});
+
+// --- the revert failure's narration ---------------------------------------
+
+const revertFailure = {
+	ok: false,
+	failures: [`${FOO} has moved on since the patch was written, so none of its 3 changes still fits`],
+	conflicts: [{
+		path: FOO,
+		error: `${FOO} has moved on since the patch was written, so none of its 3 changes still fits`,
+		total: 3,
+		regions: [
+			{ index: 0, line: 10, status: 'moved', anchor: 'a', lines: [] },
+			{ index: 1, line: 20, status: 'moved', anchor: 'b', lines: [] },
+			{ index: 2, line: 30, status: 'moved', anchor: 'c', lines: [] }
+		]
+	}]
+};
+
+test('describeApplyFailure: a failed revert blames the contributor\'s own edits, not the author (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { reverting: 'PR #123', prUrl: 'https://example.invalid/pr/1', prState: 'open' });
+
+	assert.ok(notice.headline.startsWith('PR #123 cannot be lifted back out on its own'));
+	assert.ok(/your own edits are on 3 of its 3 changes/.test(notice.headline));
+	// The pull request's author has nothing to do with a revert.
+	assert.strictEqual(notice.prUrl, null);
+	assert.strictEqual(notice.prButton, null);
+	assert.ok(!/rebase/.test(notice.advice));
+});
+
+test('describeApplyFailure: a failed revert offers the copy-and-discard exit, not another patch (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { reverting: 'PR #123', otherPatchCount: 4 });
+
+	assert.strictEqual(notice.offerDiscardToBase, true);
+	assert.strictEqual(notice.offerOtherPatches, false);
+	assert.ok(/Undoing your edits on those lines brings Revert back/.test(notice.advice));
+	assert.ok(/not a lost afternoon/.test(notice.advice));
+	// The contributor owns these lines, so the per-region detail is theirs to see.
+	assert.strictEqual(notice.items[0].regions.length, 3);
+});
+
+test('describeApplyFailure: a forward apply is unaffected by the revert framing (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { prUrl: 'https://example.invalid/pr/1', prState: 'open', otherPatchCount: 2 });
+
+	assert.strictEqual(notice.offerDiscardToBase, false);
+	assert.strictEqual(notice.offerOtherPatches, true);
+	assert.strictEqual(notice.prUrl, 'https://example.invalid/pr/1');
+	assert.ok(/author/.test(notice.advice));
+});
+
+// A file blocked for a reason that is not an edit over the patch's lines — the
+// contributor deleted it outright — must not be described as one. Withholding
+// Revert is still right; the sentence about it is what changes.
+test('describeAppliedLayer: a file that is simply gone gets its own sentence (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		revertable: false,
+		absorbed: [{ path: FOO, editedOver: false, failed: 0, total: 0 }]
+	}));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.ok(!/your own edits are on the lines/.test(face.explanation));
+	assert.ok(/no longer where it left it/.test(face.explanation));
+	// Nothing to count, so nothing is counted.
+	assert.deepStrictEqual(face.detail, []);
+});
+
+test('describeAppliedLayer: both reasons at once read as one sentence (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		files: [FOO, BAR],
+		revertable: false,
+		absorbed: [
+			{ path: FOO, editedOver: true, failed: 1, total: 2 },
+			{ path: BAR, editedOver: false, failed: 0, total: 0 }
+		]
+	}));
+
+	assert.ok(face.explanation.includes(`your own edits are on the lines it brought to ${FOO}`));
+	assert.ok(face.explanation.includes(`${BAR} is no longer where it left it`));
+	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 1 of the 2 changes it brought`]);
+});
+
+// `already-applied` is derived by testing the inverse of what is being applied,
+// so on a revert it means the opposite of what it means going forwards. Reading
+// the forward wording out loud there contradicts the headline above it.
+test('describeApplyFailure: a revert reads `already-applied` backwards (#306)', () => {
+	const withApplied = {
+		...revertFailure,
+		conflicts: [{ ...revertFailure.conflicts[0], regions: [{ index: 0, line: 10, status: 'already-applied', anchor: 'a', lines: [] }] }]
+	};
+
+	const reverting = describeApplyFailure(withApplied, { reverting: 'PR #123' });
+	assert.strictEqual(reverting.items[0].regions[0].reason, 'looks like that change is not in your checkout any more');
+
+	const forward = describeApplyFailure(withApplied, {});
+	assert.strictEqual(forward.items[0].regions[0].reason, 'looks like it is already in your checkout');
+});
+
+// --- the exits' own failures ---------------------------------------------
+
+test('absorbedExitFailure: silence when neither exit has failed (#306)', () => {
+	assert.strictEqual(absorbedExitFailure().message, '');
+	assert.strictEqual(absorbedExitFailure({ patchSaveError: '', discardError: '' }).message, '');
+});
+
+test('absorbedExitFailure: the save is the failure that must not be missed (#306)', () => {
+	const both = absorbedExitFailure({ patchSaveError: 'EACCES', discardError: 'could not reset' });
+	assert.ok(both.message.includes('EACCES'));
+	assert.ok(!both.message.includes('could not reset'));
+
+	assert.strictEqual(absorbedExitFailure({ discardError: 'could not reset' }).message, 'could not reset');
+});

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -479,7 +479,7 @@ test('describeApplyFailure: the mixed framing reads with several files on each s
 	assert.equal(result.prButton, 'Open the pull request');
 });
 
-test('describeApplyFailure: own work does not change the closed or landed framing (issue #303)', () => {
+test('describeApplyFailure: own work preserves closed framing but prevents a false landed claim (issue #303)', () => {
 	const closed = describeApplyFailure({
 		ok: false,
 		failures: [`${FOO} has moved on`],
@@ -500,8 +500,9 @@ test('describeApplyFailure: own work does not change the closed or landed framin
 		])]
 	}, { prUrl: PR_URL, prState: 'closed', ownWorkPaths: [FOO] });
 
-	assert.match(landed.headline, /likely committed to core/);
-	assert.equal(landed.prButton, null);
+	assert.match(landed.headline, /already in your checkout/);
+	assert.doesNotMatch(landed.headline, /committed to core|already in trunk/);
+	assert.equal(landed.prButton, 'Open the pull request');
 });
 
 // A patch from disk or a Trac attachment has no author to misblame, so the

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -31,6 +31,9 @@ const os = require('node:os');
 const path = require('node:path');
 const { EventEmitter } = require('node:events');
 const git = require('isomorphic-git');
+// The applied-layer module turns the handler's measured status into the
+// attribution the renderer shows.
+const { attributeConflicts } = require('../src/renderer/applied-layer.cjs');
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const MAIN_PATH = path.join(SRC_DIR, 'main.js');
 
@@ -3862,4 +3865,146 @@ test('every IPC channel is classified: wired, or explicitly not', () => {
 	// stale entry behind, claiming coverage nothing provides any more.
 	const stale = CLASSIFIED.filter((channel) => !registered.includes(channel));
 	assert.deepEqual(stale, [], 'Classified channels that main.js no longer registers');
+});
+// --- the applied patch as a layer, measured not remembered (#306) ---------
+//
+// `revertable` used to mean "we kept the text". It now means what the banner
+// asks: can this layer still be lifted out of *this* checkout, right now. That
+// is a fact about the tree, so these run against a real repo — a stub would
+// mock the very thing under test.
+
+// The parked ticket with LOGIN_DIFF applied on top of it, plus the record the
+// app writes when it applies one. `content` is what ends up in the file, so a
+// test can hand-edit over the patch's own line and ask again.
+async function ticketWithAppliedPatch(t, content) {
+	const { dir, baseOid, workFile } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	fs.writeFileSync(path.join(dir, workFile), content);
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: {
+			[dir]: {
+				tracTicket: 62281,
+				branches: {
+					'ticket/62281': {
+						tracTicket: 62281,
+						baseOid,
+						appliedPatch: {
+							label: 'PR #123',
+							appliedAt: '2026-08-12T10:00:00.000Z',
+							files: ['src/wp-login.php'],
+							text: LOGIN_DIFF
+						}
+					}
+				}
+			}
+		}
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+	return { dir, main, settings, workFile };
+}
+
+const PATCH_APPLIED = '<?php // login\n// somebody else\'s change\n';
+const EDITED_OVER = '<?php // login\n// my own version of it\n';
+
+test('site:status: a freshly applied patch is reported as still removable (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, PATCH_APPLIED);
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.label, 'PR #123');
+	assert.equal(status.appliedPatch.kept, true);
+	assert.equal(status.appliedPatch.revertable, true);
+	assert.deepEqual(status.appliedPatch.absorbed, []);
+});
+
+test('site:status: editing the patch\'s own lines absorbs it, and Revert stands down (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.revertable, false);
+	// The text is still stored — this is absorption, not a patch too large to
+	// keep, and the two get different sentences.
+	assert.equal(status.appliedPatch.kept, true);
+	assert.deepEqual(status.appliedPatch.absorbed, [{ path: 'src/wp-login.php', editedOver: true, failed: 1, total: 1 }]);
+});
+
+// Not a one-way door, and nothing persisted says otherwise: the same site,
+// the same record, answers differently the moment the overlapping edit goes.
+test('site:status: undoing the overlapping edit brings Revert back on its own (#306)', async (t) => {
+	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	assert.equal((await main.invoke('site:status', dir)).appliedPatch.revertable, false);
+
+	fs.writeFileSync(path.join(dir, workFile), PATCH_APPLIED);
+
+	const back = await main.invoke('site:status', dir);
+	assert.equal(back.appliedPatch.revertable, true);
+	assert.deepEqual(back.appliedPatch.absorbed, []);
+});
+
+// The constraint the design rests on: the slot frees on revert or on discarding
+// to base, never by absorption. The record has to survive as provenance.
+test('site:status: absorption does not free the one-patch slot (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const status = await main.invoke('site:status', dir);
+	assert.notEqual(status.appliedPatch, null, 'the record is provenance, not just an undo blob');
+
+	// And the guard still refuses a second patch on its behalf.
+	const event = createIpcEvent();
+	const { applyId } = await main.invokeWith('git:apply-patch', event, dir, { patchText: LOGIN_DIFF, label: 'PR #456' });
+	const done = await applyDone(event, applyId);
+	assert.equal(done.ok, false);
+	assert.match(done.error, /PR #123 is already applied/);
+});
+
+// A patch a trunk update reset away is not absorbed: its record is stale, and
+// Revert has to stay on screen because pressing it is what clears it.
+test('site:status: a patch the tree no longer holds keeps its Revert (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, '<?php // login\n// the ticket work\n');
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.revertable, true);
+	assert.deepEqual(status.appliedPatch.absorbed, []);
+});
+
+// The measurement must not write. `site:status` runs wherever the app re-reads
+// a site, so a check with a side effect would be a checkout mutating itself.
+test('site:status: measuring removability does not touch the checkout (#306)', async (t) => {
+	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
+	const before = fs.readFileSync(path.join(dir, workFile), 'utf8');
+
+	await main.invoke('site:status', dir);
+
+	assert.equal(fs.readFileSync(path.join(dir, workFile), 'utf8'), before);
+});
+
+// The other half of #306: the pre-apply warning names the files, and the
+// renderer's attribution module decides which of them are the contributor's.
+// The two have to agree on the same paths, which is what this pins.
+test('git:preview-patch and the applied record agree on who owns a file (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, PATCH_APPLIED);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	const status = await main.invoke('site:status', dir);
+
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+	const attributed = attributeConflicts({ conflicts: preview.conflicts, appliedPatch: status.appliedPatch });
+	assert.deepEqual(attributed.fromLayer, ['src/wp-login.php']);
+	assert.deepEqual(attributed.yours, []);
+});
+
+// And once the contributor has edited over it, the same file goes back to
+// naming their work — the answer that decides what they do next.
+test('git:preview-patch: a file edited over the patch is the contributor\'s again (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	const status = await main.invoke('site:status', dir);
+
+	const attributed = attributeConflicts({ conflicts: preview.conflicts, appliedPatch: status.appliedPatch });
+	assert.deepEqual(attributed.yours, ['src/wp-login.php']);
+	assert.deepEqual(attributed.fromLayer, []);
 });

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -2156,6 +2156,35 @@ test('git:apply-patch clears the record when the revert finds no patch to undo',
 	assert.equal(settings.values.siteMeta['/sites/wp'].appliedPatch, null);
 });
 
+test('git:apply-patch clears a stale revert record from the active ticket branch (#306)', async () => {
+	const applyPatchToDir = spy(async () => ({ ok: false, notApplied: true, error: 'That patch is not in this checkout any more.', applied: [], skipped: [] }));
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: {
+			'/sites/wp': {
+				tracTicket: 62281,
+				currentBranch: 'ticket/62281',
+				branches: { 'ticket/62281': { baseOid: 'base', appliedPatch: { label: 'L', text: 'STORED' } } }
+			}
+		}
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./patch-apply': { applyPatchToDir },
+			'./ticket-branches': { currentBranchName: async () => 'ticket/62281' }
+		}
+	});
+
+	const event = createIpcEvent();
+	const { applyId } = await main.invokeWith('git:apply-patch', event, '/sites/wp', { reverse: true });
+	const done = await applyDone(event, applyId);
+
+	assert.equal(done.recordCleared, true);
+	assert.equal(settings.values.siteMeta['/sites/wp'].branches['ticket/62281'].appliedPatch, null);
+});
+
 // The mirror of the above: a real failure must leave the record alone, or the
 // patch stays in the tree with nothing offering to undo it.
 test('git:apply-patch keeps the record when a revert fails for any other reason', async () => {

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -3914,38 +3914,25 @@ test('site:status: a freshly applied patch is reported as still removable (#306)
 	assert.equal(status.appliedPatch.label, 'PR #123');
 	assert.equal(status.appliedPatch.kept, true);
 	assert.equal(status.appliedPatch.revertable, true);
-	assert.deepEqual(status.appliedPatch.absorbed, []);
+	assert.equal(status.appliedPatch.absorbed, undefined);
 });
 
-test('site:status: editing the patch\'s own lines absorbs it, and Revert stands down (#306)', async (t) => {
+test('site:status does not diagnose patch contents during a routine status read (#306)', async (t) => {
 	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
 
 	const status = await main.invoke('site:status', dir);
 
-	assert.equal(status.appliedPatch.revertable, false);
-	// The text is still stored — this is absorption, not a patch too large to
-	// keep, and the two get different sentences.
+	// Revert itself performs the expensive check and reports any overlap. A
+	// routine status probe only says whether the text needed for that attempt was
+	// kept; it must not synchronously read and diff the patch's files.
+	assert.equal(status.appliedPatch.revertable, true);
 	assert.equal(status.appliedPatch.kept, true);
-	assert.deepEqual(status.appliedPatch.absorbed, [{ path: 'src/wp-login.php', editedOver: true, failed: 1, total: 1 }]);
+	assert.equal(status.appliedPatch.absorbed, undefined);
 });
 
-// Not a one-way door, and nothing persisted says otherwise: the same site,
-// the same record, answers differently the moment the overlapping edit goes.
-test('site:status: undoing the overlapping edit brings Revert back on its own (#306)', async (t) => {
-	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
-
-	assert.equal((await main.invoke('site:status', dir)).appliedPatch.revertable, false);
-
-	fs.writeFileSync(path.join(dir, workFile), PATCH_APPLIED);
-
-	const back = await main.invoke('site:status', dir);
-	assert.equal(back.appliedPatch.revertable, true);
-	assert.deepEqual(back.appliedPatch.absorbed, []);
-});
-
-// The constraint the design rests on: the slot frees on revert or on discarding
-// to base, never by absorption. The record has to survive as provenance.
-test('site:status: absorption does not free the one-patch slot (#306)', async (t) => {
+// The slot frees on revert or on discarding to base, never because the stored
+// patch stops fitting. The record survives as provenance.
+test('site:status: an edited applied patch still holds the one-patch slot (#306)', async (t) => {
 	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
 
 	const status = await main.invoke('site:status', dir);
@@ -3959,7 +3946,7 @@ test('site:status: absorption does not free the one-patch slot (#306)', async (t
 	assert.match(done.error, /PR #123 is already applied/);
 });
 
-// A patch a trunk update reset away is not absorbed: its record is stale, and
+// A patch a trunk update reset away is no longer in the tree: its record is stale, and
 // Revert has to stay on screen because pressing it is what clears it.
 test('site:status: a patch the tree no longer holds keeps its Revert (#306)', async (t) => {
 	const { dir, main } = await ticketWithAppliedPatch(t, '<?php // login\n// the ticket work\n');
@@ -3967,12 +3954,11 @@ test('site:status: a patch the tree no longer holds keeps its Revert (#306)', as
 	const status = await main.invoke('site:status', dir);
 
 	assert.equal(status.appliedPatch.revertable, true);
-	assert.deepEqual(status.appliedPatch.absorbed, []);
+	assert.equal(status.appliedPatch.absorbed, undefined);
 });
 
-// The measurement must not write. `site:status` runs wherever the app re-reads
-// a site, so a check with a side effect would be a checkout mutating itself.
-test('site:status: measuring removability does not touch the checkout (#306)', async (t) => {
+// A status read must not write while it reports the stored layer.
+test('site:status does not touch the checkout (#306)', async (t) => {
 	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
 	const before = fs.readFileSync(path.join(dir, workFile), 'utf8');
 
@@ -3996,15 +3982,16 @@ test('git:preview-patch and the applied record agree on who owns a file (#306)',
 	assert.deepEqual(attributed.yours, []);
 });
 
-// And once the contributor has edited over it, the same file goes back to
-// naming their work — the answer that decides what they do next.
-test('git:preview-patch: a file edited over the patch is the contributor\'s again (#306)', async (t) => {
+// A status read deliberately does not inspect every line in the file. The copy
+// therefore keeps the layer's provenance without excluding contributor edits.
+test('git:preview-patch: a layer file may also contain contributor edits (#306)', async (t) => {
 	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
 
 	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
 	const status = await main.invoke('site:status', dir);
 
 	const attributed = attributeConflicts({ conflicts: preview.conflicts, appliedPatch: status.appliedPatch });
-	assert.deepEqual(attributed.yours, ['src/wp-login.php']);
-	assert.deepEqual(attributed.fromLayer, []);
+	assert.deepEqual(attributed.yours, []);
+	assert.deepEqual(attributed.fromLayer, ['src/wp-login.php']);
+	assert.ok(attributed.sentences.some((sentence) => /may also contain your own edits/.test(sentence)));
 });

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -7,7 +7,7 @@ const os = require('os');
 const path = require('path');
 const git = require('isomorphic-git');
 const JsDiff = require('diff');
-const { applyPatchToDir, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
+const { applyPatchToDir, diagnoseRemoval, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
 const { parsePatchFiles } = require('../src/patch-plan.cjs');
 
 // A real on-disk repo, like trunk-update.integration.test.cjs: applyPatchToDir
@@ -878,4 +878,99 @@ test('diagnoseHunks: overlapping hunks that each pass alone yield null, not zero
 
 	// Sanity: the single hunk applies, so per-hunk diagnosis finds no failures.
 	assert.strictEqual(diagnoseHunks(body, file), null);
+});
+
+// --- diagnoseRemoval: can the applied layer still be taken out? (#306) ------
+//
+// The record the app keeps only ever said "a patch text was stored". These
+// exercise the question the banner actually asks, against a real checkout: is
+// the layer still separable from the contributor's own work, right now.
+
+test('diagnoseRemoval: a freshly applied patch still comes out cleanly (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// The absorption case: the contributor has edited the very line the patch
+// brought, so there is no longer a patch and an edit — there is one body of
+// work, and no revert can separate them.
+test('diagnoseRemoval: editing the patch\'s own line absorbs it (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+
+	const answer = diagnoseRemoval({ dir, patchText: FOO_PATCH });
+	assert.strictEqual(answer.missing, false);
+	assert.deepStrictEqual(answer.absorbed.map((a) => a.path), [FOO]);
+	// The counts come from diagnoseHunks, so the banner can say how much of the
+	// patch has been written over rather than only that something has.
+	assert.deepStrictEqual(answer.absorbed[0], { path: FOO, editedOver: true, failed: 1, total: 1 });
+});
+
+// Not a one-way door, and this is the test that pins it: nothing persists an
+// "absorbed" flag, so putting the line back makes the layer removable again
+// with no further action from anyone.
+test('diagnoseRemoval: undoing the overlapping edit makes it removable again (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	const patched = fs.readFileSync(path.join(dir, FOO), 'utf8');
+
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+	assert.strictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }).absorbed.length, 1);
+
+	fs.writeFileSync(path.join(dir, FOO), patched);
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// Work on a file the patch never touched is not absorption. It is the ordinary
+// state of a ticket, and it must not take Revert away.
+test('diagnoseRemoval: edits to other files leave the layer removable (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, BAR), 'my own work\n');
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// A patch a trunk update or a discard reset away is not absorbed — its record
+// is merely stale. Reporting absorption there would hide Revert, which is the
+// one button that clears the record.
+test('diagnoseRemoval: a patch the tree no longer holds reads as missing, not absorbed (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY);
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: true });
+});
+
+// Nothing here may write. The whole point of measuring instead of tracking is
+// that it can run on a status read.
+test('diagnoseRemoval: the checkout is not touched (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+	const before = snapshot(dir);
+
+	diagnoseRemoval({ dir, patchText: FOO_PATCH });
+
+	assert.deepStrictEqual(snapshot(dir), before);
+});
+
+// A revert that fails now carries the same per-region breakdown a forward apply
+// does, because that is what the panel narrates the absorption from.
+test('applyPatchToDir: a failing reverse reports which regions were edited over (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+
+	const res = await applyPatchToDir({ dir, patchText: FOO_PATCH, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.notApplied, undefined);
+	assert.strictEqual(res.conflicts.length, 1);
+	assert.strictEqual(res.conflicts[0].path, FOO);
+	assert.strictEqual(res.conflicts[0].total, 1);
+	assert.strictEqual(res.conflicts[0].regions.length, 1);
 });

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -7,7 +7,7 @@ const os = require('os');
 const path = require('path');
 const git = require('isomorphic-git');
 const JsDiff = require('diff');
-const { applyPatchToDir, diagnoseRemoval, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
+const { applyPatchToDir, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
 const { parsePatchFiles } = require('../src/patch-plan.cjs');
 
 // A real on-disk repo, like trunk-update.integration.test.cjs: applyPatchToDir
@@ -878,84 +878,6 @@ test('diagnoseHunks: overlapping hunks that each pass alone yield null, not zero
 
 	// Sanity: the single hunk applies, so per-hunk diagnosis finds no failures.
 	assert.strictEqual(diagnoseHunks(body, file), null);
-});
-
-// --- diagnoseRemoval: can the applied layer still be taken out? (#306) ------
-//
-// The record the app keeps only ever said "a patch text was stored". These
-// exercise the question the banner actually asks, against a real checkout: is
-// the layer still separable from the contributor's own work, right now.
-
-test('diagnoseRemoval: a freshly applied patch still comes out cleanly (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-
-	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
-});
-
-// The absorption case: the contributor has edited the very line the patch
-// brought, so there is no longer a patch and an edit — there is one body of
-// work, and no revert can separate them.
-test('diagnoseRemoval: editing the patch\'s own line absorbs it (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
-
-	const answer = diagnoseRemoval({ dir, patchText: FOO_PATCH });
-	assert.strictEqual(answer.missing, false);
-	assert.deepStrictEqual(answer.absorbed.map((a) => a.path), [FOO]);
-	// The counts come from diagnoseHunks, so the banner can say how much of the
-	// patch has been written over rather than only that something has.
-	assert.deepStrictEqual(answer.absorbed[0], { path: FOO, editedOver: true, failed: 1, total: 1 });
-});
-
-// Not a one-way door, and this is the test that pins it: nothing persists an
-// "absorbed" flag, so putting the line back makes the layer removable again
-// with no further action from anyone.
-test('diagnoseRemoval: undoing the overlapping edit makes it removable again (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-	const patched = fs.readFileSync(path.join(dir, FOO), 'utf8');
-
-	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
-	assert.strictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }).absorbed.length, 1);
-
-	fs.writeFileSync(path.join(dir, FOO), patched);
-	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
-});
-
-// Work on a file the patch never touched is not absorption. It is the ordinary
-// state of a ticket, and it must not take Revert away.
-test('diagnoseRemoval: edits to other files leave the layer removable (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-	fs.writeFileSync(path.join(dir, BAR), 'my own work\n');
-
-	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
-});
-
-// A patch a trunk update or a discard reset away is not absorbed — its record
-// is merely stale. Reporting absorption there would hide Revert, which is the
-// one button that clears the record.
-test('diagnoseRemoval: a patch the tree no longer holds reads as missing, not absorbed (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-	fs.writeFileSync(path.join(dir, FOO), FOO_BODY);
-
-	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: true });
-});
-
-// Nothing here may write. The whole point of measuring instead of tracking is
-// that it can run on a status read.
-test('diagnoseRemoval: the checkout is not touched (issue #306)', async (t) => {
-	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
-	await applyPatchToDir({ dir, patchText: FOO_PATCH });
-	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
-	const before = snapshot(dir);
-
-	diagnoseRemoval({ dir, patchText: FOO_PATCH });
-
-	assert.deepStrictEqual(snapshot(dir), before);
 });
 
 // A revert that fails now carries the same per-region breakdown a forward apply


### PR DESCRIPTION
## Why

An applied PR remains part of a ticket’s work, but the app described every touched file as the contributor’s own and a failed Revert could blame the PR author. That attribution is misleading and makes the safe exit hard to find.

## What changes

The applied patch is retained as a named layer:

- conflict copy says a file includes changes from the named PR and may also contain the contributor’s edits;
- Revert remains available whenever the patch text was retained;
- pressing Revert performs the existing reverse-apply check and reports overlapping edits there;
- a patch too large to retain offers save-a-copy plus discard-to-base;
- the one-patch slot remains occupied until Revert or discard clears it.

Routine `site:status` no longer reads and diffs patch files synchronously. The proactive “absorbed” classifier/state and categorical “not by you” copy have been removed.

## How to test this

**Platforms:** any.

1. Apply a PR on a linked ticket.
   **Expected:** its named banner appears with **Revert this patch**.
2. Preview another patch touching the same file.
   **Expected:** the warning says the file includes changes from the applied PR and may also contain your edits; it never says “not by you”.
3. Edit a line brought by the applied PR and press **Revert this patch**.
   **Expected:** Revert fails without touching anything and explains the overlap, offering save-a-copy/discard rather than asking the author for a rebase.
4. Undo that edit and press Revert again.
   **Expected:** it succeeds and clears the named layer.

**What must not have happened:** routine refreshes must not synchronously scan patch files; a failed Revert must not partially edit the tree or free the one-patch slot.

## Risks and limitations

The banner does not predict whether a retained patch is still reversible; it answers only when the user requests Revert. This keeps routine main-process status reads cheap and keeps error details attached to the action they explain.

The desktop flow remains to be driven from the integration artifact.

## Related

Fixes #306. Part of #309. Builds on #317 and sharpens #313.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The previous version diagnosed every applied layer during `site:status`, adding synchronous file reads and an “absorbed” state. The simplified version uses the reverse apply operation as the diagnostic only when Revert is pressed.

</details>

<details>
<summary>Review outcome</summary>

2 [fix here] — both fixed: synchronous status-path diagnosis was removed, and same-file ownership now preserves uncertainty. Lint is clean and the branch’s full suite passes 979 tests.

</details>

<details>
<summary>Implementation notes</summary>

The simplification removed 310 net lines from the reviewed version. Patch text remains in the main process and never crosses IPC.

</details>

<details>
<summary>Screenshots or recording</summary>

No new layout. The existing applied-layer and failure banners render the revised copy/actions.

</details>
