### PR TITLE
Read Git empty-file patch sections

### DIFF
--- a/src/patch-plan.cjs
+++ b/src/patch-plan.cjs
@@ -125,6 +125,94 @@ function scanSections(raw) {
 }
 
 /**
+ * The one path named by a `diff --git a/<path> b/<path>` line whose two sides
+ * are the same file — the only shape an added or deleted file can have.
+ *
+ * The line has no delimiter, so a path containing a space makes it ambiguous in
+ * general (`git apply` itself refuses such a line without `---`/`+++` to cross-
+ * check). But when both sides are the same path — and for an add or a delete
+ * they always are — the split is fixed by the line's length, so even
+ * `a/new file.php b/new file.php` reads back exactly. Git quotes a path only
+ * for characters beyond plain spaces; the quoted form carries C-style escapes,
+ * so it is left unparsed rather than guessed at.
+ *
+ * @param {string} line A `diff --git ` line.
+ * @return {string|null} The repo-relative path, or null when it cannot be read
+ *                       with certainty.
+ */
+function samePathFromGitDiffLine(line) {
+	const rest = line.slice('diff --git '.length);
+	if (!rest.startsWith('a/')) return null;
+	const length = (rest.length - 5) / 2;
+	if (!Number.isInteger(length) || length < 1) return null;
+	const filePath = rest.slice(2, 2 + length);
+	if (rest.slice(2 + length, 5 + length) !== ' b/' || rest.slice(5 + length) !== filePath) return null;
+	return filePath;
+}
+
+/**
+ * Rewrites the sections real git emits for an empty file added or deleted into
+ * the shape the rest of this parser already reads (#311).
+ *
+ * An empty file has no line to diff, so git writes its section as headers
+ * alone and — unlike this app's own generator — omits the `---`/`+++` pair
+ * entirely; the file's fate is carried by `new file mode` / `deleted file
+ * mode`. jsdiff cannot see those: such a section comes back as `{hunks: []}`
+ * with no filenames when it is last in the patch, and is silently swallowed
+ * when another section follows it. Either way one empty file used to take the
+ * whole patch down (or vanish from it) — every unrelated file included.
+ *
+ * Supplying the pair git left out, before jsdiff parses, is the whole fix: the
+ * section then parses like the app's own empty-file sections, and everything
+ * downstream — classification, layout mapping, `planApply`, the applier and
+ * its guards — treats both origins identically because they are identical.
+ *
+ * Deliberately narrow: a section is only rewritten when it carries a
+ * new/deleted file mode line, has no `---`/`+++`/hunk of its own, is not
+ * binary and not a rename, and its `diff --git` line names one unambiguous
+ * path. Anything else is left byte-for-byte alone.
+ *
+ * @param {string} text EOL-normalised patch text.
+ * @return {string}
+ */
+function supplyEmptyFileHeaders(text) {
+	const lines = text.split('\n');
+	const out = [];
+	let i = 0;
+	while (i < lines.length) {
+		out.push(lines[i]);
+		if (!lines[i].startsWith('diff --git ')) { i++; continue; }
+		let mode = '';
+		let opaque = false;
+		let end = i + 1;
+		while (end < lines.length && !lines[end].startsWith('diff --git ') && !lines[end].startsWith('Index: ')) {
+			const line = lines[end];
+			if (/^new file mode /.test(line)) mode = 'add';
+			else if (/^deleted file mode /.test(line)) mode = 'delete';
+			else if (/^(--- |\+\+\+ |@@ |GIT binary patch|rename (?:from|to) )/.test(line) || /^Binary files .* differ$/.test(line)) opaque = true;
+			end++;
+		}
+		const section = lines.slice(i + 1, end);
+		// The injected pair goes at the section's end, where git itself puts
+		// it — but ahead of any trailing blank line, which jsdiff would read
+		// as a phantom context line.
+		let tail = section.length;
+		while (tail > 0 && section[tail - 1] === '') tail--;
+		out.push(...section.slice(0, tail));
+		const filePath = mode && !opaque ? samePathFromGitDiffLine(lines[i]) : null;
+		if (filePath) {
+			out.push(
+				mode === 'add' ? '--- /dev/null' : `--- a/${filePath}`,
+				mode === 'add' ? `+++ b/${filePath}` : '+++ /dev/null'
+			);
+		}
+		out.push(...section.slice(tail));
+		i = end;
+	}
+	return out.join('\n');
+}
+
+/**
  * @param {Object} file    A jsdiff parsePatch entry.
  * @param {string} oldPath
  * @param {string} newPath
@@ -148,11 +236,17 @@ function parsePatchFiles(text) {
 	const raw = typeof text === 'string' ? text : '';
 	if (!raw.trim()) return { ok: false, error: 'The patch is empty.' };
 
+	// Normalise line endings on the way in so hunk context matches what the
+	// applier reads off disk, which is normalised the same way.
+	const normalized = normalizeEol(raw);
+
 	let parsed;
 	try {
-		// Normalise line endings on the way in so hunk context matches what the
-		// applier reads off disk, which is normalised the same way.
-		parsed = JsDiff.parsePatch(normalizeEol(raw));
+		// Real git carries an empty file added or deleted as headers alone,
+		// with no `---`/`+++` pair for jsdiff to read (#311) — supplying it
+		// here is what lets the rest of this function see those sections at
+		// all, instead of one of them rejecting the whole patch.
+		parsed = JsDiff.parsePatch(supplyEmptyFileHeaders(normalized));
 	} catch (e) {
 		return { ok: false, error: `Could not read the patch: ${String(e && e.message ? e.message : e)}` };
 	}
@@ -161,7 +255,7 @@ function parsePatchFiles(text) {
 		return { ok: false, error: 'No file changes found in the patch.' };
 	}
 
-	const sections = scanSections(normalizeEol(raw));
+	const sections = scanSections(normalized);
 	const files = [];
 
 	for (let i = 0; i < parsed.length; i++) {

--- a/src/patch-plan.cjs
+++ b/src/patch-plan.cjs
@@ -200,6 +200,13 @@ function supplyEmptyFileHeaders(text) {
 		while (tail > 0 && section[tail - 1] === '') tail--;
 		out.push(...section.slice(0, tail));
 		const filePath = mode && !opaque ? samePathFromGitDiffLine(lines[i]) : null;
+		// jsdiff can silently omit a mode-only section it cannot name when a
+		// normal section follows. Refuse the whole patch instead of reporting a
+		// partial success. Decoding Git's quoted C-style paths is deliberately
+		// outside the narrow 1.0 reader (#316).
+		if (mode && !opaque && !filePath) {
+			throw new Error('The empty file path is quoted or ambiguous.');
+		}
 		if (filePath) {
 			out.push(
 				mode === 'add' ? '--- /dev/null' : `--- a/${filePath}`,

--- a/test/patch-apply.integration.test.cjs
+++ b/test/patch-apply.integration.test.cjs
@@ -533,6 +533,56 @@ deleted file mode 100644
 	assert.strictEqual(fs.existsSync(path.join(dir, 'src/placeholder.php')), false);
 });
 
+// The read half of the same story (#316): real git writes an empty file's
+// section with no `---`/`+++` pair at all, unlike the #311 sections above.
+// Verbatim `git diff` output, inlined so the test does not need a git binary.
+// The mix — an ordinary edit alongside the empty add and delete — is the case
+// that used to fail whole-patch, so every file's fate is asserted.
+test('applyPatchToDir: a git-authored patch with empty adds and deletes applies whole (#316)', async (t) => {
+	const dir = await makeRepo(t, { 'edited.php': 'line1\nline2\n', 'was-empty.php': '' });
+	const gitPatch = `diff --git a/edited.php b/edited.php
+index c0d0fb4..83db48f 100644
+--- a/edited.php
++++ b/edited.php
+@@ -1,2 +1,3 @@
+ line1
+ line2
++line3
+diff --git a/placeholder.php b/placeholder.php
+new file mode 100644
+index 0000000..e69de29
+diff --git a/was-empty.php b/was-empty.php
+deleted file mode 100644
+index e69de29..0000000
+`;
+
+	const res = await applyPatchToDir({ dir, patchText: gitPatch });
+
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.applied.sort(), ['edited.php', 'placeholder.php', 'was-empty.php']);
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'edited.php'), 'utf8'), 'line1\nline2\nline3\n');
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'placeholder.php'), 'utf8'), '', 'the empty addition has to actually create');
+	assert.strictEqual(fs.existsSync(path.join(dir, 'was-empty.php')), false, 'the empty deletion has to actually delete');
+});
+
+// The add-side twin of the deletion guard above: a `new file mode` section
+// claims the file does not exist yet, so one already in the checkout — with
+// whatever content — is refused all-or-nothing, not overwritten or skipped.
+test('applyPatchToDir: a git-authored empty addition refuses a file that already exists (#316)', async (t) => {
+	const dir = await makeRepo(t, { 'placeholder.php': 'my own work\n' });
+	const before = snapshot(dir);
+	const addPatch = `diff --git a/placeholder.php b/placeholder.php
+new file mode 100644
+index 0000000..e69de29
+`;
+
+	const res = await applyPatchToDir({ dir, patchText: addPatch });
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /already exists/);
+	assert.deepStrictEqual(snapshot(dir), before, 'the existing file must not be touched');
+});
+
 // A rename that completes and is then undone by a later failure must restore the
 // source and remove the destination — registering each action before its
 // mutations is what lets rollback see a half-done one. (Copilot #3.)

--- a/test/patch-plan.test.cjs
+++ b/test/patch-plan.test.cjs
@@ -109,6 +109,92 @@ test('parsePatchFiles: added and deleted files are classified, not treated as re
 	assert.strictEqual(deleted.path, 'src/old.php');
 });
 
+// --- empty files as real git writes them (#316) ----------------------------
+//
+// Real git carries an added or deleted empty file as headers alone: no
+// `---`/`+++` pair at all, the fate on the `new file mode` / `deleted file
+// mode` line. The fixtures below are verbatim `git diff` output (git 2.x in a
+// scratch repo), inlined so the tests do not need a git binary; #311's own
+// sections keep the `---`/`+++` pair and are covered in ipc-wiring.test.cjs.
+const GIT_EMPTY_ADD_DIFF = `diff --git a/placeholder.php b/placeholder.php
+new file mode 100644
+index 0000000..e69de29
+`;
+
+const GIT_EMPTY_DELETE_NO_INDEX_DIFF = `diff --git a/was-empty.php b/was-empty.php
+deleted file mode 100644
+`;
+
+const GIT_MIXED_EMPTY_DIFF = `diff --git a/edited.php b/edited.php
+index c0d0fb4..83db48f 100644
+--- a/edited.php
++++ b/edited.php
+@@ -1,2 +1,3 @@
+ line1
+ line2
++line3
+diff --git a/new file.php b/new file.php
+new file mode 100644
+index 0000000..e69de29
+diff --git a/placeholder.php b/placeholder.php
+new file mode 100644
+index 0000000..e69de29
+diff --git a/was-empty.php b/was-empty.php
+deleted file mode 100644
+index e69de29..0000000
+`;
+
+test('parsePatchFiles: a git-authored empty addition parses as an add (#316)', () => {
+	const res = parsePatchFiles(GIT_EMPTY_ADD_DIFF);
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [['add', 'placeholder.php']]);
+});
+
+test('parsePatchFiles: a git-authored empty deletion parses as a delete, with or without an index line (#316)', () => {
+	const res = parsePatchFiles(GIT_EMPTY_DELETE_NO_INDEX_DIFF);
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [['delete', 'was-empty.php']]);
+
+	const withIndex = parsePatchFiles('diff --git a/was-empty.php b/was-empty.php\ndeleted file mode 100644\nindex e69de29..0000000\n');
+	assert.strictEqual(withIndex.ok, true, withIndex.error);
+	assert.deepStrictEqual(withIndex.files.map((f) => [f.kind, f.path]), [['delete', 'was-empty.php']]);
+});
+
+// The whole point of the fix: one empty-file section used to reject the entire
+// patch when it came last, and to vanish silently when another section
+// followed it — either way the unrelated files went with it. The full list is
+// what proves both failure modes gone.
+test('parsePatchFiles: one git-authored empty file does not take the rest of the patch down (#316)', () => {
+	const res = parsePatchFiles(GIT_MIXED_EMPTY_DIFF);
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [
+		['modify', 'edited.php'],
+		// A path with a space stays whole: for an add or a delete both sides of
+		// the `diff --git` line are the same path, so the split is unambiguous.
+		['add', 'new file.php'],
+		['add', 'placeholder.php'],
+		['delete', 'was-empty.php']
+	]);
+});
+
+test('parsePatchFiles: an empty add ahead of other sections keeps them all (#316)', () => {
+	const res = parsePatchFiles(GIT_EMPTY_ADD_DIFF + GITHUB_DIFF);
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [
+		['add', 'placeholder.php'],
+		['modify', 'src/wp-includes/foo.php']
+	]);
+});
+
+// A binary addition carries `new file mode` too. Its fate is the binary
+// marker's, not the mode line's — rewriting it as an empty text add would
+// report success while silently writing an empty file in an image's place.
+test('parsePatchFiles: a binary addition with new file mode stays binary (#316)', () => {
+	const res = parsePatchFiles('diff --git a/x.png b/x.png\nnew file mode 100644\nindex 0000000..1111111\nBinary files /dev/null and b/x.png differ\n');
+	assert.strictEqual(res.ok, true, res.error);
+	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [['binary', 'x.png']]);
+});
+
 // jsdiff represents a binary file as an entry with no hunks. Left unchecked
 // that reads as "a file with no changes", so applying would report success
 // while silently skipping it.

--- a/test/patch-plan.test.cjs
+++ b/test/patch-plan.test.cjs
@@ -195,6 +195,14 @@ test('parsePatchFiles: a binary addition with new file mode stays binary (#316)'
 	assert.deepStrictEqual(res.files.map((f) => [f.kind, f.path]), [['binary', 'x.png']]);
 });
 
+test('parsePatchFiles: an undecodable quoted empty-file section rejects the whole mixed patch (#316)', () => {
+	const quotedEmpty = 'diff --git "a/empty\\303\\251.txt" "b/empty\\303\\251.txt"\nnew file mode 100644\nindex 0000000..e69de29\n';
+	const res = parsePatchFiles(quotedEmpty + GITHUB_DIFF);
+
+	assert.strictEqual(res.ok, false);
+	assert.match(res.error, /empty file path/i);
+});
+
 // jsdiff represents a binary file as an entry with no hunks. Left unchecked
 // that reads as "a file with no changes", so applying would report success
 // while silently skipping it.


### PR DESCRIPTION
## Why

A Git-authored patch that adds or deletes an empty file omits the `---` / `+++` pair. The reader cannot classify that section today, so one empty file rejects the whole patch, including unrelated valid edits.

## What changes

Recognise only Git's unambiguous, text empty-file form and supply the missing headers before the existing parser runs. Binary sections, renames and ambiguous/quoted paths remain untouched rather than guessed.

## How to test this

**Platforms:** any.

**Starting state:** a site linked to a ticket, plus a patch generated by Git that edits one file, adds an empty file and deletes an empty file.

1. Open the ticket's patch action and select that patch. Expect the preview to list all three paths.
2. Apply it. Expect the ordinary edit, empty creation and empty deletion all to occur.
3. Repeat with content already present at the addition path. Expect the whole apply to fail and every file to remain unchanged.

**What must not have happened:** the empty section must not disappear silently, and a failed apply must not partially edit the tree.

The regression tests fail on the parent branch and pass here: `node --test test/patch-plan.test.cjs test/patch-apply.integration.test.cjs`.

## Risks and limitations

Git-quoted path names (for example names containing tabs, quotes, backslashes or some non-ASCII characters) are still refused. Decoding Git's C-style quoting is deliberately deferred to keep the 1.0 reader narrow.

The full desktop flow has not yet been driven by hand; it will be exercised from the integration artifact.

## Related

Fixes #316. Follow-up to #311.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The implementation normalises the narrow Git form into the header shape already supported by the parser. It does not create a second patch parser or weaken the all-or-nothing guards.

</details>

<details>
<summary>Review outcome</summary>

0 [fix here] · 1 [follow-up]. The follow-up is quoted Git paths, documented above. Lint is clean; 957 tests pass; no security, performance or cross-platform findings.

</details>

<details>
<summary>Implementation notes</summary>

Only three files change: the parser plus unit and integration coverage. There is no UI, IPC or persistence change.

</details>
