### PR TITLE
Say when a ticket is still on the trunk it was born from

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ const { normalizeEol } = require('./git-update.cjs');
 const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
 const { applyPatchToDir } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
+const { BASE_STATUS, baseIsApproximate, baseUnreadableMessage } = require('./renderer/ticket-base.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
 const { getClientId: getGithubClientId, requestDeviceCode, pollForToken, fetchViewer } = require('./github-auth.cjs');
 const { openPullRequest, buildPullRequestBody, testMode: githubTestMode } = require('./github-pr.cjs');
@@ -579,9 +580,17 @@ async function collectPullRequestFiles(dir, baseOid = null) {
     return { baseOid: base, files: entries };
 }
 
+// A base the app could not read is a patch it cannot take (#308). Every
+// generator below refuses instead of falling back, because the fallback is
+// HEAD — and HEAD on a resumed ticket is the contributor's own parked work, so
+// the "patch" would come back empty and look like there was nothing to submit.
+const NO_BASE_PATCH_ERROR = baseUnreadableMessage('no patch was created');
+
 ipcMain.handle('git:get-patch', async (_e, sitePath) => {
     try {
-        const patch = await createMinimalPatchForDir(sitePath, await patchBaseOid(sitePath));
+        const base = await patchBase(sitePath);
+        if (base.status === BASE_STATUS.UNREADABLE) return { ok: false, error: NO_BASE_PATCH_ERROR };
+        const patch = await createMinimalPatchForDir(sitePath, base.baseOid);
         return { ok: true, patch };
     } catch (e) {
         return { ok: false, error: String(e) };
@@ -589,14 +598,20 @@ ipcMain.handle('git:get-patch', async (_e, sitePath) => {
 });
 
 ipcMain.handle('git:create-patch', async (_e, sitePath) => {
-    try {
-        const patch = await createMinimalPatchForDir(sitePath, await patchBaseOid(sitePath));
+    const showPatchWindow = (text) => {
         const win = new BrowserWindow({ width: 900, height: 700, webPreferences: { contextIsolation: true, nodeIntegration: false } });
-        win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(buildPatchHtml(patch)));
+        win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(buildPatchHtml(text)));
+    };
+    try {
+        const base = await patchBase(sitePath);
+        if (base.status === BASE_STATUS.UNREADABLE) {
+            showPatchWindow(NO_BASE_PATCH_ERROR);
+            return { ok: false, error: NO_BASE_PATCH_ERROR };
+        }
+        showPatchWindow(await createMinimalPatchForDir(sitePath, base.baseOid));
         return { ok: true };
     } catch (e) {
-        const win = new BrowserWindow({ width: 900, height: 700, webPreferences: { contextIsolation: true, nodeIntegration: false } });
-        win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(buildPatchHtml('Failed to generate diff: ' + String(e))));
+        showPatchWindow('Failed to generate diff: ' + String(e));
         return { ok: false, error: String(e) };
     }
 });
@@ -612,8 +627,9 @@ ipcMain.handle('git:create-patch', async (_e, sitePath) => {
 ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
     try {
         const handoff = Boolean(options && options.handoff);
-        const baseOid = await patchBaseOid(sitePath);
-        const patch = await createMinimalPatchForDir(sitePath, baseOid);
+        const base = await patchBase(sitePath);
+        if (base.status === BASE_STATUS.UNREADABLE) return { ok: false, error: NO_BASE_PATCH_ERROR };
+        const patch = await createMinimalPatchForDir(sitePath, base.baseOid);
 
         // The header describes what was diffed, so it is read from the same
         // recorded state the status handler reports, not asked of the caller:
@@ -635,7 +651,7 @@ ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
                 // forward since (#108). Reading the date off that commit rather
                 // than the site record keeps the two halves of the line
                 // describing the same commit.
-                ...(await baseProvenance(sitePath, baseOid, meta)),
+                ...(await baseProvenance(sitePath, base, meta)),
                 generatedAt: new Date().toISOString()
             });
             name = handoffFilename({ handle, ticketId: meta.tracTicket });
@@ -779,7 +795,14 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
 
     let collected;
     try {
-        collected = await collectPullRequestFiles(sitePath, await patchBaseOid(sitePath));
+        // The base is the pull request's parent commit, so an unreadable one
+        // cannot be papered over with HEAD: that would open a pull request
+        // against the contributor's own parked work (#308).
+        const base = await patchBase(sitePath);
+        if (base.status === BASE_STATUS.UNREADABLE) {
+            return { ok: false, reason: 'error', error: baseUnreadableMessage('no pull request was opened'), stage: 'collect' };
+        }
+        collected = await collectPullRequestFiles(sitePath, base.baseOid);
     } catch (e) {
         return { ok: false, reason: 'error', error: String(e), stage: 'collect' };
     }
@@ -866,9 +889,10 @@ async function migrateSiteToBranches(sitePath) {
         const existing = await listTicketBranches(sitePath);
         // A branch that already exists was not created by this app, so its fork
         // point is not on record and cannot be recovered on a depth-1 clone.
-        // Left null deliberately: patchBaseOid has one documented fallback for
-        // exactly this, and guessing here would put a second, wrong one in the
-        // codebase. (`trunkOid` is the *current* tip, not the fork point.)
+        // Left null deliberately: `patchBase` answers `unrecorded` for exactly
+        // this and hedges every surface that shows it, where guessing here
+        // would put a second, silent guess in the codebase. (`trunkOid` is the
+        // *current* tip, not the fork point.)
         const baseOid = existing.includes(ref)
             ? null
             : (await startTicketBranch(sitePath, m.tracTicket)).baseOid;
@@ -1059,30 +1083,46 @@ async function mergeBranchMeta(sitePath, ref, patch) {
 }
 
 /**
- * The diff base for whatever is checked out: a ticket branch's recorded branch
- * point, or null on trunk — where the patch generator falls back to HEAD, which
- * is what it has always diffed against.
+ * The diff base for whatever is checked out, and how well the app knows it.
+ *
+ * Four answers, not two (#308): `trunk` has no branch point and the callers
+ * fall back to HEAD as they always have; `recorded` is the branch point the app
+ * wrote down when it created the branch; `unrecorded` is a ticket branch with
+ * none, measured against today's trunk because there is nothing better and
+ * qualified as approximate wherever it is shown; `unreadable` is a read that
+ * failed, which is emphatically not "this site is on trunk" — resolving it to
+ * that sends every measurement back to HEAD through the failure path.
  *
  * @param {string} sitePath
+ * @return {Promise<{status: string, baseOid: ?string}>}
  */
-async function patchBaseOid(sitePath) {
+async function patchBase(sitePath) {
     try {
         // What is checked out decides this, so ask the worktree before the
         // registry: a site on trunk — every site before #108, and every site
         // whose owner never linked a ticket — answers without a store read at
         // all, and takes exactly the path it always took.
-        let ref = null;
-        try { ref = await currentBranchName(sitePath); } catch {}
-        if (!ref || ref === TRUNK) return null;
+        //
+        // A *null* branch (a detached HEAD, an empty repository) is trunk's
+        // answer and always was. A *throw* is not: that is the read failing,
+        // and it falls through to the catch below.
+        const ref = await currentBranchName(sitePath);
+        if (!ref || ref === TRUNK) return { status: BASE_STATUS.TRUNK, baseOid: null };
 
         const recorded = ((await readSiteMeta(sitePath)).branches || {})[ref];
-        if (recorded && recorded.baseOid) return recorded.baseOid;
-        // A ticket branch with no recorded base (registry edited by hand, or a
-        // branch the user made themselves). The live trunk ref is the closest
-        // honest answer available.
-        return await git.resolveRef({ fs, dir: sitePath, ref: 'refs/heads/trunk' });
+        if (recorded && recorded.baseOid) return { status: BASE_STATUS.RECORDED, baseOid: recorded.baseOid };
+        // A ticket branch with no recorded base (registry edited by hand, a
+        // site adopted from disk, a branch the contributor made themselves).
+        // The live trunk ref is the closest thing available — but it is where
+        // trunk is *now*, which an update has very likely moved past the point
+        // the branch was born at, so the status says so and every surface that
+        // shows this answer hedges it.
+        return {
+            status: BASE_STATUS.UNRECORDED,
+            baseOid: await git.resolveRef({ fs, dir: sitePath, ref: 'refs/heads/trunk' })
+        };
     } catch {
-        return null;
+        return { status: BASE_STATUS.UNREADABLE, baseOid: null };
     }
 }
 
@@ -1097,20 +1137,27 @@ async function patchBaseOid(sitePath) {
  * dropped rather than guessed: a header with no date is honest, one that dates a
  * commit it is not describing is not.
  *
- * @param {string}  dir     Site working directory.
- * @param {?string} baseOid Base the patch was diffed against, or null on trunk.
- * @param {Object}  meta    The site's stored metadata.
- * @return {Promise<{trunkOid: ?string, trunkDate: ?string}>} Header fields.
+ * A branch with no recorded base is the same argument one step further (#308):
+ * today's trunk is what the patch was diffed against, so it is what the header
+ * names, but it is flagged approximate — a mentor reading "Base: trunk @ ..."
+ * as fact would rebase against a commit this ticket may never have seen.
+ *
+ * @param {string} dir  Site working directory.
+ * @param {Object} base A `patchBase` result.
+ * @param {Object} meta The site's stored metadata.
+ * @return {Promise<{trunkOid: ?string, trunkDate: ?string, baseApproximate: boolean}>} Header fields.
  */
-async function baseProvenance(dir, baseOid, meta) {
+async function baseProvenance(dir, base, meta) {
+    const baseApproximate = baseIsApproximate(base.status);
+    const { baseOid } = base;
     if (!baseOid || baseOid === meta.trunkOid) {
-        return { trunkOid: meta.trunkOid, trunkDate: meta.trunkDate };
+        return { trunkOid: meta.trunkOid, trunkDate: meta.trunkDate, baseApproximate };
     }
     try {
         const { commit } = await git.readCommit({ fs, dir, oid: baseOid });
-        return { trunkOid: baseOid, trunkDate: new Date(commit.committer.timestamp * 1000).toISOString() };
+        return { trunkOid: baseOid, trunkDate: new Date(commit.committer.timestamp * 1000).toISOString(), baseApproximate };
     } catch {
-        return { trunkOid: baseOid, trunkDate: null };
+        return { trunkOid: baseOid, trunkDate: null, baseApproximate };
     }
 }
 
@@ -1118,18 +1165,30 @@ async function baseProvenance(dir, baseOid, meta) {
  * The files standing between where this ticket started and where it is now —
  * the note's measurement (#239). Same base and same walk as the patch, filtered
  * to the rows the patch would actually speak about, so the note and the modal
- * are two renderings of one answer. On trunk `patchBaseOid` answers null and
- * the walk falls back to HEAD, which is what the note has always read there.
+ * are two renderings of one answer. On trunk `patchBase` answers no oid and the
+ * walk falls back to HEAD, which is what the note has always read there.
+ *
+ * Throws when the base could not be read (#308) rather than measuring against
+ * HEAD: on a resumed ticket HEAD is the contributor's own parked work, so the
+ * fallback answers "nothing here" about the very tree this exists to speak for.
+ * The status rides back with the files so the surfaces that show this answer
+ * can say how exact it is.
  *
  * @param {string} sitePath
- * @return {Promise<Array<string>>} Paths, gitignored ones excluded.
+ * @return {Promise<{baseStatus: string, files: Array<string>}>} Paths, gitignored ones excluded.
  */
 async function collectUnsubmittedFiles(sitePath) {
-    const baseOid = await patchBaseOid(sitePath);
-    const { files } = await collectChangedFiles(sitePath, baseOid);
-    return files
-        .filter((file) => classifyChangedFile(file).kind !== 'unchanged')
-        .map((file) => file.path);
+    const base = await patchBase(sitePath);
+    if (base.status === BASE_STATUS.UNREADABLE) {
+        throw new Error(baseUnreadableMessage('your work could not be measured against it'));
+    }
+    const { files } = await collectChangedFiles(sitePath, base.baseOid);
+    return {
+        baseStatus: base.status,
+        files: files
+            .filter((file) => classifyChangedFile(file).kind !== 'unchanged')
+            .map((file) => file.path)
+    };
 }
 
 // Two questions, deliberately two channels (#239). This one asks "are there
@@ -1155,7 +1214,10 @@ ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
 // switch — which is exactly the work the note exists to speak about.
 ipcMain.handle('git:unsubmitted-work', async (_e, sitePath) => {
     try {
-        const files = await collectUnsubmittedFiles(sitePath);
+        // The reply keeps its shape: the card's note counts files and does not
+        // yet say how exact the measurement is — qualifying it there is a
+        // follow-up, not something to smuggle in on this channel.
+        const { files } = await collectUnsubmittedFiles(sitePath);
         return { ok: true, dirty: files.length > 0, changedCount: files.length, files };
     } catch (e) {
         return { ok: false, error: String(e) };
@@ -1164,22 +1226,34 @@ ipcMain.handle('git:unsubmitted-work', async (_e, sitePath) => {
 
 // "Discard all changes" in the review-and-submit modal: throws away everything
 // the modal shows, which on a ticket branch is measured from the branch point
-// (#108/#239) and so includes the parked WIP commit. Rewinds to `patchBaseOid`
+// (#108/#239) and so includes the parked WIP commit. Rewinds to `patchBase`
 // — the same base the diff was taken against — so the modal ends on "No
 // changes". The branch survives and the ticket stays linked; only its work is
-// gone. On trunk (or a branch with no recorded base) there is nothing past
-// HEAD to rewind, so it falls back to the uncommitted-only reset.
+// gone. On trunk there is nothing past HEAD to rewind, so it falls back to the
+// uncommitted-only reset.
+//
+// A base the app could not read refuses outright (#308). The uncommitted-only
+// reset is not a safe stand-in for it: it looks like a discard, leaves the
+// parked WIP commit untouched, and the modal would come back still listing the
+// work it just promised to throw away.
 ipcMain.handle('git:discard-to-base', async (_e, sitePath) => {
     try {
-        const baseOid = await patchBaseOid(sitePath);
-        if (baseOid) {
-            await discardToBase(sitePath, baseOid);
+        const base = await patchBase(sitePath);
+        if (base.status === BASE_STATUS.UNREADABLE) {
+            return { ok: false, error: baseUnreadableMessage('nothing was discarded') };
+        }
+        if (base.baseOid) {
+            // On an unrecorded base this is today's trunk, which need not be an
+            // ancestor of the branch — `discardToBase` refuses to rewind onto a
+            // base that is not one and clears the uncommitted work only, so the
+            // guess cannot take a commit with it.
+            await discardToBase(sitePath, base.baseOid);
         } else {
             await discardChanges(sitePath);
         }
         await writeWorkMeta(sitePath, { appliedPatch: null });
         let files = null;
-        try { files = await collectUnsubmittedFiles(sitePath); } catch {}
+        try { ({ files } = await collectUnsubmittedFiles(sitePath)); } catch {}
         return files
             ? { ok: true, dirty: files.length > 0, changedCount: files.length }
             : { ok: true };
@@ -1204,7 +1278,7 @@ ipcMain.handle('git:discard-changes', async (_e, sitePath) => {
         // that fails does not turn a discard that succeeded into an error, the
         // reply just says less and the next probe fills it in.
         let files = null;
-        try { files = await collectUnsubmittedFiles(sitePath); } catch {}
+        try { ({ files } = await collectUnsubmittedFiles(sitePath)); } catch {}
         return files
             ? { ok: true, dirty: files.length > 0, changedCount: files.length }
             : { ok: true };
@@ -1447,16 +1521,21 @@ ipcMain.handle('git:preview-patch', async (_e, sitePath, patchText) => {
         const parsed = parsePatchFiles(patchText);
         if (!parsed.ok) return { ok: false, error: parsed.error };
         let dirtyPaths;
+        let baseStatus;
         try {
-            dirtyPaths = await collectUnsubmittedFiles(sitePath);
+            ({ files: dirtyPaths, baseStatus } = await collectUnsubmittedFiles(sitePath));
         } catch (e) {
             // Failing open here would promise "no collisions" precisely when the
-            // app could not look — surface the failure instead.
+            // app could not look — surface the failure instead. An unreadable
+            // base arrives here as a throw for exactly that reason (#308).
             logError('git:preview-patch', String(e && e.stack ? e.stack : e));
             return { ok: false, error: 'Could not check your work for conflicts, so the preview was not shown.' };
         }
         const plan = planApply({ files: parsed.files, dirtyPaths });
-        return { ok: true, ...plan, files: parsed.files.map((f) => ({ kind: f.kind, path: f.path })) };
+        // How exact that collision list is rides back with it: on a branch with
+        // no recorded base it was measured against today's trunk, and the panel
+        // says so rather than presenting it in the same voice as an exact one.
+        return { ok: true, ...plan, baseStatus, files: parsed.files.map((f) => ({ kind: f.kind, path: f.path })) };
     } catch (e) {
         return { ok: false, error: String(e) };
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1134,9 +1134,10 @@ async function collectUnsubmittedFiles(sitePath) {
 
 // Two questions, deliberately two channels (#239). This one asks "are there
 // edits not written down yet" — the narrow reading the checkout guards need:
-// the trunk-update dirty dialog and the patch-apply collision scan protect
-// exactly the files a force checkout would overwrite, and parked work is not
-// among them. The card's note asks `git:unsubmitted-work` instead.
+// the trunk-update dirty dialog protects exactly the files a force checkout
+// would overwrite, and parked work is not among them. Everything that asks
+// what this ticket has done — the card's note, and the patch-apply collision
+// scan (#301) — asks `git:unsubmitted-work`'s question instead.
 ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
     try {
         const files = await collectDirtyFiles(sitePath);
@@ -1433,18 +1434,26 @@ const REVERTABLE_PATCH_LIMIT = 512 * 1024;
 // Reading a patch without touching the checkout, so the contributor sees which
 // files it would change — and which of their own edits it collides with —
 // before deciding.
+//
+// Measured from the ticket's base, not from HEAD (#301). Under the
+// ticket-as-branch model a ticket's work lives in its parked WIP commit, so a
+// ticket that has been left and resumed has a worktree matching HEAD exactly:
+// HEAD-relative, the warning goes silent on precisely the tree it exists to
+// protect, and speaks up about files edited back to what the base holds. This
+// is the same measurement the patch itself is taken with, so what the warning
+// calls "your own edits" is what the patch modal would show.
 ipcMain.handle('git:preview-patch', async (_e, sitePath, patchText) => {
     try {
         const parsed = parsePatchFiles(patchText);
         if (!parsed.ok) return { ok: false, error: parsed.error };
         let dirtyPaths;
         try {
-            dirtyPaths = await collectDirtyFiles(sitePath);
+            dirtyPaths = await collectUnsubmittedFiles(sitePath);
         } catch (e) {
             // Failing open here would promise "no collisions" precisely when the
             // app could not look — surface the failure instead.
             logError('git:preview-patch', String(e && e.stack ? e.stack : e));
-            return { ok: false, error: 'Could not check your working tree for conflicts, so the preview was not shown.' };
+            return { ok: false, error: 'Could not check your work for conflicts, so the preview was not shown.' };
         }
         const plan = planApply({ files: parsed.files, dirtyPaths });
         return { ok: true, ...plan, files: parsed.files.map((f) => ({ kind: f.kind, path: f.path })) };

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const { buildMenuTemplate } = require('./menu');
 const { killChildTree } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
 const { ensureAutocrlf, readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
-const { applyPatchToDir } = require('./patch-apply');
+const { applyPatchToDir, diagnoseRemoval } = require('./patch-apply');
 const { parsePatchFiles, planApply } = require('./patch-plan.cjs');
 const { BASE_STATUS, baseIsApproximate, baseUnreadableMessage } = require('./renderer/ticket-base.cjs');
 const { fetchLinkedPrs, fetchPrDiff } = require('./github-prs');
@@ -1753,12 +1753,41 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 
 		// Summarised rather than passed through: the stored patch text is only
 		// needed by the main process to reverse it, and this is polled.
+		//
+		// `revertable` used to mean "we kept the text". It now means what the
+		// banner actually asks — can this layer still be lifted out, right now
+		// (#306) — which is a fact about the tree and has to be measured here,
+		// because the text does not cross IPC and the renderer cannot ask.
+		// The measurement is in-memory: it reads the patch's own files (one to a
+		// handful, on a call that already stats the checkout and reads a git
+		// object) and matches hunks against them. Nothing is written. It is
+		// bounded twice over — a patch bigger than REVERTABLE_PATCH_LIMIT has no
+		// stored text to check, and this handler is called on mount and after
+		// long operations, not on a timer. The costly shape is a large absorbed
+		// patch, which pays its per-hunk diagnosis on every one of those reads;
+		// if that is ever felt, a ceiling belongs in diagnoseRemoval, not here.
+		//
+		// Guarded, and it fails towards offering Revert: a check that could not
+		// run must not hide the exit. Pressing Revert then gives the real answer
+		// from the apply path, with its own explanation.
+		let absorbed = [];
+		if (work.appliedPatch && work.appliedPatch.text) {
+			try {
+				absorbed = diagnoseRemoval({ dir: sitePath, patchText: work.appliedPatch.text }).absorbed;
+			} catch (e) {
+				logError('site:status', `could not check whether ${describeRefused(work.appliedPatch.label)} still comes out of ${describeRefused(sitePath)}: ${String(e && e.stack ? e.stack : e)}`);
+			}
+		}
 		const appliedPatch = work.appliedPatch
 			? {
 				label: work.appliedPatch.label,
 				appliedAt: work.appliedPatch.appliedAt,
 				files: work.appliedPatch.files || [],
-				revertable: Boolean(work.appliedPatch.text)
+				// Whether a text was kept at all — the separate reason a patch
+				// cannot be reverted, and a different sentence from absorption.
+				kept: Boolean(work.appliedPatch.text),
+				absorbed,
+				revertable: Boolean(work.appliedPatch.text) && absorbed.length === 0
 			}
 			: null;
 

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,8 @@ const {
 	switchToBranch,
 	deleteTicketBranch
 } = require('./ticket-branches');
+const { CARRY_STATE } = require('./renderer/carry-note.cjs');
+const { carryStatus } = require('./ticket-carry');
 const { createProgressThrottle, describeSwitchProgress } = require('./switch-progress.cjs');
 const { getStore } = require('./settings-store');
 
@@ -1223,6 +1225,82 @@ ipcMain.handle('git:unsubmitted-work', async (_e, sitePath) => {
         return { ok: false, error: String(e) };
     }
 });
+
+/**
+ * The ticket's changed paths in the shape the carry classifier reads them
+ * (#305): the path, whether the app could read it, whether a text diff could
+ * ever express it, and whether the ticket removed it.
+ *
+ * The same walk and the same base as the card's note and the patch modal
+ * (#239), filtered the same way, so all three speak about one set of files.
+ * None of the three flags is dropped. A file the app cannot read and a binary
+ * both sides changed are exactly the paths a carry must refuse over, and losing
+ * either here would turn a refusal into a silent deletion on the new trunk. And
+ * whether a file was removed is a question about the walk's status codes, never
+ * about its bytes (#85, #311) — without it a file both sides deleted is
+ * indistinguishable from one the ticket edited and upstream deleted, which would
+ * refuse the whole carry over two sides that agree.
+ *
+ * @param {string}  sitePath
+ * @param {?string} baseOid
+ * @return {Promise<Array<{path: string, unreadable: boolean, binary: boolean, deleted: boolean}>>}
+ */
+async function collectCarryCandidates(sitePath, baseOid) {
+    const { files } = await collectChangedFiles(sitePath, baseOid);
+    return files
+        .map((file) => ({ file, kind: classifyChangedFile(file).kind }))
+        .filter(({ kind }) => kind !== 'unchanged')
+        .map(({ file, kind }) => ({
+            path: file.path,
+            unreadable: kind === 'unreadable',
+            binary: kind === 'binary',
+            deleted: !file.inWorkdir
+        }));
+}
+
+/**
+ * Whether this ticket is still on the trunk it was born from, and what bringing
+ * it forward would mean file by file (#305).
+ *
+ * Strictly read-only — the mutating half is its own change. On trunk there is no
+ * ticket to be behind; on a base the app never recorded or cannot read there is
+ * no comparison to make, and `unknown` says so rather than guessing, for the
+ * same reason #308 gave.
+ */
+ipcMain.handle('git:carry-status', async (_e, sitePath) => withRegisteredSite(sitePath, async () => {
+    const base = await patchBase(sitePath);
+    // `unrecorded` hands back today's trunk as a stand-in for a branch point it
+    // never wrote down (#308). Comparing that against trunk answers "current"
+    // about every such ticket, however far behind it really is — so it is
+    // reported as the unknown it is instead.
+    // `readTrunkInfo` falls back to HEAD for a repository with no `trunk`
+    // branch, and HEAD on a ticket branch is the contributor's own WIP commit —
+    // newer than the base by construction, so the fallback would report every
+    // such ticket as behind and date the gap from their own work. The ref is
+    // read directly here and its absence is an `unknown`, which is the answer
+    // the app has for "there is nothing to compare against".
+    let trunkOid = null;
+    if (base.status === BASE_STATUS.RECORDED) {
+        try { trunkOid = await git.resolveRef({ fs, dir: sitePath, ref: 'refs/heads/trunk' }); } catch {}
+    }
+    if (base.status !== BASE_STATUS.RECORDED || !trunkOid) {
+        return {
+            ok: true,
+            state: base.status === BASE_STATUS.TRUNK ? CARRY_STATE.CURRENT : CARRY_STATE.UNKNOWN,
+            baseStatus: base.status,
+            wholesale: [],
+            merge: [],
+            settled: [],
+            refused: []
+        };
+    }
+    const status = await carryStatus(sitePath, {
+        baseOid: base.baseOid,
+        trunkOid,
+        loadFiles: () => collectCarryCandidates(sitePath, base.baseOid)
+    });
+    return { ok: true, baseStatus: base.status, ...status };
+}));
 
 // "Discard all changes" in the review-and-submit modal: throws away everything
 // the modal shows, which on a ticket branch is measured from the branch point

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -378,6 +378,74 @@ function patchIsAbsent(dir, files) {
 }
 
 /**
+ * Whether the patch the app applied could still be taken back out of this
+ * checkout, asked right now rather than remembered (#306).
+ *
+ * The record the app keeps says only that a patch text was stored. That is not
+ * the question the banner needs answering: once the contributor's own edits sit
+ * on the patch's lines it has been **absorbed** — it has become their changes,
+ * and no revert can separate the two again. Undoing those edits makes it
+ * removable again, which is why this is measured on demand and never tracked as
+ * a flag.
+ *
+ * Nothing here writes. `resolveFile` reads each file and works out what a
+ * reverse *would* produce, and `diagnoseHunks` behind it says how much of the
+ * patch the file no longer holds — the same machinery the apply path uses, so
+ * there is no second way to ask whether a patch still fits. The resolved
+ * contents are discarded.
+ *
+ * A patch that is simply gone — a trunk update or a discard reset the tree — is
+ * not absorbed, and gets the same two-part guard the revert itself uses: not one
+ * file reversed, *and* the whole patch resolves forwards. Its record is stale,
+ * and Revert stays offered because pressing it is what clears it.
+ *
+ * @param {Object} root0
+ * @param {string} root0.dir       Site working directory.
+ * @param {string} root0.patchText The stored patch, forward as it was applied.
+ * @return {{absorbed: Array<{path: string, editedOver: boolean, failed: number, total: number}>, missing: boolean, error?: string}}
+ */
+function diagnoseRemoval({ dir, patchText }) {
+	const parsed = parsePatchFiles(String(patchText || ''));
+	if (!parsed.ok) return { absorbed: [], missing: false, error: parsed.error };
+
+	const absorbed = [];
+	let intact = 0;
+	for (const file of parsed.files) {
+		// Binary files were never applied, so they cannot be in the way of a
+		// removal either — the apply path skips them the same way.
+		if (file.kind === 'binary') continue;
+		const reversed = reverseFile(file);
+		const resolved = resolveFile(dir, reversed);
+		if (!resolved.error) {
+			intact += 1;
+			continue;
+		}
+		const conflict = resolved.conflict;
+		absorbed.push({
+			// The forward path, not the reversed one: a rename's reverse names the
+			// file it moves *back* to, while the record of what was applied holds
+			// the name the patch moved it to. Keyed on the reversed name, the
+			// caller's attribution could never match its own record.
+			path: file.path,
+			// Not every refusal is an edit over the patch's lines: a file the
+			// contributor deleted outright, or one a reversed add can no longer
+			// find, blocks the removal without anything having been written over.
+			// Withholding Revert is right either way — the revert is all or
+			// nothing — but the sentence about it is not, so the two are told
+			// apart here rather than guessed at by the caller.
+			editedOver: Boolean(conflict),
+			failed: conflict ? conflict.regions.length : 0,
+			total: conflict ? conflict.total : 0
+		});
+	}
+
+	if (absorbed.length && !intact && patchIsAbsent(dir, parsed.files)) {
+		return { absorbed: [], missing: true };
+	}
+	return { absorbed, missing: false };
+}
+
+/**
  * Puts back everything a failed run had already written.
  *
  * Returns the paths it could not restore. The same full-disk, lock, or
@@ -450,10 +518,12 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 			skipped.push(file.path);
 			continue;
 		}
-		// No diagnosis on a reverse: the panel discards it — the patch being
-		// reverted came through this app, and the ticket's other patches are no
-		// answer to a revert that failed.
-		const resolved = resolveFile(dir, file, { diagnose: !reverse });
+		// Diagnosed on a reverse too (#306). The ticket's other patches are still
+		// no answer to a revert that failed, but the *reason* it failed is: a
+		// revert only fails because the contributor's own edits are on the
+		// patch's lines, and naming how many of them, and where, is the whole
+		// difference between an explanation and a generic error.
+		const resolved = resolveFile(dir, file);
 		if (resolved.error) {
 			failures.push(resolved.error);
 			if (resolved.conflict) conflicts.push(resolved.conflict);
@@ -536,4 +606,4 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	return { ok: true, applied, skipped };
 }
 
-module.exports = { applyPatchToDir, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };
+module.exports = { applyPatchToDir, diagnoseRemoval, resolveInside, reverseFile, dominantEol, rollback, diagnoseHunks };

--- a/src/patch-provenance.cjs
+++ b/src/patch-provenance.cjs
@@ -124,15 +124,16 @@ function ticketNumber(ticketId) {
  * recorded.
  *
  * @param {Object}        details
- * @param {string}        [details.handle]      WordPress.org handle, already validated.
- * @param {string}        [details.event]       Where it was written — a WordCamp, a meetup.
+ * @param {string}        [details.handle]          WordPress.org handle, already validated.
+ * @param {string}        [details.event]           Where it was written — a WordCamp, a meetup.
  * @param {number|string} [details.ticketId]
  * @param {string}        [details.trunkOid]
- * @param {string}        [details.trunkDate]   ISO timestamp of the base commit.
- * @param {string}        [details.generatedAt] ISO timestamp for "now".
+ * @param {string}        [details.trunkDate]       ISO timestamp of the base commit.
+ * @param {boolean}       [details.baseApproximate] The branch point was not recorded (#308).
+ * @param {string}        [details.generatedAt]     ISO timestamp for "now".
  * @return {string}
  */
-function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, generatedAt } = {}) {
+function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, baseApproximate, generatedAt } = {}) {
 	const lines = [];
 
 	const contributor = field(handle);
@@ -152,7 +153,13 @@ function buildProvenanceHeader({ handle, event, ticketId, trunkOid, trunkDate, g
 	const based = day(trunkDate);
 	if (oid || based) {
 		const base = [oid ? oid.slice(0, SHORT_OID_LENGTH) : null, based].filter(Boolean).join(', ');
-		lines.push(`# Base: trunk @ ${base}`);
+		// A base the app worked out rather than recorded is still worth naming —
+		// a mentor with no commit at all has nothing to apply this against — but
+		// it is named as the guess it is (#308). Read as fact, it would send
+		// someone rebasing onto a commit this ticket may never have been on.
+		lines.push(baseApproximate
+			? `# Base: trunk @ ${base} (approximate — this ticket's starting point was not recorded)`
+			: `# Base: trunk @ ${base}`);
 	}
 
 	const generated = day(generatedAt);

--- a/src/pr-files.cjs
+++ b/src/pr-files.cjs
@@ -71,16 +71,23 @@ function isProbablyBinary(buf) {
 }
 
 /**
- * The mode git recorded for one path in one commit, read by walking that
- * path's trees rather than the whole commit: a full walk of wordpress-develop
- * is tens of thousands of entries to answer a question about five files.
+ * The tree entry git recorded for one path in one commit — its blob oid and
+ * its mode — read by walking that path's trees rather than the whole commit: a
+ * full walk of wordpress-develop is tens of thousands of entries to answer a
+ * question about five files.
+ *
+ * Null for a path the commit does not have, which is the answer the carry
+ * (#305) reads an addition and a deletion from: the tree, not the bytes, is
+ * what says whether a file was there. `type` rides along so a caller can tell
+ * "not there" from "there, but it is a directory" — two answers a carry has to
+ * act on differently and only one of which is absence.
  *
  * @param {Object} deps     `{ git, fs, dir }`
  * @param {string} oid
  * @param {string} filepath
- * @return {Promise<string|null>}
+ * @return {Promise<{oid: string, mode: string, type: string}|null>}
  */
-async function modeInCommit(deps, oid, filepath) {
+async function entryInCommit(deps, oid, filepath) {
 	const { git, fs, dir } = deps;
 	const { commit } = await git.readCommit({ fs, dir, oid });
 	let treeOid = commit.tree;
@@ -89,10 +96,31 @@ async function modeInCommit(deps, oid, filepath) {
 		const { tree } = await git.readTree({ fs, dir, oid: treeOid });
 		const entry = tree.find((e) => e.path === segments[i]);
 		if (!entry) return null;
-		if (i === segments.length - 1) return entry.mode;
+		if (i === segments.length - 1) return { oid: entry.oid, mode: entry.mode, type: entry.type };
+		// A file where the path expects a directory: the commit does not have
+		// `a/b` when `a` is a blob. Answering null says so; descending would hand
+		// `readTree` a blob oid, and the throw that follows is indistinguishable
+		// from a damaged object store — which the carry (#305) has to treat as a
+		// refusal rather than as absence.
+		if (entry.type !== 'tree') return null;
 		treeOid = entry.oid;
 	}
 	return null;
+}
+
+/**
+ * The mode git recorded for one *file* in one commit. A directory where the
+ * caller asked about a file is not that file, and answering with a tree's mode
+ * would put `040000` on a pull request's blob entry.
+ *
+ * @param {Object} deps     `{ git, fs, dir }`
+ * @param {string} oid
+ * @param {string} filepath
+ * @return {Promise<string|null>}
+ */
+async function modeInCommit(deps, oid, filepath) {
+	const entry = await entryInCommit(deps, oid, filepath);
+	return entry && entry.type === 'blob' ? entry.mode : null;
 }
 
 /**
@@ -177,6 +205,7 @@ module.exports = {
 	GIT_MODE_EXECUTABLE,
 	isProbablyBinary,
 	blobSha,
+	entryInCommit,
 	modeInCommit,
 	fileModeForEntry,
 	buildPullRequestEntries

--- a/src/preload.js
+++ b/src/preload.js
@@ -178,6 +178,11 @@ contextBridge.exposeInMainWorld('api', {
 ,
 	hasUnsubmittedWork: (sitePath) => ipcRenderer.invoke('git:unsubmitted-work', sitePath)
 ,
+	// Whether this ticket is still on the trunk it was born from (#305). Read
+	// only: it moves nothing, and it is cheap unless trunk really has moved past
+	// the ticket's branch point.
+	carryStatus: (sitePath) => ipcRenderer.invoke('git:carry-status', sitePath)
+,
 	discardChanges: (sitePath) => ipcRenderer.invoke('git:discard-changes', sitePath)
 ,
 	discardToBase: (sitePath) => ipcRenderer.invoke('git:discard-to-base', sitePath)

--- a/src/renderer/applied-layer.cjs
+++ b/src/renderer/applied-layer.cjs
@@ -26,6 +26,8 @@
 // directly, and neither needs a DOM.
 'use strict';
 
+const { baseIsApproximate, UNRECORDED_CLEAR_NOTE, UNRECORDED_MEASUREMENT_NOTE } = require('./ticket-base.cjs');
+
 // Saving a copy and then discarding is a recommendable way forward on this
 // project, not a defeat: a ticket's changes are one afternoon's work on a
 // checkout that gets thrown away, and redoing them is cheaper than untangling
@@ -200,4 +202,33 @@ function absorbedExitFailure({ patchSaveError = '', discardError = '' } = {}) {
 	return { message: '' };
 }
 
-module.exports = { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };
+/**
+ * The whole block above Apply: whose work a new patch would land on (#306), and
+ * how sure the app is of the base that was measured from (#308).
+ *
+ * The two were separate blocks that replaced each other, which is a choice
+ * neither of them should win: the attribution owns the file list, and the base
+ * is what says how much that list can be trusted. On an unrecorded base it can
+ * name files the contributor never touched and miss ones they did, so the
+ * sentences carry the hedge rather than standing unqualified.
+ *
+ * With nothing colliding the hedge is all that is left, and it is said quietly:
+ * "nothing collided" is not a promise an approximate base can make, but it is
+ * not an alert either.
+ *
+ * @param {Object}   [root0]
+ * @param {string[]} [root0.conflicts]    Files the incoming patch touches that the ticket has work in.
+ * @param {?Object}  [root0.appliedPatch] The layer record, when one is applied.
+ * @param {?string}  [root0.baseStatus]   A `BASE_STATUS` value from the preview.
+ * @return {?{level: 'warning'|'note', sentences: string[]}}
+ */
+function describePreviewNotice({ conflicts = [], appliedPatch = null, baseStatus = null } = {}) {
+	const { sentences } = attributeConflicts({ conflicts, appliedPatch });
+	const approximate = baseIsApproximate(baseStatus);
+	if (sentences.length) {
+		return { level: 'warning', sentences: approximate ? sentences.concat(UNRECORDED_MEASUREMENT_NOTE) : sentences };
+	}
+	return approximate ? { level: 'note', sentences: [UNRECORDED_CLEAR_NOTE] } : null;
+}
+
+module.exports = { attributeConflicts, describeAppliedLayer, describePreviewNotice, absorbedExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };

--- a/src/renderer/applied-layer.cjs
+++ b/src/renderer/applied-layer.cjs
@@ -1,0 +1,203 @@
+// What the app says about the one patch a ticket has applied (#306).
+//
+// A ticket is a branch (#108): trunk, plus at most one applied patch or pull
+// request, plus the contributor's own edits. The branch holds that faithfully.
+// What the app *said* about it did not — the applied patch was remembered as an
+// undo blob, so every file it brought was announced as the contributor's own
+// writing, and "can this be reverted" meant no more than "we kept the text".
+//
+// Two answers live here, both pure:
+//
+//   - `attributeConflicts` — whose changes are the ones a new patch would land
+//     on. A file only the applied layer touched is named as the layer's; a file
+//     the contributor has also edited over keeps naming their work, because that
+//     is the one that decides what they do next.
+//   - `describeAppliedLayer` — the banner's two faces. While the layer still
+//     comes out cleanly, Revert is offered. Once the contributor's edits sit on
+//     its lines it is **absorbed**: it has become their changes, and the honest
+//     exits are saving a copy and discarding the ticket to its base.
+//
+// Absorption is measured, never tracked — the main process re-answers it on
+// every status read, so undoing the overlapping edit brings Revert back on its
+// own. And it never frees the one-patch slot: the record survives as provenance.
+//
+// Pure and dependency-free like update-plan.cjs and apply-conflict.cjs, for the
+// same reason: the renderer bundle imports it, `node --test` requires it
+// directly, and neither needs a DOM.
+'use strict';
+
+// Saving a copy and then discarding is a recommendable way forward on this
+// project, not a defeat: a ticket's changes are one afternoon's work on a
+// checkout that gets thrown away, and redoing them is cheaper than untangling
+// them. Said once, here, so both faces that offer it say it the same way.
+const DISPOSABLE_EXIT = 'Save a copy of your work first and the ticket is safe to discard back to its base — on this project that is a normal way forward, not a lost afternoon.';
+
+// The slot does not open when a patch is absorbed. Saying so is what stops the
+// contributor reading "it is part of your changes now" as "so I can apply
+// another one".
+const SLOT_HELD = 'It still counts as this ticket\'s one applied patch, so another cannot be applied until this ticket is reverted or discarded.';
+
+/**
+ * `a`, `a and b`, `a, b and c` — a list a person reads rather than a join.
+ *
+ * @param {string[]} items
+ * @return {string}
+ */
+function listOf(items) {
+	if (items.length <= 1) return items[0] || '';
+	return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
+/**
+ * The paths of an applied layer whose lines the contributor has edited over.
+ *
+ * @param {?Object} appliedPatch
+ * @return {string[]}
+ */
+function absorbedPaths(appliedPatch) {
+	const list = appliedPatch && Array.isArray(appliedPatch.absorbed) ? appliedPatch.absorbed : [];
+	return list.map((entry) => (typeof entry === 'string' ? entry : entry && entry.path)).filter(Boolean);
+}
+
+/**
+ * Who owns each file a patch about to be applied would land on.
+ *
+ * The pre-apply warning exists to say "your work is here, and this could fail
+ * without touching it". Counting the applied layer's files as the contributor's
+ * own writing is the kind of wrong that teaches people to ignore the warning —
+ * so both are named, separately, and neither is dropped.
+ *
+ * The measurement behind `absorbed` is per-region: a file is the layer's when
+ * the layer's own lines are untouched. A contributor edit *elsewhere* in the
+ * same file therefore reads as the layer's rather than as theirs. The file is
+ * still named and the "fails without touching anything" caveat still covers it,
+ * so the warning does not go quiet — it is the attribution that is coarse, and
+ * only in that direction.
+ *
+ * @param {Object}   root0
+ * @param {string[]} [root0.conflicts]    Paths from the preview's plan.
+ * @param {?Object}  [root0.appliedPatch] The status record, or null.
+ * @return {{yours: string[], fromLayer: string[], sentences: string[]}}
+ */
+function attributeConflicts({ conflicts = [], appliedPatch = null } = {}) {
+	const paths = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
+	const layerFiles = new Set(appliedPatch && Array.isArray(appliedPatch.files) ? appliedPatch.files : []);
+	const editedOver = new Set(absorbedPaths(appliedPatch));
+
+	const fromLayer = appliedPatch ? paths.filter((p) => layerFiles.has(p) && !editedOver.has(p)) : [];
+	const claimed = new Set(fromLayer);
+	const yours = paths.filter((p) => !claimed.has(p));
+
+	const sentences = [];
+	if (yours.length) {
+		sentences.push(`You have your own edits to ${listOf(yours)}. Save a patch of your work first if you want a copy.`);
+	}
+	if (fromLayer.length) {
+		const label = appliedPatch.label || 'the patch you applied';
+		sentences.push(`${listOf(fromLayer)} ${fromLayer.length === 1 ? 'was' : 'were'} changed by ${label}, which you applied — not by you.`);
+	}
+	if (sentences.length) {
+		sentences.push('The patch is applied on top of those changes: it succeeds if they do not overlap, and fails without touching anything if they do.');
+	}
+	return { yours, fromLayer, sentences };
+}
+
+/**
+ * The applied-layer banner, in whichever face the checkout has earned.
+ *
+ * Three, not two, because "cannot be reverted" has two different causes and
+ * they need different sentences: a patch too large to keep a copy of was never
+ * revertable, and a patch whose lines have been edited over stopped being.
+ *
+ * `when` is passed in already formatted — the locale-dependent part is the
+ * component's, and keeping it out of here is what lets this be asserted on.
+ *
+ * @param {?Object} appliedPatch   The `site:status` record, or null.
+ * @param {Object}  [options]
+ * @param {string}  [options.when] Formatted apply time, or '' when unknown.
+ * @return {?Object}
+ */
+function describeAppliedLayer(appliedPatch, { when = '' } = {}) {
+	if (!appliedPatch) return null;
+
+	const label = appliedPatch.label || 'A patch';
+	const files = Array.isArray(appliedPatch.files) ? appliedPatch.files : [];
+	const absorbed = absorbedPaths(appliedPatch);
+	const kept = appliedPatch.kept === undefined ? Boolean(appliedPatch.revertable) : Boolean(appliedPatch.kept);
+
+	const summary = `is applied — ${files.length} file${files.length === 1 ? '' : 's'}${when ? `, ${when}` : ''}.`;
+
+	if (kept && !absorbed.length) {
+		return { label, summary, canRevert: true, absorbed: false, explanation: '', detail: [], note: '', offerCopy: false };
+	}
+
+	// Too large to have kept a copy of. Nothing about the tree changes this one,
+	// so it says so plainly and goes straight to the exit that always works.
+	if (!kept) {
+		return {
+			label,
+			summary,
+			canRevert: false,
+			absorbed: false,
+			explanation: `${label} was too large to keep a copy of for an undo, so it cannot be lifted back out on its own.`,
+			detail: [],
+			note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
+			offerCopy: true
+		};
+	}
+
+	// Absorbed: the contributor's edits are on the patch's own lines, so there
+	// is no longer a patch and an edit — there is one body of changes. Said as a
+	// state of the work rather than as a failure, and with the way back named,
+	// because undoing the overlapping edit really does bring Revert back.
+	//
+	// Not every file in the way was written over, though. One the contributor
+	// deleted outright blocks the removal just as firmly, and calling that "your
+	// edits are on its lines" would send them looking at lines that are not
+	// there — so the two get their own sentence, and either alone is enough for
+	// the revert to be off, because a revert is all or nothing.
+	const entries = (appliedPatch.absorbed || []).filter((entry) => entry && entry.path);
+	const written = entries.filter((entry) => entry.editedOver !== false).map((entry) => entry.path);
+	const gone = entries.filter((entry) => entry.editedOver === false).map((entry) => entry.path);
+
+	const reasons = [];
+	if (written.length) reasons.push(`your own edits are on the lines it brought to ${listOf(written)}`);
+	if (gone.length) reasons.push(`${listOf(gone)} ${gone.length === 1 ? 'is' : 'are'} no longer where it left ${gone.length === 1 ? 'it' : 'them'}`);
+
+	return {
+		label,
+		summary,
+		canRevert: false,
+		absorbed: true,
+		explanation: `${label} is part of your changes now and cannot be lifted back out on its own: ${listOf(reasons)}. Undo those edits and Revert comes back on its own.`,
+		detail: entries
+			.filter((entry) => entry.total)
+			.map((entry) => `${entry.path} — you have edited ${entry.failed} of the ${entry.total} change${entry.total === 1 ? '' : 's'} it brought`),
+		note: `${DISPOSABLE_EXIT} ${SLOT_HELD}`,
+		offerCopy: true
+	};
+}
+
+/**
+ * Whichever of the two absorbed exits failed, said where they were offered.
+ *
+ * Both report through state that belongs to somewhere else on screen — the
+ * changes note and the patch modal — and the absorbed banner is neither. A
+ * refusal that lands there is a button that did nothing, on the one way out
+ * this banner recommends, so it is repeated here rather than left behind.
+ *
+ * The save goes first: it is the step that makes discarding safe, and its
+ * failure is the one that must not be missed.
+ *
+ * @param {Object} root0
+ * @param {string} [root0.patchSaveError]
+ * @param {string} [root0.discardError]
+ * @return {{message: string}}
+ */
+function absorbedExitFailure({ patchSaveError = '', discardError = '' } = {}) {
+	if (patchSaveError) return { message: `The copy could not be saved: ${patchSaveError}` };
+	if (discardError) return { message: discardError };
+	return { message: '' };
+}
+
+module.exports = { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf, DISPOSABLE_EXIT, SLOT_HELD };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -30,17 +30,29 @@ const REASONS = {
 	moved: 'the code around it has changed'
 };
 
+// The same two statuses read backwards, for a revert (#306). `already-applied`
+// is derived by testing the inverse of what is being applied, so on a reverse it
+// means the *forward* hunk fits — that region's change is not in the checkout
+// any more. Rendering the forward wording there would put "already in your
+// checkout" under a headline saying the contributor has edited over it.
+const REVERT_REASONS = {
+	'already-applied': 'looks like that change is not in your checkout any more',
+	moved: 'the code around it has changed'
+};
+
 /**
  * One failing region, ready to render.
  *
- * @param {Object} region
+ * @param {Object}  region
+ * @param {boolean} [reversing] Whether the failed run was a revert.
  * @return {Object}
  */
-function describeRegion(region) {
+function describeRegion(region, reversing = false) {
+	const reasons = reversing ? REVERT_REASONS : REASONS;
 	return {
 		line: region.line,
 		status: region.status,
-		reason: REASONS[region.status] || 'it no longer fits',
+		reason: reasons[region.status] || 'it no longer fits',
 		// A line to search for, not a number to go to: the hunk's line numbers
 		// are in the patched file's coordinates and miss by the drift the patch
 		// failed on. The panel leads with this and keeps `line` as the fallback.
@@ -249,6 +261,36 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
 }
 
 /**
+ * The framing for a revert that would not come back out (#306).
+ *
+ * A revert fails for one reason: the contributor's own edits are on the lines
+ * the patch brought. There is no third party here and no rebase to ask anyone
+ * for — the patch and the edits are one body of work now, which is what
+ * absorption means. So the sentence names that, and the two ways forward are
+ * undoing the overlapping edits, or saving a copy and discarding the ticket to
+ * its base, which on this project is a normal step rather than a defeat.
+ *
+ * Regions are kept, unlike the pull-request framing: these lines are the
+ * contributor's own, so pointing at them is pointing at their work.
+ *
+ * @param {Array}  conflicts
+ * @param {string} label
+ * @return {{headline: string, advice: string, prButton: ?string}}
+ */
+function revertFraming(conflicts, label) {
+	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
+	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
+	const files = conflicts.length;
+	const where = files === 1 ? '' : `, across ${files} files`;
+
+	return {
+		headline: `${label} cannot be lifted back out on its own: your own edits are on ${failed} of its ${total} change${total === 1 ? '' : 's'}${where}.`,
+		advice: 'It is part of your changes now. Undoing your edits on those lines brings Revert back; otherwise save a copy of your work and discard the ticket to its base — on this project that is a normal way forward, not a lost afternoon.',
+		prButton: null
+	};
+}
+
+/**
  * Everything the panel needs to explain a failed apply, or null when there is
  * nothing to explain.
  *
@@ -273,9 +315,10 @@ function prFraming(conflicts, prState, ownWorkPaths = []) {
  * @param {?string}  [options.prState]         Its state, when known.
  * @param {string[]} [options.ownWorkPaths]    Files this ticket has work in, from
  *                                             the preview's collision list (#303).
+ * @param {?string}  [options.reverting]       Label of the layer being reverted.
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [] } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [], reverting = null } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -285,7 +328,10 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	// the panel keeps rendering it exactly as it did before.
 	if (!failures.length && !conflicts.length) return null;
 
-	const fromPr = Boolean(prUrl);
+	// A revert is never "someone else's patch does not fit": it is the
+	// contributor's own edits sitting on lines they applied. The pull-request
+	// framing would send them to an author who has nothing to do with it.
+	const fromPr = Boolean(prUrl) && !reverting;
 
 	// Each conflict is consumed as it is matched, not looked up in a map: a
 	// concatenated patch can fail the same file twice with the identical
@@ -304,7 +350,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 			failed: conflict.regions.length,
 			// For a pull request the regions are the author's problem; the file
 			// row with its counts is the whole story the contributor needs.
-			regions: fromPr ? [] : conflict.regions.map(describeRegion)
+			regions: fromPr ? [] : conflict.regions.map((region) => describeRegion(region, Boolean(reverting)))
 		};
 	});
 
@@ -314,9 +360,13 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	let advice = '';
 	let prButton = fromPr ? 'Open the pull request' : null;
 	if (conflicts.length) {
-		const framing = fromPr
-			? prFraming(conflicts, prState, ownWorkPaths)
-			: { headline: headlineFor(conflicts), advice: '', prButton: null };
+		// A failed revert is never the pull request having gone stale, so it is
+		// asked first: the only thing that stops a layer coming back out is the
+		// contributor's own work sitting on its lines (#306).
+		let framing;
+		if (reverting) framing = revertFraming(conflicts, reverting);
+		else if (fromPr) framing = prFraming(conflicts, prState, ownWorkPaths);
+		else framing = { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;
 		prButton = framing.prButton;
@@ -325,13 +375,17 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 		headline,
 		advice,
 		items,
+		// The absorbed exit, for the panel to offer alongside the sentence. Only
+		// a revert has one: every other failure left the checkout untouched, so
+		// there is nothing to save a copy of that is not already safe.
+		offerDiscardToBase: Boolean(reverting) && conflicts.length > 0,
 		// Both are offered only when they lead somewhere, the way open-failure.cjs
 		// withholds its picker: a way out that returns to the same dead end is
 		// worse than no button, because it costs a click to find that out.
-		offerOtherPatches: othersAvailable > 0,
+		offerOtherPatches: !reverting && othersAvailable > 0,
 		prUrl: prUrl && prButton ? prUrl : null,
 		prButton
 	};
 }
 
-module.exports = { describeApplyFailure, headlineFor, otherPatchCount, REASONS };
+module.exports = { describeApplyFailure, headlineFor, otherPatchCount, revertFraming, REASONS, REVERT_REASONS };

--- a/src/renderer/apply-conflict.cjs
+++ b/src/renderer/apply-conflict.cjs
@@ -106,6 +106,33 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
 		+ attachments.filter((att) => att.filename !== failedLabel).length;
 }
 
+// How many paths a sentence will name before it starts counting instead. The
+// panel already lists every failing file underneath, so the headline's job is
+// the attribution, not the inventory — and a pull request failing in a dozen
+// files would otherwise open the notice with a paragraph of paths. Same reason
+// `REGION_DETAIL_LIMIT` exists in patch-apply.js.
+const PATH_NAME_LIMIT = 3;
+
+/**
+ * The files on one side of the failure, named for a sentence.
+ *
+ * Deduplicated because a concatenated patch can fail the same file twice — the
+ * same reason `describeApplyFailure` consumes conflicts one by one instead of
+ * keying them by path.
+ *
+ * @param {Array} rows Conflicts.
+ * @return {{count: number, text: string}}
+ */
+function namePaths(rows) {
+	const paths = [...new Set(rows.map((c) => c.path))];
+	if (paths.length <= PATH_NAME_LIMIT) return { count: paths.length, text: paths.join(', ') };
+	const rest = paths.length - PATH_NAME_LIMIT;
+	return {
+		count: paths.length,
+		text: `${paths.slice(0, PATH_NAME_LIMIT).join(', ')} and ${rest} more file${rest === 1 ? '' : 's'}`
+	};
+}
+
 /**
  * The pull-request framing: whose problem this is, and how big.
  *
@@ -127,11 +154,26 @@ function otherPatchCount({ label, prs = [], attachments = [] } = {}) {
  * merge would settle — close enough to size the problem, not a claim GitHub
  * will show the identical number.
  *
- * @param {Array}   conflicts
- * @param {?string} prState   'open' | 'merged' | 'closed' | null when unknown.
+ * That same missing base is why `ownWorkPaths` is here (#303). Matching two-way
+ * cannot prove which side a single failed region belongs to, so the framing used
+ * to answer from the pull request's state alone: open meant stale, always. On a
+ * ticket someone has come back to, the ordinary reason a change will not fit is
+ * the contributor's own work sitting in the same file — and sending them to ask
+ * a stranger for a rebase that would not help is worse than saying nothing.
+ *
+ * The app cannot prove the region, but it knows the file: `ownWorkPaths` is the
+ * preview's own collision list, the files this ticket has work in measured from
+ * its base (#301). A file on that list gets the collision named for what it is
+ * and the ways out that are the contributor's own; a file off it keeps the
+ * stale-pull-request framing. When both are present the notice says both, since
+ * choosing one would be guessing again.
+ *
+ * @param {Array}    conflicts
+ * @param {?string}  prState        'open' | 'merged' | 'closed' | null when unknown.
+ * @param {string[]} [ownWorkPaths] Files this ticket has its own work in.
  * @return {{headline: string, advice: string, prButton: ?string}}
  */
-function prFraming(conflicts, prState) {
+function prFraming(conflicts, prState, ownWorkPaths = []) {
 	const failed = conflicts.reduce((sum, c) => sum + c.regions.length, 0);
 	const total = conflicts.reduce((sum, c) => sum + c.total, 0);
 	const allApplied = conflicts.every((c) => c.regions.every((r) => r.status === 'already-applied'));
@@ -151,7 +193,10 @@ function prFraming(conflicts, prState) {
 		};
 	}
 
-	const files = conflicts.length;
+	// Distinct files, not conflict rows: a concatenated patch can fail the same
+	// file twice, and the sentences below go on to name the files, so counting
+	// the rows would have the count disagreeing with the list beside it.
+	const files = new Set(conflicts.map((c) => c.path)).size;
 	const scale = `${failed} of its ${total} change${total === 1 ? '' : 's'}, in ${files} file${files === 1 ? '' : 's'},`;
 
 	// A closed pull request has no author coming back to it: asking for a
@@ -165,9 +210,40 @@ function prFraming(conflicts, prState) {
 		};
 	}
 
+	const own = new Set(ownWorkPaths);
+	const mine = namePaths(conflicts.filter((c) => own.has(c.path)));
+	const theirs = namePaths(conflicts.filter((c) => !own.has(c.path)));
+	const REBASE_IS_THEIRS = 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.';
+	// A ticket's changes are cheap to redo and expensive to untangle, so keeping
+	// a copy and starting clean is a recommended way forward here, not a defeat.
+	// What must never happen is work going quietly; going on purpose, with the
+	// copy already saved, is a good outcome.
+	const YOUR_WORK_WAY_OUT = 'Save a patch of your work first to keep a copy. Then apply this on a ticket that does not have that work, or discard it here once the copy is saved.';
+
+	// Every failing file is one this ticket has work in, so nothing here is the
+	// pull request being behind trunk, and there is no rebase to ask anyone for.
+	// The pull request is still worth opening — reading it is how the
+	// contributor decides whether to start a clean ticket for it — so the button
+	// stays and only the ask goes.
+	if (!theirs.count) {
+		return {
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way, in ${mine.text}.`,
+			advice: `This is your work meeting the pull request, not a pull request that has gone stale, so asking its author for a rebase would not help. ${YOUR_WORK_WAY_OUT}`,
+			prButton: 'Open the pull request'
+		};
+	}
+
+	if (mine.count) {
+		return {
+			headline: `This pull request does not fit your checkout: ${scale} would need rework. Your own work is in the way in ${mine.text}. The rest is the pull request being behind trunk: ${theirs.text}.`,
+			advice: `${REBASE_IS_THEIRS} Your own files are yours to sort out. ${YOUR_WORK_WAY_OUT}`,
+			prButton: 'Ask its author for a rebase'
+		};
+	}
+
 	return {
 		headline: `This pull request was written against an older trunk and no longer fits it: ${scale} would need rework.`,
-		advice: 'Bringing it up to date is its author\'s work — a rebase, or merging trunk in. Leaving a comment on the pull request to let them know is a real contribution in itself.',
+		advice: REBASE_IS_THEIRS,
 		prButton: 'Ask its author for a rebase'
 	};
 }
@@ -190,14 +266,16 @@ function prFraming(conflicts, prState) {
  * folder, a file to add that already exists) as well as the conflict that could
  * not be broken down.
  *
- * @param {Object}  result                    The apply payload from main.
- * @param {Object}  [options]
- * @param {number}  [options.otherPatchCount] Other patches on this ticket.
- * @param {?string} [options.prUrl]           The failing patch's pull request.
- * @param {?string} [options.prState]         Its state, when known.
+ * @param {Object}   result                    The apply payload from main.
+ * @param {Object}   [options]
+ * @param {number}   [options.otherPatchCount] Other patches on this ticket.
+ * @param {?string}  [options.prUrl]           The failing patch's pull request.
+ * @param {?string}  [options.prState]         Its state, when known.
+ * @param {string[]} [options.ownWorkPaths]    Files this ticket has work in, from
+ *                                             the preview's collision list (#303).
  * @return {?Object}
  */
-function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null } = {}) {
+function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, prUrl = null, prState = null, ownWorkPaths = [] } = {}) {
 	if (!result || result.ok) return null;
 
 	const failures = Array.isArray(result.failures) ? result.failures : [];
@@ -237,7 +315,7 @@ function describeApplyFailure(result, { otherPatchCount: othersAvailable = 0, pr
 	let prButton = fromPr ? 'Open the pull request' : null;
 	if (conflicts.length) {
 		const framing = fromPr
-			? prFraming(conflicts, prState)
+			? prFraming(conflicts, prState, ownWorkPaths)
 			: { headline: headlineFor(conflicts), advice: '', prButton: null };
 		headline = framing.headline;
 		advice = framing.advice;

--- a/src/renderer/carry-note.cjs
+++ b/src/renderer/carry-note.cjs
@@ -1,0 +1,230 @@
+// What the app says about a ticket still sitting on the trunk it was born from
+// (#305).
+//
+// The site moves; the ticket does not. "Update to latest trunk" parks the
+// ticket, moves trunk and resets the worktree, and leaves every ticket branch
+// exactly where it was — deliberately, because a ticket's diff base has to stay
+// fixed. The gap that opens is invisible today, and it is the reason a
+// contributor who follows every piece of staleness advice the app gives still
+// watches pull requests fail to apply.
+//
+// Two things are said here, both pure:
+//
+//   - `describeCarryNote` — the ticket card's sentence. Not an alert: nothing is
+//     broken yet, and a ticket that is a day behind is fine. It names the gap,
+//     what it will cost, and that there is an action.
+//   - `describeCarryOffer` — the offer itself, once the contributor asks. It
+//     says how many files come across untouched, how many trunk has also
+//     changed, and — before anything moves — which ones cannot come at all.
+//
+// Nothing here decides anything about the repository: the classification is
+// src/ticket-carry.js's answer and arrives already made. This is the rendering
+// of it, kept out of index.jsx so it can be asserted (see the invariant in
+// AGENTS.md's review standard), and pure and dependency-light like
+// update-plan.cjs and applied-layer.cjs.
+'use strict';
+
+const { listOf } = require('./applied-layer.cjs');
+
+/**
+ * How sure the app is that trunk has moved past this ticket.
+ *
+ * - `current` — the ticket is on the trunk the site has, or on a newer one.
+ *               Nothing to offer.
+ * - `behind`  — trunk has moved on, and the carry can be offered.
+ * - `unknown` — a commit that would not read: a site adopted from disk, a
+ *               registry naming an object this clone never had. Nothing is
+ *               offered, and nothing is claimed either.
+ *
+ * Here rather than in src/ticket-carry.js for the reason BASE_STATUS lives in
+ * ticket-base.cjs: the renderer bundle reads these, and it must not pull
+ * `isomorphic-git` in behind them.
+ */
+const CARRY_STATE = {
+	CURRENT: 'current',
+	BEHIND: 'behind',
+	UNKNOWN: 'unknown'
+};
+
+/** Why one path cannot be carried. Same list, same reason for living here. */
+const REFUSAL = {
+	/** Upstream deleted the file this ticket has edits in. */
+	UPSTREAM_DELETED: 'upstream-deleted',
+	/** Both sides created the same path. */
+	ADDED_BOTH: 'added-both',
+	/** The ticket deleted a file upstream has since changed. */
+	DELETED_BUT_CHANGED: 'deleted-but-changed',
+	/** Both sides changed the same binary file, which nothing can reconcile. */
+	BINARY_CONFLICT: 'binary-conflict',
+	/** The app could not read the file, so it cannot reproduce its bytes. */
+	UNREADABLE: 'unreadable'
+};
+
+// Why staying behind is the worse option, said in the contributor's terms
+// rather than git's. This is the whole argument for the feature and it is said
+// once, here, so the card and the offer cannot drift into two versions of it.
+const WHY_NOT_STAY = 'A ticket on an older trunk keeps failing to apply the patches and pull requests you came here to test, and the gap only widens.';
+
+// The app never silently rebases anyone (#309). The offer says so out loud,
+// because "bring this up to date" is otherwise indistinguishable from the
+// destructive buttons next to it.
+const NOTHING_MOVES_YET = 'Nothing moves until you accept, and your work stays exactly where it is if any of it cannot come across.';
+
+/**
+ * `3 files` / `1 file`.
+ *
+ * @param {number} n
+ * @param {string} [noun]
+ * @return {string}
+ */
+function plural(n, noun = 'file') {
+	return `${n} ${noun}${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * The sentence one refusal reason deserves. Each is a different thing to do
+ * next, which is why they are not one line with a file list appended.
+ *
+ * @param {string}   reason A `REFUSAL` value.
+ * @param {string[]} paths
+ * @return {string}
+ */
+function refusalSentence(reason, paths) {
+	const names = listOf(paths);
+	const many = paths.length > 1;
+	if (reason === REFUSAL.UPSTREAM_DELETED) {
+		return `Trunk has deleted ${names}, which this ticket has work in — bringing ${many ? 'them' : 'it'} forward would put back ${many ? 'files' : 'a file'} that no longer exist${many ? '' : 's'} upstream.`;
+	}
+	if (reason === REFUSAL.ADDED_BOTH) {
+		return `${names} ${many ? 'were' : 'was'} added both by this ticket and by trunk, so there is no version of ${many ? 'them' : 'it'} to carry onto.`;
+	}
+	if (reason === REFUSAL.DELETED_BUT_CHANGED) {
+		return `This ticket deletes ${names}, and trunk has changed ${many ? 'them' : 'it'} since — carrying the deletion forward would throw that work away.`;
+	}
+	if (reason === REFUSAL.BINARY_CONFLICT) {
+		return `${names} ${many ? 'are' : 'is'} binary and both this ticket and trunk changed ${many ? 'them' : 'it'} — there is no way to combine the two.`;
+	}
+	return `${names} could not be read, so ${many ? 'their' : 'its'} contents cannot be reproduced on the new trunk.`;
+}
+
+/**
+ * The refusals, grouped by reason and in a fixed order so the same set of files
+ * always reads the same way.
+ *
+ * @param {Array<{path: string, reason: string}>} refused
+ * @return {string[]}
+ */
+function refusalSentences(refused) {
+	const order = [
+		REFUSAL.UPSTREAM_DELETED,
+		REFUSAL.DELETED_BUT_CHANGED,
+		REFUSAL.ADDED_BOTH,
+		REFUSAL.BINARY_CONFLICT,
+		REFUSAL.UNREADABLE
+	];
+	return order
+		.map((reason) => ({ reason, paths: refused.filter((entry) => entry.reason === reason).map((entry) => entry.path) }))
+		.filter((group) => group.paths.length)
+		.map((group) => refusalSentence(group.reason, group.paths));
+}
+
+/**
+ * The ticket card's note, or null when there is nothing to say.
+ *
+ * Deliberately quiet. A ticket linked this morning against a trunk that moved
+ * this afternoon is in perfectly good shape, and an alert there would teach the
+ * contributor to ignore the one that matters. What it must not do is stay
+ * silent: today the gap is invisible, and the failures it causes get blamed on
+ * the pull request's author instead (#303).
+ *
+ * @param {Object} [root0]
+ * @param {string} [root0.state] A `CARRY_STATE` value.
+ * @param {string} [root0.since] Formatted date of the ticket's base, or ''.
+ * @return {?{level: string, text: string, actionLabel: string}}
+ */
+function describeCarryNote({ state = CARRY_STATE.CURRENT, since = '' } = {}) {
+	if (state !== CARRY_STATE.BEHIND) return null;
+	return {
+		level: 'note',
+		text: `This ticket started from ${since ? `trunk as of ${since}` : 'an older trunk'}, and the site has moved on since. ${WHY_NOT_STAY}`,
+		actionLabel: 'Bring this ticket up to date'
+	};
+}
+
+/**
+ * The offer, in full, once the contributor asks what the action would do.
+ *
+ * The file counts are the point of it. "Which file collided" is what a
+ * patch-based carry could have said; this can say how many files come across
+ * exactly as they are, how many trunk has also edited, and which one would no
+ * longer take the ticket's change — before anything is touched.
+ *
+ * `canCarry` is false when anything is refused, and the refusals are named
+ * rather than counted: each one is a different decision for the contributor.
+ *
+ * @param {Object}   [root0]
+ * @param {string}   [root0.state]        A `CARRY_STATE` value.
+ * @param {string[]} [root0.wholesale]    Paths upstream has not touched.
+ * @param {string[]} [root0.merge]        Paths trunk has also changed.
+ * @param {string[]} [root0.settled]      Paths trunk has already changed the same way.
+ * @param {Array}    [root0.refused]      `{ path, reason }` per refusal.
+ * @param {?Object}  [root0.appliedPatch] The applied layer (#306), when there is one.
+ * @param {string}   [root0.since]        Formatted date of the ticket's base, or ''.
+ * @return {?Object}
+ */
+function describeCarryOffer({ state = CARRY_STATE.CURRENT, wholesale = [], merge = [], settled = [], refused = [], appliedPatch = null, since = '' } = {}) {
+	if (state !== CARRY_STATE.BEHIND) return null;
+
+	const total = wholesale.length + merge.length + settled.length + refused.length;
+	const blocked = refusalSentences(refused);
+	const sentences = [];
+
+	if (!total) {
+		// The base moves and nothing else happens. Worth offering anyway: this is
+		// the ticket that has been read but not edited, and leaving it behind
+		// costs the contributor the next patch that will not apply.
+		sentences.push(`This ticket has no work on it yet, so bringing it up to date only moves the trunk it is measured against${since ? ` — it is still on trunk as of ${since}` : ''}.`);
+	} else {
+		const parts = [];
+		if (wholesale.length) parts.push(`${plural(wholesale.length)} come${wholesale.length === 1 ? 's' : ''} across exactly as ${wholesale.length === 1 ? 'it is' : 'they are'}`);
+		if (merge.length) parts.push(`${plural(merge.length)} trunk has also changed, so your change is replayed onto ${merge.length === 1 ? 'its' : 'their'} new version`);
+		// Named rather than folded into the wholesale count: trunk having already
+		// done what the ticket did is a fact about the ticket's work, and a
+		// contributor who deleted a file wants to know upstream deleted it too.
+		if (settled.length) parts.push(`${plural(settled.length)} trunk has already removed as well, so there is nothing left to carry for ${settled.length === 1 ? 'it' : 'them'}`);
+		if (parts.length) sentences.push(`Of the ${plural(total)} this ticket has work in, ${listOf(parts)}.`);
+	}
+
+	if (appliedPatch && appliedPatch.label) {
+		sentences.push(appliedPatch.revertable
+			? `${appliedPatch.label} is lifted out first so your own edits move on their own, then put back on top.`
+			: `${appliedPatch.label} is part of your changes now, so it moves with them as one.`);
+	}
+
+	if (blocked.length) {
+		sentences.push('This cannot go ahead as it stands:');
+	} else {
+		sentences.push(NOTHING_MOVES_YET);
+	}
+
+	return {
+		canCarry: blocked.length === 0,
+		headline: 'Bring this ticket up to date',
+		sentences,
+		blocked,
+		why: WHY_NOT_STAY,
+		confirmLabel: 'Bring it up to date',
+		cancelLabel: 'Leave it as it is'
+	};
+}
+
+module.exports = {
+	CARRY_STATE,
+	REFUSAL,
+	WHY_NOT_STAY,
+	NOTHING_MOVES_YET,
+	refusalSentence,
+	refusalSentences,
+	describeCarryNote,
+	describeCarryOffer
+};

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,6 +30,7 @@ import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
+import { describeOwnWorkWarning } from './ticket-base.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -98,6 +99,15 @@ const UPDATE_STEP_LABELS = {
 const UPDATE_STEP_MARKS = {
   complete: { symbol: '✓', color: '#0f5132' },
   current: { symbol: '›', color: '#0b5d95' }
+};
+// How the preview renders what it has to say about the contributor's own work
+// (#308). `warning` is the amber block that has always been there — a patch is
+// about to land on files someone edited. `note` is the quieter case: nothing
+// collided, but the base it was measured against was approximate, so the
+// silence needs a sentence rather than an alert.
+const OWN_WORK_NOTICE_STYLES = {
+  warning: { role: 'alert', style: { marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' } },
+  note: { role: undefined, style: { marginTop: 10, fontSize: 12, color: '#6c6f72' } }
 };
 // The file manager has a name on the two platforms that have one; everywhere
 // else it is whatever the desktop provides, so it is called what it is.
@@ -2728,6 +2738,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   });
   const applySteps = planApplySteps({ needsInstall: applyNeedsInstall, buildByWatcher: applyBuildByWatcher });
   const applyStepStates = updateStepStatuses(applySteps, applyState, APPLY_STATE_TO_STEP);
+  // What the preview says about the contributor's own work, and how confidently
+  // — the preview carries the status of the base it was measured against (#308).
+  const applyOwnWorkNotice = applyPreview ? describeOwnWorkWarning(applyPreview) : null;
 
   // --- Initial setup, as one chain (#246) ---
   // The third chain, and the only one nobody starts: between the clone, the
@@ -4725,9 +4738,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div style={{ marginTop: 8, fontFamily: 'monospace', fontSize: 12, color: '#3c434a', lineHeight: 1.7, overflowWrap: 'anywhere', maxHeight: 140, overflowY: 'auto' }}>
                 {applyPreview.paths.map((p) => <div key={p}>{p}</div>)}
               </div>
-              {applyPreview.conflicts.length ? (
-                <div role="alert" style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
-                  You have your own edits to {applyPreview.conflicts.join(', ')}. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.
+              {applyOwnWorkNotice ? (
+                <div role={OWN_WORK_NOTICE_STYLES[applyOwnWorkNotice.level].role} style={OWN_WORK_NOTICE_STYLES[applyOwnWorkNotice.level].style}>
+                  {applyOwnWorkNotice.text}
                 </div>
               ) : null}
               {applyPreview.unsupported.length ? (

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -31,6 +31,7 @@ import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
 import { describeAppliedLayer, describePreviewNotice, absorbedExitFailure } from './applied-layer.cjs';
+import { describeCarryNote } from './carry-note.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -1233,6 +1234,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // The unsubmitted-changes note. Null until the first probe answers, so a
   // card never opens on a note that a clean tree then takes away.
   const [worktreeDirty, setWorktreeDirty] = useState(null);
+  // Whether this ticket is still on the trunk it was born from (#305). Null
+  // until the first probe answers, for the same reason the note above is: a
+  // sentence that appears and then withdraws itself reads as a glitch.
+  const [carry, setCarry] = useState(null);
   const [discarding, setDiscarding] = useState(false);
   const [discardError, setDiscardError] = useState(null);
   const [handleInput, setHandleInput] = useState('');
@@ -1711,6 +1716,41 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     } finally { probe.inFlight = false; }
   }, [sitePath]);
 
+  // The carry probe (#305). Its own call rather than a field on the note's
+  // answer: the two ask different questions of different things — one walks the
+  // worktree, this one reads two commit objects and only walks when trunk has
+  // actually moved past the ticket — and folding them would make every note
+  // refresh pay the wrong half.
+  //
+  // A failed probe leaves the last answer standing. Like the note, this is
+  // advisory: withdrawing it over a transient git error would read as the gap
+  // having closed on its own.
+  //
+  // Guarded exactly like the note's probe beside it, and for the same two
+  // reasons: on a ticket that *is* behind this walks the whole checkout, so
+  // repeated focus events would stack walks; and the answer is a sentence naming
+  // a date, so a probe still in flight for the outgoing ticket must not land on
+  // the incoming one. `generation` is what the branch change bumps to outrank it.
+  const carryProbeRef = useRef({ inFlight: false, generation: 0, again: false });
+  const refreshCarry = useCallback(async () => {
+    const probe = carryProbeRef.current;
+    if (probe.inFlight) {
+      probe.again = true;
+      return;
+    }
+    probe.inFlight = true;
+    try {
+      do {
+        probe.again = false;
+        const generation = probe.generation;
+        try {
+          const res = await window.api.carryStatus(sitePath);
+          if (res && res.ok && probe.generation === generation) setCarry(res);
+        } catch {}
+      } while (probe.again);
+    } finally { probe.inFlight = false; }
+  }, [sitePath]);
+
   // A branch change invalidates the note outright rather than staling it: the
   // count is measured from the ticket's branch point (#239), so the previous
   // ticket's answer is not an old version of this one's, it is about a
@@ -1722,7 +1762,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     dirtyProbeRef.current.generation++;
     setWorktreeDirty(null);
     refreshDirty();
-  }, [refreshDirty]);
+    // The carry answer is per ticket too — a different branch point measured
+    // against the same trunk — so the outgoing ticket's must neither stand while
+    // the incoming one's is worked out nor land on it afterwards.
+    carryProbeRef.current.generation++;
+    setCarry(null);
+    refreshCarry();
+  }, [refreshDirty, refreshCarry]);
 
   // Only the open card probes, and only while it is open: the probe walks the
   // whole checkout, which is too much to pay for every card on the shelf. The
@@ -1730,10 +1776,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // app is the moment the answer can have changed.
   useEffect(() => {
     if (!isActive) return undefined;
-    refreshDirty();
-    window.addEventListener('focus', refreshDirty);
-    return () => window.removeEventListener('focus', refreshDirty);
-  }, [isActive, refreshDirty]);
+    const probe = () => { refreshDirty(); refreshCarry(); };
+    probe();
+    window.addEventListener('focus', probe);
+    return () => window.removeEventListener('focus', probe);
+  }, [isActive, refreshDirty, refreshCarry]);
 
   // Linking and unlinking are the same write (#109): an empty ref clears the
   // association, so Unlink needs no second channel. Resuming a ticket that
@@ -2671,6 +2718,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // #12345 is news for the ticket card, one that belongs to nothing is news
   // for the buttons that would give it somewhere to go.
   const changesNote = changesNoteParts({ ...(worktreeDirty || {}), tracTicket });
+  // The date is formatted here and the sentence is built there, the same split
+  // describeAppliedLayer's `when` uses: locale formatting is the component's,
+  // and keeping it out of the module is what lets the copy be asserted.
+  const carryNote = describeCarryNote({
+    state: carry ? carry.state : undefined,
+    since: carry && carry.baseDate ? new Date(carry.baseDate).toLocaleDateString() : ''
+  });
   const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
   const updateStepStates = updateStepStatuses(updateSteps, updateState);
 
@@ -2684,6 +2738,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     resumeWatcher();
     loadStatus().catch(() => {});
     refreshDirty();
+    // The update is the one action that opens this gap: it moves trunk and
+    // leaves every ticket branch where it was (#305). Asking again here is what
+    // puts the note on the ticket the contributor is handed back, rather than
+    // the next time the window happens to regain focus.
+    refreshCarry();
   };
 
   // Steps 2 and 3 of the chain: npm install (only when the lockfile moved,
@@ -4532,6 +4591,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div style={{ marginTop: 8, fontSize: 13, color: '#1d2327' }}>
                 {changesNoteBody}
                 <div style={{ marginTop: 4, fontSize: 12, color: '#6c6f72' }}>{changesNote.unlinkNote}</div>
+              </div>
+            ) : null}
+            {carryNote ? (
+              <div style={{ marginTop: 8, padding: '8px 10px', background: '#f0f6fc', border: '1px solid #c5d9ed', borderRadius: 6, fontSize: 12, color: '#1d2327' }}>
+                {carryNote.text}
               </div>
             ) : null}
 

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,8 +30,7 @@ import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
-import { baseIsApproximate, UNRECORDED_CLEAR_NOTE } from './ticket-base.cjs';
-import { describeAppliedLayer, attributeConflicts, absorbedExitFailure } from './applied-layer.cjs';
+import { describeAppliedLayer, describePreviewNotice, absorbedExitFailure } from './applied-layer.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -2739,10 +2738,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   });
   const applySteps = planApplySteps({ needsInstall: applyNeedsInstall, buildByWatcher: applyBuildByWatcher });
   const applyStepStates = updateStepStatuses(applySteps, applyState, APPLY_STATE_TO_STEP);
-  // What the preview says about the contributor's own work, and how confidently
-  // — the preview carries the status of the base it was measured against (#308).
-  const applyOwnWorkNotice = applyPreview ? describeOwnWorkWarning(applyPreview) : null;
-
   // The applied patch as a layer with a name (#306), not an undo blob. Both
   // answers come from the same record: whether it can still be lifted out —
   // measured in main on every status read, so it comes back on its own when the
@@ -2750,8 +2745,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const appliedLayer = describeAppliedLayer(appliedPatch, {
     when: appliedPatch?.appliedAt ? new Date(appliedPatch.appliedAt).toLocaleString() : ''
   });
-  const previewAttribution = attributeConflicts({ conflicts: applyPreview?.conflicts, appliedPatch });
-  const previewBaseApproximate = Boolean(applyPreview) && baseIsApproximate(applyPreview.baseStatus);
+  // What the preview says about the contributor's own work: whose it is (#306),
+  // and how confidently, since the preview carries the status of the base it was
+  // measured against (#308).
+  const previewNotice = applyPreview
+    ? describePreviewNotice({ conflicts: applyPreview.conflicts, appliedPatch, baseStatus: applyPreview.baseStatus })
+    : null;
   // The absorbed exits reach the same two operations the changes note does, so
   // they go through the same guard: a discard is a force checkout, and running
   // it under a live dev server or a half-finished install rewrites the tree
@@ -4777,21 +4776,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div style={{ marginTop: 8, fontFamily: 'monospace', fontSize: 12, color: '#3c434a', lineHeight: 1.7, overflowWrap: 'anywhere', maxHeight: 140, overflowY: 'auto' }}>
                 {applyPreview.paths.map((p) => <div key={p}>{p}</div>)}
               </div>
-              {/* Who the colliding work belongs to (#306) is the sentence, and
-                  how sure the app is of the base it was measured from (#308)
-                  rides with it: on an unrecorded base the list can name files
-                  the contributor never touched and miss ones they did, so an
-                  unhedged sentence would overstate what was checked. With no
-                  collisions the hedge is all that is left, said quietly —
-                  "nothing collided" is not a promise an approximate base can
-                  make. */}
-              {previewAttribution.sentences.length ? (
-                <div role="alert" style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
-                  {previewAttribution.sentences.map((sentence) => <div key={sentence} style={{ marginTop: 2 }}>{sentence}</div>)}
-                  {previewBaseApproximate ? <div style={{ marginTop: 6 }}>{UNRECORDED_CLEAR_NOTE}</div> : null}
+              {previewNotice ? (
+                <div role={OWN_WORK_NOTICE_STYLES[previewNotice.level].role} style={OWN_WORK_NOTICE_STYLES[previewNotice.level].style}>
+                  {previewNotice.sentences.map((sentence) => <div key={sentence} style={{ marginTop: 2 }}>{sentence}</div>)}
                 </div>
-              ) : previewBaseApproximate ? (
-                <div style={{ marginTop: 10, fontSize: 12, color: '#6c6f72' }}>{UNRECORDED_CLEAR_NOTE}</div>
               ) : null}
               {applyPreview.unsupported.length ? (
                 <div style={{ marginTop: 10, fontSize: 12, color: '#6e5406' }}>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2996,12 +2996,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // an already-linked site would open a Trac window nobody asked for (#292).
   const autoReadTicketRef = useRef(null);
   const tracScrapeRef = useRef(null);
+  // A Trac scrape can run up to 90s. Bump a generation on every ticket change so
+  // a scrape that resolves after the ticket has moved on is dropped, rather than
+  // shown under the wrong ticket or clearing a newer request's loading flag.
+  const scrapeGenRef = useRef(0);
   useEffect(() => {
+    // Bumped first, synchronously, before anything below can trigger a scrape
+    // (#299): loadTracAttachments reads this ref at call time, so the auto-read
+    // a few lines down must never run against last ticket's generation.
+    scrapeGenRef.current += 1;
     if (!tracTicket) {
       setTicketPatches(null);
       // Attachments are per-ticket and loaded on demand; a stale list from the
       // previous ticket must not linger, and a scrape dropped by the generation
-      // bump below must not leave a stuck spinner.
+      // bump above must not leave a stuck spinner.
       setTracAttachments(null);
       setTracAttachmentsLoading(false);
       loadedTicketRef.current = null;
@@ -3010,10 +3018,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
     if (!isActive || loadedTicketRef.current === tracTicket) return;
     // A new ticket on the active site: drop any attachments the previous one
     // loaded (and clear its loading flag, so a scrape dropped by the generation
-    // bump cannot leave a stuck spinner with no button to recover), then fetch
-    // its PRs. Marked loaded before the fetch resolves, on purpose: a failed
-    // initial fetch is not retried on every re-activation (which could keep
-    // spending a rate-limited quota) — Refresh is the retry.
+    // bump above cannot leave a stuck spinner with no button to recover), then
+    // fetch its PRs. Marked loaded before the fetch resolves, on purpose: a
+    // failed initial fetch is not retried on every re-activation (which could
+    // keep spending a rate-limited quota) — Refresh is the retry.
     setTracAttachments(null);
     setTracAttachmentsLoading(false);
     loadedTicketRef.current = tracTicket;
@@ -3030,12 +3038,6 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       if (tracScrapeRef.current) tracScrapeRef.current();
     }
   }, [tracTicket, isActive, loadTicketPatches]);
-
-  // A Trac scrape can run up to 90s. Bump a generation on every ticket change so
-  // a scrape that resolves after the ticket has moved on is dropped, rather than
-  // shown under the wrong ticket or clearing a newer request's loading flag.
-  const scrapeGenRef = useRef(0);
-  useEffect(() => { scrapeGenRef.current += 1; }, [tracTicket]);
 
   // Fetches a PR's diff and drops into the same preview the file picker uses,
   // so applying a PR and applying a downloaded patch are one path from here on.

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -30,7 +30,8 @@ import { pathBasename } from './path-basename.cjs';
 import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './site-folder.cjs';
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
-import { describeOwnWorkWarning } from './ticket-base.cjs';
+import { baseIsApproximate, UNRECORDED_CLEAR_NOTE } from './ticket-base.cjs';
+import { describeAppliedLayer, attributeConflicts, absorbedExitFailure } from './applied-layer.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -2742,6 +2743,22 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // — the preview carries the status of the base it was measured against (#308).
   const applyOwnWorkNotice = applyPreview ? describeOwnWorkWarning(applyPreview) : null;
 
+  // The applied patch as a layer with a name (#306), not an undo blob. Both
+  // answers come from the same record: whether it can still be lifted out —
+  // measured in main on every status read, so it comes back on its own when the
+  // overlapping edit is undone — and whose changes the next patch would land on.
+  const appliedLayer = describeAppliedLayer(appliedPatch, {
+    when: appliedPatch?.appliedAt ? new Date(appliedPatch.appliedAt).toLocaleString() : ''
+  });
+  const previewAttribution = attributeConflicts({ conflicts: applyPreview?.conflicts, appliedPatch });
+  const previewBaseApproximate = Boolean(applyPreview) && baseIsApproximate(applyPreview.baseStatus);
+  // The absorbed exits reach the same two operations the changes note does, so
+  // they go through the same guard: a discard is a force checkout, and running
+  // it under a live dev server or a half-finished install rewrites the tree
+  // from under it. Not re-derived here — that is how a second answer starts.
+  const absorbedExitBlocked = discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding });
+  const absorbedExit = absorbedExitFailure({ patchSaveError, discardError });
+
   // --- Initial setup, as one chain (#246) ---
   // The third chain, and the only one nobody starts: between the clone, the
   // install and the build there is no decision to make, so making the
@@ -3189,24 +3206,27 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           // A conflict is where the panel used to stop: one file named, the
           // rest of the failures left in the terminal, and no sense of whether
           // one region of twenty missed or all of them. The breakdown is what
-          // turns that into a decision (#282). A reverse is left out — the
-          // patch it names came from this app and the ticket's other patches
-          // are no help against it.
-          setApplyConflict(reverse ? null : describeApplyFailure(res, {
-            otherPatchCount: otherPatchCount({
-              label: preview?.label,
-              prs: ticketPatches?.items,
-              attachments: patchAttachments
-            }),
-            prUrl: preview?.prUrl || null,
-            prState: preview?.prState || null,
-            // The preview's own collision list: the files this ticket has work
-            // in, measured from its base (#301). Without it an open pull request
-            // is always narrated as stale, so a failure caused by the
-            // contributor's own edits sends them to ask a stranger for a rebase
-            // that would not help (#303).
-            ownWorkPaths: preview?.conflicts || []
-          }));
+          // turns that into a decision (#282). A reverse gets its own framing
+          // (#306): it fails only because the contributor's own edits are on the
+          // patch's lines, so the ticket's other patches and the pull request's
+          // author are both the wrong place to send them.
+          setApplyConflict(describeApplyFailure(res, reverse
+            ? { reverting: appliedPatch?.label || 'That patch' }
+            : {
+              otherPatchCount: otherPatchCount({
+                label: preview?.label,
+                prs: ticketPatches?.items,
+                attachments: patchAttachments
+              }),
+              prUrl: preview?.prUrl || null,
+              prState: preview?.prState || null,
+              // The preview's own collision list: the files this ticket has work
+              // in, measured from its base (#301). Without it an open pull
+              // request is always narrated as stale, so a failure caused by the
+              // contributor's own edits sends them to ask a stranger for a
+              // rebase that would not help (#303).
+              ownWorkPaths: preview?.conflicts || []
+            }));
           finishApply();
           return;
         }
@@ -4714,19 +4734,38 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
             </div>
           ) : null}
 
-          {appliedPatch && !isApplying ? (
-            <div style={{ marginTop: 12, padding: '14px 16px', border: '1px solid #94d3ae', background: '#f4fbf4', borderRadius: 8 }}>
-              <div style={{ fontSize: 13, color: '#0f5132' }}>
-                <strong>{appliedPatch.label}</strong> is applied — {appliedPatch.files.length} file{appliedPatch.files.length === 1 ? '' : 's'}
-                {appliedPatch.appliedAt ? `, ${new Date(appliedPatch.appliedAt).toLocaleString()}` : ''}.
+          {appliedLayer && !isApplying ? (
+            <div style={{ marginTop: 12, padding: '14px 16px', border: `1px solid ${appliedLayer.canRevert ? '#94d3ae' : '#dba617'}`, background: appliedLayer.canRevert ? '#f4fbf4' : '#fcf9e8', borderRadius: 8 }}>
+              <div style={{ fontSize: 13, color: appliedLayer.canRevert ? '#0f5132' : '#6e5406' }}>
+                <strong>{appliedLayer.label}</strong> {appliedLayer.summary}
               </div>
+              {appliedLayer.explanation ? (
+                <div style={{ marginTop: 8, fontSize: 12, color: '#6e5406' }}>{appliedLayer.explanation}</div>
+              ) : null}
+              {appliedLayer.detail.map((line) => (
+                <div key={line} style={{ marginTop: 4, fontSize: 12, color: '#6e5406', wordBreak: 'break-all' }}>{line}</div>
+              ))}
+              {appliedLayer.note ? (
+                <div style={{ marginTop: 8, fontSize: 12, color: '#6c6f72' }}>{appliedLayer.note}</div>
+              ) : null}
               <div style={{ marginTop: 10, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                {appliedPatch.revertable ? (
+                {appliedLayer.canRevert ? (
                   <Button variant="secondary" onClick={() => runApply({ reverse: true })} disabled={isUpdating || installing || building}>Revert this patch</Button>
-                ) : (
-                  <span style={{ fontSize: 12, color: '#6c6f72' }}>Too large to undo automatically — use Update to latest trunk to reset.</span>
-                )}
+                ) : null}
+                {appliedLayer.offerCopy ? (
+                  <>
+                    <Button variant="secondary" onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
+                    <Button variant="tertiary" onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                  </>
+                ) : null}
               </div>
+              {/* Both exits report failure through state the changes note and the
+                  patch modal own, and neither is on screen here — so a save that
+                  could not write, or a discard that refused, would be a button
+                  that did nothing on the one way out this banner recommends. */}
+              {absorbedExit.message ? (
+                <div role="alert" style={{ marginTop: 8, fontSize: 12, color: '#d63638' }}>{absorbedExit.message}</div>
+              ) : null}
             </div>
           ) : null}
 
@@ -4738,10 +4777,21 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               <div style={{ marginTop: 8, fontFamily: 'monospace', fontSize: 12, color: '#3c434a', lineHeight: 1.7, overflowWrap: 'anywhere', maxHeight: 140, overflowY: 'auto' }}>
                 {applyPreview.paths.map((p) => <div key={p}>{p}</div>)}
               </div>
-              {applyOwnWorkNotice ? (
-                <div role={OWN_WORK_NOTICE_STYLES[applyOwnWorkNotice.level].role} style={OWN_WORK_NOTICE_STYLES[applyOwnWorkNotice.level].style}>
-                  {applyOwnWorkNotice.text}
+              {/* Who the colliding work belongs to (#306) is the sentence, and
+                  how sure the app is of the base it was measured from (#308)
+                  rides with it: on an unrecorded base the list can name files
+                  the contributor never touched and miss ones they did, so an
+                  unhedged sentence would overstate what was checked. With no
+                  collisions the hedge is all that is left, said quietly —
+                  "nothing collided" is not a promise an approximate base can
+                  make. */}
+              {previewAttribution.sentences.length ? (
+                <div role="alert" style={{ marginTop: 10, padding: '8px 10px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, fontSize: 12, color: '#6e5406' }}>
+                  {previewAttribution.sentences.map((sentence) => <div key={sentence} style={{ marginTop: 2 }}>{sentence}</div>)}
+                  {previewBaseApproximate ? <div style={{ marginTop: 6 }}>{UNRECORDED_CLEAR_NOTE}</div> : null}
                 </div>
+              ) : previewBaseApproximate ? (
+                <div style={{ marginTop: 10, fontSize: 12, color: '#6c6f72' }}>{UNRECORDED_CLEAR_NOTE}</div>
               ) : null}
               {applyPreview.unsupported.length ? (
                 <div style={{ marginTop: 10, fontSize: 12, color: '#6e5406' }}>
@@ -4838,8 +4888,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     <div style={{ marginTop: 8 }}>{applyConflict.advice}</div>
                   ) : null}
 
-                  {applyConflict.offerOtherPatches || applyConflict.prUrl ? (
+                  {applyConflict.offerOtherPatches || applyConflict.prUrl || applyConflict.offerDiscardToBase ? (
                     <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      {applyConflict.offerDiscardToBase ? (
+                        <>
+                          <Button variant="secondary" isSmall onClick={savePatch} disabled={absorbedExitBlocked}>Save a copy of your work</Button>
+                          <Button variant="secondary" isSmall onClick={discardAllChanges} disabled={absorbedExitBlocked}>Discard this ticket to its base</Button>
+                        </>
+                      ) : null}
                       {applyConflict.offerOtherPatches ? (
                         <Button
                           variant="secondary"
@@ -4866,6 +4922,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                         </Button>
                       ) : null}
                     </div>
+                  ) : null}
+
+                  {applyConflict.offerDiscardToBase && absorbedExit.message ? (
+                    <div style={{ marginTop: 8 }}>{absorbedExit.message}</div>
                   ) : null}
                 </div>
               ) : null}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -3186,7 +3186,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               attachments: patchAttachments
             }),
             prUrl: preview?.prUrl || null,
-            prState: preview?.prState || null
+            prState: preview?.prState || null,
+            // The preview's own collision list: the files this ticket has work
+            // in, measured from its base (#301). Without it an open pull request
+            // is always narrated as stale, so a failure caused by the
+            // contributor's own edits sends them to ask a stranger for a rebase
+            // that would not help (#303).
+            ownWorkPaths: preview?.conflicts || []
           }));
           finishApply();
           return;

--- a/src/renderer/ticket-base.cjs
+++ b/src/renderer/ticket-base.cjs
@@ -78,53 +78,21 @@ function baseUnreadableMessage(consequence) {
 	return `Could not work out which trunk to compare your work against, so ${consequence}.`;
 }
 
-// The warning as it has always read on a site with a recorded base. Kept whole
-// and unhedged: that path is exact, and softening it would teach contributors
-// to skim the one warning that is never wrong.
-function recordedWarning(conflicts) {
-	return `You have your own edits to ${conflicts.join(', ')}. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.`;
-}
+// What an approximate base does to the file list beside it. Said in full where
+// files are named, because the consequence is the actionable half: a list built
+// against today's trunk can include files trunk itself moved on, and miss ones
+// the contributor really did edit.
+const UNRECORDED_MEASUREMENT_NOTE = 'This ticket has no record of the trunk it started from, so your work was compared against today\'s trunk instead — that can name files you never touched, and miss ones you did.';
 
-// The same warning with its uncertainty said out loud. The hedge comes first
-// because it changes what the list means: these are files that differ from
-// today's trunk, which on a branch born before the last update includes files
-// trunk itself moved on, not the contributor.
-function unrecordedWarning(conflicts) {
-	return `${conflicts.join(', ')} may hold your own edits. This ticket has no record of the trunk it started from, so your work was compared against today's trunk instead — that can name files you never touched, and miss ones you did. The patch is applied on top of whatever is there: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.`;
-}
-
-// Nothing collided, but on an approximate base "nothing collided" is not a
-// promise the app can make. Said quietly rather than as an alert: there is no
-// problem here yet, only a check that was less than exact.
+// The same fact when nothing collided, where there is no list to qualify and no
+// problem yet — only a check that was less than exact. Kept quiet for that
+// reason: an alert here would cry wolf.
 const UNRECORDED_CLEAR_NOTE = 'This ticket has no record of the trunk it started from, so the check for your own edits was made against today\'s trunk and is approximate.';
-
-/**
- * What the apply preview says about the contributor's own work, or null when
- * there is nothing to say.
- *
- * `level` picks the styling and whether it is announced: `warning` is the amber
- * block that has always been there, `note` is a quiet line that exists only to
- * stop an approximate silence from reading as a clean bill of health.
- *
- * @param {Object}   [root0]
- * @param {string[]} [root0.conflicts]  Files the patch touches that the ticket has work in.
- * @param {?string}  [root0.baseStatus] A `BASE_STATUS` value; anything else is treated as exact.
- * @return {?{level: 'warning'|'note', text: string}}
- */
-function describeOwnWorkWarning({ conflicts = [], baseStatus = BASE_STATUS.RECORDED } = {}) {
-	const files = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
-	if (!baseIsApproximate(baseStatus)) {
-		return files.length ? { level: 'warning', text: recordedWarning(files) } : null;
-	}
-	return files.length
-		? { level: 'warning', text: unrecordedWarning(files) }
-		: { level: 'note', text: UNRECORDED_CLEAR_NOTE };
-}
 
 module.exports = {
 	BASE_STATUS,
 	UNRECORDED_CLEAR_NOTE,
+	UNRECORDED_MEASUREMENT_NOTE,
 	baseIsApproximate,
-	baseUnreadableMessage,
-	describeOwnWorkWarning
+	baseUnreadableMessage
 };

--- a/src/renderer/ticket-base.cjs
+++ b/src/renderer/ticket-base.cjs
@@ -1,0 +1,130 @@
+// How much the app actually knows about the trunk a ticket started from, and
+// what it is allowed to say once it knows that (#308).
+//
+// A ticket's base is the measurement everything in the patch flow rests on:
+// what counts as the contributor's own work, what a generated patch contains,
+// which files the pre-apply warning names (#301). It used to come back as an
+// oid or `null`, which folded four situations into two answers — and both of
+// the folds were silent:
+//
+// - a branch with no recorded base got today's `trunk` substituted for it, and
+//   "Update to latest trunk" has very likely moved that past where the branch
+//   was really born, so the ticket was measured against a base it never had;
+// - anything that threw while reading it came back as `null`, which every
+//   caller reads as "this site is on trunk" — sending the measurement back to
+//   HEAD, the exact reading #301 exists to remove.
+//
+// So the status is the answer, and the oid rides along with it. `unrecorded`
+// still measures against today's trunk, because there is nothing better to
+// measure against, but wherever that answer reaches the contributor it is
+// qualified rather than stated. `unreadable` measures nothing at all.
+//
+// Pure and dependency-free like open-failure.cjs, and for the same reasons: the
+// renderer bundle imports it, `node --test` requires it directly, the main
+// process requires it for the statuses and the failure copy, and none of the
+// three needs a DOM.
+'use strict';
+
+/**
+ * The four answers to "where did this ticket start".
+ *
+ * - `trunk`      — nothing is checked out but trunk, so there is no branch
+ *                  point; callers fall back to HEAD, as they always have.
+ * - `recorded`   — the app wrote the branch point down when it created the
+ *                  branch. This is the healthy path and the only exact one.
+ * - `unrecorded` — a ticket branch with no recorded base: a registry edited by
+ *                  hand, a site adopted from disk, a branch the contributor
+ *                  made in their own git client. Measured against today's
+ *                  trunk, and said to be approximate.
+ * - `unreadable` — the read itself failed. Not the same as "on trunk", and it
+ *                  must not resolve to it.
+ */
+const BASE_STATUS = {
+	TRUNK: 'trunk',
+	RECORDED: 'recorded',
+	UNRECORDED: 'unrecorded',
+	UNREADABLE: 'unreadable'
+};
+
+/**
+ * Whether a base is exact enough to speak about without hedging. Trunk counts:
+ * there is no ticket to be wrong about.
+ *
+ * @param {?string} status A `BASE_STATUS` value.
+ * @return {boolean}
+ */
+function baseIsApproximate(status) {
+	return status === BASE_STATUS.UNRECORDED;
+}
+
+/**
+ * What the app says when it could not read the base at all.
+ *
+ * One shape, several consequences, because the consequence is the half that
+ * differs per surface and the half the contributor acts on: a preview that was
+ * not shown is a different next step from a patch that was not created. The
+ * failure is honest rather than fail-open — measuring against HEAD instead
+ * would answer the wrong question in the same voice as the right one.
+ *
+ * It says "which trunk", not "which trunk this ticket started from": the read
+ * that failed can be the branch itself, so this is also what a site with no
+ * ticket at all says when its folder has been moved or deleted, and naming a
+ * ticket there would point at something the contributor never linked.
+ *
+ * @param {string} consequence What did not happen, as a clause.
+ * @return {string}
+ */
+function baseUnreadableMessage(consequence) {
+	return `Could not work out which trunk to compare your work against, so ${consequence}.`;
+}
+
+// The warning as it has always read on a site with a recorded base. Kept whole
+// and unhedged: that path is exact, and softening it would teach contributors
+// to skim the one warning that is never wrong.
+function recordedWarning(conflicts) {
+	return `You have your own edits to ${conflicts.join(', ')}. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.`;
+}
+
+// The same warning with its uncertainty said out loud. The hedge comes first
+// because it changes what the list means: these are files that differ from
+// today's trunk, which on a branch born before the last update includes files
+// trunk itself moved on, not the contributor.
+function unrecordedWarning(conflicts) {
+	return `${conflicts.join(', ')} may hold your own edits. This ticket has no record of the trunk it started from, so your work was compared against today's trunk instead — that can name files you never touched, and miss ones you did. The patch is applied on top of whatever is there: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.`;
+}
+
+// Nothing collided, but on an approximate base "nothing collided" is not a
+// promise the app can make. Said quietly rather than as an alert: there is no
+// problem here yet, only a check that was less than exact.
+const UNRECORDED_CLEAR_NOTE = 'This ticket has no record of the trunk it started from, so the check for your own edits was made against today\'s trunk and is approximate.';
+
+/**
+ * What the apply preview says about the contributor's own work, or null when
+ * there is nothing to say.
+ *
+ * `level` picks the styling and whether it is announced: `warning` is the amber
+ * block that has always been there, `note` is a quiet line that exists only to
+ * stop an approximate silence from reading as a clean bill of health.
+ *
+ * @param {Object}   [root0]
+ * @param {string[]} [root0.conflicts]  Files the patch touches that the ticket has work in.
+ * @param {?string}  [root0.baseStatus] A `BASE_STATUS` value; anything else is treated as exact.
+ * @return {?{level: 'warning'|'note', text: string}}
+ */
+function describeOwnWorkWarning({ conflicts = [], baseStatus = BASE_STATUS.RECORDED } = {}) {
+	const files = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
+	if (!baseIsApproximate(baseStatus)) {
+		return files.length ? { level: 'warning', text: recordedWarning(files) } : null;
+	}
+	return files.length
+		? { level: 'warning', text: unrecordedWarning(files) }
+		: { level: 'note', text: UNRECORDED_CLEAR_NOTE };
+}
+
+module.exports = {
+	BASE_STATUS,
+	UNRECORDED_CLEAR_NOTE,
+	baseIsApproximate,
+	baseUnreadableMessage,
+	describeOwnWorkWarning
+};

--- a/src/ticket-carry.js
+++ b/src/ticket-carry.js
@@ -1,0 +1,281 @@
+'use strict';
+
+/**
+ * Whether a ticket is still sitting on the trunk it was born from, and what it
+ * would take to bring it forward (#305).
+ *
+ * "Update to latest trunk" updates the *site*. Ticket branches deliberately
+ * keep their own branch point, because a ticket's diff base has to stay fixed
+ * or its patch would suddenly contain everything trunk moved. The consequence
+ * is that nothing ever brings the ticket itself forward: a contributor coming
+ * back to it is working on the trunk of the day they linked it, indefinitely,
+ * and every pull request rebased since then fails to apply on it.
+ *
+ * This module is the read-only half of the answer. It says whether trunk has
+ * moved past the ticket's base, and — path by path — what carrying the ticket's
+ * work onto today's trunk would mean for each file. Nothing here writes: no ref
+ * moves, no file is touched, no index entry changes. The carry itself is its own
+ * change; this is what lets the app *offer* it honestly, and what lets the
+ * ticket card say something true before anyone clicks anything.
+ *
+ * ## Detection cannot use ancestry
+ *
+ * Sites are `depth: 1` clones and the update re-fetches at depth 1, so the new
+ * trunk tip shares no reachable history with the base a ticket was born on —
+ * `isDescendent` walks parents that were never fetched and answers wrongly or
+ * throws. So the question is asked of the two commit objects directly: a
+ * different oid, and a committer date that is strictly newer. Both are already
+ * on disk (`readTrunkInfo` and `baseProvenance` in main.js read the same
+ * objects), so this costs two object reads and no network.
+ *
+ * Equal timestamps answer "not behind". Trunk landing a commit in the same
+ * second as the ticket's base is not a gap worth offering to close, and a clock
+ * comparison that resolves ties in the other direction would offer a carry that
+ * moves nothing.
+ *
+ * ## Classifying, rather than diffing everything
+ *
+ * The carry cannot route the whole ticket through a generated patch. A unified
+ * diff cannot express a binary file, an empty add or delete (#311) or a file
+ * that would not read — and the checkout onto new trunk *deletes* every path the
+ * patch failed to represent, so a patch-only carry silently destroys work.
+ *
+ * So each changed path is classified by comparing its blob in the ticket's base
+ * against the same path in today's trunk:
+ *
+ *   - **wholesale** — upstream did not touch it (same blob oid, or absent from
+ *     both). The base side is byte-identical, so the ticket's version *is* the
+ *     result: its bytes and its mode are carried over with no text matching at
+ *     all. That is the route binaries, empty files and deletions survive.
+ *   - **merge** — upstream changed it too. Only these need a three-way-ish
+ *     reconciliation, and only these can genuinely conflict.
+ *   - **refuse** — upstream deleted a file the ticket edited, or both sides
+ *     added the same path, or the file would not read. Same rule
+ *     `staleTouchedPaths` (github-pr.cjs) already encodes for pull requests:
+ *     replacing those wholesale would silently revert somebody else's work,
+ *     and reproducing bytes that could not be read is not something to guess at.
+ *
+ * A file both sides added is refused even when the two additions happen to be
+ * identical. Comparing the ticket's own blob to decide would mean hashing the
+ * worktree on a read that the ticket card polls, to spare a case that costs the
+ * contributor one refusal they can act on — the trade is not worth the scan.
+ *
+ * No Electron dependency, so `node --test` can exercise it against real
+ * repositories (same rationale as ticket-branches.js and trunk-update.js).
+ * main.js owns the IPC plumbing and the electron-store writes.
+ */
+
+const fs = require('fs');
+const git = require('isomorphic-git');
+const { entryInCommit } = require('./pr-files.cjs');
+// The vocabulary is the renderer's, for the reason BASE_STATUS is: both sides
+// name these and only one of the two may depend on `isomorphic-git`.
+const { CARRY_STATE, REFUSAL } = require('./renderer/carry-note.cjs');
+
+/**
+ * The committer timestamp of a commit, in seconds, or null when it will not
+ * read. Committer rather than author, matching `readTrunkInfo`: a rebased or
+ * cherry-picked upstream commit keeps its original author date, which would
+ * make today's trunk look older than a ticket linked last week.
+ *
+ * @param {string} dir
+ * @param {string} oid
+ * @return {Promise<number|null>}
+ */
+async function commitTime(dir, oid) {
+	try {
+		const { commit } = await git.readCommit({ fs, dir, oid });
+		return commit.committer.timestamp;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Whether the site's trunk has moved past the commit this ticket was born on.
+ *
+ * @param {string}  dir
+ * @param {Object}  root0
+ * @param {?string} root0.baseOid  The ticket's branch point.
+ * @param {?string} root0.trunkOid Where the site's `trunk` points now.
+ * @return {Promise<{state: string, baseDate: ?string, trunkDate: ?string}>}
+ */
+async function trunkMovedPast(dir, { baseOid, trunkOid } = {}) {
+	if (!baseOid || !trunkOid) return { state: CARRY_STATE.UNKNOWN, baseDate: null, trunkDate: null };
+	if (baseOid === trunkOid) return { state: CARRY_STATE.CURRENT, baseDate: null, trunkDate: null };
+
+	const [baseSeconds, trunkSeconds] = await Promise.all([
+		commitTime(dir, baseOid),
+		commitTime(dir, trunkOid)
+	]);
+	// A base commit that will not read is the common shape of this: a site
+	// adopted from disk, or a registry entry naming an object this clone never
+	// had. Saying "unknown" is what keeps the card from claiming a ticket is
+	// current when the app has no idea.
+	if (baseSeconds === null || trunkSeconds === null) {
+		return { state: CARRY_STATE.UNKNOWN, baseDate: null, trunkDate: null };
+	}
+
+	const iso = (seconds) => new Date(seconds * 1000).toISOString();
+	return {
+		state: trunkSeconds > baseSeconds ? CARRY_STATE.BEHIND : CARRY_STATE.CURRENT,
+		baseDate: iso(baseSeconds),
+		trunkDate: iso(trunkSeconds)
+	};
+}
+
+/**
+ * What one path was at a commit — its oid, its mode and whether it is a file at
+ * all — or the fact that the read itself failed. Absence is read from the tree,
+ * never from empty bytes (#311).
+ *
+ * The two are kept apart for the reason #308 keeps `unreadable` apart from
+ * `trunk`: folded together, a damaged object store reads as "neither side has
+ * this path", which classifies it as one upstream never touched — and then
+ * writes the ticket's version over whatever upstream really has there. A read
+ * that failed is a refusal, not a licence.
+ *
+ * A directory counts as present. It is not a file the ticket's version can
+ * replace, and reading it as absence would try to write a file over a tree.
+ *
+ * @param {string}  dir
+ * @param {?string} commitOid
+ * @param {string}  filepath
+ * @return {Promise<{readable: boolean, entry: ?{oid: string, mode: string, type: string}}>}
+ */
+async function blobEntryAt(dir, commitOid, filepath) {
+	if (!commitOid) return { readable: true, entry: null };
+	try {
+		return { readable: true, entry: await entryInCommit({ git, fs, dir }, commitOid, filepath) };
+	} catch {
+		return { readable: false, entry: null };
+	}
+}
+
+/**
+ * How each of the ticket's changed paths would be carried onto today's trunk.
+ *
+ * Pure reads: two tree walks per path, both against commits already in the
+ * object store. Deliberately not a whole-tree diff of trunk against the base —
+ * that is tens of thousands of entries on a `wordpress-develop` clone, to answer
+ * a question about the handful of files the ticket actually touched.
+ *
+ * A deletion is its own question and is answered first. Whether the ticket
+ * *removed* a path is not something its bytes can say (#311), so it arrives as a
+ * flag from the walk — and without it, a file both sides deleted looks exactly
+ * like a file the ticket edited and upstream deleted, which would refuse the
+ * whole carry over two sides that agree.
+ *
+ * @param {string}  dir
+ * @param {Object}  root0
+ * @param {Array}   root0.files    `{ path, unreadable, binary, deleted }` per changed path.
+ * @param {?string} root0.baseOid  The ticket's branch point.
+ * @param {?string} root0.trunkOid Where the site's `trunk` points now.
+ * @return {Promise<{wholesale: string[], merge: string[], settled: string[], refused: Array<{path: string, reason: string}>}>}
+ */
+async function classifyCarry(dir, { files = [], baseOid, trunkOid } = {}) {
+	const wholesale = [];
+	const merge = [];
+	const settled = [];
+	const refused = [];
+
+	for (const file of files) {
+		const filepath = file && file.path;
+		if (!filepath) continue;
+		if (file.unreadable) {
+			refused.push({ path: filepath, reason: REFUSAL.UNREADABLE });
+			continue;
+		}
+
+		const base = await blobEntryAt(dir, baseOid, filepath);
+		const tip = await blobEntryAt(dir, trunkOid, filepath);
+		if (!base.readable || !tip.readable) {
+			refused.push({ path: filepath, reason: REFUSAL.UNREADABLE });
+			continue;
+		}
+
+		if (file.deleted) {
+			// The ticket removed it. Nothing is carried *into* the file, so the
+			// only question is whether upstream still has the version it removed.
+			if (!base.entry) continue;
+			if (!tip.entry) settled.push(filepath);
+			else if (base.entry.oid === tip.entry.oid) wholesale.push(filepath);
+			else refused.push({ path: filepath, reason: REFUSAL.DELETED_BUT_CHANGED });
+			continue;
+		}
+
+		if (!base.entry && !tip.entry) {
+			// Neither side has it: the ticket added it, and upstream did not.
+			wholesale.push(filepath);
+		} else if (!base.entry) {
+			refused.push({ path: filepath, reason: REFUSAL.ADDED_BOTH });
+		} else if (!tip.entry) {
+			refused.push({ path: filepath, reason: REFUSAL.UPSTREAM_DELETED });
+		} else if (base.entry.oid === tip.entry.oid) {
+			// Byte-identical on the base side, so the ticket's version *is* the
+			// result — binary or not, this is the route that carries it losslessly.
+			wholesale.push(filepath);
+		} else if (file.binary) {
+			// Both sides changed the same binary. There is no replaying one change
+			// onto the other: a unified diff cannot carry the ticket's version, and
+			// writing it wholesale would drop upstream's.
+			refused.push({ path: filepath, reason: REFUSAL.BINARY_CONFLICT });
+		} else {
+			merge.push(filepath);
+		}
+	}
+
+	return { wholesale, merge, settled, refused };
+}
+
+/**
+ * The whole read-only answer: is this ticket behind, and what would carrying it
+ * mean file by file.
+ *
+ * The changed paths come from the caller rather than being walked here, so the
+ * carry, the card's note (#239) and the patch modal all read one walk decided
+ * one way — `collectCarryCandidates` in main.js is that walk, with the same base
+ * and the same filter as the note's, and the flags the classifier needs added
+ * rather than a second opinion formed here.
+ *
+ * They arrive as a function rather than a list so the walk is never paid for
+ * when the answer does not need it. `statusMatrix` hashes every non-ignored file
+ * in a `wordpress-develop` checkout — thousands of them, on the process that
+ * draws the window — and a ticket that is already on today's trunk is the common
+ * case. Two commit reads answer that one. (A ticket that *is* behind still pays
+ * one walk here on top of the note's; sharing them across the two channels is a
+ * follow-up, not something this can do from inside the module.)
+ *
+ * @param {string}   dir
+ * @param {Object}   root0
+ * @param {Function} root0.loadFiles Resolves to `{ path, unreadable, binary, deleted }` per changed path.
+ * @param {?string}  root0.baseOid
+ * @param {?string}  root0.trunkOid
+ * @return {Promise<Object>}
+ */
+async function carryStatus(dir, { loadFiles = async () => [], baseOid, trunkOid } = {}) {
+	const moved = await trunkMovedPast(dir, { baseOid, trunkOid });
+	// Classification is only meaningful once trunk has actually moved: against
+	// an unmoved trunk every path classifies wholesale, which would read as "3
+	// files would carry cleanly" beside a carry that does nothing at all.
+	if (moved.state !== CARRY_STATE.BEHIND) {
+		return {
+			...moved,
+			baseOid: baseOid || null,
+			trunkOid: trunkOid || null,
+			wholesale: [], merge: [], settled: [], refused: []
+		};
+	}
+	const classified = await classifyCarry(dir, { files: await loadFiles(), baseOid, trunkOid });
+	return { ...moved, baseOid, trunkOid, ...classified };
+}
+
+module.exports = {
+	REFUSAL,
+	CARRY_STATE,
+	commitTime,
+	trunkMovedPast,
+	blobEntryAt,
+	classifyCarry,
+	carryStatus
+};

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -169,8 +169,9 @@ async function discardToBase(dir, baseOid) {
 	}
 	const ref = (await git.currentBranch({ fs, dir, fullname: false })) || 'trunk';
 	// Only rewind the ref when baseOid really is this branch's own history — its
-	// point off trunk. patchBaseOid falls back to the live `trunk` tip for a
-	// branch with no recorded base (hand-created, or a hand-edited registry);
+	// point off trunk. `patchBase` in main.js answers `unrecorded` for a branch
+	// with no recorded base (hand-created, or a hand-edited registry) and hands
+	// over the live `trunk` tip with it;
 	// that tip need not be an ancestor of HEAD, and moving the ref onto it would
 	// orphan the branch's commits and re-point it at unrelated work. When it is
 	// not an ancestor, leave the ref alone and just reset the worktree to HEAD —

--- a/test/applied-layer.test.cjs
+++ b/test/applied-layer.test.cjs
@@ -1,0 +1,258 @@
+'use strict';
+
+// The applied patch as a layer with a name (#306): who owns which file, and
+// which of the banner's faces the checkout has earned. Pure — the module holds
+// the branching so the component does not, which is what makes this reachable.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { attributeConflicts, describeAppliedLayer, absorbedExitFailure, listOf } = require('../src/renderer/applied-layer.cjs');
+const { describeApplyFailure } = require('../src/renderer/apply-conflict.cjs');
+
+const FOO = 'src/wp-login.php';
+const BAR = 'src/wp-admin/edit.php';
+
+const layer = (over = {}) => ({
+	label: 'PR #123',
+	appliedAt: '2026-08-12T10:00:00.000Z',
+	files: [FOO],
+	kept: true,
+	absorbed: [],
+	revertable: true,
+	...over
+});
+
+// --- attribution ----------------------------------------------------------
+
+test('attributeConflicts: a file only the applied patch touched is not called your work (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO],
+		appliedPatch: layer()
+	});
+
+	assert.deepStrictEqual(yours, []);
+	assert.deepStrictEqual(fromLayer, [FOO]);
+	// The warning does not go quiet — the file is still named, just attributed.
+	assert.ok(sentences.some((s) => s.includes(FOO) && s.includes('PR #123')));
+	assert.ok(!sentences.some((s) => s.startsWith('You have your own edits')));
+});
+
+test('attributeConflicts: a file the contributor also edited keeps naming their work (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO],
+		appliedPatch: layer({ absorbed: [{ path: FOO, failed: 1, total: 3 }], revertable: false })
+	});
+
+	assert.deepStrictEqual(yours, [FOO]);
+	assert.deepStrictEqual(fromLayer, []);
+	assert.ok(sentences[0].startsWith('You have your own edits'));
+});
+
+test('attributeConflicts: the two owners are named separately, not merged (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({
+		conflicts: [FOO, BAR],
+		appliedPatch: layer()
+	});
+
+	assert.deepStrictEqual(yours, [BAR]);
+	assert.deepStrictEqual(fromLayer, [FOO]);
+	assert.strictEqual(sentences.length, 3);
+	assert.ok(sentences[0].includes(BAR) && !sentences[0].includes(FOO));
+	assert.ok(sentences[1].includes(FOO) && !sentences[1].includes(BAR));
+});
+
+test('attributeConflicts: with no patch applied every file is the contributor\'s (#306)', () => {
+	const { yours, fromLayer, sentences } = attributeConflicts({ conflicts: [FOO, BAR], appliedPatch: null });
+
+	assert.deepStrictEqual(yours, [FOO, BAR]);
+	assert.deepStrictEqual(fromLayer, []);
+	assert.ok(sentences[0].startsWith('You have your own edits'));
+});
+
+test('attributeConflicts: a clean tree says nothing at all (#306)', () => {
+	assert.deepStrictEqual(attributeConflicts({ conflicts: [], appliedPatch: layer() }).sentences, []);
+	assert.deepStrictEqual(attributeConflicts().sentences, []);
+});
+
+test('listOf: reads as a sentence rather than a join (#306)', () => {
+	assert.strictEqual(listOf([]), '');
+	assert.strictEqual(listOf(['a']), 'a');
+	assert.strictEqual(listOf(['a', 'b']), 'a and b');
+	assert.strictEqual(listOf(['a', 'b', 'c']), 'a, b and c');
+});
+
+// --- the banner's faces ---------------------------------------------------
+
+test('describeAppliedLayer: nothing applied, nothing to say (#306)', () => {
+	assert.strictEqual(describeAppliedLayer(null), null);
+});
+
+test('describeAppliedLayer: while it still comes out, Revert is the only offer (#306)', () => {
+	const face = describeAppliedLayer(layer(), { when: '12/08/2026' });
+
+	assert.strictEqual(face.canRevert, true);
+	assert.strictEqual(face.absorbed, false);
+	assert.strictEqual(face.offerCopy, false);
+	assert.strictEqual(face.explanation, '');
+	assert.strictEqual(face.summary, 'is applied — 1 file, 12/08/2026.');
+});
+
+test('describeAppliedLayer: absorbed drops Revert and offers the copy-and-discard exit (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		revertable: false,
+		absorbed: [{ path: FOO, failed: 2, total: 5 }]
+	}));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.strictEqual(face.absorbed, true);
+	assert.strictEqual(face.offerCopy, true);
+	assert.ok(face.explanation.includes(FOO));
+	assert.ok(face.explanation.includes('part of your changes now'));
+	// Not a one-way door, and the banner has to say so.
+	assert.ok(/Undo those edits and Revert comes back/.test(face.explanation));
+	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 2 of the 5 changes it brought`]);
+});
+
+// The constraint the whole design rests on: absorption is not a way to apply a
+// second patch. The banner has to say the slot is still taken.
+test('describeAppliedLayer: absorption does not free the one-patch slot (#306)', () => {
+	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
+
+	assert.ok(/one applied patch/.test(face.note));
+	assert.ok(/reverted or discarded/.test(face.note));
+});
+
+// Discarding is a recommendable step here, not an admission of failure — the
+// wording is the point, so it is asserted rather than left to drift.
+test('describeAppliedLayer: the exit is worded as a normal way forward (#306)', () => {
+	const face = describeAppliedLayer(layer({ revertable: false, absorbed: [{ path: FOO, failed: 1, total: 1 }] }));
+
+	assert.ok(/not a lost afternoon/.test(face.note));
+	assert.ok(/Save a copy of your work/.test(face.note));
+});
+
+test('describeAppliedLayer: a patch too large to keep is a different sentence from absorption (#306)', () => {
+	const face = describeAppliedLayer(layer({ kept: false, revertable: false }));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.strictEqual(face.absorbed, false);
+	assert.strictEqual(face.offerCopy, true);
+	assert.ok(/too large to keep a copy of/.test(face.explanation));
+	assert.deepStrictEqual(face.detail, []);
+});
+
+// A record written before this change carries `revertable` and no `kept`.
+test('describeAppliedLayer: an older record without `kept` still reads correctly (#306)', () => {
+	assert.strictEqual(describeAppliedLayer({ label: 'x', files: [FOO], revertable: true }).canRevert, true);
+	assert.strictEqual(describeAppliedLayer({ label: 'x', files: [FOO], revertable: false }).canRevert, false);
+});
+
+// --- the revert failure's narration ---------------------------------------
+
+const revertFailure = {
+	ok: false,
+	failures: [`${FOO} has moved on since the patch was written, so none of its 3 changes still fits`],
+	conflicts: [{
+		path: FOO,
+		error: `${FOO} has moved on since the patch was written, so none of its 3 changes still fits`,
+		total: 3,
+		regions: [
+			{ index: 0, line: 10, status: 'moved', anchor: 'a', lines: [] },
+			{ index: 1, line: 20, status: 'moved', anchor: 'b', lines: [] },
+			{ index: 2, line: 30, status: 'moved', anchor: 'c', lines: [] }
+		]
+	}]
+};
+
+test('describeApplyFailure: a failed revert blames the contributor\'s own edits, not the author (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { reverting: 'PR #123', prUrl: 'https://example.invalid/pr/1', prState: 'open' });
+
+	assert.ok(notice.headline.startsWith('PR #123 cannot be lifted back out on its own'));
+	assert.ok(/your own edits are on 3 of its 3 changes/.test(notice.headline));
+	// The pull request's author has nothing to do with a revert.
+	assert.strictEqual(notice.prUrl, null);
+	assert.strictEqual(notice.prButton, null);
+	assert.ok(!/rebase/.test(notice.advice));
+});
+
+test('describeApplyFailure: a failed revert offers the copy-and-discard exit, not another patch (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { reverting: 'PR #123', otherPatchCount: 4 });
+
+	assert.strictEqual(notice.offerDiscardToBase, true);
+	assert.strictEqual(notice.offerOtherPatches, false);
+	assert.ok(/Undoing your edits on those lines brings Revert back/.test(notice.advice));
+	assert.ok(/not a lost afternoon/.test(notice.advice));
+	// The contributor owns these lines, so the per-region detail is theirs to see.
+	assert.strictEqual(notice.items[0].regions.length, 3);
+});
+
+test('describeApplyFailure: a forward apply is unaffected by the revert framing (#306)', () => {
+	const notice = describeApplyFailure(revertFailure, { prUrl: 'https://example.invalid/pr/1', prState: 'open', otherPatchCount: 2 });
+
+	assert.strictEqual(notice.offerDiscardToBase, false);
+	assert.strictEqual(notice.offerOtherPatches, true);
+	assert.strictEqual(notice.prUrl, 'https://example.invalid/pr/1');
+	assert.ok(/author/.test(notice.advice));
+});
+
+// A file blocked for a reason that is not an edit over the patch's lines — the
+// contributor deleted it outright — must not be described as one. Withholding
+// Revert is still right; the sentence about it is what changes.
+test('describeAppliedLayer: a file that is simply gone gets its own sentence (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		revertable: false,
+		absorbed: [{ path: FOO, editedOver: false, failed: 0, total: 0 }]
+	}));
+
+	assert.strictEqual(face.canRevert, false);
+	assert.ok(!/your own edits are on the lines/.test(face.explanation));
+	assert.ok(/no longer where it left it/.test(face.explanation));
+	// Nothing to count, so nothing is counted.
+	assert.deepStrictEqual(face.detail, []);
+});
+
+test('describeAppliedLayer: both reasons at once read as one sentence (#306)', () => {
+	const face = describeAppliedLayer(layer({
+		files: [FOO, BAR],
+		revertable: false,
+		absorbed: [
+			{ path: FOO, editedOver: true, failed: 1, total: 2 },
+			{ path: BAR, editedOver: false, failed: 0, total: 0 }
+		]
+	}));
+
+	assert.ok(face.explanation.includes(`your own edits are on the lines it brought to ${FOO}`));
+	assert.ok(face.explanation.includes(`${BAR} is no longer where it left it`));
+	assert.deepStrictEqual(face.detail, [`${FOO} — you have edited 1 of the 2 changes it brought`]);
+});
+
+// `already-applied` is derived by testing the inverse of what is being applied,
+// so on a revert it means the opposite of what it means going forwards. Reading
+// the forward wording out loud there contradicts the headline above it.
+test('describeApplyFailure: a revert reads `already-applied` backwards (#306)', () => {
+	const withApplied = {
+		...revertFailure,
+		conflicts: [{ ...revertFailure.conflicts[0], regions: [{ index: 0, line: 10, status: 'already-applied', anchor: 'a', lines: [] }] }]
+	};
+
+	const reverting = describeApplyFailure(withApplied, { reverting: 'PR #123' });
+	assert.strictEqual(reverting.items[0].regions[0].reason, 'looks like that change is not in your checkout any more');
+
+	const forward = describeApplyFailure(withApplied, {});
+	assert.strictEqual(forward.items[0].regions[0].reason, 'looks like it is already in your checkout');
+});
+
+// --- the exits' own failures ---------------------------------------------
+
+test('absorbedExitFailure: silence when neither exit has failed (#306)', () => {
+	assert.strictEqual(absorbedExitFailure().message, '');
+	assert.strictEqual(absorbedExitFailure({ patchSaveError: '', discardError: '' }).message, '');
+});
+
+test('absorbedExitFailure: the save is the failure that must not be missed (#306)', () => {
+	const both = absorbedExitFailure({ patchSaveError: 'EACCES', discardError: 'could not reset' });
+	assert.ok(both.message.includes('EACCES'));
+	assert.ok(!both.message.includes('could not reset'));
+
+	assert.strictEqual(absorbedExitFailure({ discardError: 'could not reset' }).message, 'could not reset');
+});

--- a/test/apply-conflict.test.cjs
+++ b/test/apply-conflict.test.cjs
@@ -350,6 +350,161 @@ test('describeApplyFailure: a pull request already in trunk asks for nothing (is
 	assert.equal(result.advice, '');
 });
 
+// --- whose work is actually in the way (#303) ----------------------------
+//
+// The framing above answers from the pull request's state alone, so an open one
+// is always "stale, ask for a rebase". On a resumed ticket the usual reason a
+// change will not fit is the contributor's own work in the same file, and that
+// button asks a stranger for work that would not help. The app cannot prove
+// which side a single region belongs to — it matches without the PR's base — but
+// it knows which files this ticket has work in, and that is enough.
+
+test('describeApplyFailure: a failure in the contributor\'s own file is not blamed on the author (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// The culprit is named, and it is not the pull request's age.
+	assert.match(result.headline, /Your own work is in the way/);
+	assert.doesNotMatch(result.headline, /older trunk/);
+	// No rebase to ask for, and no button offering one. The advice says the ask
+	// would not help; what it never does is hand the work to the author.
+	assert.doesNotMatch(result.advice, /author's work/);
+	// The pull request is still reachable — reading it is how the contributor
+	// decides whether to start a clean ticket for it. Only the ask is gone.
+	assert.equal(result.prButton, 'Open the pull request');
+	assert.equal(result.prUrl, PR_URL);
+	// What actually moves it forward: a copy, then a clean ticket or a discard.
+	assert.match(result.advice, /Save a patch of your work/);
+	assert.match(result.advice, /discard it here/);
+	// The scale still says how much missed — that decision is unchanged.
+	assert.match(result.headline, /1 of its 4 changes, in 1 file/);
+});
+
+test('describeApplyFailure: a failure in files the ticket never touched keeps the stale framing (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 4, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [BAR] });
+
+	assert.match(result.headline, /written against an older trunk/);
+	assert.doesNotMatch(result.headline, /Your own work/);
+	assert.match(result.advice, /author's work/);
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+});
+
+test('describeApplyFailure: a failure in both kinds of file says both (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${BAR} has moved on`],
+		conflicts: [
+			conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(BAR, 2, [{ index: 0, line: 11, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// Each file is named on the side it belongs to; neither is picked over the
+	// other, because the app has no way to know which one really failed first.
+	assert.match(result.headline, new RegExp(`Your own work is in the way in ${FOO}`));
+	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}`));
+	// The rebase ask survives, because there is a file it genuinely applies to.
+	assert.match(result.advice, /author's work/);
+	assert.match(result.advice, /Save a patch of your work/);
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+	assert.equal(result.prUrl, PR_URL);
+});
+
+// The headline names files, so the two things that break a list break it here:
+// a patch that fails the same file twice, and a patch that fails more files than
+// a sentence can carry. The panel prints every failing file underneath anyway,
+// so past a few the headline counts instead of listing.
+test('describeApplyFailure: the named files are deduplicated and capped (issue #303)', () => {
+	const twice = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${FOO} has moved on`],
+		conflicts: [
+			conflict(FOO, 2, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(FOO, 2, [{ index: 0, line: 40, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	// A concatenated patch failing the same file twice must not name it twice —
+	// nor count it twice in the same sentence that goes on to list it.
+	assert.match(twice.headline, new RegExp(`in ${FOO}\\.$`));
+	assert.match(twice.headline, /in 1 file,/);
+
+	const many = ['a', 'b', 'c', 'd', 'e'].map((n) => `src/wp-includes/${n}.php`);
+	const wide = describeApplyFailure({
+		ok: false,
+		failures: many.map((p) => `${p} has moved on`),
+		conflicts: many.map((p) => conflict(p, 1, [{ index: 0, line: 1, status: 'moved' }]))
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: many });
+
+	assert.match(wide.headline, /a\.php, src\/wp-includes\/b\.php, src\/wp-includes\/c\.php and 2 more files/);
+	assert.doesNotMatch(wide.headline, /e\.php/);
+});
+
+// Both sides can hold several files, and the sentence has to read as English
+// either way — which is why neither list is followed by a verb agreeing with it.
+test('describeApplyFailure: the mixed framing reads with several files on each side (issue #303)', () => {
+	const BAZ = 'src/wp-includes/baz.php';
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`, `${BAR} has moved on`, `${BAZ} has moved on`],
+		conflicts: [
+			conflict(FOO, 1, [{ index: 0, line: 7, status: 'moved' }]),
+			conflict(BAR, 1, [{ index: 0, line: 11, status: 'moved' }]),
+			conflict(BAZ, 1, [{ index: 0, line: 13, status: 'moved' }])
+		]
+	}, { prUrl: PR_URL, prState: 'open', ownWorkPaths: [FOO] });
+
+	assert.match(result.headline, new RegExp(`the pull request being behind trunk: ${BAR}, ${BAZ}\\.$`));
+	assert.equal(result.prButton, 'Ask its author for a rebase');
+});
+
+test('describeApplyFailure: own work does not change the closed or landed framing (issue #303)', () => {
+	const closed = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved' }])]
+	}, { prUrl: PR_URL, prState: 'closed', ownWorkPaths: [FOO] });
+
+	// Nobody is coming back to a closed pull request whatever is in the way, and
+	// its discussion is still the thing worth reading.
+	assert.match(closed.headline, /closed and was written against an older trunk/);
+	assert.equal(closed.prButton, 'See why it was closed');
+
+	const landed = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 2, [
+			{ index: 0, line: 4, status: 'already-applied' },
+			{ index: 1, line: 9, status: 'already-applied' }
+		])]
+	}, { prUrl: PR_URL, prState: 'closed', ownWorkPaths: [FOO] });
+
+	assert.match(landed.headline, /likely committed to core/);
+	assert.equal(landed.prButton, null);
+});
+
+// A patch from disk or a Trac attachment has no author to misblame, so the
+// own-work list changes nothing there — the full per-region breakdown is still
+// the only way out, and it stays.
+test('describeApplyFailure: a loose patch is unaffected by the own-work list (issue #303)', () => {
+	const result = describeApplyFailure({
+		ok: false,
+		failures: [`${FOO} has moved on`],
+		conflicts: [conflict(FOO, 3, [{ index: 0, line: 7, status: 'moved', lines: ['-x', '+y'] }])]
+	}, { ownWorkPaths: [FOO] });
+
+	assert.match(result.headline, /1 of this patch's 3 changes/);
+	assert.equal(result.advice, '');
+	assert.equal(result.items[0].regions.length, 1);
+});
+
 test('describeApplyFailure: a loose patch keeps the full breakdown — there is no author to send to (issue #282)', () => {
 	const result = describeApplyFailure({
 		ok: false,

--- a/test/carry-note.test.cjs
+++ b/test/carry-note.test.cjs
@@ -1,0 +1,143 @@
+'use strict';
+
+// What the app says about a ticket left on an older trunk (#305). Pure copy,
+// so this asserts the sentences a contributor reads — not that a function was
+// called. The three things it must always do: stay quiet when there is nothing
+// to say, name the consequence of staying behind, and refuse before anything
+// moves when a file cannot come across.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+	CARRY_STATE,
+	REFUSAL,
+	WHY_NOT_STAY,
+	NOTHING_MOVES_YET,
+	refusalSentences,
+	describeCarryNote,
+	describeCarryOffer
+} = require('../src/renderer/carry-note.cjs');
+
+// --- the card's note -------------------------------------------------------
+
+test('a ticket that is current, or that the app cannot place, gets no note (issue #305)', () => {
+	assert.equal(describeCarryNote({ state: CARRY_STATE.CURRENT }), null);
+	assert.equal(describeCarryNote({ state: CARRY_STATE.UNKNOWN }), null);
+	assert.equal(describeCarryNote({}), null);
+});
+
+test('a ticket behind trunk is told what staying behind costs (issue #305)', () => {
+	const note = describeCarryNote({ state: CARRY_STATE.BEHIND, since: '10 January 2026' });
+	assert.match(note.text, /10 January 2026/);
+	assert.ok(note.text.includes(WHY_NOT_STAY), 'the note must name the consequence, not just the fact');
+	assert.equal(note.level, 'note', 'nothing is broken yet — an alert here would cry wolf');
+});
+
+test('the note still says something when the base date is unknown (issue #305)', () => {
+	const note = describeCarryNote({ state: CARRY_STATE.BEHIND, since: '' });
+	assert.match(note.text, /an older trunk/);
+	assert.doesNotMatch(note.text, /undefined|Invalid Date/);
+});
+
+// --- the offer -------------------------------------------------------------
+
+test('the offer counts what carries cleanly and what trunk has also changed (issue #305)', () => {
+	const offer = describeCarryOffer({
+		state: CARRY_STATE.BEHIND,
+		wholesale: ['src/wp-login.php', 'src/notes.php'],
+		merge: ['src/class-wp-query.php']
+	});
+	assert.equal(offer.canCarry, true);
+	const text = offer.sentences.join(' ');
+	assert.match(text, /3 files/);
+	assert.match(text, /2 files come across exactly as they are/);
+	assert.match(text, /1 file trunk has also changed/);
+	assert.ok(text.includes(NOTHING_MOVES_YET), 'the offer must say nothing moves until it is accepted');
+});
+
+test('one file of each kind reads as singular (issue #305)', () => {
+	const offer = describeCarryOffer({ state: CARRY_STATE.BEHIND, wholesale: ['a.php'], merge: ['b.php'] });
+	const text = offer.sentences.join(' ');
+	assert.match(text, /1 file comes across exactly as it is/);
+	assert.match(text, /replayed onto its new version/);
+});
+
+test('a ticket with no work still gets an offer, and it says the base is all that moves (issue #305)', () => {
+	const offer = describeCarryOffer({ state: CARRY_STATE.BEHIND, since: '10 January 2026' });
+	assert.equal(offer.canCarry, true);
+	assert.match(offer.sentences.join(' '), /no work on it yet/);
+});
+
+test('a refused file blocks the offer and is named, not counted (issue #305)', () => {
+	const offer = describeCarryOffer({
+		state: CARRY_STATE.BEHIND,
+		wholesale: ['src/wp-login.php'],
+		refused: [{ path: 'src/gone.php', reason: REFUSAL.UPSTREAM_DELETED }]
+	});
+	assert.equal(offer.canCarry, false);
+	assert.equal(offer.blocked.length, 1);
+	assert.match(offer.blocked[0], /src\/gone\.php/);
+	assert.ok(
+		!offer.sentences.join(' ').includes(NOTHING_MOVES_YET),
+		'promising nothing moves is beside the point when the answer is that it cannot'
+	);
+});
+
+test('each refusal reason gets its own sentence, in a stable order (issue #305)', () => {
+	const sentences = refusalSentences([
+		{ path: 'e.php', reason: REFUSAL.UNREADABLE },
+		{ path: 'a.php', reason: REFUSAL.UPSTREAM_DELETED },
+		{ path: 'd.png', reason: REFUSAL.BINARY_CONFLICT },
+		{ path: 'c.php', reason: REFUSAL.ADDED_BOTH },
+		{ path: 'b.php', reason: REFUSAL.DELETED_BUT_CHANGED }
+	]);
+	assert.equal(sentences.length, 5);
+	assert.match(sentences[0], /Trunk has deleted a\.php/);
+	assert.match(sentences[1], /This ticket deletes b\.php/);
+	assert.match(sentences[2], /c\.php was added both/);
+	assert.match(sentences[3], /d\.png is binary/);
+	assert.match(sentences[4], /e\.php could not be read/);
+});
+
+test('a file trunk removed the same way is counted, not silently dropped (issue #305)', () => {
+	const offer = describeCarryOffer({
+		state: CARRY_STATE.BEHIND,
+		wholesale: ['a.php'],
+		settled: ['gone.php']
+	});
+	assert.equal(offer.canCarry, true);
+	const text = offer.sentences.join(' ');
+	assert.match(text, /2 files this ticket has work in/);
+	assert.match(text, /1 file trunk has already removed as well/);
+});
+
+test('several files sharing a reason share one sentence (issue #305)', () => {
+	const sentences = refusalSentences([
+		{ path: 'a.php', reason: REFUSAL.UPSTREAM_DELETED },
+		{ path: 'b.php', reason: REFUSAL.UPSTREAM_DELETED }
+	]);
+	assert.equal(sentences.length, 1);
+	assert.match(sentences[0], /a\.php and b\.php/);
+	assert.match(sentences[0], /them/, 'the plural has to agree, or the sentence reads as machine output');
+});
+
+test('an applied layer is named, and the two faces read differently (issue #305, #306)', () => {
+	const liftable = describeCarryOffer({
+		state: CARRY_STATE.BEHIND,
+		wholesale: ['a.php'],
+		appliedPatch: { label: 'Pull request #1234', revertable: true }
+	});
+	assert.match(liftable.sentences.join(' '), /Pull request #1234 is lifted out first/);
+
+	const absorbed = describeCarryOffer({
+		state: CARRY_STATE.BEHIND,
+		wholesale: ['a.php'],
+		appliedPatch: { label: 'Pull request #1234', revertable: false }
+	});
+	assert.match(absorbed.sentences.join(' '), /part of your changes now, so it moves with them as one/);
+});
+
+test('no offer is made for a ticket that is not behind (issue #305)', () => {
+	assert.equal(describeCarryOffer({ state: CARRY_STATE.CURRENT, wholesale: ['a.php'] }), null);
+	assert.equal(describeCarryOffer({ state: CARRY_STATE.UNKNOWN }), null);
+});

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -578,6 +578,91 @@ test('git:unsubmitted-work counts what the patch would speak about (#239, #85)',
 	assert.ok(wide.files.includes('logo.png'), 'a binary change still counts — the patch names it');
 });
 
+// --- git:carry-status — is this ticket still on the trunk it was born on? ---
+//
+// Read-only by construction (#305): the mutating carry is its own change, and
+// what this channel must never do is move a ref or touch a file. Driven against
+// a real repository, because the answer is two commit objects and three tree
+// lookups — a stub would be mocking the thing under test.
+
+/**
+ * Moves `trunk` past the ticket's branch point the way the site update does,
+ * leaving the ticket branch checked out and untouched.
+ *
+ * The timestamp is explicit and in the future: the fixture's base commit is
+ * stamped "now", and a second commit in the same second is the tie the
+ * detection deliberately answers "not behind" to.
+ *
+ * @param {string}   dir
+ * @param {Function} mutate Called with `dir`; makes trunk's own changes.
+ * @return {Promise<string>} The new trunk oid.
+ */
+async function advanceTrunkPast(dir, mutate) {
+	const restore = await git.currentBranch({ fs, dir, fullname: false });
+	const later = Math.floor(Date.now() / 1000) + 3600;
+	const author = { name: 'test', email: 'test@example.com', timestamp: later, timezoneOffset: 0 };
+	await git.checkout({ fs, dir, ref: 'trunk', force: true });
+	await mutate(dir);
+	for (const [filepath, , workdir] of await git.statusMatrix({ fs, dir })) {
+		if (workdir === 0) await git.remove({ fs, dir, filepath });
+		else await git.add({ fs, dir, filepath });
+	}
+	const oid = await git.commit({ fs, dir, message: 'upstream', author, committer: author });
+	await git.checkout({ fs, dir, ref: restore, force: true });
+	return oid;
+}
+
+test('git:carry-status says a ticket is behind and what each file would mean (#305)', async (t) => {
+	const { dir, baseOid, workFile } = await parkedTicketRepo(t);
+	// Both halves of the classification: a file trunk also edits, and a file only
+	// the ticket has. The ticket's own addition lands after the upstream commit,
+	// or the fixture would hand it to trunk as well.
+	await advanceTrunkPast(dir, (d) => fs.writeFileSync(path.join(d, workFile), '<?php // login\n// upstream moved on\n'));
+	fs.writeFileSync(path.join(dir, 'settled.php'), '<?php // only the ticket has this\n');
+	const main = parkedTicketMain(dir, baseOid);
+
+	const res = await main.invoke('git:carry-status', dir);
+	assert.equal(res.ok, true);
+	assert.equal(res.state, 'behind');
+	assert.deepEqual(res.merge, [workFile], 'a file trunk also changed has to be replayed, not overwritten');
+	assert.deepEqual(res.wholesale, ['settled.php']);
+	assert.deepEqual(res.refused, []);
+
+	// The claim the whole feature rests on: asking changed nothing.
+	assert.equal(await git.currentBranch({ fs, dir, fullname: false }), 'ticket/62281');
+	assert.equal(fs.readFileSync(path.join(dir, workFile), 'utf8'), '<?php // login\n// the ticket work\n');
+});
+
+test('git:carry-status says nothing about a ticket on today\'s trunk (#305)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t);
+	const main = parkedTicketMain(dir, baseOid);
+
+	const res = await main.invoke('git:carry-status', dir);
+	assert.equal(res.state, 'current');
+	assert.deepEqual(res.wholesale, [], 'nothing is classified against a trunk that has not moved');
+});
+
+// An unrecorded base is today's trunk standing in for a branch point nobody
+// wrote down (#308). Compared against trunk it answers "current" about every
+// such ticket however far behind it is, so it is reported as the unknown it is.
+test('git:carry-status answers unknown for a base it never recorded (#305, #308)', async (t) => {
+	const { dir } = await parkedTicketRepo(t);
+	await advanceTrunkPast(dir, (d) => fs.writeFileSync(path.join(d, 'upstream.php'), '<?php // new\n'));
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				sites: [dir],
+				siteMeta: { [dir]: { tracTicket: 62281, branches: { 'ticket/62281': { tracTicket: 62281 } } } }
+			}).stubs
+		}
+	});
+
+	const res = await main.invoke('git:carry-status', dir);
+	assert.equal(res.state, 'unknown');
+	assert.equal(res.baseStatus, 'unrecorded');
+});
+
 // What a discard leaves behind rides on its reply: on a ticket branch the
 // parked work survives the reset (destroying a ticket is what deleting its
 // branch is for), so answering "clean" would hide the note over work that is
@@ -3721,6 +3806,7 @@ const WIRED = new Set([
 	'url:open',
 	'git:worktree-dirty',
 	'git:unsubmitted-work',
+	'git:carry-status',
 	'git:discard-changes',
 	'git:discard-to-base',
 	'git:update-trunk',

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -465,24 +465,31 @@ test('git:discard-changes resets through trunk-update and clears the applied-pat
 // A site the way the ticket-as-branch model leaves it: the contributor's work
 // parked in the branch's single WIP commit, the worktree clean. `git status`
 // says nothing; the patch says +1 line. The note has to side with the patch.
-async function parkedTicketRepo(t) {
+// `workFile` is where the parked edit lands. The default keeps this repo as the
+// note's tests have always had it; the patch-preview tests below ask for the
+// `src/` layout instead, because a patch's paths are read through
+// `mapToSrcLayout` and a collision is a string match on the result.
+async function parkedTicketRepo(t, { workFile = 'wp-login.php' } = {}) {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-parked-'));
 	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
 	await git.init({ fs, dir, defaultBranch: 'trunk' });
 	const author = { name: 'test', email: 'test@example.com' };
-	fs.writeFileSync(path.join(dir, 'wp-login.php'), '<?php // login\n');
-	await git.add({ fs, dir, filepath: 'wp-login.php' });
+	const abs = path.join(dir, workFile);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	const baseText = '<?php // login\n';
+	fs.writeFileSync(abs, baseText);
+	await git.add({ fs, dir, filepath: workFile });
 	const baseOid = await git.commit({ fs, dir, message: 'trunk snapshot', author });
 	await git.branch({ fs, dir, ref: 'ticket/62281', object: 'trunk', checkout: true });
-	fs.writeFileSync(path.join(dir, 'wp-login.php'), '<?php // login\n// the ticket work\n');
-	await git.add({ fs, dir, filepath: 'wp-login.php' });
+	fs.writeFileSync(abs, `${baseText}// the ticket work\n`);
+	await git.add({ fs, dir, filepath: workFile });
 	await git.commit({
 		fs, dir,
 		message: 'Work in progress (WordPress Contributor Toolkit)',
 		author,
 		parent: [baseOid]
 	});
-	return { dir, baseOid };
+	return { dir, baseOid, workFile, baseText };
 }
 
 function parkedTicketMain(dir, baseOid) {
@@ -1750,6 +1757,68 @@ test('git:preview-patch reads the patch through patch-plan', async () => {
 
 	assert.deepEqual(parsePatchFiles.calls, [['PATCH TEXT']]);
 	assert.deepEqual(result, { ok: false, error: 'unreadable' });
+});
+
+// --- what the collision warning is measured against (#301) ----------------
+
+// A patch against `src/wp-login.php`, the file the parked repo's ticket work is
+// in. Written the way the app's own reader expects to read it back.
+const LOGIN_DIFF = `diff --git a/src/wp-login.php b/src/wp-login.php
+index 384bf9e..dbfa038 100644
+--- a/src/wp-login.php
++++ b/src/wp-login.php
+@@ -1,2 +1,2 @@
+ <?php // login
+-// the ticket work
++// somebody else's change
+`;
+
+// The silence #301 is about, end to end. A resumed ticket has its work in the
+// WIP commit and a worktree that matches it exactly, so the narrow question
+// answers "clean" — correctly, and it must keep doing so for the checkout
+// guards. The warning cannot be built on that answer: measured from HEAD it
+// says nothing at all, and the patch lands on top of the contributor's work
+// with no warning.
+test('git:preview-patch warns about work parked in the WIP commit (#301)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const main = parkedTicketMain(dir, baseOid);
+
+	const narrow = await main.invoke('git:worktree-dirty', dir);
+	assert.equal(narrow.dirty, false, 'nothing is uncommitted — the guards keep their answer');
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+});
+
+// The other direction: a file edited back to what the base holds carries none
+// of the contributor's work, whatever HEAD says about it. Announcing it sends
+// someone looking for changes they never made.
+test('git:preview-patch does not warn about a file that matches the base (#301)', async (t) => {
+	const { dir, baseOid, workFile, baseText } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	// Differs from HEAD (the parked commit), identical to the branch point.
+	fs.writeFileSync(path.join(dir, workFile), baseText);
+	const main = parkedTicketMain(dir, baseOid);
+
+	const narrow = await main.invoke('git:worktree-dirty', dir);
+	assert.equal(narrow.dirty, true, 'HEAD-relative this file reads as edited');
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.conflicts, []);
+});
+
+// And a patch that touches nothing the ticket has worked on still warns about
+// nothing — the wider baseline widens what counts as the contributor's work,
+// it does not warn about every file in the patch.
+test('git:preview-patch stays quiet about files the ticket never touched (#301)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const main = parkedTicketMain(dir, baseOid);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF.replace(/wp-login\.php/g, 'wp-signup.php'));
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.paths, ['src/wp-signup.php']);
+	assert.deepEqual(preview.conflicts, []);
 });
 
 // git:apply-patch reads the store for its guard before delegating, which is the

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -31,6 +31,10 @@ const os = require('node:os');
 const path = require('node:path');
 const { EventEmitter } = require('node:events');
 const git = require('isomorphic-git');
+// The one module these tests read an answer *through* rather than around: what
+// the preview's base status means for the contributor is the module's to say,
+// and #308's point is that the two halves agree.
+const { describeOwnWorkWarning } = require('../src/renderer/ticket-base.cjs');
 
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const MAIN_PATH = path.join(SRC_DIR, 'main.js');
@@ -989,7 +993,12 @@ test('a tree whose only change is binary still reports no changes (#85)', async 
 // The other two entry points into the same patch path. They differ only in what
 // they do with the result — a window, or a save dialog — so what is checked here
 // is that they go through it at all rather than assembling a diff of their own.
-test('git:create-patch and git:save-patch generate the patch the same way', async () => {
+// A real repository rather than a path that is not one: reading the ticket's
+// base is the handler's first step (#308), and a directory that is not a
+// repository now stops there with "the base could not be read" instead of
+// reaching the patch path this test is about.
+test('git:create-patch and git:save-patch generate the patch the same way', async (t) => {
+	const dir = await fixtureRepo(t);
 	for (const channel of ['git:create-patch', 'git:save-patch']) {
 		// Throwing ends the handler at its first delegation — which is also what
 		// keeps this test off the network, since the next step fetches
@@ -997,9 +1006,9 @@ test('git:create-patch and git:save-patch generate the patch the same way', asyn
 		const ensureAutocrlf = spy(async () => { throw new Error('not a repository'); });
 		const main = loadMain({ stubs: { ...silentLogging(), './trunk-update': { ensureAutocrlf } } });
 
-		await main.invoke(channel, '/sites/wp');
+		await main.invoke(channel, dir);
 
-		assert.deepEqual(ensureAutocrlf.calls, [['/sites/wp']], channel);
+		assert.deepEqual(ensureAutocrlf.calls, [[dir]], channel);
 	}
 });
 
@@ -1819,6 +1828,165 @@ test('git:preview-patch stays quiet about files the ticket never touched (#301)'
 	assert.equal(preview.ok, true);
 	assert.deepEqual(preview.paths, ['src/wp-signup.php']);
 	assert.deepEqual(preview.conflicts, []);
+});
+
+// --- what the app says when it does not know the base (#308) --------------
+
+// The same repo the tests above use, with trunk moved on after the branch was
+// born — the shape "Update to latest trunk" leaves, and the reason substituting
+// today's trunk for an unrecorded base is a guess rather than a reading. The
+// branch does not carry `src/wp-signup.php`, so measured against today's trunk
+// it looks like the contributor deleted a file they have never opened.
+async function movedOnTrunkRepo(t) {
+	const repo = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const { dir } = repo;
+	const author = { name: 'test', email: 'test@example.com' };
+	await git.checkout({ fs, dir, ref: 'trunk' });
+	fs.writeFileSync(path.join(dir, 'src', 'wp-signup.php'), '<?php // signup\n');
+	await git.add({ fs, dir, filepath: 'src/wp-signup.php' });
+	await git.commit({ fs, dir, message: 'trunk moves on', author });
+	await git.checkout({ fs, dir, ref: 'ticket/62281' });
+	return repo;
+}
+
+// A patch against the file only today's trunk has.
+const SIGNUP_DIFF = `diff --git a/src/wp-signup.php b/src/wp-signup.php
+index 384bf9e..dbfa038 100644
+--- a/src/wp-signup.php
++++ b/src/wp-signup.php
+@@ -1 +1,2 @@
+ <?php // signup
++// somebody else's change
+`;
+
+// The healthy path, pinned: a recorded base is exact and says so, which is what
+// keeps the warning above unhedged.
+test('git:preview-patch reports a recorded base as recorded (#308)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	const main = parkedTicketMain(dir, baseOid);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.equal(preview.baseStatus, 'recorded');
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+});
+
+// A site on trunk keeps its own answer: there is no ticket to be unsure about,
+// and the walk falls back to HEAD as it always has.
+test('git:preview-patch reports a site on trunk as on trunk (#308)', async (t) => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-base-trunk-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: 'trunk' });
+	fs.mkdirSync(path.join(dir, 'src'));
+	fs.writeFileSync(path.join(dir, 'src', 'wp-login.php'), '<?php // login\n');
+	await git.add({ fs, dir, filepath: 'src/wp-login.php' });
+	await git.commit({ fs, dir, message: 'init', author: { name: 'test', email: 'test@example.com' } });
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...fakeSettingsStore({ sites: [dir], siteMeta: { [dir]: {} } }).stubs }
+	});
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.equal(preview.baseStatus, 'trunk');
+	assert.deepEqual(preview.conflicts, []);
+});
+
+// No recorded base — a registry written by the pre-#108 migration for a branch
+// it did not create, a site adopted from disk. The measurement still happens,
+// because today's trunk is the only base available; what changes is that the
+// answer no longer arrives in the same voice as an exact one. `wp-signup.php`
+// is the proof it needs hedging: the contributor has never touched it.
+test('git:preview-patch still measures an unrecorded base, and says it is approximate (#308)', async (t) => {
+	const { dir } = await movedOnTrunkRepo(t);
+	const main = parkedTicketMain(dir, null);
+
+	const preview = await main.invoke('git:preview-patch', dir, SIGNUP_DIFF);
+
+	assert.equal(preview.ok, true, 'an unknown base still measures — there is nothing better available');
+	assert.equal(preview.baseStatus, 'unrecorded');
+	assert.deepEqual(preview.conflicts, ['src/wp-signup.php']);
+	// And that is exactly the announcement the contributor did not earn, which
+	// is why the panel hedges it rather than stating it.
+	const notice = describeOwnWorkWarning(preview);
+	assert.equal(notice.level, 'warning');
+	assert.ok(notice.text.startsWith('src/wp-signup.php may hold your own edits.'));
+	assert.ok(notice.text.includes('no record of the trunk it started from'));
+});
+
+// The contributor's real work is still found on an unrecorded base — hedging
+// the answer must not mean withholding it.
+test('git:preview-patch on an unrecorded base still names the contributor\'s own work (#308)', async (t) => {
+	const { dir } = await movedOnTrunkRepo(t);
+	const main = parkedTicketMain(dir, null);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.ok, true);
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+});
+
+// A repo whose `trunk` ref is gone: the base cannot be recorded and cannot be
+// worked out either. Before #308 this came back as null, which every caller
+// reads as "this site is on trunk" — so the walk fell back to HEAD, a resumed
+// ticket matches HEAD exactly, and the preview reported a clean tree over a
+// morning's work. It has to fail instead.
+async function unreadableBaseRepo(t) {
+	const repo = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	await git.deleteBranch({ fs, dir: repo.dir, ref: 'trunk' });
+	return repo;
+}
+
+test('git:preview-patch fails honestly when the base cannot be read (#308)', async (t) => {
+	const { dir } = await unreadableBaseRepo(t);
+	const main = parkedTicketMain(dir, null);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+
+	assert.equal(preview.ok, false, 'an unreadable base must not read as a clean tree');
+	assert.match(preview.error, /could not/i);
+	assert.equal(preview.conflicts, undefined);
+});
+
+// The same failure on the question the card asks. Answering "nothing here"
+// would be the #301 silence again, reached through the failure path.
+test('git:unsubmitted-work fails rather than reporting a clean tree it could not measure (#308)', async (t) => {
+	const { dir } = await unreadableBaseRepo(t);
+	const main = parkedTicketMain(dir, null);
+
+	const res = await main.invoke('git:unsubmitted-work', dir);
+
+	assert.equal(res.ok, false);
+	assert.match(res.error, /which trunk to compare your work against/);
+});
+
+// And on the destructive one. The uncommitted-only reset is not a safe stand-in
+// for a discard to base: it looks like it worked, leaves the parked WIP commit
+// where it was, and the modal comes back listing the work it just promised to
+// throw away.
+test('git:discard-to-base refuses rather than half-discarding on an unreadable base (#308)', async (t) => {
+	const { dir, workFile } = await unreadableBaseRepo(t);
+	fs.writeFileSync(path.join(dir, 'loose.php'), '<?php // uncommitted\n');
+	const main = parkedTicketMain(dir, null);
+
+	const res = await main.invoke('git:discard-to-base', dir);
+
+	assert.equal(res.ok, false);
+	assert.match(res.error, /nothing was discarded/);
+	assert.equal(fs.existsSync(path.join(dir, 'loose.php')), true, 'nothing was discarded, so nothing was discarded');
+	assert.match(fs.readFileSync(path.join(dir, workFile), 'utf8'), /the ticket work/);
+});
+
+// A patch cannot be taken against a base the app could not read: the fallback
+// is HEAD, and HEAD on a resumed ticket is the contributor's own parked work,
+// so the "patch" would come back empty and read as nothing to submit.
+test('git:get-patch refuses an unreadable base rather than diffing against HEAD (#308)', async (t) => {
+	const { dir } = await unreadableBaseRepo(t);
+	const main = parkedTicketMain(dir, null);
+
+	const res = await main.invoke('git:get-patch', dir);
+
+	assert.equal(res.ok, false);
+	assert.match(res.error, /which trunk to compare your work against/);
+	assert.equal(res.patch, undefined);
 });
 
 // git:apply-patch reads the store for its guard before delegating, which is the

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -31,10 +31,11 @@ const os = require('node:os');
 const path = require('node:path');
 const { EventEmitter } = require('node:events');
 const git = require('isomorphic-git');
-// The one module these tests read an answer *through* rather than around: what
+// The two modules these tests read an answer *through* rather than around: what
 // the preview's base status means for the contributor is the module's to say,
 // and #308's point is that the two halves agree.
 const { describeOwnWorkWarning } = require('../src/renderer/ticket-base.cjs');
+const { attributeConflicts } = require('../src/renderer/applied-layer.cjs');
 
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const MAIN_PATH = path.join(SRC_DIR, 'main.js');
@@ -3823,3 +3824,146 @@ test('every IPC channel is classified: wired, or explicitly not', () => {
 	assert.deepEqual(stale, [], 'Classified channels that main.js no longer registers');
 });
 
+
+// --- the applied patch as a layer, measured not remembered (#306) ---------
+//
+// `revertable` used to mean "we kept the text". It now means what the banner
+// asks: can this layer still be lifted out of *this* checkout, right now. That
+// is a fact about the tree, so these run against a real repo — a stub would
+// mock the very thing under test.
+
+// The parked ticket with LOGIN_DIFF applied on top of it, plus the record the
+// app writes when it applies one. `content` is what ends up in the file, so a
+// test can hand-edit over the patch's own line and ask again.
+async function ticketWithAppliedPatch(t, content) {
+	const { dir, baseOid, workFile } = await parkedTicketRepo(t, { workFile: 'src/wp-login.php' });
+	fs.writeFileSync(path.join(dir, workFile), content);
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: {
+			[dir]: {
+				tracTicket: 62281,
+				branches: {
+					'ticket/62281': {
+						tracTicket: 62281,
+						baseOid,
+						appliedPatch: {
+							label: 'PR #123',
+							appliedAt: '2026-08-12T10:00:00.000Z',
+							files: ['src/wp-login.php'],
+							text: LOGIN_DIFF
+						}
+					}
+				}
+			}
+		}
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+	return { dir, main, settings, workFile };
+}
+
+const PATCH_APPLIED = '<?php // login\n// somebody else\'s change\n';
+const EDITED_OVER = '<?php // login\n// my own version of it\n';
+
+test('site:status: a freshly applied patch is reported as still removable (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, PATCH_APPLIED);
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.label, 'PR #123');
+	assert.equal(status.appliedPatch.kept, true);
+	assert.equal(status.appliedPatch.revertable, true);
+	assert.deepEqual(status.appliedPatch.absorbed, []);
+});
+
+test('site:status: editing the patch\'s own lines absorbs it, and Revert stands down (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.revertable, false);
+	// The text is still stored — this is absorption, not a patch too large to
+	// keep, and the two get different sentences.
+	assert.equal(status.appliedPatch.kept, true);
+	assert.deepEqual(status.appliedPatch.absorbed, [{ path: 'src/wp-login.php', editedOver: true, failed: 1, total: 1 }]);
+});
+
+// Not a one-way door, and nothing persisted says otherwise: the same site,
+// the same record, answers differently the moment the overlapping edit goes.
+test('site:status: undoing the overlapping edit brings Revert back on its own (#306)', async (t) => {
+	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	assert.equal((await main.invoke('site:status', dir)).appliedPatch.revertable, false);
+
+	fs.writeFileSync(path.join(dir, workFile), PATCH_APPLIED);
+
+	const back = await main.invoke('site:status', dir);
+	assert.equal(back.appliedPatch.revertable, true);
+	assert.deepEqual(back.appliedPatch.absorbed, []);
+});
+
+// The constraint the design rests on: the slot frees on revert or on discarding
+// to base, never by absorption. The record has to survive as provenance.
+test('site:status: absorption does not free the one-patch slot (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const status = await main.invoke('site:status', dir);
+	assert.notEqual(status.appliedPatch, null, 'the record is provenance, not just an undo blob');
+
+	// And the guard still refuses a second patch on its behalf.
+	const event = createIpcEvent();
+	const { applyId } = await main.invokeWith('git:apply-patch', event, dir, { patchText: LOGIN_DIFF, label: 'PR #456' });
+	const done = await applyDone(event, applyId);
+	assert.equal(done.ok, false);
+	assert.match(done.error, /PR #123 is already applied/);
+});
+
+// A patch a trunk update reset away is not absorbed: its record is stale, and
+// Revert has to stay on screen because pressing it is what clears it.
+test('site:status: a patch the tree no longer holds keeps its Revert (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, '<?php // login\n// the ticket work\n');
+
+	const status = await main.invoke('site:status', dir);
+
+	assert.equal(status.appliedPatch.revertable, true);
+	assert.deepEqual(status.appliedPatch.absorbed, []);
+});
+
+// The measurement must not write. `site:status` runs wherever the app re-reads
+// a site, so a check with a side effect would be a checkout mutating itself.
+test('site:status: measuring removability does not touch the checkout (#306)', async (t) => {
+	const { dir, main, workFile } = await ticketWithAppliedPatch(t, EDITED_OVER);
+	const before = fs.readFileSync(path.join(dir, workFile), 'utf8');
+
+	await main.invoke('site:status', dir);
+
+	assert.equal(fs.readFileSync(path.join(dir, workFile), 'utf8'), before);
+});
+
+// The other half of #306: the pre-apply warning names the files, and the
+// renderer's attribution module decides which of them are the contributor's.
+// The two have to agree on the same paths, which is what this pins.
+test('git:preview-patch and the applied record agree on who owns a file (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, PATCH_APPLIED);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	const status = await main.invoke('site:status', dir);
+
+	assert.deepEqual(preview.conflicts, ['src/wp-login.php']);
+	const attributed = attributeConflicts({ conflicts: preview.conflicts, appliedPatch: status.appliedPatch });
+	assert.deepEqual(attributed.fromLayer, ['src/wp-login.php']);
+	assert.deepEqual(attributed.yours, []);
+});
+
+// And once the contributor has edited over it, the same file goes back to
+// naming their work — the answer that decides what they do next.
+test('git:preview-patch: a file edited over the patch is the contributor\'s again (#306)', async (t) => {
+	const { dir, main } = await ticketWithAppliedPatch(t, EDITED_OVER);
+
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	const status = await main.invoke('site:status', dir);
+
+	const attributed = attributeConflicts({ conflicts: preview.conflicts, appliedPatch: status.appliedPatch });
+	assert.deepEqual(attributed.yours, ['src/wp-login.php']);
+	assert.deepEqual(attributed.fromLayer, []);
+});

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -34,8 +34,8 @@ const git = require('isomorphic-git');
 // The two modules these tests read an answer *through* rather than around: what
 // the preview's base status means for the contributor is the module's to say,
 // and #308's point is that the two halves agree.
-const { describeOwnWorkWarning } = require('../src/renderer/ticket-base.cjs');
-const { attributeConflicts } = require('../src/renderer/applied-layer.cjs');
+const { UNRECORDED_MEASUREMENT_NOTE } = require('../src/renderer/ticket-base.cjs');
+const { attributeConflicts, describePreviewNotice } = require('../src/renderer/applied-layer.cjs');
 
 const SRC_DIR = path.join(__dirname, '..', 'src');
 const MAIN_PATH = path.join(SRC_DIR, 'main.js');
@@ -1908,10 +1908,10 @@ test('git:preview-patch still measures an unrecorded base, and says it is approx
 	assert.deepEqual(preview.conflicts, ['src/wp-signup.php']);
 	// And that is exactly the announcement the contributor did not earn, which
 	// is why the panel hedges it rather than stating it.
-	const notice = describeOwnWorkWarning(preview);
+	const notice = describePreviewNotice(preview);
 	assert.equal(notice.level, 'warning');
-	assert.ok(notice.text.startsWith('src/wp-signup.php may hold your own edits.'));
-	assert.ok(notice.text.includes('no record of the trunk it started from'));
+	assert.ok(notice.sentences[0].startsWith('You have your own edits to src/wp-signup.php.'));
+	assert.ok(notice.sentences.includes(UNRECORDED_MEASUREMENT_NOTE));
 });
 
 // The contributor's real work is still found on an unrecorded base — hedging

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -7,7 +7,7 @@ const os = require('os');
 const path = require('path');
 const git = require('isomorphic-git');
 const JsDiff = require('diff');
-const { applyPatchToDir, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
+const { applyPatchToDir, diagnoseRemoval, resolveInside, dominantEol, rollback, diagnoseHunks } = require('../src/patch-apply');
 const { parsePatchFiles } = require('../src/patch-plan.cjs');
 
 // A real on-disk repo, like trunk-update.integration.test.cjs: applyPatchToDir
@@ -791,4 +791,99 @@ test('diagnoseHunks: overlapping hunks that each pass alone yield null, not zero
 
 	// Sanity: the single hunk applies, so per-hunk diagnosis finds no failures.
 	assert.strictEqual(diagnoseHunks(body, file), null);
+});
+
+// --- diagnoseRemoval: can the applied layer still be taken out? (#306) ------
+//
+// The record the app keeps only ever said "a patch text was stored". These
+// exercise the question the banner actually asks, against a real checkout: is
+// the layer still separable from the contributor's own work, right now.
+
+test('diagnoseRemoval: a freshly applied patch still comes out cleanly (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// The absorption case: the contributor has edited the very line the patch
+// brought, so there is no longer a patch and an edit — there is one body of
+// work, and no revert can separate them.
+test('diagnoseRemoval: editing the patch\'s own line absorbs it (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+
+	const answer = diagnoseRemoval({ dir, patchText: FOO_PATCH });
+	assert.strictEqual(answer.missing, false);
+	assert.deepStrictEqual(answer.absorbed.map((a) => a.path), [FOO]);
+	// The counts come from diagnoseHunks, so the banner can say how much of the
+	// patch has been written over rather than only that something has.
+	assert.deepStrictEqual(answer.absorbed[0], { path: FOO, editedOver: true, failed: 1, total: 1 });
+});
+
+// Not a one-way door, and this is the test that pins it: nothing persists an
+// "absorbed" flag, so putting the line back makes the layer removable again
+// with no further action from anyone.
+test('diagnoseRemoval: undoing the overlapping edit makes it removable again (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	const patched = fs.readFileSync(path.join(dir, FOO), 'utf8');
+
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+	assert.strictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }).absorbed.length, 1);
+
+	fs.writeFileSync(path.join(dir, FOO), patched);
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// Work on a file the patch never touched is not absorption. It is the ordinary
+// state of a ticket, and it must not take Revert away.
+test('diagnoseRemoval: edits to other files leave the layer removable (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, BAR), 'my own work\n');
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: false });
+});
+
+// A patch a trunk update or a discard reset away is not absorbed — its record
+// is merely stale. Reporting absorption there would hide Revert, which is the
+// one button that clears the record.
+test('diagnoseRemoval: a patch the tree no longer holds reads as missing, not absorbed (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), FOO_BODY);
+
+	assert.deepStrictEqual(diagnoseRemoval({ dir, patchText: FOO_PATCH }), { absorbed: [], missing: true });
+});
+
+// Nothing here may write. The whole point of measuring instead of tracking is
+// that it can run on a status read.
+test('diagnoseRemoval: the checkout is not touched (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY, [BAR]: BAR_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+	const before = snapshot(dir);
+
+	diagnoseRemoval({ dir, patchText: FOO_PATCH });
+
+	assert.deepStrictEqual(snapshot(dir), before);
+});
+
+// A revert that fails now carries the same per-region breakdown a forward apply
+// does, because that is what the panel narrates the absorption from.
+test('applyPatchToDir: a failing reverse reports which regions were edited over (issue #306)', async (t) => {
+	const dir = await makeRepo(t, { [FOO]: FOO_BODY });
+	await applyPatchToDir({ dir, patchText: FOO_PATCH });
+	fs.writeFileSync(path.join(dir, FOO), 'one\nMY OWN VERSION\nthree\n');
+
+	const res = await applyPatchToDir({ dir, patchText: FOO_PATCH, reverse: true });
+
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.notApplied, undefined);
+	assert.strictEqual(res.conflicts.length, 1);
+	assert.strictEqual(res.conflicts[0].path, FOO);
+	assert.strictEqual(res.conflicts[0].total, 1);
+	assert.strictEqual(res.conflicts[0].regions.length, 1);
 });

--- a/test/patch-provenance.test.cjs
+++ b/test/patch-provenance.test.cjs
@@ -58,6 +58,16 @@ test('buildProvenanceHeader: a base with only one half of it still says that hal
 	assert.ok(buildProvenanceHeader({ trunkDate: FULL.trunkDate }).includes('# Base: trunk @ 2026-08-05\n'));
 });
 
+// A base the app worked out rather than recorded is still the commit the patch
+// was diffed against, so it is named — but a mentor reading it as fact would
+// rebase onto a commit this ticket may never have been on (issue #308).
+test('buildProvenanceHeader: an approximate base says so on its own line (issue #308)', () => {
+	const header = buildProvenanceHeader({ ...FULL, baseApproximate: true });
+	assert.ok(header.includes('# Base: trunk @ 59a1c3e, 2026-08-05 (approximate — this ticket\'s starting point was not recorded)\n'));
+	// The recorded path is untouched: no hedge appears where the base is exact.
+	assert.ok(!buildProvenanceHeader(FULL).includes('approximate'));
+});
+
 test('buildProvenanceHeader: nothing to say produces no header at all (issue #166)', () => {
 	assert.strictEqual(buildProvenanceHeader(), '');
 	assert.strictEqual(buildProvenanceHeader({}), '');

--- a/test/pr-files.test.cjs
+++ b/test/pr-files.test.cjs
@@ -37,9 +37,12 @@ function fakeGitWithModes(modes) {
 				const segment = rest.split('/')[0];
 				if (seen.has(segment)) continue;
 				seen.add(segment);
+				// `type` as isomorphic-git reports it: the caller tells a directory
+				// from a file by it, and a fake that omits it would let a tree pass
+				// for a blob here while the real thing does not.
 				tree.push(rest.includes('/')
-					? { path: segment, oid: `${prefix}${segment}`, mode: '040000' }
-					: { path: segment, oid: `blob-${p}`, mode: modes[p] });
+					? { path: segment, oid: `${prefix}${segment}`, mode: '040000', type: 'tree' }
+					: { path: segment, oid: `blob-${p}`, mode: modes[p], type: 'blob' });
 			}
 			return { tree };
 		}
@@ -102,6 +105,19 @@ test('an added file on Windows has no recorded mode and no bit: 100644', async (
 		{ path: 'new-file.php', inHead: false, inWorkdir: true }
 	);
 	assert.strictEqual(mode, GIT_MODE_FILE);
+});
+
+// A directory is not the file that was asked about. Answering with a tree's
+// `040000` would put a directory mode on a pull request's blob entry, and — for
+// the carry (#305) — would read "upstream has a directory here" as "upstream
+// does not have this path", which is the difference between a refusal and
+// writing a file over a tree.
+test('a path that is a directory in the commit has no file mode', async () => {
+	const mode = await fileModeForEntry(
+		deps({ platform: 'win32', git: fakeGitWithModes({ 'tools/build.sh': '100755' }) }),
+		{ path: 'tools', inHead: true, inWorkdir: false }
+	);
+	assert.strictEqual(mode, GIT_MODE_FILE, 'falls through to the default rather than reporting 040000');
 });
 
 // A deletion's mode lookup must never stat the path — the file is gone.

--- a/test/ticket-base.test.cjs
+++ b/test/ticket-base.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+	BASE_STATUS,
+	UNRECORDED_CLEAR_NOTE,
+	baseIsApproximate,
+	baseUnreadableMessage,
+	describeOwnWorkWarning
+} = require('../src/renderer/ticket-base.cjs');
+
+// The healthy path, and the one that must not move: a recorded base is exact,
+// so the warning reads exactly as it always has (issue #308).
+test('describeOwnWorkWarning: a recorded base warns without hedging (issue #308)', () => {
+	const notice = describeOwnWorkWarning({
+		conflicts: ['src/wp-login.php'],
+		baseStatus: BASE_STATUS.RECORDED
+	});
+	assert.strictEqual(notice.level, 'warning');
+	assert.strictEqual(
+		notice.text,
+		'You have your own edits to src/wp-login.php. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.'
+	);
+	assert.ok(!notice.text.includes('approximate'));
+	assert.ok(!notice.text.includes('may hold'));
+});
+
+test('describeOwnWorkWarning: an exact base with no collisions says nothing (issue #308)', () => {
+	assert.strictEqual(describeOwnWorkWarning({ conflicts: [], baseStatus: BASE_STATUS.RECORDED }), null);
+	assert.strictEqual(describeOwnWorkWarning({ conflicts: [], baseStatus: BASE_STATUS.TRUNK }), null);
+	// No status at all is the pre-#308 shape of the payload, and is treated as
+	// exact: a preview from an older main process must not start hedging.
+	assert.strictEqual(describeOwnWorkWarning({ conflicts: [] }), null);
+	assert.strictEqual(describeOwnWorkWarning(), null);
+});
+
+// The list is still shown — it is the best the app has — but as a list of
+// candidates, not of facts. Measured against today's trunk, it can name files
+// trunk moved on rather than the contributor.
+test('describeOwnWorkWarning: an unrecorded base qualifies the warning (issue #308)', () => {
+	const notice = describeOwnWorkWarning({
+		conflicts: ['src/wp-login.php', 'src/wp-signup.php'],
+		baseStatus: BASE_STATUS.UNRECORDED
+	});
+	assert.strictEqual(notice.level, 'warning');
+	assert.ok(notice.text.startsWith('src/wp-login.php, src/wp-signup.php may hold your own edits.'));
+	assert.ok(notice.text.includes('no record of the trunk it started from'));
+	assert.ok(notice.text.includes('today\'s trunk'));
+	// The advice that follows is unchanged — the hedge qualifies the list, not
+	// what applying the patch does.
+	assert.ok(notice.text.includes('fails without touching anything if they do'));
+});
+
+// Silence is an answer too, and on an approximate base it is not one the app
+// can stand behind: a file the contributor did edit can be missing from a list
+// measured against the wrong trunk.
+test('describeOwnWorkWarning: an unrecorded base with no collisions is not a clean bill of health (issue #308)', () => {
+	const notice = describeOwnWorkWarning({ conflicts: [], baseStatus: BASE_STATUS.UNRECORDED });
+	assert.strictEqual(notice.level, 'note');
+	assert.strictEqual(notice.text, UNRECORDED_CLEAR_NOTE);
+	assert.ok(notice.text.includes('approximate'));
+});
+
+test('baseIsApproximate: only an unrecorded base is (issue #308)', () => {
+	assert.strictEqual(baseIsApproximate(BASE_STATUS.UNRECORDED), true);
+	assert.strictEqual(baseIsApproximate(BASE_STATUS.RECORDED), false);
+	assert.strictEqual(baseIsApproximate(BASE_STATUS.TRUNK), false);
+	assert.strictEqual(baseIsApproximate(BASE_STATUS.UNREADABLE), false);
+	assert.strictEqual(baseIsApproximate(undefined), false);
+});
+
+// One shape, several consequences: what did not happen is the half the
+// contributor acts on, and it differs per surface.
+test('baseUnreadableMessage: names the failure and its consequence (issue #308)', () => {
+	assert.strictEqual(
+		baseUnreadableMessage('no patch was created'),
+		'Could not work out which trunk to compare your work against, so no patch was created.'
+	);
+	assert.ok(baseUnreadableMessage('nothing was discarded').endsWith('so nothing was discarded.'));
+});

--- a/test/ticket-base.test.cjs
+++ b/test/ticket-base.test.cjs
@@ -7,8 +7,16 @@ const {
 	UNRECORDED_CLEAR_NOTE,
 	baseIsApproximate,
 	baseUnreadableMessage,
-	describeOwnWorkWarning
+	UNRECORDED_MEASUREMENT_NOTE
 } = require('../src/renderer/ticket-base.cjs');
+// The preview notice these sentences end up inside is composed there (#306/#308
+// name the same block), so its cases live beside the attribution they qualify.
+const { describePreviewNotice } = require('../src/renderer/applied-layer.cjs');
+
+const describeOwnWorkWarning = (preview) => {
+	const notice = describePreviewNotice(preview || {});
+	return notice ? { level: notice.level, text: notice.sentences.join(' ') } : null;
+};
 
 // The healthy path, and the one that must not move: a recorded base is exact,
 // so the warning reads exactly as it always has (issue #308).
@@ -20,7 +28,7 @@ test('describeOwnWorkWarning: a recorded base warns without hedging (issue #308)
 	assert.strictEqual(notice.level, 'warning');
 	assert.strictEqual(
 		notice.text,
-		'You have your own edits to src/wp-login.php. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy.'
+		'You have your own edits to src/wp-login.php. Save a patch of your work first if you want a copy. The patch is applied on top of those changes: it succeeds if they do not overlap, and fails without touching anything if they do.'
 	);
 	assert.ok(!notice.text.includes('approximate'));
 	assert.ok(!notice.text.includes('may hold'));
@@ -44,8 +52,8 @@ test('describeOwnWorkWarning: an unrecorded base qualifies the warning (issue #3
 		baseStatus: BASE_STATUS.UNRECORDED
 	});
 	assert.strictEqual(notice.level, 'warning');
-	assert.ok(notice.text.startsWith('src/wp-login.php, src/wp-signup.php may hold your own edits.'));
-	assert.ok(notice.text.includes('no record of the trunk it started from'));
+	assert.ok(notice.text.startsWith('You have your own edits to src/wp-login.php and src/wp-signup.php.'));
+	assert.ok(notice.text.includes(UNRECORDED_MEASUREMENT_NOTE));
 	assert.ok(notice.text.includes('today\'s trunk'));
 	// The advice that follows is unchanged — the hedge qualifies the list, not
 	// what applying the patch does.

--- a/test/ticket-carry.integration.test.cjs
+++ b/test/ticket-carry.integration.test.cjs
@@ -1,0 +1,323 @@
+'use strict';
+
+// Integration tests for src/ticket-carry.js (#305) against real on-disk
+// repositories — no mocking of isomorphic-git, same as the ticket-branches and
+// trunk-update suites.
+//
+// The two questions under test are both answered from commit objects, so a
+// stub would be mocking the thing being tested: whether trunk has moved past a
+// ticket's branch point, and what each of the ticket's changed paths would mean
+// on the new trunk.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const git = require('isomorphic-git');
+const { trunkMovedPast, classifyCarry, carryStatus } = require('../src/ticket-carry.js');
+const { CARRY_STATE, REFUSAL } = require('../src/renderer/carry-note.cjs');
+
+const TRUNK = 'trunk';
+const AUTHOR = { name: 'test', email: 'test@example.com' };
+
+// Explicit timestamps, because the whole detection rests on them and two
+// commits made in the same test run land in the same second otherwise — which
+// is precisely the tie the module answers "not behind" to.
+const BASE_TIME = Math.floor(Date.UTC(2026, 0, 10) / 1000);
+const LATER_TIME = Math.floor(Date.UTC(2026, 1, 20) / 1000);
+
+const stamped = (timestamp) => ({ ...AUTHOR, timestamp, timezoneOffset: 0 });
+
+/**
+ * A site as the app makes one: a `trunk` branch over a wordpress-develop-shaped
+ * tree, plus the gitignored substrate a ticket must never disturb.
+ *
+ * @param {Object} t node:test's context, for the temp-directory cleanup.
+ */
+async function makeSite(t) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ticket-carry-test-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: TRUNK });
+	fs.writeFileSync(path.join(dir, '.gitignore'), 'node_modules/\nbuild/\n');
+	fs.writeFileSync(path.join(dir, 'wp-login.php'), '<?php // trunk\n');
+	fs.writeFileSync(path.join(dir, 'doomed.php'), '<?php // to be deleted\n');
+	fs.writeFileSync(path.join(dir, 'settled.php'), '<?php // nobody touches this\n');
+	await git.add({ fs, dir, filepath: ['.gitignore', 'wp-login.php', 'doomed.php', 'settled.php'] });
+	const baseOid = await git.commit({
+		fs, dir, message: 'trunk', author: stamped(BASE_TIME), committer: stamped(BASE_TIME)
+	});
+
+	fs.mkdirSync(path.join(dir, 'node_modules', 'react'), { recursive: true });
+	fs.writeFileSync(path.join(dir, 'node_modules', 'react', 'index.js'), 'expensive\n');
+	return { dir, baseOid };
+}
+
+/**
+ * Moves `trunk` on the way the site update does — a second commit, later in
+ * time — and puts the worktree back where it was, so a test can go on reading
+ * the ticket's side.
+ *
+ * @param {string}   dir
+ * @param {Function} mutate      Called with `dir`; makes trunk's own changes.
+ * @param {number}   [timestamp]
+ * @return {Promise<string>} The new trunk oid.
+ */
+async function advanceTrunk(dir, mutate, timestamp = LATER_TIME) {
+	const restore = (await git.currentBranch({ fs, dir, fullname: false })) || TRUNK;
+	await git.checkout({ fs, dir, ref: TRUNK, force: true });
+	await mutate(dir);
+	const matrix = await git.statusMatrix({ fs, dir });
+	for (const [filepath, , workdir] of matrix) {
+		if (workdir === 0) await git.remove({ fs, dir, filepath });
+		else await git.add({ fs, dir, filepath });
+	}
+	const oid = await git.commit({
+		fs, dir, message: 'upstream', author: stamped(timestamp), committer: stamped(timestamp)
+	});
+	await git.checkout({ fs, dir, ref: restore, force: true });
+	return oid;
+}
+
+// --- is this ticket behind? ------------------------------------------------
+
+test('a ticket on the trunk the site has is current (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const moved = await trunkMovedPast(dir, { baseOid, trunkOid: baseOid });
+	assert.equal(moved.state, CARRY_STATE.CURRENT);
+});
+
+test('a trunk commit newer than the ticket\'s base is behind, with both dates (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const moved = await trunkMovedPast(dir, { baseOid, trunkOid });
+	assert.equal(moved.state, CARRY_STATE.BEHIND);
+	assert.equal(moved.baseDate, new Date(BASE_TIME * 1000).toISOString());
+	assert.equal(moved.trunkDate, new Date(LATER_TIME * 1000).toISOString());
+});
+
+// Depth-1 clones are the whole reason this is a timestamp comparison: the two
+// commits share no reachable history, so an ancestry check would answer wrongly
+// or throw. Asserted by making trunk a commit with no parent at all — exactly
+// what a shallow re-fetch produces.
+test('detection does not need the two commits to share history (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const blob = await git.writeBlob({ fs, dir, blob: Buffer.from('<?php // unrelated\n') });
+	const tree = await git.writeTree({ fs, dir, tree: [{ mode: '100644', path: 'wp-login.php', oid: blob, type: 'blob' }] });
+	const trunkOid = await git.writeCommit({
+		fs, dir,
+		commit: {
+			tree, parent: [],
+			author: stamped(LATER_TIME), committer: stamped(LATER_TIME),
+			message: 'shallow tip\n'
+		}
+	});
+	// Ancestry has no signal to give here: the new tip is not reachable from the
+	// old base and never will be on a shallow clone, so a descendant check says
+	// "no" about a trunk that is plainly newer. The timestamps do not.
+	assert.equal(
+		await git.isDescendent({ fs, dir, oid: trunkOid, ancestor: baseOid }),
+		false,
+		'the fixture must really be an unrelated tip, or this proves nothing'
+	);
+
+	assert.equal((await trunkMovedPast(dir, { baseOid, trunkOid })).state, CARRY_STATE.BEHIND);
+});
+
+test('a trunk no newer than the base is not behind, tie included (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const sameSecond = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // same second\n'), BASE_TIME);
+	assert.equal((await trunkMovedPast(dir, { baseOid, trunkOid: sameSecond })).state, CARRY_STATE.CURRENT);
+});
+
+test('a base commit that will not read answers unknown, never current (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const missing = '0'.repeat(40);
+	assert.equal((await trunkMovedPast(dir, { baseOid: missing, trunkOid: baseOid })).state, CARRY_STATE.UNKNOWN);
+	assert.equal((await trunkMovedPast(dir, { baseOid: null, trunkOid: baseOid })).state, CARRY_STATE.UNKNOWN);
+});
+
+// --- what each path would mean --------------------------------------------
+
+test('a path upstream never touched carries wholesale (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'wp-login.php' }], baseOid, trunkOid });
+	assert.deepEqual(out, { wholesale: ['wp-login.php'], merge: [], settled: [], refused: [] });
+});
+
+test('a file neither side has — the ticket added it — carries wholesale (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'src/brand-new.php' }], baseOid, trunkOid });
+	assert.deepEqual(out.wholesale, ['src/brand-new.php']);
+	assert.deepEqual(out.refused, []);
+});
+
+test('a path upstream has also changed goes through the patch route (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'wp-login.php'), '<?php // upstream edit\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'wp-login.php' }], baseOid, trunkOid });
+	assert.deepEqual(out, { wholesale: [], merge: ['wp-login.php'], settled: [], refused: [] });
+});
+
+test('a file upstream deleted that the ticket has work in is refused (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.unlinkSync(path.join(d, 'doomed.php')));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'doomed.php' }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'doomed.php', reason: REFUSAL.UPSTREAM_DELETED }]);
+	assert.deepEqual(out.wholesale, []);
+});
+
+test('a path both sides added is refused rather than overwritten (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => {
+		fs.mkdirSync(path.join(d, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(d, 'src', 'contested.php'), '<?php // upstream added this\n');
+	});
+
+	const out = await classifyCarry(dir, { files: [{ path: 'src/contested.php' }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'src/contested.php', reason: REFUSAL.ADDED_BOTH }]);
+});
+
+test('a binary only the ticket changed still carries wholesale (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	// The route a patch-only carry could never take: no diff is involved, so
+	// binariness is irrelevant when upstream has not touched the file.
+	const out = await classifyCarry(dir, { files: [{ path: 'logo.png', binary: true }], baseOid, trunkOid });
+	assert.deepEqual(out.wholesale, ['logo.png']);
+	assert.deepEqual(out.refused, []);
+});
+
+test('a binary both sides changed is refused — nothing can combine the two (issue #305)', async (t) => {
+	const { dir } = await makeSite(t);
+	fs.writeFileSync(path.join(dir, 'logo.png'), Buffer.from([0x89, 0x50, 0x00, 0x01]));
+	await git.add({ fs, dir, filepath: 'logo.png' });
+	const withBinary = await git.commit({
+		fs, dir, message: 'base with binary', author: stamped(BASE_TIME), committer: stamped(BASE_TIME)
+	});
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'logo.png'), Buffer.from([0x89, 0x50, 0x00, 0x02])));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'logo.png', binary: true }], baseOid: withBinary, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'logo.png', reason: REFUSAL.BINARY_CONFLICT }]);
+	assert.deepEqual(out.merge, [], 'a binary must never reach the patch route');
+});
+
+// Whether the ticket removed a file is a question about the walk's status codes,
+// not about its bytes (#85, #311). Without the flag, both of the cases below
+// look identical to "the ticket edited a file trunk deleted" — and the first
+// would refuse the whole carry over two sides that agree.
+test('a file both sides deleted needs no carrying and blocks nothing (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.unlinkSync(path.join(d, 'doomed.php')));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'doomed.php', deleted: true }], baseOid, trunkOid });
+	assert.deepEqual(out.settled, ['doomed.php']);
+	assert.deepEqual(out.refused, [], 'two sides agreeing is not a conflict');
+	assert.deepEqual(out.wholesale, []);
+});
+
+test('a file the ticket deleted that upstream never touched carries wholesale (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'doomed.php', deleted: true }], baseOid, trunkOid });
+	assert.deepEqual(out.wholesale, ['doomed.php']);
+	assert.deepEqual(out.refused, []);
+});
+
+test('a file the ticket deleted that upstream has since changed is refused (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'doomed.php'), '<?php // upstream still wants this\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'doomed.php', deleted: true }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'doomed.php', reason: REFUSAL.DELETED_BUT_CHANGED }]);
+});
+
+// A read that failed is not absence. Folded together, a damaged object store
+// reads as "neither side has this path" — which classifies wholesale and would
+// write the ticket's version over whatever upstream really has there.
+test('a base commit that will not read refuses rather than reading as absence (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'wp-login.php' }], baseOid: '0'.repeat(40), trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'wp-login.php', reason: REFUSAL.UNREADABLE }]);
+	assert.deepEqual(out.wholesale, [], 'an unreadable side must never come out as "upstream never touched it"');
+	assert.notEqual(baseOid, null);
+});
+
+test('a file the app could not read is refused before any comparison (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'settled.php'), '<?php // upstream\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'wp-login.php', unreadable: true }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'wp-login.php', reason: REFUSAL.UNREADABLE }]);
+	assert.deepEqual(out.wholesale, []);
+});
+
+test('a directory upstream put where the ticket has a file is not read as that file (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => {
+		fs.mkdirSync(path.join(d, 'notes'), { recursive: true });
+		fs.writeFileSync(path.join(d, 'notes', 'inner.php'), '<?php // upstream\n');
+	});
+
+	// `notes` is a tree upstream and a blob the ticket added: refused as an
+	// addition on both sides, not silently treated as an untouched path.
+	const out = await classifyCarry(dir, { files: [{ path: 'notes' }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, [{ path: 'notes', reason: REFUSAL.ADDED_BOTH }]);
+});
+
+// The mirror of the case above: upstream has a *file* where the ticket has a
+// directory, so `notes/inner.php` genuinely does not exist upstream. It must
+// come out as absence — descending into a blob throws, and a throw here means
+// "unreadable", which would refuse a carry that has no problem.
+test('a file under a path upstream turned into a file reads as absent, not unreadable (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(path.join(d, 'notes'), '<?php // upstream made this a file\n'));
+
+	const out = await classifyCarry(dir, { files: [{ path: 'notes/inner.php' }], baseOid, trunkOid });
+	assert.deepEqual(out.refused, []);
+	assert.deepEqual(out.wholesale, ['notes/inner.php']);
+});
+
+// --- the whole answer ------------------------------------------------------
+
+test('carryStatus never walks the worktree for a ticket that is not behind (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	let walked = 0;
+	const status = await carryStatus(dir, {
+		baseOid,
+		trunkOid: baseOid,
+		loadFiles: async () => { walked++; return [{ path: 'wp-login.php' }]; }
+	});
+	assert.equal(status.state, CARRY_STATE.CURRENT);
+	assert.equal(walked, 0, 'the expensive scan must not be paid for the common answer');
+	assert.deepEqual(status.wholesale, []);
+});
+
+test('carryStatus reports the gap and the per-file classification together (issue #305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	const trunkOid = await advanceTrunk(dir, (d) => {
+		fs.writeFileSync(path.join(d, 'wp-login.php'), '<?php // upstream edit\n');
+		fs.unlinkSync(path.join(d, 'doomed.php'));
+	});
+
+	const status = await carryStatus(dir, {
+		baseOid,
+		trunkOid,
+		loadFiles: async () => [{ path: 'wp-login.php' }, { path: 'settled.php' }, { path: 'doomed.php' }]
+	});
+	assert.equal(status.state, CARRY_STATE.BEHIND);
+	assert.deepEqual(status.merge, ['wp-login.php']);
+	assert.deepEqual(status.wholesale, ['settled.php']);
+	assert.deepEqual(status.refused, [{ path: 'doomed.php', reason: REFUSAL.UPSTREAM_DELETED }]);
+});

--- a/test/trac-ticket-scrape-ordering.test.cjs
+++ b/test/trac-ticket-scrape-ordering.test.cjs
@@ -1,0 +1,36 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// #299: the auto-read effect and the scrapeGenRef bump were two separate
+// useEffects, both keyed off tracTicket. React runs same-component passive
+// effects in declaration order, so the auto-scrape fired before the
+// generation bump — loadTracAttachments captured a stale gen, and its
+// finally guard (`gen === scrapeGenRef.current`) never matched, leaving the
+// "Reading ticket..." spinner stuck. The fix bumps the generation
+// synchronously, ahead of the auto-triggered scrape, in the same effect.
+test('scrape ordering: scrapeGenRef bumps before the auto-triggered scrape fires (issue #299)', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer', 'index.jsx'), 'utf8');
+
+	const genBumpIdx = source.indexOf('scrapeGenRef.current += 1');
+	const scrapeCallIdx = source.indexOf('tracScrapeRef.current()');
+
+	assert.ok(genBumpIdx !== -1, 'expected to find the scrapeGenRef bump in index.jsx');
+	assert.ok(scrapeCallIdx !== -1, 'expected to find the auto-triggered tracScrapeRef.current() call in index.jsx');
+	assert.ok(
+		genBumpIdx < scrapeCallIdx,
+		'scrapeGenRef must bump before the auto-scrape fires, or loadTracAttachments captures a stale generation and its loading flag never clears (#299)'
+	);
+
+	// A second useEffect bumping the generation, declared after the
+	// auto-scrape effect, is exactly the ordering bug: same-component
+	// passive effects run in declaration order, so a later effect cannot
+	// beat an earlier one's synchronous body.
+	assert.strictEqual(
+		source.split('scrapeGenRef.current += 1').length - 1,
+		1,
+		'expected exactly one scrapeGenRef bump; a separate effect duplicating it reintroduces the ordering race (#299)'
+	);
+});

--- a/test/trunk-update.integration.test.cjs
+++ b/test/trunk-update.integration.test.cjs
@@ -99,8 +99,8 @@ test('discardToBase: a base that is not an ancestor of HEAD does not rewind the 
 	await git.add({ fs, dir, filepath: 'text.txt' });
 	const wip = await git.commit({ fs, dir, message: 'WIP', author: AUTHOR, parent: [trunkStart] });
 	// Trunk advances to a commit that is a sibling of the ticket HEAD, not an
-	// ancestor — the shape patchBaseOid's fallback would hand a branch with no
-	// recorded base once trunk has moved on.
+	// ancestor — the shape `patchBase` hands over for a branch with no recorded
+	// base once trunk has moved on.
 	await git.checkout({ fs, dir, ref: 'trunk' });
 	fs.writeFileSync(path.join(dir, 'other.txt'), 'unrelated trunk work\n');
 	await git.add({ fs, dir, filepath: 'other.txt' });


### PR DESCRIPTION
## Why

"Update to latest trunk" updates the **site**. Ticket branches deliberately keep their own branch
point — a ticket's diff base has to stay fixed, or its patch would suddenly contain everything trunk
moved — so nothing ever brings the ticket itself forward. A contributor returning to a ticket is
working on the trunk of the day they linked it, indefinitely, and a pull request its author rebased
last week fails to apply on it. Today that gap is completely invisible: the app says nothing, and
#303's narration then blames the pull request's author.

This is the **read-only detection** half of #305. The action that closes the gap is the stacked
follow-up; this is what has to be true before the app can offer it honestly.

## What changes

Two new modules and one new read-only IPC channel.

**`src/ticket-carry.js`** (Electron-free, like `ticket-branches.js`) answers two questions:

- *Is this ticket behind?* By comparing the two commit objects' **committer timestamps**, not by
  ancestry. Sites are `depth: 1` clones and the update re-fetches at depth 1, so a new trunk tip
  shares no reachable history with an old base — `isDescendent` answers `false` about a trunk that is
  plainly newer. A tie answers "not behind": a commit landing in the same second is not a gap worth
  offering to close.
- *What would carrying each file mean?* Each of the ticket's changed paths is classified by comparing
  its blob in the ticket's base against the same path in today's trunk: **wholesale** (upstream never
  touched it — its bytes are the answer), **merge** (upstream changed it too, so the ticket's change
  has to be replayed onto theirs), or **refused** (upstream deleted it, both sides added it, both
  sides changed the same binary, or it would not read).

**`src/renderer/carry-note.cjs`** (pure) holds the copy: the ticket card's note and the offer's
sentences, including the refusal sentence each reason deserves. `CARRY_STATE` and `REFUSAL` live
there rather than in `ticket-carry.js` for the reason `BASE_STATUS` lives in `ticket-base.cjs` — the
renderer bundle reads them and must not pull `isomorphic-git` in behind them.

**`git:carry-status`** is strictly read-only: it moves no ref, touches no file, writes no index
entry. It is also cheap in the common case — two commit reads answer "current", and the worktree walk
only happens once trunk really has moved past the branch point (`carryStatus` takes the file list as
a thunk for exactly this).

`entryInCommit` is factored out of `pr-files.cjs`'s `modeInCommit` and now carries the entry's
`type`, so a directory upstream put where the ticket has a file reads as *present* rather than as
absence. `modeInCommit` gained a matching guard — it used to be able to answer `040000` for a
directory.

**Deliberately not in this PR:** the carry itself. No ref moves, no marker, no offer button, no
failure narration. The card's note is informational only; the action it names ships with the carry in
the stacked PR.

## How to test this

**Platforms:** any.

**Starting state:** a site with `wordpress-develop` cloned and installed, and a Trac ticket number.

1. **Link a ticket** and edit `src/wp-login.php`. The card shows your unsubmitted-work note as usual,
   and **no** trunk note — the ticket was born on today's trunk.
2. **Click "Update to latest trunk"** and let it finish. You are put back on the ticket.
3. **Look at the ticket card.** If upstream really moved (check the trunk date in the panel changed),
   a blue note now says the ticket started from trunk as of *that* date and that the site has moved
   on, and names the consequence — patches and pull requests will keep failing to apply.
   *If upstream did not move that day, the note is correctly absent; `git log` the site's `trunk` to
   confirm before calling this a failure.*
4. **Switch to another ticket and back.** The note is cleared while the new ticket is measured and
   comes back for the ticket it belongs to — it must never show the previous ticket's date.
5. **Unlink the ticket.** The note goes: on trunk there is no ticket to be behind.

**What must not have happened:**

- **Nothing moved.** After every step above, `git -C <site> status`, the checked-out branch, and the
  ticket's WIP commit oid are exactly what they were. This channel is read-only and that is the whole
  claim of the PR.
- `node_modules` was not touched, and no install or build was triggered.
- The card did not stall. The probe walks the checkout only when the ticket is behind; opening a card
  for a ticket that is current must feel the same as before.
- No note appeared on a ticket whose base the app never recorded (a site adopted from disk). That
  case answers `unknown`, not `current` and not `behind` — an unrecorded base is today's trunk
  standing in for a branch point nobody wrote down (#308), and comparing it against trunk would say
  "current" about every such ticket however far behind it is.

**What could not be tested by hand:** the binary-conflict refusal and the unreadable-file refusal
need upstream to change the same binary the ticket changed, or a file that fails to read mid-walk —
neither is reachable against real `wordpress-develop` in a session. Both are covered against real
repositories in `test/ticket-carry.integration.test.cjs`.

## Risks and limitations

- **This is the bottom of a stack of two and is not much use alone.** The note names a consequence
  with no action attached until the carry lands on top of it. `describeCarryOffer`, `WHY_NOT_STAY`,
  `NOTHING_MOVES_YET` and `refusalSentence` are exported and tested but have no call site in the app
  yet, for the same reason — they are the offer's copy, not dead code.
- A path both sides added is refused even when the two additions happen to be identical. Comparing
  the ticket's own blob to spare that case would mean hashing the worktree on a read the card makes,
  which is not worth it for one refusal the contributor can act on.
- The classification is per path, not per hunk. It says a file will need replaying, not whether the
  replay will succeed — that answer needs the patch machinery, and it belongs with the carry.
- Detection rests on commit timestamps, so a trunk commit stamped in the past (a rewritten history
  upstream) would read as "not behind". Ancestry is not available as a cross-check on a depth-1
  clone; the committer date is what `readTrunkInfo` and the staleness dot already trust.

## Related

Part of #305. Part of #309. Builds on #306 (`applied-layer.cjs`, whose `listOf` the copy reuses) and
#308 (`BASE_STATUS`, which decides when the answer is `unknown`).

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Routing the whole carry through a generated patch was considered and rejected**, and it is why the
classifier exists at all rather than a simple "does the ticket's patch still apply" check. A unified
diff cannot express a binary, an empty add or delete (#311) or a file that would not read — and the
checkout onto new trunk *deletes* every path the patch failed to represent, so a patch-only carry
silently destroys work. Classifying per path is what lets the wholesale route exist, and the wholesale
route is what makes the carry lossless.

**Ancestry was the obvious detection and does not work here.** `isDescendent` is what `discardToBase`
uses, and it is right there — but it is right for a base that is genuinely in the branch's history.
A trunk tip fetched at depth 1 is not: `test/ticket-carry.integration.test.cjs` builds a parentless
upstream tip, exactly what a shallow re-fetch produces, and asserts `isDescendent` answers `false`
about it while the timestamp comparison answers "behind".

**A whole-tree diff of trunk against the base** would have given the same classification with less
code. It is tens of thousands of tree entries on a `wordpress-develop` clone, on the process that
draws the window, to answer a question about the handful of files the ticket touched. Two tree walks
per changed path is the cheap shape.

**The file list is a thunk, not a list.** `statusMatrix` hashes every non-ignored file in the
checkout, and "this ticket is on today's trunk" is the common answer. Passing the walk in as a
function is what keeps the card's probe from paying for it every time.

**`CARRY_STATE`/`REFUSAL` live in the renderer module**, which reads backwards until you notice
`ticket-base.cjs` does the same with `BASE_STATUS`: both sides name the vocabulary and only the main
process is allowed to depend on `isomorphic-git`.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**2 [fix here] · 3 [follow-up] — both `[fix here]` fixed, 2 of 3 follow-ups fixed, 1 deferred.**
`npm run lint` clean, `npm test` 1036/1036.

Fixed:

1. **Architecture 🟡 [fix here]** — `collectCarryCandidates` dropped the walk's `inWorkdir` flag, so
   the classifier could not tell a path the ticket *edited* from one it *deleted*. A file both sides
   deleted read as "upstream deleted a file this ticket has work in" and refused the whole carry over
   two sides that agree — with copy that was wrong for the case as well. A `deleted` flag now rides
   along (the same shape as `binary`), deletions are answered first, and the three outcomes are
   separated: both deleted → nothing to carry (`settled`), upstream untouched → wholesale, upstream
   changed it since → a refusal of its own (`DELETED_BUT_CHANGED`). Three tests.
2. **Architecture 🟡 [fix here]** — `refreshCarry` had neither the in-flight coalescing nor the
   generation guard that `refreshDirty` has directly above it, so a probe for the outgoing ticket
   could land its date on the incoming one, and repeated focus events stacked full checkout walks. It
   now uses the same `carryProbeRef` shape, and the branch change bumps its generation.
3. **Architecture 🔵 [follow-up]** — `blobEntryAt` collapsed "the commit does not have this path" and
   "the read threw" into one `null`, which classified a damaged object store as *wholesale* — the
   ticket's version written over whatever upstream really has. The two are now separate
   (`{ readable, entry }`) and an unreadable side refuses. Fixed rather than deferred: it is the
   silent-data-loss direction. `entryInCommit` also stops descending into a blob, so a path under a
   file upstream reads as genuine absence instead of a throw. Two tests.
4. **Architecture 🔵 [follow-up]** — `readTrunkInfo` falls back to `HEAD`, and `HEAD` on a ticket
   branch is the contributor's own WIP commit, so a site with no `trunk` ref would have been told its
   ticket is behind *its own work*. The handler now resolves `refs/heads/trunk` directly and answers
   `unknown` when it is not there.

Deferred:

5. **Performance 🔵 [follow-up]** — once a ticket is behind, `git:unsubmitted-work` and
   `git:carry-status` each run their own `collectChangedFiles` pass. Sharing one walk across two IPC
   channels needs a cache with an invalidation story, which is a change of its own and not one to
   smuggle into this PR. The `carryStatus` docstring claimed the walk *was* shared; that claim is
   corrected to say plainly what is and is not avoided, so the next reader does not stop looking.

</details>

<details>
<summary>Implementation notes</summary>

- `entryInCommit` is the old `modeInCommit` body with the last-segment guard lifted out and `type`
  added to the result. `modeInCommit` keeps its signature and gains a real correction: it used to
  return `040000` when the path named a directory, which would have gone onto a pull request's blob
  entry. `test/pr-files.test.cjs`'s fake now reports `type` the way `isomorphic-git` does — a fake
  that omitted it was letting a tree pass for a blob where the real thing does not.
- `collectCarryCandidates` in `main.js` reuses `collectChangedFiles` + `classifyChangedFile`, so the
  carry, the card's note (#239) and the patch modal are three readings of one walk against one base
  and cannot disagree about what changed.
- The renderer's carry probe is its own call rather than a field on the note's answer: the two ask
  different questions of different things, and folding them would make every note refresh pay the
  wrong half. It re-runs on focus, after a branch change, and after a trunk update — the last one is
  what puts the note on the ticket the contributor is handed back to.
- Tests: 14 against real on-disk repositories (`test/ticket-carry.integration.test.cjs`), 11 on the
  copy (`test/carry-note.test.cjs`), 3 on the channel (`test/ipc-wiring.test.cjs`), 1 added to
  `test/pr-files.test.cjs` for the directory case.

</details>

<details>
<summary>Screenshots or recording</summary>

The only visible surface is one note on the ticket card, and it appears only for a ticket whose base
is older than the site's trunk — reproducing it for a screenshot needs a site updated after the
ticket was linked. Its wording is asserted in `test/carry-note.test.cjs`.

</details>
