### PR TITLE
Explain why discard is unavailable

### DIFF
--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -123,18 +123,6 @@ function noteAfterProbe(_current, result) {
 }
 
 /**
- * Whether the modal's discard link is inert: while the diff is loading there
- * is nothing to confirm against, with no changes there is nothing to lose,
- * and mid-discard a second click would race the first.
- *
- * @param {{patchLoading?: boolean, patchHasChanges?: boolean, discarding?: boolean}} state
- * @return {boolean}
- */
-function modalDiscardDisabled({ patchLoading, patchHasChanges, discarding } = {}) {
-	return Boolean(patchLoading || discarding || !patchHasChanges);
-}
-
-/**
  * Whether a discard may run at all right now. The same states that block
  * starting a trunk update block a discard, and for the same reason: both
  * rewrite the tree under whatever npm is doing to it, and a force checkout
@@ -149,4 +137,28 @@ function discardBlocked({ isUpdating, installing, building, devServerActive, dis
 	return Boolean(isUpdating || installing || building || devServerActive || discarding);
 }
 
-module.exports = { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE };
+/**
+ * The explanation shown when the modal's discard action is unavailable.
+ *
+ * One operation can leave several guards true while state settles. Report the
+ * action already underway first, then the transient patch state, and finally
+ * the process the contributor can stop or wait for.
+ *
+ * @param {{patchLoading?: boolean, patchLoadFailed?: boolean, patchHasChanges?: boolean,
+ *          isUpdating?: boolean, installing?: boolean, building?: boolean,
+ *          devServerActive?: boolean, discarding?: boolean}} state
+ * @return {string|null}
+ */
+function discardDisabledReason({ patchLoading, patchLoadFailed, patchHasChanges, isUpdating, installing, building, devServerActive, discarding } = {}) {
+	if (discarding) return 'Changes are already being discarded.';
+	if (patchLoading) return 'Wait for your changes to finish loading.';
+	if (patchLoadFailed) return 'Changes could not be loaded.';
+	if (!patchHasChanges) return 'There are no changes to discard.';
+	if (isUpdating) return 'Wait for the trunk update to finish before discarding changes.';
+	if (installing) return 'Wait for the installation to finish before discarding changes.';
+	if (building) return 'Wait for the build to finish before discarding changes.';
+	if (devServerActive) return 'Stop the dev server before discarding changes.';
+	return null;
+}
+
+module.exports = { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -15,7 +15,8 @@ import {
   SnackbarList,
   TextControl,
   TextareaControl,
-  Spinner
+  Spinner,
+  Tooltip
 } from '@wordpress/components';
 import { plus, chevronLeft, chevronRight, chevronDown, copy as copyIcon, check as checkIcon, edit, download, comment } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
@@ -46,7 +47,7 @@ import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
-import { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, modalDiscardDisabled, discardBlocked, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
+import { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
 import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
@@ -69,6 +70,28 @@ const COPY_BUTTON_LABELS = {
   copied: 'Copied',
   failed: 'Could not copy'
 };
+
+// One discard action, wherever it is offered. Keeping the disabled rendering
+// here means the ticket note cannot lose the explanation while the review
+// modal keeps it (or vice versa).
+function DiscardChangesLink({ label, onClick, reason, style }) {
+  if (!reason) {
+    return <Button variant="link" isDestructive onClick={onClick} style={style}>{label}</Button>;
+  }
+  return (
+    <Tooltip text={reason} placement="bottom">
+      <Button
+        variant="link"
+        isDestructive
+        onClick={onClick}
+        disabled
+        accessibleWhenDisabled
+        description={reason}
+        style={style}
+      >{label}</Button>
+    </Tooltip>
+  );
+}
 // What the app is doing while a pull request is being opened (#167). Each step
 // is named because they take visibly different amounts of time — forking is the
 // slow one, and an unlabelled spinner there reads as a hang.
@@ -1212,6 +1235,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const [isPatchOpen, setIsPatchOpen] = useState(false);
   const [patchText, setPatchText] = useState('');
   const [patchLoading, setPatchLoading] = useState(false);
+  const [patchLoadFailed, setPatchLoadFailed] = useState(false);
   // What the last save did, reported in the modal rather than in an alert:
   // the destination panel is where the contributor is looking, and the path
   // matters — it is the file they are about to upload or hand over (#166).
@@ -3369,11 +3393,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // after a discard is the "nothing to send" banner.
   const loadPatchText = async () => {
     setPatchLoading(true);
+    setPatchLoadFailed(false);
     try {
       const res = await window.api.getPatch(sitePath);
       if (res && res.ok) setPatchText((res.patch && res.patch.trim().length) ? res.patch : 'No changes.');
-      else setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
+      else {
+        setPatchLoadFailed(true);
+        setPatchText(res && res.error ? `Error: ${res.error}` : 'Failed to generate patch');
+      }
     } catch (e) {
+      setPatchLoadFailed(true);
       setPatchText(`Error: ${e && e.message ? e.message : String(e)}`);
     } finally {
       setPatchLoading(false);
@@ -3383,6 +3412,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const openPatchModal = async ()=>{
     setIsPatchOpen(true);
     setPatchText('');
+    setPatchLoadFailed(false);
     // Last time's outcome belongs to last time's patch.
     setPatchSaved(null);
     setPatchSaveError('');
@@ -3441,7 +3471,18 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       {changesNote.lead}
       <Button variant="link" onClick={openPatchModal} disabled={isUpdating}>{changesNote.patchLabel}</Button>
       {changesNote.middle}
-      <Button variant="link" isDestructive onClick={discardAllChanges} disabled={discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}>{changesNote.discardLabel}</Button>
+      <DiscardChangesLink
+        label={changesNote.discardLabel}
+        onClick={discardAllChanges}
+        reason={discardDisabledReason({
+          patchHasChanges: true,
+          isUpdating,
+          installing,
+          building,
+          devServerActive: isDevProcessActive,
+          discarding
+        })}
+      />
       {changesNote.end}
       {discardError ? <div style={{ color: '#d63638', fontSize: 12, marginTop: 4 }}>{discardError}</div> : null}
     </>
@@ -3480,6 +3521,16 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const patchHasChanges = Boolean(patchText)
     && hasDiffLines(patchText)
     && !patchText.startsWith('Error');
+  const modalDiscardReason = discardDisabledReason({
+    patchLoading,
+    patchLoadFailed,
+    patchHasChanges,
+    isUpdating,
+    installing,
+    building,
+    devServerActive: isDevProcessActive,
+    discarding
+  });
 
   // Saving the file, for every destination that needs one (#166). `handoff`
   // asks the main process for the provenance header and the name that carries
@@ -5212,13 +5263,12 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                       {tracTicket ? `Your changes for ticket #${tracTicket}` : 'Your changes'}
                       <span style={{ fontWeight:400 }}>
                         {'('}
-                        <Button
-                          variant="link"
-                          isDestructive
+                        <DiscardChangesLink
+                          label="Discard all changes"
                           onClick={discardAllChanges}
-                          disabled={modalDiscardDisabled({ patchLoading, patchHasChanges, discarding }) || discardBlocked({ isUpdating, installing, building, devServerActive: isDevProcessActive, discarding })}
+                          reason={modalDiscardReason}
                           style={{ fontSize: 12 }}
-                        >Discard all changes</Button>
+                        />
                         {')'}
                       </span>
                     </div>

--- a/test/changes-note.test.cjs
+++ b/test/changes-note.test.cjs
@@ -3,14 +3,16 @@
 // DOM; index.jsx only interleaves the parts with its two link buttons.
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
 	changesNoteParts,
 	discardOutcome,
 	noteAfterDiscard,
 	noteAfterProbe,
-	modalDiscardDisabled,
 	discardBlocked,
+	discardDisabledReason,
 	DISCARD_CONFIRM_MESSAGE
 } = require('../src/renderer/changes-note.cjs');
 
@@ -162,16 +164,6 @@ test('noteAfterProbe clears an old count when the base cannot be measured (#308)
 		{ dirty: true, changedCount: 2 }
 	);
 });
-
-test('modalDiscardDisabled frees the link only for a loaded diff with changes', () => {
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: false }), false);
-	assert.equal(modalDiscardDisabled({ patchLoading: true, patchHasChanges: true, discarding: false }), true);
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: false, discarding: false }), true);
-	assert.equal(modalDiscardDisabled({ patchLoading: false, patchHasChanges: true, discarding: true }), true);
-	assert.equal(modalDiscardDisabled({}), true);
-	assert.equal(modalDiscardDisabled(), true);
-});
-
 test('discardBlocked holds the discard while anything is rewriting the tree', () => {
 	// The same states that block starting a trunk update: a force checkout
 	// under a running install, build or dev server corrupts both.
@@ -180,4 +172,29 @@ test('discardBlocked holds the discard while anything is rewriting the tree', ()
 	for (const flag of ['isUpdating', 'installing', 'building', 'devServerActive', 'discarding']) {
 		assert.equal(discardBlocked({ [flag]: true }), true, flag);
 	}
+});
+
+test('discardDisabledReason explains every state that makes discard unavailable', () => {
+	assert.equal(discardDisabledReason({ patchLoading: true, patchHasChanges: true }), 'Wait for your changes to finish loading.');
+	assert.equal(discardDisabledReason({ patchLoadFailed: true, patchHasChanges: false }), 'Changes could not be loaded.');
+	assert.equal(discardDisabledReason({ patchHasChanges: false }), 'There are no changes to discard.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, discarding: true }), 'Changes are already being discarded.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, isUpdating: true }), 'Wait for the trunk update to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, installing: true }), 'Wait for the installation to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, building: true }), 'Wait for the build to finish before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true, devServerActive: true }), 'Stop the dev server before discarding changes.');
+	assert.equal(discardDisabledReason({ patchHasChanges: true }), null);
+});
+
+test('discardDisabledReason reports the operation in progress before secondary blockers', () => {
+	assert.equal(
+		discardDisabledReason({ patchLoading: true, patchHasChanges: false, discarding: true, devServerActive: true }),
+		'Changes are already being discarded.'
+	);
+});
+
+test('both visible discard links use the shared explanatory control', () => {
+	const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer', 'index.jsx'), 'utf8');
+	const uses = source.match(/<DiscardChangesLink\b/g) || [];
+	assert.equal(uses.length, 2, 'the ticket note and review modal must share the tooltip-enabled discard link');
 });


### PR DESCRIPTION
## Why

PR #324 was marked merged by GitHub's stacked-PR endpoint, but its squash commit was attached to the old stacked base rather than to `trunk`. The tested discard explanation is therefore absent from `trunk`, despite #324 appearing merged.

## What changes

This lands the exact #324 patch directly on current `trunk`. It adds the same disabled-link explanation beside both “Discard all changes” entry points; there is no new behavior beyond the version already approved on macOS and Windows.

## How to test this

**Platforms:** macOS and Windows.

**Starting state:** a linked ticket with one local edit and the dev server running.

1. Open **Review & submit changes** and hover **Discard all changes**. It must explain that the dev server must be stopped first.
2. Close the dialog and hover **discard your changes** in the ticket summary. It must show the same explanation.
3. Stop the dev server. Both discard actions must become available.

**What must not have happened:**

- Merely hovering or opening the explanation must not discard work.
- The explanation must not remain after the dev server stops.

These steps were completed against the approved integration artifact at commit `012d7df` on macOS and Windows.

## Risks and limitations

This recovery commit has the exact same Git tree as the reviewed #324 head. Self-review: 0 [fix here] · 0 [follow-up].

## Related

Replacement landing for #324. Follow-up to #323.

---

<details>
<summary>Design decisions and alternatives considered</summary>

A standalone PR is necessary because merging the old stacked PR again is impossible and reusing its stale stack base could repeat the topology error. The patch itself is unchanged.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. The recovery commit and #324 resolve to the same Git tree. Lint, 1008 Node tests, 1008 Electron tests, `build:once`, and `git diff --check` all pass.

</details>

<details>
<summary>Implementation notes</summary>

Recovery head before squash: `752a79a`. Tree: `f7048eb8ca9606b998c81ebaaf1a3868695e4d38`.

</details>

<details>
<summary>Screenshots or recording</summary>

The visible behavior is unchanged from #324 and was manually validated in the approved integration artifact on both target platforms.

</details>
