### PR TITLE
Clear resolved patch errors after discard

### DIFF
--- a/src/renderer/changes-note.cjs
+++ b/src/renderer/changes-note.cjs
@@ -84,6 +84,20 @@ function discardOutcome(res) {
 }
 
 /**
+ * Apply-related feedback after attempting the destructive exit from a ticket.
+ * A failure preserves the layer and the error that explains why it remains;
+ * success clears both because the ticket is back at its base.
+ *
+ * @param {{ok?: boolean}} outcome The discard result.
+ * @param {*}              current The apply feedback currently on screen.
+ * @return {*}
+ */
+function applyFeedbackAfterDiscard(outcome, current) {
+	if (!outcome || !outcome.ok) return current;
+	return { appliedPatch: null, applyError: '', applyConflict: null, applyNotice: '' };
+}
+
+/**
  * What the note shows in the frame straight after a discard, before any probe
  * has walked the checkout again.
  *
@@ -161,4 +175,4 @@ function discardDisabledReason({ patchLoading, patchLoadFailed, patchHasChanges,
 	return null;
 }
 
-module.exports = { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE };
+module.exports = { changesNoteParts, discardOutcome, applyFeedbackAfterDiscard, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -47,7 +47,7 @@ import { describeSwitchProgress } from '../switch-progress.cjs';
 import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
-import { changesNoteParts, discardOutcome, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
+import { changesNoteParts, discardOutcome, applyFeedbackAfterDiscard, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
 import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
@@ -3456,7 +3456,11 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         return;
       }
       applyDiscardToNote(outcome);
-      setAppliedPatch(null);
+      const feedback = applyFeedbackAfterDiscard(outcome);
+      setAppliedPatch(feedback.appliedPatch);
+      setApplyError(feedback.applyError);
+      setApplyConflict(feedback.applyConflict);
+      setApplyNotice(feedback.applyNotice);
       writeToTerminal('\nDiscarded local changes.\n');
       confirm('All changes discarded.');
       if (isPatchOpen) await loadPatchText();

--- a/test/discard-apply-state.test.cjs
+++ b/test/discard-apply-state.test.cjs
@@ -1,0 +1,29 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { applyFeedbackAfterDiscard } = require('../src/renderer/changes-note.cjs');
+
+test('a successful discard clears the apply failure it resolved', () => {
+	assert.deepEqual(applyFeedbackAfterDiscard({ ok: true }, {
+		appliedPatch: { label: 'PR #13017' },
+		applyError: 'The patch could not be lifted back out.',
+		applyConflict: { headline: '1 change needs rework' },
+		applyNotice: 'Older notice'
+	}), {
+		appliedPatch: null,
+		applyError: '',
+		applyConflict: null,
+		applyNotice: ''
+	});
+});
+
+test('a failed discard preserves the failure the contributor still needs', () => {
+	const current = {
+		appliedPatch: { label: 'PR #13017' },
+		applyError: 'The patch could not be lifted back out.',
+		applyConflict: { headline: '1 change needs rework' },
+		applyNotice: ''
+	};
+	assert.strictEqual(applyFeedbackAfterDiscard({ ok: false }, current), current);
+});


### PR DESCRIPTION
## Why

After a contributor chooses **Discard this ticket to its base** from a failed Revert, the discard succeeds but the old red patch error remains on screen. The checkout is clean, yet the interface still claims the operation failed.

The original #325 belonged to the stale stack that GitHub closed while #324 was being recovered, so this PR lands the already approved fix directly on `trunk`.

## What changes

After a successful discard, clear the stale apply error and related preview state. If discard fails, retain all of that state so the contributor can still understand and recover from the failure.

## How to test this

**Platforms:** macOS and Windows.

**Starting state:** ticket #65819 linked, PR #13017 applied, with this contributor edit on an applied line in `tests/phpunit/tests/customize/widgets.php`:

```php
$this->assertIsCallable( $args['sanitize_callback'], 'sanitize_callback is callable' ); // Mi cambio.
```

1. Click **Revert this patch**. Revert must be rejected, the checkout must remain unchanged, and the red error must offer **Save a copy of your work** and **Discard this ticket to its base**.
2. Click **Discard this ticket to its base**.
3. The applied PR, contributor edit, applied-layer card, and red error must all disappear. Ticket #65819 must remain linked.

**What must not have happened:**

- A failed discard must not clear the error or preview state.
- The ticket itself must not be unlinked.
- No unrelated ticket work may be removed.

This flow passed in the approved integration artifact at commit `012d7df` on macOS and Windows.

## Risks and limitations

The final Git tree is exactly the tree manually approved for the release candidate. Self-review: 0 [fix here] · 0 [follow-up].

## Related

Replacement landing for #325. Follow-up to #318 and #330.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The cleanup is derived in the existing pure reducer and only committed after `outcome.ok`. Keeping failure state unchanged avoids hiding recovery information after an unsuccessful destructive operation.

A standalone PR avoids reusing the closed stack topology that caused #324 not to land on `trunk`.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. Lint, 1010/1010 tests, and `git diff --check` pass. The branch resolves to approved tree `d3904782d5e434df8591e99d3ccf2a49a52ebcc9`.

</details>

<details>
<summary>Implementation notes</summary>

Recovery head before squash: `6a88a26`. It contains one commit directly on #330's squash commit.

</details>

<details>
<summary>Screenshots or recording</summary>

The user-visible flow was manually validated on both target platforms in the approved integration artifact.

</details>
