### PR TITLE
Warn when trunk moved past a ticket base

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1716,6 +1716,10 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		// would carry the other one's "patch applied · Revert" banner over, and
 		// Revert would reverse its hunks against this ticket's tree.
 		const work = await readWorkMeta(sitePath);
+		// A recorded branch point and the current trunk tip are enough to warn
+		// that the context changed (#305). Missing metadata stays false: 1.0
+		// refuses to guess, and deliberately offers no checkout rewrite.
+		const ticketBehindTrunk = Boolean(m.tracTicket && work.baseOid && trunkOid && work.baseOid !== trunkOid);
 
 		// Summarised rather than passed through: the stored patch text is only
 		// needed by the main process to reverse it, and this is polled.
@@ -1736,9 +1740,9 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 			}
 			: null;
 
-		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(work.updateIncomplete), tracTicket: m.tracTicket || null, appliedPatch };
+		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(work.updateIncomplete), tracTicket: m.tracTicket || null, ticketBehindTrunk, appliedPatch };
 	} catch {
-		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false, tracTicket: null, appliedPatch: null };
+		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false, tracTicket: null, ticketBehindTrunk: false, appliedPatch: null };
 	}
 });
 

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -41,6 +41,7 @@ import { prDateLabel } from './pr-date-label.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
+import { ticketTrunkNotice } from './ticket-trunk-notice.cjs';
 import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
@@ -1268,6 +1269,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [waitingForWatch, setWaitingForWatch] = useState(false);
   // Trac ticket association (#109)
   const [tracTicket, setTracTicket] = useState(null);
+  const [ticketBehindTrunk, setTicketBehindTrunk] = useState(false);
   const [ticketInput, setTicketInput] = useState('');
   const [ticketError, setTicketError] = useState('');
   const [ticketSaving, setTicketSaving] = useState(false);
@@ -1619,6 +1621,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       setTrunkDate(s?.trunkDate || null);
       setUpdateIncomplete(Boolean(s?.updateIncomplete));
       setTracTicket(s?.tracTicket || null);
+      setTicketBehindTrunk(Boolean(s?.ticketBehindTrunk));
       setAppliedPatch(s?.appliedPatch || null);
       if (metaPatchRef.current) {
         // A null trunkDate here means the git read failed (e.g. clone still
@@ -2662,6 +2665,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // #12345 is news for the ticket card, one that belongs to nothing is news
   // for the buttons that would give it somewhere to go.
   const changesNote = changesNoteParts({ ...(worktreeDirty || {}), tracTicket });
+  const staleTicketNotice = ticketTrunkNotice({ ticketId: tracTicket, behind: ticketBehindTrunk });
   const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
   const updateStepStates = updateStepStatuses(updateSteps, updateState);
 
@@ -4465,6 +4469,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
               <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketActionsBlocked}>Unlink</Button>
             </div>
+
+            {staleTicketNotice ? (
+              <div role="status" style={{ marginTop: 10, padding: '10px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, color: '#6e5406', fontSize: 12 }}>
+                <div style={{ fontWeight: 600 }}>{staleTicketNotice.title}</div>
+                <div style={{ marginTop: 4 }}>{staleTicketNotice.body}</div>
+              </div>
+            ) : null}
 
             {tracInfo ? (
               <div style={{ marginTop: 10 }}>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1762,6 +1762,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         }
         return;
       }
+      // The status belongs to the branch we just left. Clear it in the same
+      // render that names the new ticket; loadStatus will restore the new
+      // branch's answer below (#305).
+      setTicketBehindTrunk(false);
       setTracTicket(res.ticket);
       if (res.ticket) autoReadTicketRef.current = res.ticket;
       setTicketInput('');

--- a/src/renderer/ticket-trunk-notice.cjs
+++ b/src/renderer/ticket-trunk-notice.cjs
@@ -3,19 +3,18 @@
 /**
  * The intentionally limited 1.0 answer when a ticket predates current trunk.
  * Detection is useful; rewriting a contributor's checkout is not required.
- * Missing metadata stays silent because inequality cannot be inferred safely.
+ * The main process performs the recorded-base comparison. Unknown stays silent.
  *
- * @param {Object} root0
- * @param {string|number|null} root0.ticketId
- * @param {?string} root0.baseOid
- * @param {?string} root0.trunkOid
+ * @param {Object}             root0
+ * @param {string|number|null} root0.ticketId Ticket currently linked.
+ * @param {boolean}            root0.behind   Whether its base differs from trunk.
  * @return {{title: string, body: string}|null}
  */
-function ticketTrunkNotice({ ticketId = null, baseOid = null, trunkOid = null } = {}) {
-	if (!ticketId || !baseOid || !trunkOid || baseOid === trunkOid) return null;
+function ticketTrunkNotice({ ticketId = null, behind = false } = {}) {
+	if (!ticketId || !behind) return null;
 	return {
 		title: 'Trunk has moved since this ticket started.',
-		body: `Newer patches may not apply cleanly. Save a copy of your work, delete this ticket’s work from the site, then link #${ticketId} again to start from the current trunk.`
+		body: `Newer patches may not apply cleanly. Save a copy of your work, unlink the ticket, delete its work from the site, then link #${ticketId} again to start from the current trunk.`
 	};
 }
 

--- a/src/renderer/ticket-trunk-notice.cjs
+++ b/src/renderer/ticket-trunk-notice.cjs
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * The intentionally limited 1.0 answer when a ticket predates current trunk.
+ * Detection is useful; rewriting a contributor's checkout is not required.
+ * Missing metadata stays silent because inequality cannot be inferred safely.
+ *
+ * @param {Object} root0
+ * @param {string|number|null} root0.ticketId
+ * @param {?string} root0.baseOid
+ * @param {?string} root0.trunkOid
+ * @return {{title: string, body: string}|null}
+ */
+function ticketTrunkNotice({ ticketId = null, baseOid = null, trunkOid = null } = {}) {
+	if (!ticketId || !baseOid || !trunkOid || baseOid === trunkOid) return null;
+	return {
+		title: 'Trunk has moved since this ticket started.',
+		body: `Newer patches may not apply cleanly. Save a copy of your work, delete this ticket’s work from the site, then link #${ticketId} again to start from the current trunk.`
+	};
+}
+
+module.exports = { ticketTrunkNotice };

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -2781,6 +2781,25 @@ test('site:status does not guess that a ticket is behind without a recorded base
 	assert.equal(status.ticketBehindTrunk, false);
 });
 
+test('site:status reports a ticket born from current trunk as current (#305)', async () => {
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { tracTicket: 61002, currentBranch: 'ticket/61002', branches: { 'ticket/61002': { baseOid: 'same' } } } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./trunk-update': { readTrunkInfo: async () => ({ trunkOid: 'same', trunkDate: 'd' }) },
+			'./ticket-branches': { currentBranchName: async () => 'ticket/61002' }
+		}
+	});
+
+	const status = await main.invoke('site:status', '/sites/wp');
+
+	assert.equal(status.ticketBehindTrunk, false);
+});
+
 test('a checkout that died mid-switch blocks further switching (issue #108)', async () => {
 	const switchToBranch = spy(async () => ({ switched: true }));
 	const settings = fakeSettingsStore({

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -2733,6 +2733,7 @@ test('the applied patch belongs to the ticket, not the site (issue #108)', async
 		siteMeta: {
 			'/sites/wp': {
 				currentBranch: 'ticket/61002',
+				tracTicket: 61002,
 				// The site-level value: what a pre-#108 install left behind, and
 				// what the migration copies onto the ticket it belonged to. It
 				// must never be what the panel reads once a ticket is active.
@@ -2758,6 +2759,26 @@ test('the applied patch belongs to the ticket, not the site (issue #108)', async
 	// Reading it from the site would show ticket A's patch while on ticket B —
 	// and offer a Revert that reverses A's hunks against B's tree.
 	assert.equal(status.appliedPatch, null, 'the other ticket\'s applied patch must not leak here');
+	assert.equal(status.ticketBehindTrunk, true, 'the active ticket started before the current trunk');
+});
+
+test('site:status does not guess that a ticket is behind without a recorded base (#305)', async () => {
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { tracTicket: 61002, currentBranch: 'ticket/61002', branches: { 'ticket/61002': { baseOid: null } } } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./trunk-update': { readTrunkInfo: async () => ({ trunkOid: 'new', trunkDate: 'd' }) },
+			'./ticket-branches': { currentBranchName: async () => 'ticket/61002' }
+		}
+	});
+
+	const status = await main.invoke('site:status', '/sites/wp');
+
+	assert.equal(status.ticketBehindTrunk, false);
 });
 
 test('a checkout that died mid-switch blocks further switching (issue #108)', async () => {

--- a/test/ticket-trunk-notice.test.cjs
+++ b/test/ticket-trunk-notice.test.cjs
@@ -2,20 +2,29 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 const { ticketTrunkNotice } = require('../src/renderer/ticket-trunk-notice.cjs');
 
 test('ticketTrunkNotice says what changed and gives the deliberately manual exit (#305)', () => {
-	assert.deepStrictEqual(ticketTrunkNotice({ ticketId: 123, baseOid: 'old', trunkOid: 'new' }), {
+	assert.deepStrictEqual(ticketTrunkNotice({ ticketId: 123, behind: true }), {
 		title: 'Trunk has moved since this ticket started.',
-		body: 'Newer patches may not apply cleanly. Save a copy of your work, delete this ticket’s work from the site, then link #123 again to start from the current trunk.'
+		body: 'Newer patches may not apply cleanly. Save a copy of your work, unlink the ticket, delete its work from the site, then link #123 again to start from the current trunk.'
 	});
 });
 
-test('ticketTrunkNotice stays silent without a recorded comparison (#305)', () => {
+test('ticketTrunkNotice stays silent without a ticket or a known move (#305)', () => {
 	for (const state of [
-		{ ticketId: null, baseOid: 'old', trunkOid: 'new' },
-		{ ticketId: 123, baseOid: null, trunkOid: 'new' },
-		{ ticketId: 123, baseOid: 'old', trunkOid: null },
-		{ ticketId: 123, baseOid: 'same', trunkOid: 'same' }
+		{ ticketId: null, behind: true },
+		{ ticketId: 123, behind: false },
+		{ ticketId: 123 }
 	]) assert.equal(ticketTrunkNotice(state), null);
+});
+
+test('the ticket card renders the stale-ticket notice returned by status (#305)', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer', 'index.jsx'), 'utf8');
+	assert.match(source, /setTicketBehindTrunk\(Boolean\(s\?\.ticketBehindTrunk\)\)/);
+	assert.match(source, /ticketTrunkNotice\(\{ ticketId: tracTicket, behind: ticketBehindTrunk \}\)/);
+	assert.match(source, /staleTicketNotice\.title/);
+	assert.match(source, /staleTicketNotice\.body/);
 });

--- a/test/ticket-trunk-notice.test.cjs
+++ b/test/ticket-trunk-notice.test.cjs
@@ -27,4 +27,9 @@ test('the ticket card renders the stale-ticket notice returned by status (#305)'
 	assert.match(source, /ticketTrunkNotice\(\{ ticketId: tracTicket, behind: ticketBehindTrunk \}\)/);
 	assert.match(source, /staleTicketNotice\.title/);
 	assert.match(source, /staleTicketNotice\.body/);
+	assert.match(
+		source,
+		/setTicketBehindTrunk\(false\);\s+setTracTicket\(res\.ticket\);/,
+		'a switched ticket must not render with the previous ticket\'s stale flag'
+	);
 });

--- a/test/ticket-trunk-notice.test.cjs
+++ b/test/ticket-trunk-notice.test.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { ticketTrunkNotice } = require('../src/renderer/ticket-trunk-notice.cjs');
+
+test('ticketTrunkNotice says what changed and gives the deliberately manual exit (#305)', () => {
+	assert.deepStrictEqual(ticketTrunkNotice({ ticketId: 123, baseOid: 'old', trunkOid: 'new' }), {
+		title: 'Trunk has moved since this ticket started.',
+		body: 'Newer patches may not apply cleanly. Save a copy of your work, delete this ticket’s work from the site, then link #123 again to start from the current trunk.'
+	});
+});
+
+test('ticketTrunkNotice stays silent without a recorded comparison (#305)', () => {
+	for (const state of [
+		{ ticketId: null, baseOid: 'old', trunkOid: 'new' },
+		{ ticketId: 123, baseOid: null, trunkOid: 'new' },
+		{ ticketId: 123, baseOid: 'old', trunkOid: null },
+		{ ticketId: 123, baseOid: 'same', trunkOid: 'same' }
+	]) assert.equal(ticketTrunkNotice(state), null);
+});


### PR DESCRIPTION
## Why

A ticket can remain on the trunk snapshot where it started after the site updates trunk. Newer patches may then fail, but 1.0 should warn without attempting to rewrite a newcomer’s worktree.

## What changes

`site:status` compares the ticket’s recorded base OID with the current trunk OID. When they differ, the existing Trac ticket card shows one notice with the deliberately manual exit: save a copy, unlink, delete that ticket’s work, and link it again.

There is no carry-forward operation, classifier, patch transport, new persistence, or network request. Missing base metadata stays silent rather than guessed.

## How to test this

**Platforms:** any.

**Starting state:** a site with ticket A linked and an uncommitted edit on it.

1. Use **Update to latest trunk** after trunk has advanced. Return to ticket A.
   **Expected:** its card says “Trunk has moved since this ticket started” and gives the save → Unlink → delete → re-link sequence.
2. Save the patch, click **Unlink**, delete ticket A from **Your tickets on this site**, then link A again.
   **Expected:** the new ticket starts on current trunk and the notice is gone.
3. Switch from an older ticket to a ticket created on current trunk.
   **Expected:** the old notice never appears with the new ticket number.

**What must not have happened:** no branch, file or metadata is changed merely by displaying the notice; work is removed only after the existing explicit delete confirmation.

The state/copy tests fail on the parent branch and pass here. Lint, Node tests and Electron-bundled-Node tests are green.

## Risks and limitations

OID inequality proves that trunk changed, not whether a particular patch will conflict. The wording therefore says patches “may” fail. Tickets without a recorded base get no notice because the app cannot compare them honestly.

The desktop flow remains to be driven from the integration artifact.

## Related

Part of #305 and #309. The automatic carry-forward PRs #320 and #321 remain post-1.0.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The 1.0 boundary is observation plus an exit made from existing safe operations. Rewriting the ticket onto new trunk introduces conflict classification, recovery state and concurrency hazards that are not needed to ship an honest experimental release.

</details>

<details>
<summary>Review outcome</summary>

2 [fix here] · 0 [follow-up] — both fixed. The stale flag is cleared atomically when a switch names the next ticket, and IPC now pins the equal-base case. Final review found no security, performance, compatibility or proportionality findings. `npm run lint` is clean and `npm run test:electron` passes 984 tests.

</details>

<details>
<summary>Implementation notes</summary>

Five files, 117 added lines including tests. The only new value crossing IPC is `ticketBehindTrunk: boolean`.

</details>

<details>
<summary>Screenshots or recording</summary>

Not yet captured. The visible notice will be exercised from the signed integration artifact.

</details>
