### PR TITLE
Explain why discard is unavailable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1716,6 +1716,10 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 		// would carry the other one's "patch applied · Revert" banner over, and
 		// Revert would reverse its hunks against this ticket's tree.
 		const work = await readWorkMeta(sitePath);
+		// A recorded branch point and the current trunk tip are enough to warn
+		// that the context changed (#305). Missing metadata stays false: 1.0
+		// refuses to guess, and deliberately offers no checkout rewrite.
+		const ticketBehindTrunk = Boolean(m.tracTicket && work.baseOid && trunkOid && work.baseOid !== trunkOid);
 
 		// Summarised rather than passed through: the stored patch text is only
 		// needed by the main process to reverse it, and this is polled.
@@ -1736,9 +1740,9 @@ ipcMain.handle('site:status', async (_e, sitePath) => {
 			}
 			: null;
 
-		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(work.updateIncomplete), tracTicket: m.tracTicket || null, appliedPatch };
+		return { hasNodeModules, hasBuilt, skipInitWizard: Boolean(m.skipInitWizard), initialized: Boolean(m.initialized), installFailed: Boolean(m.installFailed), trunkOid, trunkDate, updateIncomplete: Boolean(work.updateIncomplete), tracTicket: m.tracTicket || null, ticketBehindTrunk, appliedPatch };
 	} catch {
-		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false, tracTicket: null, appliedPatch: null };
+		return { hasNodeModules: false, hasBuilt: false, skipInitWizard: false, initialized: false, installFailed: false, trunkOid: null, trunkDate: null, updateIncomplete: false, tracTicket: null, ticketBehindTrunk: false, appliedPatch: null };
 	}
 });
 

--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -123,18 +123,6 @@ function noteAfterProbe(_current, result) {
 }
 
 /**
- * Whether the modal's discard link is inert: while the diff is loading there
- * is nothing to confirm against, with no changes there is nothing to lose,
- * and mid-discard a second click would race the first.
- *
- * @param {{patchLoading?: boolean, patchHasChanges?: boolean, discarding?: boolean}} state
- * @return {boolean}
- */
-function modalDiscardDisabled({ patchLoading, patchHasChanges, discarding } = {}) {
-	return Boolean(patchLoading || discarding || !patchHasChanges);
-}
-
-/**
  * Whether a discard may run at all right now. The same states that block
  * starting a trunk update block a discard, and for the same reason: both
  * rewrite the tree under whatever npm is doing to it, and a force checkout
@@ -149,4 +137,28 @@ function discardBlocked({ isUpdating, installing, building, devServerActive, dis
 	return Boolean(isUpdating || installing || building || devServerActive || discarding);
 }
 
-module.exports = { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE };
+/**
+ * The explanation shown when the modal's discard action is unavailable.
+ *
+ * One operation can leave several guards true while state settles. Report the
+ * action already underway first, then the transient patch state, and finally
+ * the process the contributor can stop or wait for.
+ *
+ * @param {{patchLoading?: boolean, patchLoadFailed?: boolean, patchHasChanges?: boolean,
+ *          isUpdating?: boolean, installing?: boolean, building?: boolean,
+ *          devServerActive?: boolean, discarding?: boolean}} state
+ * @return {string|null}
+ */
+function discardDisabledReason({ patchLoading, patchLoadFailed, patchHasChanges, isUpdating, installing, building, devServerActive, discarding } = {}) {
+	if (discarding) return 'Changes are already being discarded.';
+	if (patchLoading) return 'Wait for your changes to finish loading.';
+	if (patchLoadFailed) return 'Changes could not be loaded.';
+	if (!patchHasChanges) return 'There are no changes to discard.';
+	if (isUpdating) return 'Wait for the trunk update to finish before discarding changes.';
+	if (installing) return 'Wait for the installation to finish before discarding changes.';
+	if (building) return 'Wait for the build to finish before discarding changes.';
+	if (devServerActive) return 'Stop the dev server before discarding changes.';
+	return null;
+}
+
+module.exports = { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -41,6 +41,7 @@ import { prDateLabel } from './pr-date-label.cjs';
 import { ticketUrl, attachUrl } from './trac-ticket.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
+import { ticketTrunkNotice } from './ticket-trunk-notice.cjs';
 import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
@@ -1268,6 +1269,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [waitingForWatch, setWaitingForWatch] = useState(false);
   // Trac ticket association (#109)
   const [tracTicket, setTracTicket] = useState(null);
+  const [ticketBehindTrunk, setTicketBehindTrunk] = useState(false);
   const [ticketInput, setTicketInput] = useState('');
   const [ticketError, setTicketError] = useState('');
   const [ticketSaving, setTicketSaving] = useState(false);
@@ -1619,6 +1621,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       setTrunkDate(s?.trunkDate || null);
       setUpdateIncomplete(Boolean(s?.updateIncomplete));
       setTracTicket(s?.tracTicket || null);
+      setTicketBehindTrunk(Boolean(s?.ticketBehindTrunk));
       setAppliedPatch(s?.appliedPatch || null);
       if (metaPatchRef.current) {
         // A null trunkDate here means the git read failed (e.g. clone still
@@ -1759,6 +1762,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         }
         return;
       }
+      // The status belongs to the branch we just left. Clear it in the same
+      // render that names the new ticket; loadStatus will restore the new
+      // branch's answer below (#305).
+      setTicketBehindTrunk(false);
       setTracTicket(res.ticket);
       if (res.ticket) autoReadTicketRef.current = res.ticket;
       setTicketInput('');
@@ -2662,6 +2669,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // #12345 is news for the ticket card, one that belongs to nothing is news
   // for the buttons that would give it somewhere to go.
   const changesNote = changesNoteParts({ ...(worktreeDirty || {}), tracTicket });
+  const staleTicketNotice = ticketTrunkNotice({ ticketId: tracTicket, behind: ticketBehindTrunk });
   const updateSteps = planUpdateSteps({ lockfileChanged: updateLockfileChanged });
   const updateStepStates = updateStepStatuses(updateSteps, updateState);
 
@@ -4465,6 +4473,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               ) : null}
               <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketActionsBlocked}>Unlink</Button>
             </div>
+
+            {staleTicketNotice ? (
+              <div role="status" style={{ marginTop: 10, padding: '10px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, color: '#6e5406', fontSize: 12 }}>
+                <div style={{ fontWeight: 600 }}>{staleTicketNotice.title}</div>
+                <div style={{ marginTop: 4 }}>{staleTicketNotice.body}</div>
+              </div>
+            ) : null}
 
             {tracInfo ? (
               <div style={{ marginTop: 10 }}>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -15,7 +15,8 @@ import {
   SnackbarList,
   TextControl,
   TextareaControl,
-  Spinner
+  Spinner,
+  Tooltip
 } from '@wordpress/components';
 import { plus, chevronLeft, chevronRight, chevronDown, copy as copyIcon, check as checkIcon, edit, download, comment } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
@@ -46,7 +47,7 @@ import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
-import { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
+import { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
 import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
@@ -69,6 +70,28 @@ const COPY_BUTTON_LABELS = {
   copied: 'Copied',
   failed: 'Could not copy'
 };
+
+// One discard action, wherever it is offered. Keeping the disabled rendering
+// here means the ticket note cannot lose the explanation while the review
+// modal keeps it (or vice versa).
+function DiscardChangesLink({ label, onClick, reason, style }) {
+  if (!reason) {
+    return <Button variant="link" isDestructive onClick={onClick} style={style}>{label}</Button>;
+  }
+  return (
+    <Tooltip text={reason} placement="bottom">
+      <Button
+        variant="link"
+        isDestructive
+        onClick={onClick}
+        disabled
+        accessibleWhenDisabled
+        description={reason}
+        style={style}
+      >{label}</Button>
+    </Tooltip>
+  );
+}
 // What the app is doing while a pull request is being opened (#167). Each step
 // is named because they take visibly different amounts of time — forking is the
 // slow one, and an unlabelled spinner there reads as a hang.
@@ -1212,6 +1235,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [isPatchOpen, setIsPatchOpen] = useState(false);
   const [patchText, setPatchText] = useState('');
   const [patchLoading, setPatchLoading] = useState(false);
+  const [patchLoadFailed, setPatchLoadFailed] = useState(false);
   // What the last save did, reported in the modal rather than in an alert:
   // the destination panel is where the contributor is looking, and the path
   // matters — it is the file they are about to upload or hand over (#166).
@@ -3369,11 +3393,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // after a discard is the "nothing to send" banner.
   const loadPatchText = async () => {
     setPatchLoading(true);
+    setPatchLoadFailed(false);
     try {
       const res = await window.api.getPatch(sitePath);
       if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
-      else setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
+      else {
+        setPatchLoadFailed(true);
+        setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
+      }
     } catch (e) {
+      setPatchLoadFailed(true);
       setPatchText(`Error: ${e && e.message ? e.message : String(e)}`);
     } finally {
       setPatchLoading(false);
@@ -3383,6 +3412,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const openPatchModal = async ()=>{
     setIsPatchOpen(true);
     setPatchText('');
+    setPatchLoadFailed(false);
     // Last time's outcome belongs to last time's patch.
     setPatchSaved(null);
     setPatchSaveError('');
@@ -3441,7 +3471,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {changesNote.lead}
       <Button variant="link" onClick={openPatchModal} disabled={isUpdating}>{changesNote.patchLabel}</Button>
       {changesNote.middle}
-      <Button variant="link" isDestructive onClick={discardAllChanges} disabled={discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}>{changesNote.discardLabel}</Button>
+      <DiscardChangesLink
+        label={changesNote.discardLabel}
+        onClick={discardAllChanges}
+        reason={discardDisabledReason({
+          patchHasChanges: true,
+          isUpdating,
+          installing,
+          building,
+          devServerActive: isDevProcessActive,
+          discarding
+        })}
+      />
       {changesNote.end}
       {discardError ? <div style={{ color: '#d63638', fontSize: 12, marginTop: 4 }}>{discardError}</div> : null}
     </>
@@ -3480,6 +3521,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const patchHasChanges = Boolean(patchText)
     && hasDiffLines(patchText)
     && !patchText.startsWith('Error');
+  const modalDiscardReason = discardDisabledReason({
+    patchLoading,
+    patchLoadFailed,
+    patchHasChanges,
+    isUpdating,
+    installing,
+    building,
+    devServerActive: isDevProcessActive,
+    discarding
+  });
 
   // Saving the file, for every destination that needs one (#166). `handoff`
   // asks the main process for the provenance header and the name that carries
@@ -5212,13 +5263,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                       {tracTicket ? `Your changes for ticket #${tracTicket}` : 'Your changes'}
                       <span style={{ fontWeight:400 }}>
                         {'('}
-                        <Button
-                          variant="link"
-                          isDestructive
+                        <DiscardChangesLink
+                          label="Discard all changes"
                           onClick={discardAllChanges}
-                          disabled={modalDiscardDisabled({ patchLoading, patchHasChanges, discarding }) || discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}
+                          reason={modalDiscardReason}
                           style={{ fontSize: 12 }}
-                        >Discard all changes</Button>
+                        />
                         {')'}
                       </span>
                     </div>

--- a/src/renderer/ticket-trunk-notice.cjs
+++ b/src/renderer/ticket-trunk-notice.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * The intentionally limited 1.0 answer when a ticket predates current trunk.
+ * Detection is useful; rewriting a contributor's checkout is not required.
+ * The main process performs the recorded-base comparison. Unknown stays silent.
+ *
+ * @param {Object}             root0
+ * @param {string|number|null} root0.ticketId Ticket currently linked.
+ * @param {boolean}            root0.behind   Whether its base differs from trunk.
+ * @return {{title: string, body: string}|null}
+ */
+function ticketTrunkNotice({ ticketId = null, behind = false } = {}) {
+	if (!ticketId || !behind) return null;
+	return {
+		title: 'Trunk has moved since this ticket started.',
+		body: `Newer patches may not apply cleanly. Save a copy of your work, unlink the ticket, delete its work from the site, then link #${ticketId} again to start from the current trunk.`
+	};
+}
+
+module.exports = { ticketTrunkNotice };

--- a/test/changes-note.test.cjs
+++ b/test/changes-note.test.cjs
@@ -3,14 +3,16 @@
 // DOM; index.jsx only interleaves the parts with its two link buttons.
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
 	changesNoteParts,
 	discardOutcome,
 	noteAfterDiscard,
 	noteAfterProbe,
-	modalDiscardDisabled,
 	discardBlocked,
+	discardDisabledReason,
 	DISCARD_CONFIRM_MESSAGE
 } = require('../src/renderer/changes-note.cjs');
 
@@ -162,16 +164,6 @@ test('noteAfterProbe clears an old count when the base cannot be measured (#308)
 		{ dirty: true, changedCount: 2 }
 	);
 });
-
-test('modalDiscardDisabled frees the link only for a loaded diff with changes', () => {
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: false }), false);
-	assert.equal(modalDiscardDisabled({ patchLoading: true, patchHasChanges: true, discarding: false }), true);
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: false, discarding: false }), true);
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: true }), true);
-	assert.equal(modalDiscardDisabled({}), true);
-	assert.equal(modalDiscardDisabled(), true);
-});
-
 test('discardBlocked holds the discard while anything is rewriting the tree', () => {
 	// The same states that block starting a trunk update: a force checkout
 	// under a running install, build or dev server corrupts both.
@@ -180,4 +172,29 @@ test('discardBlocked holds the discard while anything is rewriting the tree', ()
 	for (const flag of ['isUpdating', 'installing', 'building', 'devServerActive', 'discarding']) {
 		assert.equal(discardBlocked({ [flag]: true }), true, flag);
 	}
+});
+
+test('discardDisabledReason explains every state that makes discard unavailable', () => {
+	assert.equal(discardDisabledReason({ patchLoading: true, patchHasChanges: true }), 'Wait for your changes to finish loading.');
+	assert.equal(discardDisabledReason({ patchLoadFailed: true, patchHasChanges: false }), 'Changes could not be loaded.');
+	assert.equal(discardDisabledReason({ patchHasChanges: false }), 'There are no changes to discard.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, discarding: true }), 'Changes are already being discarded.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, isUpdating: true }), 'Wait for the trunk update to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, installing: true }), 'Wait for the installation to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, building: true }), 'Wait for the build to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, devServerActive: true }), 'Stop the dev server before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true }), null);
+});
+
+test('discardDisabledReason reports the operation in progress before secondary blockers', () => {
+	assert.equal(
+		discardDisabledReason({ patchLoading: true, patchHasChanges: false, discarding: true, devServerActive: true }),
+		'Changes are already being discarded.'
+	);
+});
+
+test('both visible discard links use the shared explanatory control', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer', 'index.jsx'), 'utf8');
+	const uses = source.match(/<DiscardChangesLink\b/g) || [];
+	assert.equal(uses.length, 2, 'the ticket note and review modal must share the tooltip-enabled discard link');
 });

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -2733,6 +2733,7 @@ test('the applied patch belongs to the ticket, not the site (issue #108)', async
 		siteMeta: {
 			'/sites/wp': {
 				currentBranch: 'ticket/61002',
+				tracTicket: 61002,
 				// The site-level value: what a pre-#108 install left behind, and
 				// what the migration copies onto the ticket it belonged to. It
 				// must never be what the panel reads once a ticket is active.
@@ -2758,6 +2759,45 @@ test('the applied patch belongs to the ticket, not the site (issue #108)', async
 	// Reading it from the site would show ticket A's patch while on ticket B —
 	// and offer a Revert that reverses A's hunks against B's tree.
 	assert.equal(status.appliedPatch, null, 'the other ticket\'s applied patch must not leak here');
+	assert.equal(status.ticketBehindTrunk, true, 'the active ticket started before the current trunk');
+});
+
+test('site:status does not guess that a ticket is behind without a recorded base (#305)', async () => {
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { tracTicket: 61002, currentBranch: 'ticket/61002', branches: { 'ticket/61002': { baseOid: null } } } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./trunk-update': { readTrunkInfo: async () => ({ trunkOid: 'new', trunkDate: 'd' }) },
+			'./ticket-branches': { currentBranchName: async () => 'ticket/61002' }
+		}
+	});
+
+	const status = await main.invoke('site:status', '/sites/wp');
+
+	assert.equal(status.ticketBehindTrunk, false);
+});
+
+test('site:status reports a ticket born from current trunk as current (#305)', async () => {
+	const settings = fakeSettingsStore({
+		sites: ['/sites/wp'],
+		siteMeta: { '/sites/wp': { tracTicket: 61002, currentBranch: 'ticket/61002', branches: { 'ticket/61002': { baseOid: 'same' } } } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./trunk-update': { readTrunkInfo: async () => ({ trunkOid: 'same', trunkDate: 'd' }) },
+			'./ticket-branches': { currentBranchName: async () => 'ticket/61002' }
+		}
+	});
+
+	const status = await main.invoke('site:status', '/sites/wp');
+
+	assert.equal(status.ticketBehindTrunk, false);
 });
 
 test('a checkout that died mid-switch blocks further switching (issue #108)', async () => {

--- a/test/ticket-trunk-notice.test.cjs
+++ b/test/ticket-trunk-notice.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { ticketTrunkNotice } = require('../src/renderer/ticket-trunk-notice.cjs');
+
+test('ticketTrunkNotice says what changed and gives the deliberately manual exit (#305)', () => {
+	assert.deepStrictEqual(ticketTrunkNotice({ ticketId: 123, behind: true }), {
+		title: 'Trunk has moved since this ticket started.',
+		body: 'Newer patches may not apply cleanly. Save a copy of your work, unlink the ticket, delete its work from the site, then link #123 again to start from the current trunk.'
+	});
+});
+
+test('ticketTrunkNotice stays silent without a ticket or a known move (#305)', () => {
+	for (const state of [
+		{ ticketId: null, behind: true },
+		{ ticketId: 123, behind: false },
+		{ ticketId: 123 }
+	]) assert.equal(ticketTrunkNotice(state), null);
+});
+
+test('the ticket card renders the stale-ticket notice returned by status (#305)', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer', 'index.jsx'), 'utf8');
+	assert.match(source, /setTicketBehindTrunk\(Boolean\(s\?\.ticketBehindTrunk\)\)/);
+	assert.match(source, /ticketTrunkNotice\(\{ ticketId: tracTicket, behind: ticketBehindTrunk \}\)/);
+	assert.match(source, /staleTicketNotice\.title/);
+	assert.match(source, /staleTicketNotice\.body/);
+	assert.match(
+		source,
+		/setTicketBehindTrunk\(false\);\s+setTracTicket\(res\.ticket\);/,
+		'a switched ticket must not render with the previous ticket\'s stale flag'
+	);
+});


### PR DESCRIPTION
## Why

When a discard link is disabled, it currently looks unavailable without explaining what the contributor must stop or wait for. This is especially confusing while the dev server is running, because both the ticket card and the review modal keep the action visible but inert.

## What changes

Both discard entry points now use the same control. When disabled, it remains keyboard-focusable and shows the concrete blocker in a tooltip and accessible description: patch loading failure, an operation in progress, installation, build, trunk update, or the dev server.

The existing discard guards and destructive action are unchanged. This adds explanation only.

## How to test this

Platforms: any — this changes renderer state and copy, not paths or processes.

**Starting state:** a linked ticket with one local edit and the dev server running.

1. On the ticket card, hover **discard your changes**, then focus it with the keyboard.
   **Expected:** both routes explain “Stop the dev server before discarding changes.”
2. Open **Review & submit changes**.
   **Expected:** **Discard all changes** is disabled.
3. Hover that link, then focus it with the keyboard.
   **Expected:** it gives the same dev-server explanation as the ticket card.
4. Stop the dev server and reopen the modal.
   **Expected:** both discard links are enabled and no tooltip is shown.
5. Start a build or installation and inspect both links while it runs.
   **Expected:** both tooltips name that operation rather than the dev server.
6. If patch generation fails, inspect the modal link.
   **Expected:** it says the changes could not be loaded, not that there are no changes.

**What must not have happened:** focusing or clicking either disabled link must not discard anything; stopping the blocker must restore the existing confirmation-and-discard flow.

The shared-control regression fails before this correction and passes after it in `test/changes-note.test.cjs`.

## Risks and limitations

The modal tooltip has been driven successfully from a signed macOS artifact. The ticket-card route still needs confirmation from the rebuilt signed artifact. The explanation follows the first applicable blocker when several operations are settling at once.

## Related

Follow-up to #323.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The existing WordPress components `Tooltip` and `Button accessibleWhenDisabled` APIs keep the reason available to mouse, keyboard and assistive-technology users. A title attribute would not provide equivalent keyboard behavior. A shared renderer component prevents the two visible discard links from drifting again.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up] across architecture, security, performance, cross-platform and tests.

`npm run build:once`, `npm run lint`, `npm test` (989/989) and `npm run test:electron` (989/989) pass.

</details>

<details>
<summary>Implementation notes</summary>

The reason and its priority live in `changes-note.cjs`; `DiscardChangesLink` renders the same enabled or tooltip-wrapped button for the ticket card and modal.

</details>

<details>
<summary>Screenshots or recording</summary>

The modal tooltip was confirmed from the prior signed macOS integration artifact. The ticket-card tooltip will be retested from the rebuilt artifact for `v1.0-rc2`.

</details>
