### PR TITLE
Offer to bring a ticket forward onto the trunk the site now has

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,6 @@ const fse = require('fs-extra');
 const nodeHttp = require('http');
 const git = require('isomorphic-git');
 const http = require('isomorphic-git/http/node');
-const JsDiff = require('diff');
 const { spawn } = require('child_process');
 const { SMTPServer } = require('smtp-server');
 const { simpleParser } = require('mailparser');
@@ -53,7 +52,8 @@ const {
 	deleteTicketBranch
 } = require('./ticket-branches');
 const { CARRY_STATE } = require('./renderer/carry-note.cjs');
-const { carryStatus } = require('./ticket-carry');
+const { unifiedSection } = require('./patch-text.cjs');
+const { carryStatus, trunkMovedPast, carryTicketForward, reconcileCarry } = require('./ticket-carry');
 const { createProgressThrottle, describeSwitchProgress } = require('./switch-progress.cjs');
 const { getStore } = require('./settings-store');
 
@@ -492,51 +492,13 @@ async function createMinimalPatchForDir(dir, baseOid = null) {
             binaries.push(file.path);
             continue;
         }
-        const gone = !file.inWorkdir;
         const { a, b } = kind;
-        // `/dev/null` names whichever side does not exist, and it is not
-        // decoration: classify() in patch-plan.cjs reads an add or a delete
-        // from the filename alone, never from "the hunk removes every line".
-        // Named `b/<path>`, a deletion comes back through this app's own
-        // reader as a modification, and the applier writes an empty file where
-        // the patch said remove.
-        //
-        // Which side exists is the walk's answer, not the buffers'.
-        const oldName = file.inHead ? `a/${file.path}` : '/dev/null';
-        const newName = gone ? '/dev/null' : `b/${file.path}`;
-        // No blank line between sections. jsdiff keeps consuming lines past a
-        // `\ No newline at end of file` marker, so a separator becomes a
-        // phantom empty context line and the section stops applying to any
-        // file that does not end in a newline — the file it just described.
-        // Each section already ends in one.
-        patch += withoutPhantomNoNewline(
-            JsDiff.createTwoFilesPatch(oldName, newName, a, b, '', '', { context: 3 }),
-            gone && a.endsWith('\n')
-        );
+        // Which side exists is the walk's answer, not the buffers'; the
+        // `/dev/null` naming that rests on it lives in patch-text.cjs, shared
+        // with the carry (#305) so the two cannot answer it differently.
+        patch += unifiedSection({ path: file.path, inOld: file.inHead, inNew: file.inWorkdir, a, b });
     }
     return skippedNotice(binaries, unreadable) + (patch || 'No changes.');
-}
-
-/**
- * Drops the `\ No newline at end of file` marker jsdiff adds to a deletion
- * whether or not it is true (#85).
- *
- * jsdiff decides the marker from the *new* side, and a deletion's new side is
- * the empty string — which it reads as "no trailing newline", so every deletion
- * comes out claiming the removed file lacked one. The marker attaches to the
- * preceding `-` line, so on a file that did end in a newline it asserts
- * something false about the old side and `git apply` refuses the patch — the
- * whole patch, since it is all-or-nothing, unrelated files included. `patch(1)`
- * tolerates it; the destination is a Trac ticket read by a committer running
- * `git apply`, so tolerance elsewhere is not enough.
- *
- * @param {string}  section One createTwoFilesPatch section.
- * @param {boolean} phantom True when the marker is jsdiff's invention.
- * @return {string} The section, marker removed only when it was not earned.
- */
-function withoutPhantomNoNewline(section, phantom) {
-    if (!phantom) return section;
-    return section.replace(/\n\\ No newline at end of file\n$/, '\n');
 }
 
 /**
@@ -588,8 +550,16 @@ async function collectPullRequestFiles(dir, baseOid = null) {
 // the "patch" would come back empty and look like there was nothing to submit.
 const NO_BASE_PATCH_ERROR = baseUnreadableMessage('no patch was created');
 
+// An unfinished carry or switch is the other reason not to measure (#305). It
+// is the same shape of refusal as an unreadable base and for a sharper reason:
+// the recorded branch point is not where the branch is, so every diff taken from
+// it would be confidently wrong rather than absent — a patch the contributor
+// hands over, or a pull request they open, carrying files they never touched.
+
 ipcMain.handle('git:get-patch', async (_e, sitePath) => {
     try {
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) return blocked;
         const base = await patchBase(sitePath);
         if (base.status === BASE_STATUS.UNREADABLE) return { ok: false, error: NO_BASE_PATCH_ERROR };
         const patch = await createMinimalPatchForDir(sitePath, base.baseOid);
@@ -605,6 +575,11 @@ ipcMain.handle('git:create-patch', async (_e, sitePath) => {
         win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(buildPatchHtml(text)));
     };
     try {
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) {
+            showPatchWindow(blocked.error);
+            return blocked;
+        }
         const base = await patchBase(sitePath);
         if (base.status === BASE_STATUS.UNREADABLE) {
             showPatchWindow(NO_BASE_PATCH_ERROR);
@@ -628,6 +603,8 @@ ipcMain.handle('git:create-patch', async (_e, sitePath) => {
 // gets attached to a ticket.
 ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
     try {
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) return blocked;
         const handoff = Boolean(options && options.handoff);
         const base = await patchBase(sitePath);
         if (base.status === BASE_STATUS.UNREADABLE) return { ok: false, error: NO_BASE_PATCH_ERROR };
@@ -794,6 +771,9 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
         return { ok: false, reason: 'no-ticket', error: 'Link a Trac ticket to this site first.', stage: 'auth' };
     }
     const { wporgHandle: handle = null, contributionEvent = null } = s.get('preferences') || {};
+
+    const blocked = await reconcileBlock(sitePath);
+    if (blocked) return { ...blocked, reason: 'error', stage: 'collect' };
 
     let collected;
     try {
@@ -962,6 +942,39 @@ async function midSwitchBlock(sitePath) {
         switchInProgress,
         error: `A previous switch from ${switchInProgress.from} to ${switchInProgress.to} did not finish. `
             + `Retry it before making other changes — your work on ${switchInProgress.from} is still committed on that branch.`
+    };
+}
+
+/**
+ * The one "this site needs reconciling before anything else" check (#305).
+ *
+ * Two markers, folded into one gate because they have the same consequence for
+ * every caller: the app's record of where the work is has stopped matching the
+ * repository, so anything that reads a diff would render a wrong one and
+ * anything that parks would commit over the good commit.
+ *
+ * The carry marker reaches further than the switch marker does, and has to. A
+ * half-finished switch leaves the recorded base still correct; a half-finished
+ * carry does not — between the ref moving and the store write, `baseOid` names a
+ * commit the branch is no longer on. Every surface measured from that base is
+ * then wrong in the quiet way: the patch modal shows a diff that is not the
+ * contributor's work, the card's note counts the wrong files, and a pull request
+ * opened from it would carry them.
+ *
+ * @param {string} sitePath
+ * @return {Promise<?Object>} A refusal to return as-is, or null.
+ */
+async function reconcileBlock(sitePath) {
+    const blocked = await midSwitchBlock(sitePath);
+    if (blocked) return blocked;
+    const { carryInProgress } = await readSiteMeta(sitePath);
+    if (!carryInProgress) return null;
+    return {
+        ok: false,
+        code: 'carry-incomplete',
+        carryInProgress: { ref: carryInProgress.ref || null },
+        error: `Bringing ${carryInProgress.ref || 'this ticket'} up to date did not finish, so this site is `
+            + 'between two states. Put it back before making other changes.'
     };
 }
 
@@ -1216,6 +1229,8 @@ ipcMain.handle('git:worktree-dirty', async (_e, sitePath) => {
 // switch — which is exactly the work the note exists to speak about.
 ipcMain.handle('git:unsubmitted-work', async (_e, sitePath) => {
     try {
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) return blocked;
         // The reply keeps its shape: the card's note counts files and does not
         // yet say how exact the measurement is — qualifying it there is a
         // follow-up, not something to smuggle in on this channel.
@@ -1268,6 +1283,8 @@ async function collectCarryCandidates(sitePath, baseOid) {
  * same reason #308 gave.
  */
 ipcMain.handle('git:carry-status', async (_e, sitePath) => withRegisteredSite(sitePath, async () => {
+    const blocked = await reconcileBlock(sitePath);
+    if (blocked) return blocked;
     const base = await patchBase(sitePath);
     // `unrecorded` hands back today's trunk as a stand-in for a branch point it
     // never wrote down (#308). Comparing that against trunk answers "current"
@@ -1302,6 +1319,133 @@ ipcMain.handle('git:carry-status', async (_e, sitePath) => withRegisteredSite(si
     return { ok: true, baseStatus: base.status, ...status };
 }));
 
+/**
+ * Brings a ticket forward onto the trunk the site now has (#305).
+ *
+ * Long-running — two checkouts of a `wordpress-develop` worktree — so it streams
+ * like `git:update-trunk` does rather than resolving with accumulated output:
+ * `{ carryId }` comes back immediately and the work reports on the log and done
+ * channels. `updateSwitchLogger` is what turns the switch progress into lines,
+ * the same surface the trunk update writes to, so the two checkouts inside a
+ * carry do not need a second progress display to disagree with the first.
+ *
+ * Offered and confirmed, never automatic and never part of the site update: the
+ * renderer only reaches this when a contributor has read the offer and accepted
+ * it (#309).
+ */
+ipcMain.handle('git:carry-ticket', async (event, sitePath) => {
+    const carryId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const sender = event.sender;
+    const sendLog = (data) => {
+        try { sender.send('git:carry-ticket:log', { carryId, data }); } catch {}
+    };
+    const sendDone = (payload) => {
+        try { sender.send('git:carry-ticket:done', { carryId, ...payload }); } catch {}
+    };
+
+    (async () => {
+        try {
+            const s = await getStore();
+            if (!(s.get('sites') || []).includes(sitePath)) {
+                sendDone({ ok: false, error: 'Site is not registered' });
+                return;
+            }
+            const blocked = await reconcileBlock(sitePath);
+            if (blocked) { sendLog(`\n${blocked.error}\n`); sendDone(blocked); return; }
+
+            const { ref, meta } = await activeBranch(sitePath, { migrate: true });
+            if (ref === TRUNK || !meta || !meta.baseOid) {
+                sendDone({ ok: false, error: 'There is no ticket here with a recorded starting point to bring forward.' });
+                return;
+            }
+            const trunkOid = await git.resolveRef({ fs, dir: sitePath, ref: 'refs/heads/trunk' });
+            // Two full checkouts of a wordpress-develop worktree is not a thing
+            // to do for no reason. The UI only offers this when the ticket is
+            // behind; the handler checks rather than trusting it, because the
+            // renderer's answer can be seconds old and a carry that moves
+            // nothing still costs the contributor a minute of their session.
+            const moved = await trunkMovedPast(sitePath, { baseOid: meta.baseOid, trunkOid });
+            if (moved.state !== CARRY_STATE.BEHIND) {
+                sendDone({ ok: true, upToDate: true, branch: ref, state: moved.state });
+                return;
+            }
+
+            const log = updateSwitchLogger(sendLog);
+            let result;
+            try {
+                result = await carryTicketForward({
+                    dir: sitePath,
+                    ref,
+                    baseOid: meta.baseOid,
+                    trunkOid,
+                    appliedPatch: (await readWorkMeta(sitePath)).appliedPatch || null,
+                    onProgress: log.emit,
+                    onLog: sendLog,
+                    // The two store writes and the mid-switch marker, injected so
+                    // the module itself stays Electron-free and `node --test` can
+                    // drive it against a real repository.
+                    setMarker: (marker) => mergeSiteMeta(sitePath, { carryInProgress: marker }),
+                    setBase: ({ baseOid }) => mergeBranchMeta(sitePath, ref, { baseOid }),
+                    runSwitch: (run) => withSwitchMarker(sitePath, run)
+                });
+            } finally {
+                // The last line of the stage it died in is the one line worth
+                // having when it dies — same reason the trunk update flushes.
+                log.flush();
+            }
+
+            // A layer that did not go back on is no longer applied, and the
+            // record has to go with it or the panel offers a revert for a patch
+            // that is not in the checkout (#184's shape, #306's record).
+            if (result.ok && result.patchKept === false) {
+                await mergeBranchMeta(sitePath, ref, { appliedPatch: null });
+            }
+            sendDone({ branch: ref, ...result });
+        } catch (e) {
+            logError('git:carry-ticket', String(e && e.stack ? e.stack : e));
+            sendLog(`\nBringing the ticket up to date failed: ${String(e && e.message ? e.message : e)}\n`);
+            // Deliberately not clearing the carry marker: a throw from here is
+            // the case the marker exists for, and dropping it would leave the
+            // contributor's commit reachable through nothing at all.
+            sendDone({ ok: false, error: String(e && e.message ? e.message : e), stage: (e && e.stage) || null });
+        }
+    })();
+
+    return { carryId };
+});
+
+/**
+ * Puts a site back after a carry that did not finish (#305).
+ *
+ * The marker's `oldOid` is the only record of where the contributor's work was —
+ * parking reparents rather than stacking, so no reflog holds it — and this is
+ * what spends it. Clearing the marker only after the repair succeeds: a failed
+ * reconcile that dropped it would leave the site blocked on nothing and the
+ * commit findable by nothing.
+ */
+ipcMain.handle('git:carry-reconcile', async (event, sitePath) => withRegisteredSite(sitePath, async () => {
+    const { carryInProgress } = await readSiteMeta(sitePath);
+    if (!carryInProgress) return { ok: true, reconciled: false };
+
+    const progress = switchProgressReporter(event, sitePath);
+    try {
+        const result = await reconcileCarry({ dir: sitePath, marker: carryInProgress, onProgress: progress.emit });
+        // The base was only ever written after the new commit existed, so a
+        // marker still being here means it was never moved — but it is restored
+        // explicitly rather than assumed, because "probably unchanged" is not a
+        // thing to leave a diff base resting on.
+        await mergeBranchMeta(sitePath, carryInProgress.ref, { baseOid: carryInProgress.baseOid || null });
+        await mergeSiteMeta(sitePath, {
+            carryInProgress: null,
+            currentBranch: carryInProgress.ref,
+            tracTicket: ticketIdFromRef(carryInProgress.ref)
+        });
+        return { ok: true, reconciled: true, ...result };
+    } finally {
+        progress.flush();
+    }
+}));
+
 // "Discard all changes" in the review-and-submit modal: throws away everything
 // the modal shows, which on a ticket branch is measured from the branch point
 // (#108/#239) and so includes the parked WIP commit. Rewinds to `patchBase`
@@ -1316,6 +1460,15 @@ ipcMain.handle('git:carry-status', async (_e, sitePath) => withRegisteredSite(si
 // work it just promised to throw away.
 ipcMain.handle('git:discard-to-base', async (_e, sitePath) => {
     try {
+        // This rewinds the branch to `patchBase`, and an unfinished carry is
+        // exactly the state that says the recorded base is not where the branch
+        // is — discarding onto it would throw away work against the wrong
+        // target. (`git:discard-changes` is deliberately not gated: it resets to
+        // HEAD and consults no base, so it stays available.) The collision's
+        // "save a copy, then discard and bring it up to date" is unaffected — a
+        // failed carry clears the marker before it reports.
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) return blocked;
         const base = await patchBase(sitePath);
         if (base.status === BASE_STATUS.UNREADABLE) {
             return { ok: false, error: baseUnreadableMessage('nothing was discarded') };
@@ -1384,7 +1537,7 @@ ipcMain.handle('git:update-trunk', async (event, sitePath) => {
         try {
             // The update rewrites `trunk` and checks it out, so it has to run
             // from trunk (#108). Park the ticket first, and return to it after.
-            const blocked = await midSwitchBlock(sitePath);
+            const blocked = await reconcileBlock(sitePath);
             if (blocked) { sendLog(`\n${blocked.error}\n`); sendDone(blocked); return; }
 
             const active = await activeBranch(sitePath, { migrate: true });
@@ -1596,6 +1749,8 @@ const REVERTABLE_PATCH_LIMIT = 512 * 1024;
 // calls "your own edits" is what the patch modal would show.
 ipcMain.handle('git:preview-patch', async (_e, sitePath, patchText) => {
     try {
+        const blocked = await reconcileBlock(sitePath);
+        if (blocked) return blocked;
         const parsed = parsePatchFiles(patchText);
         if (!parsed.ok) return { ok: false, error: parsed.error };
         let dirtyPaths;
@@ -1661,6 +1816,11 @@ ipcMain.handle('git:apply-patch', async (event, sitePath, options = {}) => {
             // gate sites:set-ticket applies before it touches metadata.
             if (!(s.get('sites') || []).includes(sitePath)) {
                 sendDone({ ok: false, error: 'Site is not registered' });
+                return;
+            }
+            const blocked = await reconcileBlock(sitePath);
+            if (blocked) {
+                sendDone(blocked);
                 return;
             }
             const stored = (await readWorkMeta(sitePath)).appliedPatch;
@@ -2073,7 +2233,7 @@ ipcMain.handle('sites:set-ticket', async (event, sitePath, ref, options) => with
 	const parsed = parseTicketRef(raw);
 	if (!parsed.ok) return { ok: false, error: parsed.error };
 
-	const blocked = await midSwitchBlock(sitePath);
+	const blocked = await reconcileBlock(sitePath);
 	if (blocked) return blocked;
 	const branchRef = ticketBranchRef(parsed.id);
 	const { ref: current, meta } = await activeBranch(sitePath, { migrate: true });
@@ -2166,7 +2326,7 @@ ipcMain.handle('branches:list', async (_e, sitePath) => withRegisteredSite(siteP
 }));
 
 ipcMain.handle('branches:switch', async (event, sitePath, targetRef) => withRegisteredSite(sitePath, async () => {
-	const blocked = await midSwitchBlock(sitePath);
+	const blocked = await reconcileBlock(sitePath);
 	if (blocked) return blocked;
 	const { ref: current, meta } = await activeBranch(sitePath, { migrate: true });
 	const progress = switchProgressReporter(event, sitePath);

--- a/src/patch-text.cjs
+++ b/src/patch-text.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Rendering one file's change as a unified-diff section.
+ *
+ * Lifted out of main.js when the carry (#305) needed the same rendering for a
+ * different pair of sides — the ticket's own change, base commit against parked
+ * commit, rather than base commit against working tree. Two builders would have
+ * meant two answers to the `/dev/null` question below, and this app reads its
+ * own patches back.
+ *
+ * Pure and dependency-light so `node --test` can drive it directly.
+ */
+
+const JsDiff = require('diff');
+
+/**
+ * Drops the `\ No newline at end of file` marker jsdiff adds to a deletion
+ * whether or not it is true (#85).
+ *
+ * jsdiff decides the marker from the *new* side, and a deletion's new side is
+ * the empty string — which it reads as "no trailing newline", so every deletion
+ * comes out claiming the removed file lacked one. The marker attaches to the
+ * preceding `-` line, so on a file that did end in a newline it asserts
+ * something false about the old side and `git apply` refuses the patch — the
+ * whole patch, since it is all-or-nothing, unrelated files included. `patch(1)`
+ * tolerates it; the destination is a Trac ticket read by a committer running
+ * `git apply`, so tolerance elsewhere is not enough.
+ *
+ * @param {string}  section One createTwoFilesPatch section.
+ * @param {boolean} phantom True when the marker is jsdiff's invention.
+ * @return {string} The section, marker removed only when it was not earned.
+ */
+function withoutPhantomNoNewline(section, phantom) {
+	if (!phantom) return section;
+	return section.replace(/\n\\ No newline at end of file\n$/, '\n');
+}
+
+/**
+ * One file's section of a unified diff.
+ *
+ * `/dev/null` names whichever side does not exist, and it is not decoration:
+ * `classify()` in patch-plan.cjs reads an add or a delete from the filename
+ * alone, never from "the hunk removes every line". Named `b/<path>`, a deletion
+ * comes back through this app's own reader as a modification, and the applier
+ * writes an empty file where the patch said remove.
+ *
+ * Which side exists is the caller's answer — the walk's status codes or a tree
+ * lookup — never the buffers'. An added or deleted *empty* file is exactly the
+ * case where the bytes say "unchanged" and the codes say otherwise (#85, #311).
+ *
+ * No blank line is added after a section. jsdiff keeps consuming lines past a
+ * `\ No newline at end of file` marker, so a separator becomes a phantom empty
+ * context line and the section stops applying to any file that does not end in
+ * a newline — the file it just described. Each section already ends in one.
+ *
+ * @param {Object}  root0
+ * @param {string}  root0.path
+ * @param {boolean} root0.inOld True when the old side has the file.
+ * @param {boolean} root0.inNew True when the new side has the file.
+ * @param {string}  root0.a     Old contents, '' when absent.
+ * @param {string}  root0.b     New contents, '' when absent.
+ * @return {string}
+ */
+function unifiedSection({ path, inOld, inNew, a, b }) {
+	const oldName = inOld ? `a/${path}` : '/dev/null';
+	const newName = inNew ? `b/${path}` : '/dev/null';
+	return withoutPhantomNoNewline(
+		JsDiff.createTwoFilesPatch(oldName, newName, a, b, '', '', { context: 3 }),
+		!inNew && a.endsWith('\n')
+	);
+}
+
+module.exports = { withoutPhantomNoNewline, unifiedSection };

--- a/src/preload.js
+++ b/src/preload.js
@@ -183,6 +183,29 @@ contextBridge.exposeInMainWorld('api', {
 	// the ticket's branch point.
 	carryStatus: (sitePath) => ipcRenderer.invoke('git:carry-status', sitePath)
 ,
+	// Bringing the ticket forward (#305). Two checkouts of a wordpress-develop
+	// worktree, so it streams like the trunk update rather than resolving with
+	// everything at the end.
+	carryTicketForward: async (sitePath, onLog, onDone) => {
+		const { carryId } = await ipcRenderer.invoke('git:carry-ticket', sitePath);
+		const logHandler = (_e, payload) => {
+			if (payload.carryId === carryId && onLog) onLog(payload);
+		};
+		const doneHandler = (_e, payload) => {
+			if (payload.carryId === carryId) {
+				ipcRenderer.removeListener('git:carry-ticket:log', logHandler);
+				ipcRenderer.removeListener('git:carry-ticket:done', doneHandler);
+				if (onDone) onDone(payload);
+			}
+		};
+		ipcRenderer.on('git:carry-ticket:log', logHandler);
+		ipcRenderer.on('git:carry-ticket:done', doneHandler);
+		return { carryId };
+	}
+,
+	// Putting the site back after a carry that did not finish.
+	reconcileCarry: (sitePath) => ipcRenderer.invoke('git:carry-reconcile', sitePath)
+,
 	discardChanges: (sitePath) => ipcRenderer.invoke('git:discard-changes', sitePath)
 ,
 	discardToBase: (sitePath) => ipcRenderer.invoke('git:discard-to-base', sitePath)

--- a/src/renderer/carry-note.cjs
+++ b/src/renderer/carry-note.cjs
@@ -46,6 +46,14 @@ const CARRY_STATE = {
 	UNKNOWN: 'unknown'
 };
 
+/** Why a carry stopped. Same reason for living here as the two below. */
+const CARRY_FAILURE = {
+	/** A path the classifier will not carry. Nothing was touched. */
+	REFUSED: 'refused',
+	/** The ticket's change no longer applies to trunk's version of a file. */
+	CONFLICT: 'conflict'
+};
+
 /** Why one path cannot be carried. Same list, same reason for living here. */
 const REFUSAL = {
 	/** Upstream deleted the file this ticket has edits in. */
@@ -218,13 +226,108 @@ function describeCarryOffer({ state = CARRY_STATE.CURRENT, wholesale = [], merge
 	};
 }
 
+/**
+ * How a finished carry reads, in either outcome.
+ *
+ * The failure is the interesting one, and its shape is #309's first constraint
+ * rather than a fallback: **discarding is the recommended way out, not the last
+ * resort.** This app is for a contributor whose goal is one pull request in one
+ * day. A ticket's changes are an afternoon on a checkout they will throw away —
+ * cheap to redo and cheaper to throw away than to untangle — and a contributor
+ * stuck reconciling a branch is a contributor not contributing.
+ *
+ * So the refusal does three things and deliberately not a fourth. It names what
+ * no longer takes the ticket's change. It says why staying behind is the worse
+ * option, which is the half a "could not apply" error never says. And it offers
+ * saving a copy in one click, which is what makes discarding safe and therefore
+ * recommendable. What it does not do is offer to reconcile: there is no
+ * three-way merge UI here and there is not going to be one. Losing work silently
+ * is the only unacceptable outcome; losing it on purpose, with the copy already
+ * offered, is a good one.
+ *
+ * @param {Object}   [root0]
+ * @param {boolean}  [root0.ok]
+ * @param {string}   [root0.code]          A `CARRY_FAILURE` value when `ok` is false.
+ * @param {string[]} [root0.wholesale]
+ * @param {string[]} [root0.merge]
+ * @param {string[]} [root0.conflictPaths] The files that actually collided.
+ * @param {Array}    [root0.refused]
+ * @param {?boolean} [root0.patchKept]     Null when no layer was lifted out.
+ * @param {?string}  [root0.patchLabel]
+ * @return {{tone: string, headline: string, sentences: string[], blocked: string[], offerCopy: boolean, offerDiscard: boolean}}
+ */
+function describeCarryOutcome({ ok = false, code = '', wholesale = [], merge = [], conflictPaths = [], refused = [], patchKept = null, patchLabel = null } = {}) {
+	if (ok) {
+		const carried = wholesale.length + merge.length;
+		const sentences = [carried
+			? `${plural(carried)} came across, and this ticket is now measured against today's trunk.`
+			: 'This ticket is now measured against today\'s trunk.'];
+		// The one thing that can be less than a full success: the layer did not
+		// go back on. Said plainly, and with the record gone, so the panel does
+		// not offer a revert for something that is no longer there.
+		if (patchKept === false) {
+			sentences.push(`${patchLabel || 'The patch you had applied'} does not apply to today's trunk, so it did not come back. Your own work did. It is no longer counted as applied, so you can apply a rebased version of it.`);
+		}
+		return { tone: 'success', headline: 'This ticket is up to date', sentences, blocked: [], offerCopy: false, offerDiscard: false };
+	}
+
+	// The files that really collided, not every file that took the replay route:
+	// the replay is all-or-nothing across the whole patch, so one bad file stops
+	// four good ones, and naming all five as collisions is the kind of imprecision
+	// that makes the whole message untrustworthy. `merge` is the fallback for a
+	// failure that produced no per-file diagnosis at all.
+	const collided = conflictPaths.length ? conflictPaths : merge;
+	const blocked = code === CARRY_FAILURE.CONFLICT
+		? collided.map((path) => `Your change to ${path} no longer fits trunk's version of it.`)
+		: refusalSentences(refused);
+
+	return {
+		tone: 'error',
+		headline: 'This ticket could not be brought up to date',
+		sentences: [
+			'Nothing moved — your ticket is exactly as it was.',
+			WHY_NOT_STAY,
+			'Save a copy of your work, then discard this ticket back to its base and it starts again on today\'s trunk. On this project that is a normal way forward, not a lost afternoon.'
+		],
+		blocked,
+		offerCopy: true,
+		offerDiscard: true
+	};
+}
+
+/**
+ * What the app says when a carry was interrupted and the site needs putting
+ * back together.
+ *
+ * Its own copy rather than the mid-switch sentence, because the two are
+ * different situations with the same shape: a mid-switch failure left work
+ * committed on a branch that still points at it, and this left a branch that may
+ * not. Saying "your work is still committed on that branch" here would be a
+ * guess about the one thing the contributor needs to be true.
+ *
+ * @param {?Object} marker The stored `{ ref }`, when there is one.
+ * @return {?{message: string, actionLabel: string}}
+ */
+function describeCarryInterrupted(marker) {
+	if (!marker || !marker.ref) return null;
+	return {
+		message: `Bringing ${marker.ref} up to date did not finish, so this site is between two states. `
+			+ 'Put it back before doing anything else — your work is recorded and this restores it, '
+			+ 'along with the ticket exactly as it was before.',
+		actionLabel: 'Put this ticket back'
+	};
+}
+
 module.exports = {
 	CARRY_STATE,
+	CARRY_FAILURE,
 	REFUSAL,
 	WHY_NOT_STAY,
 	NOTHING_MOVES_YET,
 	refusalSentence,
 	refusalSentences,
 	describeCarryNote,
-	describeCarryOffer
+	describeCarryOffer,
+	describeCarryOutcome,
+	describeCarryInterrupted
 };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -31,7 +31,7 @@ import { sanitizeSiteFolder, resolveTargetDir, directoryFromFileEntry } from './
 import { noticeForOpenResult } from './open-failure.cjs';
 import { describeApplyFailure, otherPatchCount } from './apply-conflict.cjs';
 import { describeAppliedLayer, describePreviewNotice, absorbedExitFailure } from './applied-layer.cjs';
-import { describeCarryNote } from './carry-note.cjs';
+import { describeCarryNote, describeCarryOffer, describeCarryOutcome, describeCarryInterrupted } from './carry-note.cjs';
 import { trunkAgeInfo, planUpdateSteps, updateStepStatuses, SKIP_INSTALL_MESSAGE, planApplySteps, planWatchImpact, APPLY_STATE_TO_STEP, planSetupSteps, SETUP_STATE_TO_STEP, setupOutcome } from './update-plan.cjs';
 import { pickLatest } from '../latest-patch.cjs';
 import { beginSetup, adoptSetupPath, discardSetup, rowPathAfterStatus } from './pending-setup.cjs';
@@ -1238,6 +1238,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // until the first probe answers, for the same reason the note above is: a
   // sentence that appears and then withdraws itself reads as a glitch.
   const [carry, setCarry] = useState(null);
+  // The offer is opened by the contributor, never by the probe: the app does not
+  // silently rebase anyone (#309), and a panel that appears on its own is one
+  // step from a panel that acts on its own.
+  const [carryOffered, setCarryOffered] = useState(false);
+  const [carryRunning, setCarryRunning] = useState(false);
+  const [carryOutcome, setCarryOutcome] = useState(null);
   const [discarding, setDiscarding] = useState(false);
   const [discardError, setDiscardError] = useState(null);
   const [handleInput, setHandleInput] = useState('');
@@ -1745,7 +1751,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         const generation = probe.generation;
         try {
           const res = await window.api.carryStatus(sitePath);
-          if (res && res.ok && probe.generation === generation) setCarry(res);
+          // An interrupted carry comes back as a refusal rather than a status,
+          // and it is the one answer that must not be dropped: it is the only
+          // route to the button that puts the site back, and the marker behind
+          // it is the only record of where the contributor's work went.
+          const usable = res && (res.ok || res.code === 'carry-incomplete');
+          if (usable && probe.generation === generation) setCarry(res);
         } catch {}
       } while (probe.again);
     } finally { probe.inFlight = false; }
@@ -1758,17 +1769,28 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // count and the incoming ticket's number in the same sentence, over a
   // discard link — so the note is cleared while the new walk runs, and the
   // generation bump keeps the outgoing branch's answer from landing on it.
-  const reprobeAfterBranchChange = useCallback(() => {
+  // Re-measuring after the base itself moved. Everything the card says is
+  // measured from the branch point, so all of it is stale at once — but what the
+  // carry just *reported* is not, and clearing it here is what would swallow the
+  // whole failure panel: the report and the re-probe arrive in the same React
+  // batch, so the panel would be unmounted before it ever rendered.
+  const reprobeAfterCarry = useCallback(() => {
     dirtyProbeRef.current.generation++;
     setWorktreeDirty(null);
     refreshDirty();
-    // The carry answer is per ticket too — a different branch point measured
-    // against the same trunk — so the outgoing ticket's must neither stand while
-    // the incoming one's is worked out nor land on it afterwards.
     carryProbeRef.current.generation++;
     setCarry(null);
+    setCarryOffered(false);
     refreshCarry();
   }, [refreshDirty, refreshCarry]);
+
+  // A branch change is the same re-measurement plus one more thing: the outgoing
+  // ticket's outcome is not an old version of the incoming ticket's, it is about
+  // a different body of work, so it goes.
+  const reprobeAfterBranchChange = useCallback(() => {
+    reprobeAfterCarry();
+    setCarryOutcome(null);
+  }, [reprobeAfterCarry]);
 
   // Only the open card probes, and only while it is open: the probe walks the
   // whole checkout, which is too much to pay for every card on the shelf. The
@@ -2721,10 +2743,87 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // The date is formatted here and the sentence is built there, the same split
   // describeAppliedLayer's `when` uses: locale formatting is the component's,
   // and keeping it out of the module is what lets the copy be asserted.
-  const carryNote = describeCarryNote({
-    state: carry ? carry.state : undefined,
-    since: carry && carry.baseDate ? new Date(carry.baseDate).toLocaleDateString() : ''
-  });
+  const carrySince = carry && carry.baseDate ? new Date(carry.baseDate).toLocaleDateString() : '';
+  const carryNote = describeCarryNote({ state: carry ? carry.state : undefined, since: carrySince });
+  const carryOffer = carryOffered
+    ? describeCarryOffer({ ...(carry || {}), appliedPatch, since: carrySince })
+    : null;
+  // An interrupted carry outranks everything else the card would say: the
+  // recorded base is not where the branch is, so every other sentence on the
+  // card is measured from the wrong place until this is put back.
+  const carryInterrupted = carry && carry.code === 'carry-incomplete'
+    ? describeCarryInterrupted(carry.carryInProgress)
+    : null;
+
+  // Accepting the offer. Streams into the terminal the trunk update already
+  // writes to, so the two checkouts inside a carry report where a contributor
+  // is already looking for the progress of a long git operation.
+  const runCarry = async () => {
+    setCarryOffered(false);
+    setCarryOutcome(null);
+    setCarryRunning(true);
+    markTerminalRunning(true);
+    writeToTerminal(`\nBringing #${tracTicket} up to date…\n`);
+    try {
+      await window.api.carryTicketForward(
+        sitePath,
+        ({ data }) => writeToTerminal(data),
+        (payload) => {
+          setCarryRunning(false);
+          markTerminalRunning(false);
+          setCarryOutcome(payload);
+          if (payload.ok) {
+            confirm('This ticket is up to date');
+            // Its applied layer may not have come back, and the base has moved,
+            // so both the banner and the note are re-read rather than adjusted.
+            loadStatus().catch(() => {});
+          }
+          // Not reprobeAfterBranchChange: that clears the outcome, and the two
+          // land in one React batch — the panel just set would never render.
+          reprobeAfterCarry();
+        }
+      );
+    } catch (e) {
+      setCarryRunning(false);
+      markTerminalRunning(false);
+      setCarryOutcome({ ok: false, error: e && e.message ? e.message : String(e) });
+    }
+  };
+
+  // "Save a copy, then discard and update" — the recommended way out of a
+  // collision (#309), as one chosen outcome rather than three steps the
+  // contributor has to sequence. The discard only runs once the dialog has
+  // really produced a file, and the carry only runs once the discard has: a
+  // cancelled save cancels the whole thing and leaves the ticket untouched.
+  const saveCopyThenDiscardAndCarry = async () => {
+    const savedTo = await savePatchFile();
+    if (!savedTo) return;
+    const outcome = discardOutcome(await window.api.discardToBase(sitePath));
+    if (!outcome.ok) {
+      setCarryOutcome({ ok: false, error: outcome.message });
+      return;
+    }
+    applyDiscardToNote(outcome);
+    setAppliedPatch(null);
+    writeToTerminal(`\nSaved a copy to ${savedTo} and discarded this ticket back to its base.\n`);
+    await runCarry();
+  };
+
+  const reconcileCarry = async () => {
+    setCarryRunning(true);
+    try {
+      const res = await window.api.reconcileCarry(sitePath);
+      if (!res || !res.ok) {
+        setCarryOutcome({ ok: false, error: (res && res.error) || 'The site could not be put back.' });
+        return;
+      }
+      confirm('This ticket is back as it was');
+      reprobeAfterCarry();
+      loadStatus().catch(() => {});
+    } finally {
+      setCarryRunning(false);
+    }
+  };
   const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
   const updateStepStates = updateStepStatuses(updateSteps, updateState);
 
@@ -4593,11 +4692,89 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ marginTop: 4, fontSize: 12, color: '#6c6f72' }}>{changesNote.unlinkNote}</div>
               </div>
             ) : null}
-            {carryNote ? (
-              <div style={{ marginTop: 8, padding: '8px 10px', background: '#f0f6fc', border: '1px solid #c5d9ed', borderRadius: 6, fontSize: 12, color: '#1d2327' }}>
-                {carryNote.text}
+            {/* Bringing this ticket forward (#305). One block with three faces:
+                the quiet note, the offer once it is asked for, and whatever the
+                carry ended in. An interrupted carry replaces all three — nothing
+                else the card says can be trusted until the site is put back. */}
+            {carryInterrupted ? (
+              <div style={{ marginTop: 8, padding: '10px 12px', background: '#fcf0f1', border: '1px solid #d63638', borderRadius: 6, fontSize: 12, color: '#8a2424' }}>
+                <div>{carryInterrupted.message}</div>
+                <Button variant="primary" isBusy={carryRunning} disabled={carryRunning} onClick={reconcileCarry} style={{ marginTop: 8, fontSize: 12 }}>
+                  {carryInterrupted.actionLabel}
+                </Button>
               </div>
-            ) : null}
+            ) : (
+              <>
+                {carryNote && !carryOffer && !carryOutcome ? (
+                  <div style={{ marginTop: 8, padding: '8px 10px', background: '#f0f6fc', border: '1px solid #c5d9ed', borderRadius: 6, fontSize: 12, color: '#1d2327' }}>
+                    <div>{carryNote.text}</div>
+                    <Button
+                      variant="link"
+                      isBusy={carryRunning}
+                      disabled={carryRunning || ticketActionsBlocked}
+                      onClick={() => setCarryOffered(true)}
+                      style={{ marginTop: 4, fontSize: 12 }}
+                    >{carryNote.actionLabel}</Button>
+                  </div>
+                ) : null}
+
+                {carryOffer ? (
+                  <div style={{ marginTop: 8, padding: '10px 12px', background: '#f0f6fc', border: '1px solid #c5d9ed', borderRadius: 6, fontSize: 12, color: '#1d2327' }}>
+                    <div style={{ fontWeight: 600 }}>{carryOffer.headline}</div>
+                    {carryOffer.sentences.map((s) => <div key={s} style={{ marginTop: 4 }}>{s}</div>)}
+                    {carryOffer.blocked.length ? (
+                      <ul style={{ margin: '4px 0 0 16px' }}>
+                        {carryOffer.blocked.map((s) => <li key={s}>{s}</li>)}
+                      </ul>
+                    ) : null}
+                    <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                      {carryOffer.canCarry ? (
+                        <Button variant="primary" isBusy={carryRunning} disabled={carryRunning || ticketActionsBlocked} onClick={runCarry} style={{ fontSize: 12 }}>
+                          {carryOffer.confirmLabel}
+                        </Button>
+                      ) : (
+                        <Button variant="secondary" disabled={carryRunning || ticketActionsBlocked} onClick={saveCopyThenDiscardAndCarry} style={{ fontSize: 12 }}>
+                          Save a copy, then discard and bring it up to date
+                        </Button>
+                      )}
+                      <Button variant="link" disabled={carryRunning} onClick={() => setCarryOffered(false)} style={{ fontSize: 12 }}>
+                        {carryOffer.cancelLabel}
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {carryOutcome ? (() => {
+                  const told = describeCarryOutcome(carryOutcome);
+                  const failed = told.tone === 'error';
+                  return (
+                    <div style={{ marginTop: 8, padding: '10px 12px', borderRadius: 6, fontSize: 12,
+                      background: failed ? '#fcf0f1' : '#edfaef',
+                      border: `1px solid ${failed ? '#d63638' : '#00a32a'}`,
+                      color: failed ? '#8a2424' : '#0d5320' }}>
+                      <div style={{ fontWeight: 600 }}>{told.headline}</div>
+                      {told.sentences.map((s) => <div key={s} style={{ marginTop: 4 }}>{s}</div>)}
+                      {carryOutcome.error && !told.blocked.length ? <div style={{ marginTop: 4 }}>{carryOutcome.error}</div> : null}
+                      {told.blocked.length ? (
+                        <ul style={{ margin: '4px 0 0 16px' }}>
+                          {told.blocked.map((s) => <li key={s}>{s}</li>)}
+                        </ul>
+                      ) : null}
+                      <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                        {told.offerDiscard ? (
+                          <Button variant="secondary" disabled={carryRunning || ticketActionsBlocked} onClick={saveCopyThenDiscardAndCarry} style={{ fontSize: 12 }}>
+                            Save a copy, then discard and bring it up to date
+                          </Button>
+                        ) : null}
+                        <Button variant="link" disabled={carryRunning} onClick={() => setCarryOutcome(null)} style={{ fontSize: 12 }}>
+                          {failed ? 'Leave it as it is' : 'Dismiss'}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })() : null}
+              </>
+            )}
 
             <div ref={ticketPatchesRef} style={{ marginTop: 16, borderTop: '1px solid #f0f0f1', paddingTop: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>

--- a/src/ticket-branches.js
+++ b/src/ticket-branches.js
@@ -299,16 +299,38 @@ async function switchToBranch(dir, ref, { baseOid, author = WIP_AUTHOR, onProgre
 		({ parked } = await parkCurrentWork(dir, { baseOid, author, onProgress: report }));
 	}
 
-	// Tagged with the stage it died in, the same contract updateToLatestTrunk
-	// uses, because the two halves fail very differently.
-	//
-	// `git.checkout` writes HEAD only after every file operation has succeeded.
-	// A failure part-way — an EPERM on Windows from an editor or an antivirus
-	// holding a file is the realistic trigger — therefore leaves HEAD on the
-	// branch we are leaving, over a half-swapped worktree. Parking again in that
-	// state would commit the mixed tree over the good WIP commit and, because
-	// parking rewrites rather than appends, put the real work out of reach. The
-	// caller has to record that and refuse to park until it is reconciled.
+	// See forceCheckout for the failure contract this leans on.
+	await forceCheckout(dir, { ref, from, onProgress: report });
+	if (report) report({ stage: 'done', from });
+	return { switched: true, from, to: ref, parked };
+}
+
+/**
+ * The forced checkout every branch move here ends in, with the failure contract
+ * its callers depend on.
+ *
+ * Tagged with the stage it died in, the same contract updateToLatestTrunk uses,
+ * because the two halves fail very differently.
+ *
+ * `git.checkout` writes HEAD only after every file operation has succeeded. A
+ * failure part-way — an EPERM on Windows from an editor or an antivirus holding
+ * a file is the realistic trigger — therefore leaves HEAD on the branch we are
+ * leaving, over a half-swapped worktree. Parking again in that state would
+ * commit the mixed tree over the good WIP commit and, because parking rewrites
+ * rather than appends, put the real work out of reach. The caller has to record
+ * that and refuse to park until it is reconciled.
+ *
+ * Its own function because the carry (#305) needs the identical contract on a
+ * checkout that is not a `switchToBranch` — it moves onto a tree it has just
+ * written, which `switchToBranch`'s dirty-trunk guard would refuse.
+ *
+ * @param {string}   dir
+ * @param {Object}   root0
+ * @param {string}   root0.ref
+ * @param {?string}  [root0.from]       Branch being left, for the error and the progress.
+ * @param {Function} [root0.onProgress]
+ */
+async function forceCheckout(dir, { ref, from = null, onProgress = null }) {
 	try {
 		// No `nonBlocking`/`batchSize`: measured, the progress events already
 		// arrive spread across the whole checkout without them, and yielding to
@@ -319,7 +341,7 @@ async function switchToBranch(dir, ref, { baseOid, author = WIP_AUTHOR, onProgre
 			dir,
 			ref,
 			force: true,
-			...(report ? { onProgress: (p) => report(mapCheckoutPhase(p)) } : {})
+			...(onProgress ? { onProgress: (p) => onProgress(mapCheckoutPhase(p)) } : {})
 		});
 	} catch (e) {
 		if (e && typeof e === 'object') {
@@ -329,8 +351,6 @@ async function switchToBranch(dir, ref, { baseOid, author = WIP_AUTHOR, onProgre
 		}
 		throw e;
 	}
-	if (report) report({ stage: 'done', from });
-	return { switched: true, from, to: ref, parked };
 }
 
 /**
@@ -384,6 +404,7 @@ module.exports = {
 	countChangesAgainst,
 	parkCurrentWork,
 	startTicketBranch,
+	forceCheckout,
 	switchToBranch,
 	deleteTicketBranch
 };

--- a/src/ticket-carry.js
+++ b/src/ticket-carry.js
@@ -11,12 +11,16 @@
  * back to it is working on the trunk of the day they linked it, indefinitely,
  * and every pull request rebased since then fails to apply on it.
  *
- * This module is the read-only half of the answer. It says whether trunk has
- * moved past the ticket's base, and — path by path — what carrying the ticket's
- * work onto today's trunk would mean for each file. Nothing here writes: no ref
- * moves, no file is touched, no index entry changes. The carry itself is its own
- * change; this is what lets the app *offer* it honestly, and what lets the
- * ticket card say something true before anyone clicks anything.
+ * So this module answers three things, and the file is in that order. Whether
+ * trunk has moved past the ticket's base. What carrying the ticket's work onto
+ * today's trunk would mean for each file — both of those are pure reads, which
+ * is what lets the app *offer* the carry honestly and lets the ticket card say
+ * something true before anyone clicks anything. And then, below the divider,
+ * the carry itself, whose ordering is documented on `carryTicketForward`
+ * because the ordering *is* the safety property.
+ *
+ * The carry is offered and confirmed, never automatic and never part of the
+ * site update — the app does not silently rebase anyone (#309).
  *
  * ## Detection cannot use ancestry
  *
@@ -66,11 +70,23 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const git = require('isomorphic-git');
-const { entryInCommit } = require('./pr-files.cjs');
+const { entryInCommit, modeInCommit, GIT_MODE_EXECUTABLE } = require('./pr-files.cjs');
+const { normalizeEol, normalizeEolBuffer } = require('./git-update.cjs');
+const { unifiedSection } = require('./patch-text.cjs');
+const { applyPatchToDir, diagnoseRemoval } = require('./patch-apply.js');
+const {
+	TRUNK,
+	WIP_MESSAGE,
+	WIP_AUTHOR,
+	parkCurrentWork,
+	switchToBranch,
+	forceCheckout
+} = require('./ticket-branches.js');
 // The vocabulary is the renderer's, for the reason BASE_STATUS is: both sides
 // name these and only one of the two may depend on `isomorphic-git`.
-const { CARRY_STATE, REFUSAL } = require('./renderer/carry-note.cjs');
+const { CARRY_STATE, CARRY_FAILURE, REFUSAL } = require('./renderer/carry-note.cjs');
 
 /**
  * The committer timestamp of a commit, in seconds, or null when it will not
@@ -270,12 +286,433 @@ async function carryStatus(dir, { loadFiles = async () => [], baseOid, trunkOid 
 	return { ...moved, baseOid, trunkOid, ...classified };
 }
 
+// --- performing the carry --------------------------------------------------
+//
+// Everything above is a read. Everything below moves a ref and rewrites a
+// working tree, which makes the *order* the load-bearing part.
+//
+// The branch ref is the only handle on the WIP commit. Parking reparents onto
+// the base rather than stacking, so the previous WIP commit becomes unreachable
+// the moment the branch moves — there is no reflog to fall back on and no second
+// ref to find it by. So nothing moves the ref until the new state is proven, and
+// the one window in which no ref points at the old work is spanned by a marker
+// holding its oid. `reconcileCarry` is what that marker is for.
+
+/**
+ * The bytes and mode to put on the new trunk for one path, read from the parked
+ * commit rather than from disk.
+ *
+ * The commit is the truth here, and deliberately so: the checkout onto trunk is
+ * about to overwrite the working tree, so anything read from it afterwards is
+ * trunk's. A path the parked commit does not have is one the ticket deleted —
+ * the tree says so, never the bytes (#85, #311).
+ *
+ * @param {string}   dir
+ * @param {Object}   root0
+ * @param {string}   root0.wipOid
+ * @param {string[]} root0.paths
+ * @return {Promise<Array<{path: string, deleted: boolean, oid: ?string, mode: ?string, content: ?Buffer}>>}
+ */
+async function readCarryPayload(dir, { wipOid, paths }) {
+	const payload = [];
+	for (const filepath of paths) {
+		const entry = await entryInCommit({ git, fs, dir }, wipOid, filepath);
+		if (!entry || entry.type !== 'blob') {
+			payload.push({ path: filepath, deleted: true, oid: null, mode: null, content: null });
+			continue;
+		}
+		const { blob } = await git.readBlob({ fs, dir, oid: wipOid, filepath });
+		payload.push({
+			path: filepath,
+			deleted: false,
+			oid: entry.oid,
+			// The mode git recorded, not the one the filesystem would report. On
+			// Windows there is no executable bit to read at all, so a file that
+			// arrived as 100755 would be demoted by anything that asked the
+			// filesystem — the argument fileModeForEntry makes for pull requests.
+			mode: entry.mode,
+			content: Buffer.from(blob)
+		});
+	}
+	return payload;
+}
+
+/**
+ * The ticket's own change to the paths trunk has also touched, as a patch.
+ *
+ * Only these go through `applyPatchToDir`, so upstream's other edits to the same
+ * file survive. Built from the two commits rather than from the working tree,
+ * because by the time it is applied the working tree is trunk's.
+ *
+ * @param {string}   dir
+ * @param {Object}   root0
+ * @param {string}   root0.baseOid
+ * @param {string}   root0.wipOid
+ * @param {string[]} root0.paths
+ * @return {Promise<string>} '' when there is nothing to replay.
+ */
+async function buildCarryPatch(dir, { baseOid, wipOid, paths }) {
+	let patch = '';
+	for (const filepath of paths) {
+		const before = await git.readBlob({ fs, dir, oid: baseOid, filepath }).catch(() => null);
+		const after = await git.readBlob({ fs, dir, oid: wipOid, filepath }).catch(() => null);
+		patch += unifiedSection({
+			path: filepath,
+			inOld: Boolean(before),
+			inNew: Boolean(after),
+			a: before ? normalizeEol(Buffer.from(before.blob).toString('utf8')) : '',
+			b: after ? normalizeEol(Buffer.from(after.blob).toString('utf8')) : ''
+		});
+	}
+	return patch;
+}
+
+/**
+ * Writes one carried path onto the checked-out trunk.
+ *
+ * The executable bit is put on the file as well as into the index, on the
+ * platforms that have one. The commit would be right either way — the mode goes
+ * into the tree explicitly — but the *next* park reads the mode off `lstat`, so
+ * a file left at 0644 on disk would have the bit the carry just preserved taken
+ * straight back off it by the following save.
+ *
+ * @param {string} dir
+ * @param {Object} entry      A readCarryPayload row.
+ * @param {string} [platform] Injected so both branches are testable from one machine.
+ */
+function writeCarriedFile(dir, entry, platform = process.platform) {
+	const abs = path.join(dir, entry.path);
+	if (entry.deleted) {
+		fs.rmSync(abs, { force: true });
+		return;
+	}
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, entry.content);
+	// Windows has no bit to set, and asking it to chmod an executable is a
+	// no-op at best — there the mode recorded in the tree is the only truth,
+	// which is the argument fileModeForEntry already makes.
+	if (platform !== 'win32' && entry.mode === GIT_MODE_EXECUTABLE) {
+		try { fs.chmodSync(abs, 0o755); } catch {}
+	}
+}
+
+/**
+ * Stages the carried paths with the oid and mode they are meant to have, and
+ * commits them as the branch's single WIP commit on the new base.
+ *
+ * `updateIndex` rather than `add`, because `add` recomputes the mode from the
+ * filesystem — which on Windows has no executable bit, so a 100755 file would be
+ * silently demoted by the very operation meant to preserve it.
+ *
+ * @param {string}   dir
+ * @param {Object}   root0
+ * @param {string}   root0.ref
+ * @param {string}   root0.trunkOid
+ * @param {Array}    root0.payload  readCarryPayload rows.
+ * @param {string[]} root0.merged   Paths applyPatchToDir wrote, whose bytes are on disk.
+ * @param {Object}   root0.author
+ * @return {Promise<string>} The new WIP commit's oid.
+ */
+async function commitCarriedWork(dir, { ref, trunkOid, payload, merged, author }) {
+	// A ticket with nothing on it — read but never edited — gets its base moved
+	// and no commit at all. An empty WIP commit would be a change to the branch
+	// that no work asked for, and the patch it generates is the same either way.
+	if (!payload.length && !merged.length) return trunkOid;
+
+	for (const entry of payload) {
+		if (entry.deleted) {
+			try { await git.remove({ fs, dir, filepath: entry.path }); } catch {}
+			continue;
+		}
+		await git.updateIndex({ fs, dir, filepath: entry.path, oid: entry.oid, mode: parseInt(entry.mode, 8), add: true });
+	}
+	for (const filepath of merged) {
+		// The patched bytes, LF-normalised the way `add` would: a checkout made by
+		// native git on Windows has CRLF on disk while every blob in the store is
+		// LF, and writing the raw bytes would commit a file whose every line
+		// differs from upstream's.
+		const content = normalizeEolBuffer(fs.readFileSync(path.join(dir, filepath)));
+		const oid = await git.writeBlob({ fs, dir, blob: content });
+		const mode = await modeInCommit({ git, fs, dir }, trunkOid, filepath);
+		await git.updateIndex({ fs, dir, filepath, oid, mode: parseInt(mode || '100644', 8), add: true });
+	}
+	return git.commit({ fs, dir, message: WIP_MESSAGE, author, parent: [trunkOid], ref: `refs/heads/${ref}` });
+}
+
+/**
+ * Brings a ticket's accumulated work onto the trunk the site now has (#305).
+ *
+ * The order is the safety property, and it is the whole design:
+ *
+ *  1. Park, so every edit is in the branch's WIP commit and nothing lives only
+ *     on disk. (The caller has already refused if the site needs reconciling.)
+ *  2. Read the payload and classify. Pure reads — a refusal here has touched
+ *     nothing at all.
+ *  3. Decide the layers. With a patch applied whose text still reverses cleanly,
+ *     lifting it out first is what keeps the contributor's own edits separable;
+ *     an absorbed one moves with them as a single layer, because folding it in
+ *     would destroy the revert the record still promises.
+ *  4. **Persist the marker**, carrying the WIP commit's oid. From here until the
+ *     new commit exists, this is the only thing that keeps the old work
+ *     findable — parking reparents, so no reflog holds it.
+ *  5. Switch to trunk. The ticket ref still points at the old WIP commit, so a
+ *     failure here is today's known mid-switch state and the existing guard
+ *     handles it.
+ *  6. Write. A failure costs nothing: check back out to the ticket, drop the
+ *     marker, report. This is where a genuine conflict surfaces.
+ *  7. Only now move the ref, commit the carried work onto the new base, record
+ *     it, and clear the marker.
+ *  8. Put an applied patch back, if one was lifted out. By this point the carry
+ *     has already succeeded, so a patch that no longer applies loses its record
+ *     rather than the contributor losing their work.
+ *
+ * Electron-free like the rest of the module: the two store writes arrive as
+ * `setMarker` and `setBase`, and `runSwitch` is where main.js wraps a checkout
+ * in its mid-switch marker. `node --test` passes in-memory equivalents and
+ * drives the whole thing against a real repository.
+ *
+ * @param {Object}   root0
+ * @param {string}   root0.dir
+ * @param {string}   root0.ref            The ticket branch.
+ * @param {string}   root0.baseOid        Its current branch point.
+ * @param {string}   root0.trunkOid       Where the site's `trunk` points now.
+ * @param {?Object}  [root0.appliedPatch] The stored layer record (#306), or null.
+ * @param {Object}   [root0.author]
+ * @param {Function} [root0.setMarker]    Persists (or clears, on null) the carry marker.
+ * @param {Function} [root0.setBase]      Records the branch's new branch point.
+ * @param {Function} [root0.runSwitch]    Wraps a checkout in the mid-switch marker.
+ * @param {Function} [root0.onProgress]
+ * @param {Function} [root0.onLog]
+ * @return {Promise<Object>}
+ */
+async function carryTicketForward({
+	dir,
+	ref,
+	baseOid,
+	trunkOid,
+	appliedPatch = null,
+	author = WIP_AUTHOR,
+	setMarker = async () => {},
+	setBase = async () => {},
+	runSwitch = (run) => run(),
+	onProgress = null,
+	onLog = () => {}
+}) {
+	onLog(`Saving your work on ${ref} before anything moves…\n`);
+	await parkCurrentWork(dir, { baseOid, author, onProgress });
+	const wipOid = await git.resolveRef({ fs, dir, ref });
+
+	// Everything from here to the marker is a read.
+	const candidates = await collectTicketChanges(dir, baseOid);
+	const classified = await classifyCarry(dir, { files: candidates, baseOid, trunkOid });
+	if (classified.refused.length) {
+		onLog('\nNothing was moved.\n');
+		return { ok: false, code: CARRY_FAILURE.REFUSED, oid: wipOid, ...classified };
+	}
+
+	// A patch whose text still comes out cleanly is lifted off first, so what is
+	// carried is the contributor's own writing and the patch goes back on top.
+	// One that has been edited over cannot be lifted at all (#306) — it has
+	// become their changes, and it travels as part of them.
+	let liftable = null;
+	if (appliedPatch && appliedPatch.text) {
+		let absorbed = [];
+		try { ({ absorbed } = diagnoseRemoval({ dir, patchText: appliedPatch.text })); } catch { absorbed = [{}]; }
+		if (!absorbed.length) liftable = appliedPatch;
+	}
+
+	// The load-bearing write. Past this line the old WIP commit is reachable only
+	// through the oid recorded here.
+	await setMarker({ ref, oldOid: wipOid, trunkOid, baseOid });
+
+	let ownOid = wipOid;
+	if (liftable) {
+		onLog(`\nLifting ${liftable.label || 'the applied patch'} out so your own work moves on its own…\n`);
+		const undo = await applyPatchToDir({ dir, patchText: liftable.text, reverse: true, onLog });
+		if (undo.ok) {
+			await parkCurrentWork(dir, { baseOid, author, onProgress });
+			ownOid = await git.resolveRef({ fs, dir, ref });
+		} else {
+			// All-or-nothing: nothing was written, so the tree is still the full
+			// WIP. Carry it as one layer rather than abandoning the carry.
+			onLog('It could not be lifted out, so it moves as part of your changes.\n');
+			liftable = null;
+		}
+	}
+
+	// Re-derived only when the lift actually happened, because that is the only
+	// thing that shrinks the set — the classification above still holds (this is
+	// a subset of it) and cannot produce a refusal it did not already produce.
+	// Without a lift the two answers are identical, and the walk behind them
+	// hashes every non-ignored file in the checkout.
+	const own = ownOid === wipOid
+		? classified
+		: await classifyCarry(dir, { files: await collectTicketChanges(dir, baseOid), baseOid, trunkOid });
+	const payload = await readCarryPayload(dir, { wipOid: ownOid, paths: own.wholesale });
+	const patchText = own.merge.length
+		? await buildCarryPatch(dir, { baseOid, wipOid: ownOid, paths: own.merge })
+		: '';
+
+	onLog(`\nMoving ${ref} onto trunk ${trunkOid.slice(0, 7)}…\n`);
+	await runSwitch(() => switchToBranch(dir, TRUNK, { baseOid, author, onProgress }));
+
+	try {
+		// The fallible half first, so a conflict has written nothing at all.
+		if (patchText) {
+			const replay = await applyPatchToDir({ dir, patchText, onLog });
+			if (!replay.ok) {
+				const conflict = new Error(replay.error || 'Your change no longer applies to this file.');
+				conflict.replay = replay;
+				throw conflict;
+			}
+		}
+		for (const entry of payload) writeCarriedFile(dir, entry);
+	} catch (e) {
+		// "Nothing moved" has to be true, and lifting a layer out already moved
+		// the ref: it re-parked, so the branch is at the contributor's work
+		// *without* the patch. Putting the ref back before the checkout is what
+		// makes this the no-op it claims to be — otherwise the layer would be
+		// silently un-applied and, once the marker is cleared below, gone.
+		onLog('\nPutting your ticket back exactly as it was…\n');
+		if (ownOid !== wipOid) {
+			await git.writeRef({ fs, dir, ref: `refs/heads/${ref}`, value: wipOid, force: true });
+		}
+		await runSwitch(() => forceCheckout(dir, { ref, from: TRUNK, onProgress }));
+		// Only now: with the ref back on the WIP commit, the marker is the last
+		// thing still pointing at a state that no longer needs recovering.
+		await setMarker(null);
+		const conflicts = (e && e.replay && e.replay.conflicts) || [];
+		return {
+			ok: false,
+			code: CARRY_FAILURE.CONFLICT,
+			oid: wipOid,
+			conflicts,
+			failures: (e && e.replay && e.replay.failures) || [String(e && e.message ? e.message : e)],
+			// Which files actually collided, as opposed to which ones were merely
+			// on the replay route. `applyPatchToDir` is all-or-nothing across the
+			// whole patch, so without this the report names every replayed file as
+			// a collision — and naming the file is the point of the report.
+			conflictPaths: conflicts.map((c) => c && c.path).filter(Boolean),
+			...own
+		};
+	}
+
+	// Proven. Move the ref, commit onto the new base, and close the window.
+	await git.writeRef({ fs, dir, ref: `refs/heads/${ref}`, value: trunkOid, force: true });
+	// Symbolic, not a checkout: the branch now *is* trunk, and the working tree
+	// is already trunk plus the carried work. A checkout here would either undo
+	// the writes or refuse the dirty tree.
+	await git.writeRef({ fs, dir, ref: 'HEAD', value: `refs/heads/${ref}`, force: true, symbolic: true });
+	const newOid = await commitCarriedWork(dir, { ref, trunkOid, payload, merged: own.merge, author });
+	await setBase({ baseOid: trunkOid, oid: newOid });
+	await setMarker(null);
+
+	// The carry is done; the layer is a separate promise. A patch that no longer
+	// applies to today's trunk loses its record here rather than taking the
+	// contributor's work down with it.
+	let patchKept = null;
+	if (liftable) {
+		onLog(`\nPutting ${liftable.label || 'the applied patch'} back on top…\n`);
+		const again = await applyPatchToDir({ dir, patchText: liftable.text, onLog });
+		patchKept = again.ok;
+		if (again.ok) {
+			await parkCurrentWork(dir, { baseOid: trunkOid, author, onProgress });
+		}
+	}
+
+	return {
+		ok: true,
+		oid: await git.resolveRef({ fs, dir, ref }),
+		previousOid: wipOid,
+		baseOid: trunkOid,
+		patchKept,
+		patchLabel: liftable ? (liftable.label || null) : null,
+		...own
+	};
+}
+
+/**
+ * The ticket's changed paths, in the shape `classifyCarry` reads them.
+ *
+ * The same scan `collectCarryCandidates` in main.js makes, minus the parts that
+ * only the patch modal needs — kept here so the carry can re-ask after lifting a
+ * layer out without crossing back over IPC.
+ *
+ * @param {string} dir
+ * @param {string} baseOid
+ * @return {Promise<Array<{path: string, unreadable: boolean, binary: boolean, deleted: boolean}>>}
+ */
+async function collectTicketChanges(dir, baseOid) {
+	const matrix = await git.statusMatrix({ fs, dir, ref: baseOid });
+	const files = [];
+	for (const [filepath, head, workdir] of matrix) {
+		if (head === workdir) continue;
+		const gone = workdir === 0;
+		let work = null;
+		if (!gone) {
+			work = await fs.promises.readFile(path.join(dir, filepath)).catch(() => null);
+			if (!work) {
+				files.push({ path: filepath, unreadable: true, binary: false, deleted: false });
+				continue;
+			}
+		}
+		const base = head
+			? await git.readBlob({ fs, dir, oid: baseOid, filepath }).catch(() => null)
+			: null;
+		if (head && !base) {
+			files.push({ path: filepath, unreadable: true, binary: false, deleted: gone });
+			continue;
+		}
+		const binary = Boolean((work && work.includes(0)) || (base && Buffer.from(base.blob).includes(0)));
+		files.push({ path: filepath, unreadable: false, binary, deleted: gone });
+	}
+	return files;
+}
+
+/**
+ * Puts a ticket back where the marker says it was.
+ *
+ * The recovery for the one window a carry cannot make atomic: between the marker
+ * being written and the new commit existing, the branch ref may have been left
+ * anywhere, and the old WIP commit is reachable only through the oid the marker
+ * holds. Pointing the branch back at it and checking it out is the whole repair.
+ *
+ * Safe to run when nothing was actually lost — a marker left behind by a carry
+ * that had already finished puts the branch back at its pre-carry commit, which
+ * undoes the carry rather than damaging anything. That is the direction to fail
+ * in: the contributor can carry again, and the alternative is guessing.
+ *
+ * @param {Object}   root0
+ * @param {string}   root0.dir
+ * @param {Object}   root0.marker       A `{ ref, oldOid }` record.
+ * @param {Function} [root0.onProgress]
+ * @return {Promise<{ok: true, ref: string, oid: string}>}
+ */
+async function reconcileCarry({ dir, marker, onProgress = null }) {
+	const { ref, oldOid } = marker || {};
+	if (!ref || !oldOid) {
+		const error = new Error('The interrupted carry left no record of where your work was.');
+		error.code = 'carry-marker-incomplete';
+		throw error;
+	}
+	await git.writeRef({ fs, dir, ref: `refs/heads/${ref}`, value: oldOid, force: true });
+	await git.writeRef({ fs, dir, ref: 'HEAD', value: `refs/heads/${ref}`, force: true, symbolic: true });
+	await forceCheckout(dir, { ref, from: null, onProgress });
+	return { ok: true, ref, oid: oldOid };
+}
+
 module.exports = {
 	REFUSAL,
 	CARRY_STATE,
+	CARRY_FAILURE,
 	commitTime,
 	trunkMovedPast,
 	blobEntryAt,
 	classifyCarry,
-	carryStatus
+	carryStatus,
+	collectTicketChanges,
+	readCarryPayload,
+	buildCarryPatch,
+	carryTicketForward,
+	reconcileCarry
 };

--- a/test/carry-forward.integration.test.cjs
+++ b/test/carry-forward.integration.test.cjs
@@ -1,0 +1,495 @@
+'use strict';
+
+// The carry itself (#305), against real on-disk repositories.
+//
+// Nothing here is stubbed, and `applyPatchToDir` in particular is not: a
+// collision has to come from real bytes in a real repo, or the test proves that
+// a mock returned what it was told to. Same reason the classifier's suite runs
+// against real commits — this is a feature about what is actually on disk
+// afterwards, and every assertion below is about that.
+//
+// The fixture mirrors ticket-branches.integration.test.cjs's `makeSite` — a
+// `trunk` branch over a wordpress-develop-shaped tree, a gitignored
+// `node_modules`, a file to delete — and adds the one thing the carry needs:
+// trunk can be advanced by a second commit while the ticket stays where it was.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const git = require('isomorphic-git');
+const {
+	carryTicketForward,
+	reconcileCarry,
+	collectTicketChanges,
+	buildCarryPatch,
+	CARRY_FAILURE,
+	REFUSAL
+} = require('../src/ticket-carry.js');
+const { startTicketBranch, parkCurrentWork, currentBranchName } = require('../src/ticket-branches.js');
+const { applyPatchToDir } = require('../src/patch-apply.js');
+
+const TRUNK = 'trunk';
+const TICKET = 'ticket/59234';
+const AUTHOR = { name: 'test', email: 'test@example.com' };
+
+const BASE_TIME = Math.floor(Date.UTC(2026, 0, 10) / 1000);
+const LATER_TIME = Math.floor(Date.UTC(2026, 1, 20) / 1000);
+const stamped = (timestamp) => ({ ...AUTHOR, timestamp, timezoneOffset: 0 });
+
+const abs = (dir, file) => path.join(dir, file);
+const read = (dir, file) => fs.readFileSync(abs(dir, file), 'utf8');
+const exists = (dir, file) => fs.existsSync(abs(dir, file));
+
+async function makeSite(t) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'carry-forward-test-'));
+	t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+	await git.init({ fs, dir, defaultBranch: TRUNK });
+	fs.writeFileSync(abs(dir, '.gitignore'), 'node_modules/\nbuild/\n');
+	fs.writeFileSync(abs(dir, 'wp-login.php'), '<?php // trunk\n');
+	fs.writeFileSync(abs(dir, 'doomed.php'), '<?php // to be deleted\n');
+	fs.writeFileSync(abs(dir, 'untouched.php'), 'one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\n');
+	// A `src/` file too, because a handed-over patch's paths are read through
+	// `mapToSrcLayout` — a layer fixture outside it would never resolve.
+	fs.mkdirSync(abs(dir, 'src'), { recursive: true });
+	fs.writeFileSync(abs(dir, 'src/wp-settings.php'), '<?php // settings\n');
+	await git.add({ fs, dir, filepath: ['.gitignore', 'wp-login.php', 'doomed.php', 'untouched.php', 'src/wp-settings.php'] });
+	const baseOid = await git.commit({
+		fs, dir, message: 'trunk', author: stamped(BASE_TIME), committer: stamped(BASE_TIME)
+	});
+
+	// The substrate: gitignored, expensive, and must survive the carry.
+	fs.mkdirSync(abs(dir, 'node_modules/react'), { recursive: true });
+	fs.writeFileSync(abs(dir, 'node_modules/react/index.js'), 'expensive\n');
+	return { dir, baseOid };
+}
+
+/**
+ * Advances `trunk` by a second commit, later in time, and returns the site to
+ * whatever was checked out — the shape "Update to latest trunk" leaves behind.
+ *
+ * @param {string}   dir
+ * @param {Function} mutate Called with `dir`; makes trunk's own changes.
+ * @return {Promise<string>} The new trunk oid.
+ */
+async function advanceTrunk(dir, mutate) {
+	const restore = (await currentBranchName(dir)) || TRUNK;
+	await git.checkout({ fs, dir, ref: TRUNK, force: true });
+	await mutate(dir);
+	for (const [filepath, , workdir] of await git.statusMatrix({ fs, dir })) {
+		if (workdir === 0) await git.remove({ fs, dir, filepath });
+		else await git.add({ fs, dir, filepath });
+	}
+	const oid = await git.commit({
+		fs, dir, message: 'upstream', author: stamped(LATER_TIME), committer: stamped(LATER_TIME)
+	});
+	await git.checkout({ fs, dir, ref: restore, force: true });
+	return oid;
+}
+
+/**
+ * A site with a ticket branch holding the contributor's work, and a trunk that
+ * has moved past it — the state the carry exists for.
+ *
+ * @param {Object}   t
+ * @param {Function} ticketWork   Called with `dir` on the ticket branch.
+ * @param {Function} upstreamWork Called with `dir` on trunk.
+ */
+async function siteBehindTrunk(t, ticketWork, upstreamWork) {
+	const { dir, baseOid } = await makeSite(t);
+	await startTicketBranch(dir, 59234);
+	await ticketWork(dir);
+	await parkCurrentWork(dir, { baseOid, author: AUTHOR });
+	const trunkOid = await advanceTrunk(dir, upstreamWork);
+	return { dir, baseOid, trunkOid };
+}
+
+/** Collects everything the carry would persist, without any electron-store. */
+function recorder() {
+	const state = { marker: null, base: null, markers: [] };
+	return {
+		state,
+		setMarker: async (marker) => { state.marker = marker; state.markers.push(marker); },
+		setBase: async (base) => { state.base = base; }
+	};
+}
+
+/**
+ * The patch this ticket would produce now, built by the app's own machinery
+ * against whatever base it is on.
+ *
+ * @param {string} dir
+ * @param {string} baseOid
+ * @return {Promise<string>}
+ */
+async function patchOfTicketWork(dir, baseOid) {
+	const changes = await collectTicketChanges(dir, baseOid);
+	return buildCarryPatch(dir, {
+		baseOid,
+		wipOid: await git.resolveRef({ fs, dir, ref: TICKET }),
+		paths: changes.filter((c) => !c.binary && !c.unreadable).map((c) => c.path)
+	});
+}
+
+// --- the point of the whole feature ---------------------------------------
+
+// Before the carry, the ticket's patch is written against a trunk that has
+// moved: applying it upstream fails, and generating it against today's trunk
+// would embed reversed upstream hunks. Afterwards it contains the contributor's
+// change and nothing else. That assertion *is* the feature.
+test('a disjoint change carries, and the patch afterwards holds only the contributor\'s work (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'wp-login.php'), '<?php // trunk\n// my fix\n'),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nthree\nfour\nfive\nsix\nseven\nupstream\n')
+	);
+	const store = recorder();
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...store });
+	assert.equal(res.ok, true);
+	assert.equal(res.baseOid, trunkOid);
+	assert.deepEqual(store.state.base, { baseOid: trunkOid, oid: res.oid });
+	assert.equal(store.state.marker, null, 'the marker is cleared once the new state exists');
+
+	// On the ticket, with both changes present.
+	assert.equal(await currentBranchName(dir), TICKET);
+	assert.equal(read(dir, 'wp-login.php'), '<?php // trunk\n// my fix\n');
+	assert.equal(read(dir, 'untouched.php').endsWith('upstream\n'), true, 'upstream\'s change came with the new base');
+
+	// And the branch really is based on the new trunk.
+	const log = await git.log({ fs, dir, ref: TICKET });
+	assert.equal(log[0].commit.parent[0], trunkOid);
+
+	const patch = await patchOfTicketWork(dir, trunkOid);
+	assert.match(patch, /\+\/\/ my fix/);
+	assert.doesNotMatch(patch, /untouched\.php/, 'the patch must not mention a file only trunk changed');
+	assert.doesNotMatch(patch, /^-upstream$/m, 'and it must not reverse an upstream hunk');
+});
+
+// The case the rejected patch-only design could never have handled: a unified
+// diff cannot carry bytes, so the checkout onto new trunk would have deleted
+// this file outright.
+test('a binary file carries byte-identically (#305)', async (t) => {
+	const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02, 0xff, 0x00]);
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => {
+			fs.mkdirSync(abs(d, 'assets'), { recursive: true });
+			fs.writeFileSync(abs(d, 'assets/logo.png'), bytes);
+		},
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+	assert.equal(res.ok, true);
+	assert.deepEqual(fs.readFileSync(abs(dir, 'assets/logo.png')), bytes);
+
+	// And it is committed, not merely left on disk: the next switch must not lose it.
+	const { blob } = await git.readBlob({ fs, dir, oid: res.oid, filepath: 'assets/logo.png' });
+	assert.deepEqual(Buffer.from(blob), bytes);
+});
+
+// #311's case, and the reason the carry reads absence from trees rather than
+// bytes: both sides of an empty add compare equal as text.
+test('an empty added file survives the carry (#305, #311)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'placeholder.php'), ''),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+	assert.equal(res.ok, true);
+	assert.equal(exists(dir, 'placeholder.php'), true, 'an empty file the ticket added must not vanish');
+	assert.equal(read(dir, 'placeholder.php'), '');
+	assert.ok((await git.listFiles({ fs, dir, ref: TICKET })).includes('placeholder.php'));
+});
+
+test('a deletion carries (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.unlinkSync(abs(d, 'doomed.php')),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+	assert.equal(res.ok, true);
+	assert.equal(exists(dir, 'doomed.php'), false, 'the file must stay deleted on the new trunk');
+	assert.equal((await git.listFiles({ fs, dir, ref: TICKET })).includes('doomed.php'), false);
+});
+
+// Asserted on the recorded mode rather than on the filesystem, so it holds on
+// Windows — where there is no executable bit to read and `git.add` would demote
+// a 100755 file to 100644 on the way through.
+test('the executable bit is preserved, in the commit not just on disk (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => {
+			fs.mkdirSync(abs(d, 'tools'), { recursive: true });
+			fs.writeFileSync(abs(d, 'tools/build.sh'), '#!/bin/sh\necho hi\n', { mode: 0o755 });
+		},
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+	// Parked on POSIX, so the branch really does record 100755 going in. On a
+	// platform that cannot express it there is nothing to preserve, and the
+	// assertion below would be about the fixture rather than the carry.
+	const before = await git.walk({
+		fs, dir,
+		trees: [git.TREE({ ref: TICKET })],
+		map: async (filepath, [entry]) => (filepath === 'tools/build.sh' ? entry.mode() : undefined)
+	});
+	if (before[0] !== 0o100755) {
+		t.skip('this filesystem does not record an executable bit');
+		return;
+	}
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+	assert.equal(res.ok, true);
+
+	const after = await git.walk({
+		fs, dir,
+		trees: [git.TREE({ ref: res.oid })],
+		map: async (filepath, [entry]) => (filepath === 'tools/build.sh' ? entry.mode() : undefined)
+	});
+	assert.equal(after[0], 0o100755, 'the mode git recorded has to survive, whatever the filesystem says');
+
+	// And on disk too, or the very next park — which reads the mode off lstat —
+	// takes the bit straight back off the file the carry just preserved it on.
+	// eslint-disable-next-line no-bitwise -- 0o111 is the executable bit; masking is how a POSIX mode is read.
+	assert.notEqual(fs.statSync(abs(dir, 'tools/build.sh')).mode & 0o111, 0);
+	fs.appendFileSync(abs(dir, 'tools/build.sh'), 'echo again\n');
+	await parkCurrentWork(dir, { baseOid: trunkOid, author: AUTHOR });
+	const afterPark = await git.walk({
+		fs, dir,
+		trees: [git.TREE({ ref: TICKET })],
+		map: async (filepath, [entry]) => (filepath === 'tools/build.sh' ? entry.mode() : undefined)
+	});
+	assert.equal(afterPark[0], 0o100755, 'and it has to survive the next save, not just the carry');
+});
+
+test('the gitignored substrate is never touched (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'wp-login.php'), '<?php // trunk\n// my fix\n'),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+	const dep = abs(dir, 'node_modules/react/index.js');
+	const before = fs.statSync(dep).mtimeMs;
+
+	await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+
+	assert.equal(fs.readFileSync(dep, 'utf8'), 'expensive\n');
+	assert.equal(fs.statSync(dep).mtimeMs, before, 'node_modules must not be rewritten by a carry');
+	assert.equal((await git.listFiles({ fs, dir, ref: TICKET })).some((f) => f.startsWith('node_modules/')), false);
+});
+
+// --- when it will not go through ------------------------------------------
+
+// The refusal that matters most: a real conflict, from real bytes. Both sides
+// edit the same lines, so the replay genuinely cannot apply — and the ticket
+// has to come out of it byte-for-byte and commit-for-commit unchanged.
+test('a collision refuses and leaves the ticket exactly as it was (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nMINE\nfour\nfive\nsix\nseven\neight\n'),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nTHEIRS\nfour\nfive\nsix\nseven\neight\n')
+	);
+	const store = recorder();
+	const oidBefore = await git.resolveRef({ fs, dir, ref: TICKET });
+	const contentsBefore = read(dir, 'untouched.php');
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...store });
+	assert.equal(res.ok, false);
+	assert.equal(res.code, CARRY_FAILURE.CONFLICT);
+	assert.deepEqual(res.merge, ['untouched.php'], 'the report names the file that no longer takes the change');
+
+	// The oid, not just the contents: a rewritten WIP commit with identical
+	// bytes would still have thrown the contributor's history away.
+	assert.equal(await git.resolveRef({ fs, dir, ref: TICKET }), oidBefore);
+	assert.equal(await currentBranchName(dir), TICKET);
+	assert.equal(read(dir, 'untouched.php'), contentsBefore);
+	assert.equal(read(dir, 'wp-login.php'), '<?php // trunk\n');
+	assert.equal(store.state.marker, null, 'a failed carry leaves no marker behind');
+	assert.equal(store.state.base, null, 'and does not move the recorded base');
+	assert.ok(store.state.markers.length >= 1, 'but it did set one while the tree was in motion');
+});
+
+test('a file upstream deleted that the ticket edited gets its own refusal (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'doomed.php'), '<?php // still working on this\n'),
+		(d) => fs.unlinkSync(abs(d, 'doomed.php'))
+	);
+	const store = recorder();
+	const oidBefore = await git.resolveRef({ fs, dir, ref: TICKET });
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...store });
+	assert.equal(res.ok, false);
+	assert.equal(res.code, CARRY_FAILURE.REFUSED);
+	assert.deepEqual(res.refused, [{ path: 'doomed.php', reason: REFUSAL.UPSTREAM_DELETED }]);
+
+	// Refused before anything moved at all, so not even a marker was written.
+	assert.equal(await git.resolveRef({ fs, dir, ref: TICKET }), oidBefore);
+	assert.equal(read(dir, 'doomed.php'), '<?php // still working on this\n');
+	assert.deepEqual(store.state.markers, []);
+});
+
+// --- nothing to carry ------------------------------------------------------
+
+test('a ticket with no work moves its base and goes nowhere near the patch code (#305)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	await startTicketBranch(dir, 59234);
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n'));
+	const store = recorder();
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...store });
+	assert.equal(res.ok, true);
+	assert.deepEqual(res.merge, [], 'nothing to replay means the patch machinery is never reached');
+	assert.deepEqual(res.wholesale, []);
+	assert.equal(store.state.base.baseOid, trunkOid);
+	assert.equal(await git.resolveRef({ fs, dir, ref: TICKET }), trunkOid, 'the branch is trunk, with no WIP commit on it');
+	assert.equal(read(dir, 'untouched.php'), 'upstream only\n');
+});
+
+// --- with a patch applied on top (#306) ------------------------------------
+
+// The patch a mentor handed over, in the shape the app stores it: text kept, so
+// it can be lifted out. Written against the ticket's own base.
+const LAYER_PATCH = [
+	'--- a/src/wp-settings.php',
+	'+++ b/src/wp-settings.php',
+	'@@ -1 +1,2 @@',
+	' <?php // settings',
+	'+// from the pull request',
+	''
+].join('\n');
+
+test('with a liftable patch applied, both layers come across (#305, #306)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	await startTicketBranch(dir, 59234);
+	// The contributor's own work, then somebody else's patch on top of it.
+	fs.writeFileSync(abs(dir, 'my-notes.php'), '<?php // mine\n');
+	const applied = await applyPatchToDir({ dir, patchText: LAYER_PATCH });
+	assert.equal(applied.ok, true, 'the fixture has to really apply, or this proves nothing');
+	await parkCurrentWork(dir, { baseOid, author: AUTHOR });
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n'));
+
+	const res = await carryTicketForward({
+		dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR,
+		appliedPatch: { label: 'Pull request #1234', text: LAYER_PATCH },
+		...recorder()
+	});
+	assert.equal(res.ok, true);
+	assert.equal(res.patchKept, true);
+	assert.equal(read(dir, 'my-notes.php'), '<?php // mine\n', 'the contributor\'s own work came across');
+	assert.match(read(dir, 'src/wp-settings.php'), /from the pull request/, 'and the layer went back on top');
+	assert.equal(read(dir, 'untouched.php'), 'upstream only\n', 'on the new trunk');
+});
+
+test('a stored patch that no longer applies loses its record, not the contributor\'s work (#305, #306)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	await startTicketBranch(dir, 59234);
+	fs.writeFileSync(abs(dir, 'my-notes.php'), '<?php // mine\n');
+	assert.equal((await applyPatchToDir({ dir, patchText: LAYER_PATCH })).ok, true);
+	await parkCurrentWork(dir, { baseOid, author: AUTHOR });
+	// Upstream rewrote the very line the patch anchors on, so it lifts out
+	// cleanly here and refuses to go back on over there. Real bytes, no stub.
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(abs(d, 'src/wp-settings.php'), '<?php // upstream rewrote this file entirely\n'));
+
+	const res = await carryTicketForward({
+		dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR,
+		appliedPatch: { label: 'Pull request #1234', text: LAYER_PATCH },
+		...recorder()
+	});
+	assert.equal(res.ok, true, 'the contributor\'s own work still carried');
+	assert.equal(res.patchKept, false);
+	assert.equal(res.patchLabel, 'Pull request #1234', 'the message can name the pull request');
+	assert.equal(read(dir, 'my-notes.php'), '<?php // mine\n');
+	assert.match(read(dir, 'src/wp-settings.php'), /upstream rewrote this file entirely/);
+});
+
+// The cell the other tests do not reach: a lift succeeded, so the ref has
+// already moved to the contributor's work *without* the layer — and then the
+// replay collides. "Nothing moved" has to be literally true, layer included.
+test('a collision after the layer was lifted out puts the layer back too (#305, #306)', async (t) => {
+	const { dir, baseOid } = await makeSite(t);
+	await startTicketBranch(dir, 59234);
+	// Work on a file trunk is about to move underneath, plus a patch on another.
+	fs.writeFileSync(abs(dir, 'untouched.php'), 'one\ntwo\nMINE\nfour\nfive\nsix\nseven\neight\n');
+	assert.equal((await applyPatchToDir({ dir, patchText: LAYER_PATCH })).ok, true);
+	await parkCurrentWork(dir, { baseOid, author: AUTHOR });
+	const oidBefore = await git.resolveRef({ fs, dir, ref: TICKET });
+	const trunkOid = await advanceTrunk(dir, (d) => fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nTHEIRS\nfour\nfive\nsix\nseven\neight\n'));
+	const store = recorder();
+
+	const res = await carryTicketForward({
+		dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR,
+		appliedPatch: { label: 'Pull request #1234', text: LAYER_PATCH },
+		...store
+	});
+	assert.equal(res.ok, false);
+	assert.equal(res.code, CARRY_FAILURE.CONFLICT);
+
+	// Every part of "exactly as it was", including the part the lift moved.
+	assert.equal(await git.resolveRef({ fs, dir, ref: TICKET }), oidBefore, 'the WIP commit must be the one the ticket had');
+	assert.equal(await currentBranchName(dir), TICKET);
+	assert.equal(read(dir, 'untouched.php'), 'one\ntwo\nMINE\nfour\nfive\nsix\nseven\neight\n');
+	assert.match(read(dir, 'src/wp-settings.php'), /from the pull request/, 'the lifted layer has to come back');
+	assert.equal(store.state.marker, null);
+});
+
+// A refusal names the file that actually collided, not every file that happened
+// to take the replay route — `applyPatchToDir` is all-or-nothing, so one bad
+// file stops the good ones with it.
+test('a collision reports which file collided, not the whole replay set (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => {
+			fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nMINE\nfour\nfive\nsix\nseven\neight\n');
+			fs.writeFileSync(abs(d, 'wp-login.php'), '<?php // trunk\n// mine too\n');
+		},
+		(d) => {
+			fs.writeFileSync(abs(d, 'untouched.php'), 'one\ntwo\nTHEIRS\nfour\nfive\nsix\nseven\neight\n');
+			fs.writeFileSync(abs(d, 'wp-login.php'), '<?php // trunk\n// and a line upstream added at the end\n');
+		}
+	);
+
+	const res = await carryTicketForward({ dir, ref: TICKET, baseOid, trunkOid, author: AUTHOR, ...recorder() });
+	assert.equal(res.ok, false);
+	assert.equal(res.merge.length, 2, 'both files took the replay route');
+	assert.deepEqual(res.conflictPaths, ['untouched.php'], 'only one of them actually collided');
+});
+
+// --- recovery --------------------------------------------------------------
+
+// The window the marker exists for: the branch ref has moved and no ref points
+// at the contributor's work any more. Set by hand, as a crash would leave it.
+test('reconciling an interrupted carry puts the branch back where the marker says (#305)', async (t) => {
+	const { dir, baseOid, trunkOid } = await siteBehindTrunk(
+		t,
+		(d) => fs.writeFileSync(abs(d, 'wp-login.php'), '<?php // trunk\n// my fix\n'),
+		(d) => fs.writeFileSync(abs(d, 'untouched.php'), 'upstream only\n')
+	);
+	const oldOid = await git.resolveRef({ fs, dir, ref: TICKET });
+
+	// Exactly the state a crash between step 4 and step 7 leaves: the ref moved
+	// onto trunk, the worktree trunk's, and only the marker knowing better.
+	await git.writeRef({ fs, dir, ref: `refs/heads/${TICKET}`, value: trunkOid, force: true });
+	await git.checkout({ fs, dir, ref: TICKET, force: true });
+	assert.equal(read(dir, 'wp-login.php'), '<?php // trunk\n', 'the fixture must really have lost the work');
+
+	const res = await reconcileCarry({ dir, marker: { ref: TICKET, oldOid, trunkOid, baseOid } });
+	assert.deepEqual(res, { ok: true, ref: TICKET, oid: oldOid });
+	assert.equal(await git.resolveRef({ fs, dir, ref: TICKET }), oldOid);
+	assert.equal(await currentBranchName(dir), TICKET);
+	assert.equal(read(dir, 'wp-login.php'), '<?php // trunk\n// my fix\n', 'and the worktree comes back with it');
+});
+
+test('a marker with nothing to point at refuses rather than guessing (#305)', async (t) => {
+	const { dir } = await makeSite(t);
+	await assert.rejects(
+		() => reconcileCarry({ dir, marker: { ref: TICKET } }),
+		(e) => e.code === 'carry-marker-incomplete'
+	);
+});

--- a/test/carry-note.test.cjs
+++ b/test/carry-note.test.cjs
@@ -10,12 +10,15 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
 	CARRY_STATE,
+	CARRY_FAILURE,
 	REFUSAL,
 	WHY_NOT_STAY,
 	NOTHING_MOVES_YET,
 	refusalSentences,
 	describeCarryNote,
-	describeCarryOffer
+	describeCarryOffer,
+	describeCarryOutcome,
+	describeCarryInterrupted
 } = require('../src/renderer/carry-note.cjs');
 
 // --- the card's note -------------------------------------------------------
@@ -140,4 +143,86 @@ test('an applied layer is named, and the two faces read differently (issue #305,
 test('no offer is made for a ticket that is not behind (issue #305)', () => {
 	assert.equal(describeCarryOffer({ state: CARRY_STATE.CURRENT, wholesale: ['a.php'] }), null);
 	assert.equal(describeCarryOffer({ state: CARRY_STATE.UNKNOWN }), null);
+});
+
+// --- what it says afterwards ----------------------------------------------
+
+test('a finished carry says how much came across and nothing else (issue #305)', () => {
+	const out = describeCarryOutcome({ ok: true, wholesale: ['a.php', 'b.php'], merge: ['c.php'] });
+	assert.equal(out.tone, 'success');
+	assert.match(out.sentences.join(' '), /3 files came across/);
+	assert.equal(out.offerDiscard, false, 'a success must not recommend throwing the work away');
+});
+
+// The half-success: the carry worked, the layer did not come back. Both facts
+// have to be said, and the record is gone, so the panel must not go on offering
+// a revert for a patch that is no longer there.
+test('a layer that no longer applies is named, and the work is still reported as carried (#305, #306)', () => {
+	const out = describeCarryOutcome({
+		ok: true,
+		wholesale: ['a.php'],
+		patchKept: false,
+		patchLabel: 'Pull request #1234'
+	});
+	assert.equal(out.tone, 'success');
+	const text = out.sentences.join(' ');
+	assert.match(text, /Pull request #1234 does not apply to today's trunk/);
+	assert.match(text, /Your own work did/);
+	assert.match(text, /no longer counted as applied/);
+});
+
+// #309's first constraint, in copy: discarding is the recommended way out, and
+// the copy is what makes it safe. No reconciliation is offered, on purpose.
+test('a collision recommends saving a copy and discarding, and says why staying is worse (#305, #309)', () => {
+	const out = describeCarryOutcome({
+		ok: false,
+		code: CARRY_FAILURE.CONFLICT,
+		merge: ['src/class-wp-query.php']
+	});
+	assert.equal(out.tone, 'error');
+	assert.equal(out.offerCopy, true);
+	assert.equal(out.offerDiscard, true);
+	const text = out.sentences.join(' ');
+	assert.match(text, /Nothing moved/);
+	assert.ok(text.includes(WHY_NOT_STAY), 'the contributor has to be told why staying behind is worse');
+	assert.match(text, /Save a copy of your work/);
+	assert.deepEqual(out.blocked, ['Your change to src/class-wp-query.php no longer fits trunk\'s version of it.']);
+});
+
+// The replay is all-or-nothing across the whole patch, so one bad file stops
+// the good ones with it. Naming all of them as collisions is what makes the
+// message stop being worth reading.
+test('a collision names the file that collided, not everything on the replay route (issue #305)', () => {
+	const out = describeCarryOutcome({
+		ok: false,
+		code: CARRY_FAILURE.CONFLICT,
+		merge: ['a.php', 'b.php', 'c.php'],
+		conflictPaths: ['b.php']
+	});
+	assert.deepEqual(out.blocked, ['Your change to b.php no longer fits trunk\'s version of it.']);
+});
+
+test('a collision with no per-file diagnosis falls back to the replay set (issue #305)', () => {
+	const out = describeCarryOutcome({ ok: false, code: CARRY_FAILURE.CONFLICT, merge: ['a.php'], conflictPaths: [] });
+	assert.equal(out.blocked.length, 1, 'saying nothing would be worse than saying too much');
+});
+
+test('a refusal narrates its reasons rather than the files that were fine (#305)', () => {
+	const out = describeCarryOutcome({
+		ok: false,
+		code: CARRY_FAILURE.REFUSED,
+		wholesale: ['fine.php'],
+		refused: [{ path: 'gone.php', reason: REFUSAL.UPSTREAM_DELETED }]
+	});
+	assert.equal(out.blocked.length, 1);
+	assert.match(out.blocked[0], /Trunk has deleted gone\.php/);
+});
+
+test('an interrupted carry is named only when there is a record to act on (issue #305)', () => {
+	assert.equal(describeCarryInterrupted(null), null);
+	assert.equal(describeCarryInterrupted({}), null);
+	const block = describeCarryInterrupted({ ref: 'ticket/59234', oldOid: 'abc123' });
+	assert.match(block.message, /ticket\/59234/);
+	assert.match(block.message, /did not finish/);
+	assert.ok(block.actionLabel);
 });

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -663,6 +663,101 @@ test('git:carry-status answers unknown for a base it never recorded (#305, #308)
 	assert.equal(res.baseStatus, 'unrecorded');
 });
 
+// --- git:carry-ticket and its recovery (#305) ------------------------------
+
+test('git:carry-ticket streams, moves the branch onto trunk, and records the new base (#305)', async (t) => {
+	const { dir, baseOid, workFile } = await parkedTicketRepo(t);
+	const trunkOid = await advanceTrunkPast(dir, (d) => fs.writeFileSync(path.join(d, 'upstream.php'), '<?php // new\n'));
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: { [dir]: { tracTicket: 62281, branches: { 'ticket/62281': { tracTicket: 62281, baseOid } } } }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+	const event = createIpcEvent();
+
+	const { carryId } = await main.invokeWith('git:carry-ticket', event, dir);
+	const done = await waitForDone(event, 'git:carry-ticket:done', 'carryId', carryId);
+
+	assert.equal(done.ok, true);
+	assert.ok(
+		event.sent.some((m) => m.channel === 'git:carry-ticket:log'),
+		'a multi-checkout operation has to stream, not accumulate'
+	);
+	// The branch really moved, and the store agrees with the repository.
+	const meta = settings.values.siteMeta[dir];
+	assert.equal(meta.branches['ticket/62281'].baseOid, trunkOid);
+	assert.equal(meta.carryInProgress, null, 'the marker is cleared once the new state exists');
+	const log = await git.log({ fs, dir, ref: 'ticket/62281' });
+	assert.equal(log[0].commit.parent[0], trunkOid);
+	// The contributor's work, on the new trunk.
+	assert.match(fs.readFileSync(path.join(dir, workFile), 'utf8'), /the ticket work/);
+	assert.equal(fs.existsSync(path.join(dir, 'upstream.php')), true);
+});
+
+// The marker's whole job: everything that reads a diff has to stop, because the
+// recorded base is not where the branch is any more.
+test('an unfinished carry blocks the note, the patch modal and the pull request (#305)', async (t) => {
+	const { dir, baseOid } = await parkedTicketRepo(t);
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({
+				sites: [dir],
+				siteMeta: {
+					[dir]: {
+						tracTicket: 62281,
+						branches: { 'ticket/62281': { tracTicket: 62281, baseOid } },
+						carryInProgress: { ref: 'ticket/62281', oldOid: baseOid }
+					}
+				}
+			}).stubs
+		}
+	});
+
+	for (const channel of ['git:unsubmitted-work', 'git:get-patch', 'git:save-patch', 'git:carry-status']) {
+		const res = await main.invoke(channel, dir);
+		assert.equal(res.ok, false, `${channel} must refuse while the site needs reconciling`);
+		assert.equal(res.code, 'carry-incomplete', channel);
+	}
+	const preview = await main.invoke('git:preview-patch', dir, LOGIN_DIFF);
+	assert.equal(preview.code, 'carry-incomplete');
+	const pr = await main.invoke('github:open-pr', dir, {});
+	assert.equal(pr.ok, false, 'a pull request built on a stale base would carry files nobody touched');
+});
+
+test('git:carry-reconcile puts the branch back where the marker says (#305)', async (t) => {
+	const { dir, baseOid, workFile } = await parkedTicketRepo(t);
+	const oldOid = await git.resolveRef({ fs, dir, ref: 'ticket/62281' });
+	const trunkOid = await advanceTrunkPast(dir, (d) => fs.writeFileSync(path.join(d, 'upstream.php'), '<?php // new\n'));
+	// The state a crash mid-carry leaves: the branch moved off the work, and
+	// only the marker knowing where it went.
+	await git.writeRef({ fs, dir, ref: 'refs/heads/ticket/62281', value: trunkOid, force: true });
+	await git.checkout({ fs, dir, ref: 'ticket/62281', force: true });
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: {
+			[dir]: {
+				branches: { 'ticket/62281': { tracTicket: 62281, baseOid: trunkOid } },
+				carryInProgress: { ref: 'ticket/62281', oldOid, baseOid, trunkOid }
+			}
+		}
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+
+	const res = await main.invokeWith('git:carry-reconcile', createIpcEvent(), dir);
+	assert.equal(res.ok, true);
+	assert.equal(res.reconciled, true);
+	assert.equal(await git.resolveRef({ fs, dir, ref: 'ticket/62281' }), oldOid);
+	assert.match(fs.readFileSync(path.join(dir, workFile), 'utf8'), /the ticket work/);
+
+	const meta = settings.values.siteMeta[dir];
+	assert.equal(meta.carryInProgress, null);
+	assert.equal(meta.branches['ticket/62281'].baseOid, baseOid, 'the base goes back too, not just the ref');
+	assert.equal(meta.tracTicket, 62281);
+	// And the site is usable again.
+	assert.equal((await main.invoke('git:unsubmitted-work', dir)).ok, true);
+});
+
 // What a discard leaves behind rides on its reply: on a ticket branch the
 // parked work survives the reset (destroying a ticket is what deleting its
 // branch is for), so answering "clean" would hide the note over work that is
@@ -849,6 +944,7 @@ test('git:get-patch normalizes both sides of the diff through git-update', async
 	const main = loadMain({
 		stubs: {
 			...silentLogging(),
+			...fakeSettingsStore({}).stubs,
 			'./git-update.cjs': { normalizeEol },
 			'./trunk-update': { ensureAutocrlf }
 		}
@@ -883,7 +979,9 @@ test('git:get-patch includes an untracked file without staging it (issues #108, 
 	fs.mkdirSync(path.join(dir, 'node_modules'));
 	fs.writeFileSync(path.join(dir, 'node_modules', 'junk.js'), 'noise\n');
 
-	const main = loadMain({ stubs: { ...silentLogging(), './trunk-update': { ensureAutocrlf: async () => {} } } });
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...fakeSettingsStore({}).stubs, './trunk-update': { ensureAutocrlf: async () => {} } }
+	});
 	const before = await git.statusMatrix({ fs, dir });
 	const result = await main.invoke('git:get-patch', dir);
 
@@ -914,8 +1012,19 @@ async function patchRepo(t, files) {
 	return dir;
 }
 
+// The settings stub is not optional here even though none of these tests care
+// about the registry: every patch generator now asks whether the site needs
+// reconciling first (#305), and that reads electron-store — which without the
+// seam pulls the real `electron` in through the ESM loader, where the harness's
+// require hook cannot reach it.
 function patchMain() {
-	return loadMain({ stubs: { ...silentLogging(), './trunk-update': { ensureAutocrlf: async () => {} } } });
+	return loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore({}).stubs,
+			'./trunk-update': { ensureAutocrlf: async () => {} }
+		}
+	});
 }
 
 // The patch is what a contributor hands over, so a change it does not mention
@@ -1090,7 +1199,9 @@ test('git:create-patch and git:save-patch generate the patch the same way', asyn
 		// keeps this test off the network, since the next step fetches
 		// wordpress-develop when the repository has no origin/trunk.
 		const ensureAutocrlf = spy(async () => { throw new Error('not a repository'); });
-		const main = loadMain({ stubs: { ...silentLogging(), './trunk-update': { ensureAutocrlf } } });
+		const main = loadMain({
+			stubs: { ...silentLogging(), ...fakeSettingsStore({}).stubs, './trunk-update': { ensureAutocrlf } }
+		});
 
 		await main.invoke(channel, dir);
 
@@ -1846,7 +1957,9 @@ test('sites:set-ticket refuses unregistered site paths before writing metadata',
 
 test('git:preview-patch reads the patch through patch-plan', async () => {
 	const parsePatchFiles = spy(() => ({ ok: false, error: 'unreadable' }));
-	const main = loadMain({ stubs: { ...silentLogging(), './patch-plan.cjs': { parsePatchFiles, planApply: () => ({}) } } });
+	const main = loadMain({
+		stubs: { ...silentLogging(), ...fakeSettingsStore({}).stubs, './patch-plan.cjs': { parsePatchFiles, planApply: () => ({}) } }
+	});
 
 	const result = await main.invoke('git:preview-patch', '/sites/wp', 'PATCH TEXT');
 
@@ -3807,6 +3920,8 @@ const WIRED = new Set([
 	'git:worktree-dirty',
 	'git:unsubmitted-work',
 	'git:carry-status',
+	'git:carry-ticket',
+	'git:carry-reconcile',
 	'git:discard-changes',
 	'git:discard-to-base',
 	'git:update-trunk',


### PR DESCRIPTION
> **Stacked on #320**, which added the read-only detection this acts on. Review that one first; this
> diff is against its branch.

## Why

#320 taught the app to *see* that a ticket is still on the trunk it was born from. This is the action
that closes the gap: **bring this ticket up to date**, offered when the contributor comes back to the
ticket and confirmed before anything moves.

Without it, the only ways off an old trunk are destructive and unexplained — discard the ticket's
work, or delete the branch — and a contributor who follows every piece of staleness advice the app
gives still watches rebased pull requests fail to apply, indefinitely.

## What changes

**The carry does not route the ticket through a generated patch.** That design was considered and
rejected: a unified diff cannot express a binary, an empty add or delete (#311), or a file that would
not read, and the checkout onto new trunk **deletes** every path the patch failed to represent. So
each changed path is classified (#320's classifier) and takes the route it can survive:

- **Untouched upstream** — the ticket's bytes and mode go across wholesale, through
  `readCarryPayload` + `git.updateIndex`. No text matching at all: the base side is byte-identical,
  so the ticket's version *is* the result. This is how a binary, an empty file, a deletion and an
  executable bit survive.
- **Touched upstream** — only these go through `applyPatchToDir`, so upstream's other edits to that
  file survive. A failure here is a genuine conflict.
- **Refused** — upstream deleted it, both sides added it, both sides changed the same binary, or it
  would not read. Refused *before anything moves*.

**The ordering is the safety property**, and it is what to review hardest. The branch ref is the only
handle on the WIP commit — parking reparents onto the base rather than stacking, so there is no
reflog to fall back on. So: park → classify (pure reads; a refusal here has touched nothing) → decide
the layers → **persist a marker holding the old commit's oid** → switch to trunk → write → *only
then* move the ref, commit onto the new base, record it, clear the marker. A failure at the write
step costs nothing: the ref has not moved, so checking the branch out again restores every path.
`git:carry-reconcile` spends the marker if the app dies in the one window the marker exists for.

**The marker blocks more than the switch marker does**, folded into one `reconcileBlock` gate: the
card's note, all three patch generators, the preview, the apply and the pull-request flow. Between
the ref moving and the store write, the recorded base names a commit the branch is no longer on, and
every one of those would render a confidently wrong diff rather than none.

**Two layers, not one.** With a patch applied whose text still reverses cleanly, it is lifted out
first so the contributor's own edits move on their own, then put back on top. Folding it in would
destroy the revert the record still promises. An **absorbed** patch (#306) moves with the work as a
single layer, which is correct — it *has* become their changes. And if the patch no longer applies to
today's trunk, the contributor's own work still carried and the *record* is what gets dropped, so
they can apply a rebased version.

**When it collides, discarding is what is recommended** — #309's first constraint, not a fallback.
The failure names what no longer fits, says why staying behind is worse, and offers *save a copy,
then discard and bring it up to date* as one action. There is deliberately **no reconciliation UI**:
losing work silently is the only unacceptable outcome; losing it on purpose with the copy already
offered is a good one.

**Deliberately not in this PR:** any automatic carry (it is never part of the site update — the app
does not silently rebase anyone); a three-way merge; carrying more than one patch layer; and the
guide, which is #314.

## How to test this

**Platforms:** any. Buildkite builds a signed artifact for this branch; check it matches the head
commit.

**Starting state:** a site with `wordpress-develop` cloned, installed and built, and two Trac ticket
numbers. Start by clicking **Update to latest trunk** so the site is current before you link
anything.

1. **Link ticket A.** Edit `src/wp-login.php` — add a comment line near the top. Also add a new file
   `src/my-notes.php` and delete a file you do not need.
2. **Update to latest trunk again**, some hours or a day later, so upstream really has moved. You are
   put back on ticket A.
   → The card shows a blue note: this ticket started from trunk as of *(the older date)*, and why
   staying behind will keep costing you.
3. **Click "Bring this ticket up to date".**
   → An offer appears counting your files: how many come across exactly as they are, how many trunk
   has also changed. It says nothing moves until you accept. **Nothing has moved yet** — confirm with
   `git -C <site> log --oneline -1 ticket/<A>` before and after opening the offer.
4. **Click "Bring it up to date".** The terminal streams the two checkouts.
   → Your edit to `src/wp-login.php`, your new file and your deletion are all still exactly as you
   left them, *and* today's upstream changes are in the checkout alongside them.
   → **Save the ticket's patch** (Review and submit → Save). It contains your three changes and
   **nothing else** — no upstream file, no reversed upstream hunk. That assertion is the feature.
5. **Force a collision.** On ticket B, edit a line in a file that upstream is actively changing (pick
   one from `git -C <site> log -1 --stat trunk`), then update trunk again and accept the offer.
   → It refuses. It names the file, says nothing moved, says why staying behind is worse, and offers
   *Save a copy, then discard and bring it up to date*.
   → **Check the ticket is untouched**: `git -C <site> log --oneline -1 ticket/<B>` is the same oid as
   before, and every file on disk is byte-identical.
6. **Take that offer.** A save dialog appears; save the file. The ticket is discarded back to its
   base and then brought up to date in one go. Open the saved `.diff` — your work is in it.
   → Cancel the save dialog instead, on a second run: **nothing** should happen. No discard, no carry.
7. **A ticket with nothing on it.** Link ticket B fresh, update trunk, accept the offer. It says there
   is no work yet and only the base moves; afterwards the branch is exactly trunk.
8. **With a pull request applied.** Apply a pull request that touches a file trunk has not moved,
   update trunk, then accept the offer. The offer says the patch is lifted out first and put back on
   top; afterwards the panel still shows it applied, with Revert offered.

**What must not have happened:**

- **No edit disappeared, at any step** — not the file you edited, not the file you added, not the
  file you deleted, and not on the refusal path.
- **`node_modules` was not reinstalled or rebuilt**, and no install or build ran that the app did not
  announce.
- The saved patch after a carry contains **only your files**. An upstream filename in it, or a `-`
  line you did not write, is the failure this whole PR exists to prevent.
- The ticket's WIP commit oid did not change on a refusal. Contents matching is not enough — check
  the oid.
- No ticket changed its base without you accepting first. In particular, **"Update to latest trunk"
  must still leave every ticket branch exactly where it was.**

**What could not be tested by hand:** the recovery path. Reaching it needs the app to die between the
marker being written and the new commit existing — a window of a few hundred milliseconds that I
could not stage by hand. It is covered two ways instead: `test/carry-forward.integration.test.cjs`
sets the marker by hand over a branch that has genuinely lost its work and asserts the branch and the
worktree both come back, and `test/ipc-wiring.test.cjs` drives the same through
`git:carry-reconcile` and checks the recorded base goes back with it. The same is true of a checkout
failing part-way (an EPERM from an antivirus holding a file), which is the pre-existing mid-switch
path this reuses rather than adds to.

## Risks and limitations

- **This is the riskiest change in the batch**: it rewrites a branch and a working tree. The mitigation
  is the ordering and the marker, and the tests assert the oid rather than the contents on every
  failure path, precisely because identical bytes over a rewritten commit is the failure that would
  otherwise pass.
- **The recovery is deliberately blunt.** A marker left behind by a carry that had in fact finished
  puts the branch back at its pre-carry commit — undoing the carry rather than damaging anything. That
  is the direction to fail in: the contributor can carry again, and the alternative is guessing.
- **A refusal is per file, not per hunk.** Upstream deleting a file this ticket edited stops the whole
  carry, even though the other files would have gone across. Partial carries were not built: half a
  ticket on a new base is a state nothing else in the app knows how to describe.
- **Line endings.** Wholesale-carried files are written from the blob, so they land LF — which is what
  every isomorphic-git checkout in this app already writes. On a site cloned by native git with CRLF
  on disk, a carried file will be LF where its neighbours are CRLF. Content is identical and
  `core.autocrlf` makes git hash them the same; it is a cosmetic inconsistency, called out because it
  is the kind of thing that surfaces on Windows and nowhere else.
- **Not tried against a real `wordpress-develop`** at full size. The two checkouts a carry performs
  are the same operation a ticket switch already does, so the cost should be a ticket switch twice
  over, but I have not measured it on a 5k-file tree.

## Related

Fixes #305. Part of #309. Stacked on #320. Builds on #306 (the applied layer's provenance decides
whether a patch is lifted out or moves as one) and #311 (absence is read from trees, never from
bytes — the case a carry would turn from cosmetic into destructive).

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Routing the whole carry through a generated patch — rejected.** It is the obvious implementation
and it silently destroys work: the patch cannot represent a binary, an empty add or delete, or an
unreadable file, and the checkout onto new trunk deletes every path the patch did not carry. The
classifier exists to keep those files off the patch route entirely.

**Refusing outright while a patch is applied — rejected in favour of handling the layers.** #306
already measures whether the stored patch still reverses cleanly, so the information needed to lift
it out and put it back was on hand. Refusing would have made "apply a pull request" and "stay current"
mutually exclusive, which is the pair of things a Contributor Day is made of. What is *not* done is
carrying a single layer while a patch is applied and liftable — that would fold someone else's patch
into the contributor's WIP commit and destroy the revert.

**Building the new commit by hand rather than by checkout.** The ref moves, then HEAD is repointed
symbolically — no checkout — because at that moment the branch *is* trunk and the working tree is
already trunk plus the carried work. A checkout there would either undo the writes or refuse the dirty
tree.

**`git.updateIndex` with an explicit mode rather than `git.add`.** `add` recomputes the mode from the
filesystem, and Windows has no executable bit — so the operation meant to preserve a 100755 file would
be the one that demoted it. The mode comes from the parked commit, the same argument
`fileModeForEntry` makes for pull requests.

**The mid-switch marker is reused, not replaced.** A carry contains two ordinary branch switches, and
they fail the way every other switch in the app fails; `runSwitch` is where main.js wraps them in
`withSwitchMarker`. The carry marker is a *second*, wider marker because it guards a different thing:
not "the worktree is half-swapped" but "the recorded base is not where the branch is".

**`forceCheckout` was extracted rather than duplicated** because the carry's abort path needs
`switchToBranch`'s error contract on a checkout `switchToBranch` itself would refuse — it moves onto a
tree the carry has just written, which the dirty-trunk guard exists to stop.

**`patch-text.cjs` was extracted** for the same reason: the carry renders a unified diff from two
commits where main.js renders one from a commit and the working tree, and two builders would have
meant two answers to the `/dev/null` question that this app reads its own patches back through.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**7 findings — 3 🔴 · 2 🟡 · 2 🔵 · 5 [fix here] · 2 [follow-up]. All 7 fixed.**
`npm run lint` clean, `npm test` 1061/1061.

The review was asked specifically to hammer the ordering, and confirmed the main sequence holds: the
marker precedes every operation that can move the branch ref, and a throw anywhere inside the window
leaves it set. It found the hole in the one place the code clears it *early* — finding 3, the worst
of the seven.

🔴 **Architecture [fix here]** — `src/ticket-carry.js`, the conflict path. "Nothing moved" was not
true once a layer had been lifted out: the lift re-parks, so the branch was already at the
contributor's work *without* the patch. The abort checked the branch out and cleared the marker, so
the layer was silently un-applied and its commit unreachable, while the panel went on offering
Revert for a patch no longer in the checkout and the message said the ticket was exactly as it was.
The ref is now put back to the pre-carry commit *before* the checkout and before the marker is
cleared. Two tests: the lift × conflict cell, asserting the oid **and** that the layer is back on
disk.

🔴 **Architecture [fix here]** — `src/renderer/index.jsx`. The carry's done handler set the outcome
and then called `reprobeAfterBranchChange`, which clears it. Both landed in one React batch, so the
outcome panel never mounted — killing the success confirmation and, expensively, the *entire failure
panel*: the named collision, the explanation, and the "save a copy, then discard" button. On a
collision the contributor would have watched the terminal stop and seen nothing else. Split into
`reprobeAfterCarry` (re-measures, keeps the report) and `reprobeAfterBranchChange` (also drops it,
which is right when the ticket itself changed).

🔴 **Architecture [fix here]** — `src/renderer/index.jsx`. `refreshCarry` stored the reply only when
`res.ok`, but an interrupted carry comes back from the gate as `{ ok: false, code:
'carry-incomplete' }` — so the recovery banner was unreachable and `git:carry-reconcile`, the only
consumer of the marker's `oldOid` and the only route back to the contributor's commit, had no entry
point in the UI. Exactly the state the whole marker design exists to survive. The refusal is now
stored.

🟡 **Tests [fix here]** — the lift × conflict cell had no test; that is why finding 3 survived. Added,
plus a second on which file a collision names.

🟡 **Architecture [fix here]** — the failure copy built its file list from every path on the replay
route, so a ticket with five replayed files and one real collision was told all five no longer fit.
`applyPatchToDir` already returns per-file diagnoses and they were being dropped; `conflictPaths` now
carries them through, with `merge` as the fallback when a failure produced no diagnosis at all.

🔵 **Cross-platform [fix here]** — a newly added executable landed on disk at 0644. The commit was
right (the mode goes into the tree explicitly), but the *next* park reads the mode off `lstat`, so the
following save took the bit straight back off. `writeCarriedFile` now chmods on POSIX, and the test
asserts the mode survives a subsequent park as well as the carry.

🔵 **Performance [follow-up], fixed anyway** — the classification was re-derived unconditionally after
the lift step, a whole extra `statusMatrix` over the checkout on the common carry where no lift
happened and the answer is identical. Skipped when nothing was lifted.

Two notes the review raised that became changes rather than caveats: `git:discard-to-base` is now
behind the same gate (it rewinds to the recorded base, which is precisely what an unfinished carry
declares untrustworthy — `git:discard-changes` stays open, since it resets to HEAD and consults no
base), and `git:carry-ticket` now confirms the ticket really is behind before spending two checkouts
on it, rather than trusting a renderer answer that can be seconds old.

</details>

<details>
<summary>Implementation notes</summary>

- `carryTicketForward` is Electron-free like the rest of `ticket-carry.js`: the two store writes
  arrive as `setMarker`/`setBase` and the mid-switch wrapper as `runSwitch`, so `node --test` drives
  the whole thing against real on-disk repositories with in-memory equivalents.
- `git:carry-ticket` streams `{ carryId }` + log/done channels like `git:update-trunk`, and reuses
  `updateSwitchLogger` so both checkouts report into the terminal the contributor is already watching
  rather than a second progress surface that can disagree with the first.
- A ticket with nothing on it gets no commit at all — the base moves and the branch is trunk. An empty
  WIP commit would be a change to the branch that no work asked for.
- Gating the patch generators on `reconcileBlock` means they now read `electron-store`, which several
  existing tests did not stub because those handlers never touched it. Those tests gained the settings
  seam; without it the harness pulls the real `electron` in through the ESM loader, where its require
  hook cannot reach.
- Tests: 13 new integration tests against real repositories (`test/carry-forward.integration.test.cjs`)
  covering the must-cover list — disjoint carry with the patch assertion, binary, empty add, deletion,
  executable bit (asserted on the recorded mode), `node_modules` untouched, collision with the oid
  asserted, upstream deletion, both layers, a layer that no longer applies, recovery, and nothing to
  carry. Plus 6 on the copy and 3 on the channels. `applyPatchToDir` is never stubbed: every collision
  comes from real bytes in a real repo.

</details>

<details>
<summary>Screenshots or recording</summary>

Not captured. The offer and the refusal only appear on a ticket whose base is genuinely older than the
site's trunk, which needs a site updated after the ticket was linked and a real upstream commit in
between — the same reason step 2 of the testing steps takes a day to set up honestly rather than
minutes. Every string on screen is asserted in `test/carry-note.test.cjs`.

</details>
