### PR TITLE
Prevent submitting an applied patch as your own work

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -651,12 +651,17 @@ ipcMain.handle('git:create-patch', async (_e, sitePath) => {
 // `{ handoff: true }` is the only difference: the file gets the header from
 // patch-provenance.cjs and a name that says whose work it is, so someone else
 // can push it and the props still land on the person who wrote it. Every other
-// caller — the Trac destination, the save-before-update prompt — passes nothing
-// and gets the bare diff under the name it has always had, because that is what
-// gets attached to a ticket.
+// Trac names its destination so the ownership guard can distinguish a file for
+// submission from an ordinary backup. Both it and the save-before-update path
+// still get the bare diff under the name it has always had.
 ipcMain.handle('git:save-patch', async (_e, sitePath, options) => {
     try {
         const handoff = Boolean(options && options.handoff);
+        const submission = handoff || (options && options.destination === 'trac');
+        if (submission) {
+            const refusal = await appliedPatchSubmissionRefusal(sitePath);
+            if (refusal) return refusal;
+        }
         const baseOid = await patchBaseOid(sitePath);
         const patch = await createMinimalPatchForDir(sitePath, baseOid);
 
@@ -820,6 +825,8 @@ ipcMain.handle('github:open-pr', async (event, sitePath, options = {}) => {
     if (!ticketId) {
         return { ok: false, reason: 'no-ticket', error: 'Link a Trac ticket to this site first.', stage: 'auth' };
     }
+    const ownershipRefusal = await appliedPatchSubmissionRefusal(sitePath);
+    if (ownershipRefusal) return { ...ownershipRefusal, stage: 'ownership' };
     const { wporgHandle: handle = null, contributionEvent = null } = s.get('preferences') || {};
 
     let collected;
@@ -1088,6 +1095,32 @@ function switchProgressReporter(event, sitePath) {
 async function readWorkMeta(sitePath) {
     const { ref, meta, site } = await activeBranch(sitePath);
     return ref === TRUNK || !meta ? site : meta;
+}
+
+/**
+ * Refuse to publish a checkout that still contains a named patch layer (#328).
+ *
+ * The diff against the ticket's base contains both that layer and any edits
+ * made after it. There is no honest single owner for that combined diff, and
+ * the app cannot separate the two safely. An ordinary, unattributed Save is
+ * deliberately not routed through this guard: it remains available as the
+ * backup contributors are told to make before reverting or discarding work.
+ *
+ * @param {string} sitePath
+ * @return {Promise<?{ok: false, reason: string, error: string}>}
+ */
+async function appliedPatchSubmissionRefusal(sitePath) {
+    const appliedPatch = (await readWorkMeta(sitePath)).appliedPatch;
+    if (!appliedPatch) return null;
+
+    const label = typeof appliedPatch.label === 'string' && appliedPatch.label.trim()
+        ? appliedPatch.label.trim()
+        : 'The patch you applied';
+    return {
+        ok: false,
+        reason: 'applied-patch',
+        error: `${label} is applied. Revert it before submitting this checkout as your own work.`
+    };
 }
 
 async function writeWorkMeta(sitePath, patch) {

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2769,6 +2769,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   const appliedLayer = describeAppliedLayer(appliedPatch, {
     when: appliedPatch?.appliedAt ? new Date(appliedPatch.appliedAt).toLocaleString() : ''
   });
+  const appliedPatchLabel = appliedPatch?.label || 'The patch you applied';
   const previewAttribution = attributeConflicts({ conflicts: applyPreview?.conflicts, appliedPatch });
   // The layer exits reach the same two operations the changes note does, so
   // they go through the same guard: a discard is a force checkout, and running
@@ -3538,9 +3539,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
 
   // Saving the file, for every destination that needs one (#166). `handoff`
   // asks the main process for the provenance header and the name that carries
-  // the handle; without it this is the plain diff the Save button has always
-  // produced. Returns the path so a caller can say what it did next — the Trac
-  // route saves and then opens the attach page.
+  // the handle; `destination: 'trac'` keeps the diff plain but lets main enforce
+  // the same applied-layer guard as the UI. With no options this is the backup
+  // the Save button has always produced. Returns the path so a caller can say
+  // what it did next — the Trac route saves and then opens the attach page.
   const savePatchFile = async (options) => {
     setPatchSaved(null);
     setPatchSaveError('');
@@ -3570,7 +3572,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // The page is opened only after a file exists, so the browser never lands on
   // an attach form with nothing to attach.
   const saveForTrac = async () => {
-    const filePath = await savePatchFile();
+    const filePath = await savePatchFile({ destination: 'trac' });
     if (filePath && tracTicket) window.api.openExternal(attachUrl(tracTicket));
   };
 
@@ -3684,6 +3686,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // deep and unreadable at the point where the wording matters most, so the
   // states get early returns and the card body gets one call.
   const renderPullRequestBody = () => {
+    if (appliedPatch) {
+      return (
+        <div style={{ fontSize:12, color:'#6e5406', lineHeight:1.5 }}>
+          Revert {appliedPatchLabel} before opening a pull request from this checkout.
+        </div>
+      );
+    }
+
     if (prResult) {
       return (
         <>
@@ -5353,6 +5363,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   <div style={{ fontSize:12, color:'#6c6f72', lineHeight:1.5 }}>The pull request is the one the app sends for you. The other two save a file for you to send.</div>
                   </div>
 
+                  {appliedPatch ? (
+                    <div role="alert" style={{ padding:'10px 12px', background:'#fcf9e8', border:'1px solid #dba617', borderRadius:6, fontSize:12, color:'#6e5406', lineHeight:1.5 }}>
+                      <strong>{appliedPatchLabel} is part of this checkout.</strong>{' '}
+                      The app cannot safely separate its author’s changes from edits made afterward, so this combined patch cannot be submitted as your work. You can still use <strong>Save</strong> to keep an unattributed copy; revert the applied patch before submitting.
+                    </div>
+                  ) : null}
+
                   {/*
                     Alone in its own group, because it is the one destination
                     that acts for the contributor: it signs them in, forks, and
@@ -5409,7 +5426,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                       after="No automated checks. Often followed by a request to open a pull request."
                     >
                       {tracTicket ? (
-                        <Button variant="primary" onClick={saveForTrac} style={{ justifyContent:'center' }}>
+                        <Button variant="primary" onClick={saveForTrac} disabled={Boolean(appliedPatch)} style={{ justifyContent:'center' }}>
                           Save, then open #{tracTicket}
                         </Button>
                       ) : (
@@ -5447,7 +5464,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                     >
                       {wporg?.handle && !editingHandle ? (
                         <>
-                          <Button variant="primary" onClick={saveForHandoff} style={{ justifyContent:'center' }}>
+                          <Button variant="primary" onClick={saveForHandoff} disabled={Boolean(appliedPatch)} style={{ justifyContent:'center' }}>
                             Save patch as {wporg.handle}
                           </Button>
                           {/*

--- a/test/ipc-wiring.test.cjs
+++ b/test/ipc-wiring.test.cjs
@@ -1287,6 +1287,35 @@ test('git:save-patch with handoff writes the header above the diff, and it still
 	assert.deepEqual(parsed.files.map((f) => f.path), ['text.txt']);
 });
 
+// An applied pull request is a named layer, not the current contributor's
+// work. The app cannot split later edits out of that layer reliably, so it may
+// save the combined checkout as an unattributed backup but must not prepare it
+// for submission under a new owner (#328).
+test('git:save-patch refuses submission destinations while a patch is applied, but still saves a copy (#328)', async (t) => {
+	const dir = await fixtureRepo(t);
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: { [dir]: { tracTicket: 62281, appliedPatch: { label: 'PR #6717', text: 'STORED' } } },
+		preferences: { wporgHandle: 'janedoe' }
+	});
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+
+	const handoff = await main.invoke('git:save-patch', dir, { handoff: true });
+	const trac = await main.invoke('git:save-patch', dir, { destination: 'trac' });
+
+	assert.deepEqual(handoff, {
+		ok: false,
+		reason: 'applied-patch',
+		error: 'PR #6717 is applied. Revert it before submitting this checkout as your own work.'
+	});
+	assert.deepEqual(trac, handoff);
+	assert.deepEqual(main.calls.showSaveDialog, [], 'a refused submission must not create a file');
+
+	const copy = await main.invoke('git:save-patch', dir);
+	assert.equal(copy.canceled, true);
+	assert.equal(main.calls.showSaveDialog.length, 1, 'an unattributed backup remains available');
+});
+
 // --- provenance:* -> src/wporg-handle.cjs + src/patch-provenance.cjs (#166) ---
 
 // The handle becomes a filename and a line in a file other people read, so it
@@ -3770,6 +3799,38 @@ test('github:open-pr refuses before it reaches GitHub when nothing is signed in,
 	await settle();
 
 	assert.equal((await main.invoke('github:open-pr', dir, {})).reason, 'no-ticket');
+	assert.deepEqual(openPullRequest.calls, []);
+});
+
+test('github:open-pr refuses another author\'s applied patch before it reaches GitHub (#328)', async (t) => {
+	const dir = await fixtureRepo(t);
+	const auth = fakeGithubAuth({ login: 'janedoe' });
+	const openPullRequest = spy(async () => ({ ok: true }));
+	const settings = fakeSettingsStore({
+		sites: [dir],
+		siteMeta: { [dir]: { tracTicket: 62281, appliedPatch: { label: 'PR #6717', text: 'STORED' } } }
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'./github-auth.cjs': auth,
+			'./github-pr.cjs': { openPullRequest, buildPullRequestBody: () => '' }
+		}
+	});
+
+	await main.invokeWith('github:sign-in', createIpcEvent());
+	await settle();
+	await settle();
+
+	const result = await main.invoke('github:open-pr', dir, {});
+
+	assert.deepEqual(result, {
+		ok: false,
+		reason: 'applied-patch',
+		error: 'PR #6717 is applied. Revert it before submitting this checkout as your own work.',
+		stage: 'ownership'
+	});
 	assert.deepEqual(openPullRequest.calls, []);
 });
 


### PR DESCRIPTION
## Why

After applying another contributor's patch or pull request, the toolkit still offered to submit the combined checkout under the current user's identity. This could misattribute or republish someone else's work when saving a mentor handoff, attaching to Trac, or opening another pull request.

## What changes

Submission destinations are blocked while a named patch layer is applied. The ordinary **Save** action remains available as an unattributed backup, and the main process enforces the same ownership guard so the renderer cannot bypass it.

## How to test this

Platforms: any.

**Starting state:** A site linked to a Trac ticket, with a linked pull request applied and no edits of your own.

1. Open **Review & submit changes**. Confirm the panel identifies the applied pull request and explains that the combined patch cannot be submitted as your work.
2. Click **Save**. Confirm an unattributed `wordpress.patch` backup can still be saved.
3. Confirm **Open a pull request**, **Save, then open #…**, and **Save patch as …** are unavailable.
4. Revert the applied pull request, reopen **Review & submit changes**, and confirm the submission destinations are available again.

**What must not have happened:** No attributed handoff file, Trac attachment flow, GitHub branch, or pull request should be created while the applied patch remains. Saving the backup must not revert or discard any checkout changes.

Regression coverage: `git:save-patch refuses submission destinations while a patch is applied, but still saves a copy (#328)` and `github:open-pr refuses another author's applied patch before it reaches GitHub (#328)` fail without the main-process guard.

## Risks and limitations

The app deliberately blocks the entire combined checkout because it cannot safely separate later edits from the applied author's changes. The visible flow was not driven manually in Electron during this change.

Self-review: 1 `[fix here]` finding remains—the presentation decision is still branched inside `index.jsx` instead of a tested renderer module. It is consciously deferred because the main-process guard independently enforces the safety boundary; extracting the renderer presentation belongs in a follow-up.

## Related

Fixes #328.

---

<details>
<summary>Design decisions and alternatives considered</summary>

Preserving the original author's attribution would also be misleading when the contributor edits the applied work afterward. Blocking publication while retaining an unattributed backup is the only behavior that does not guess ownership.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

1 `[fix here]` · 0 `[follow-up]` — the open finding is documented under **Risks and limitations**. Architecture, security, performance, cross-platform behavior, and test coverage were otherwise clean. `npm run lint`, `npm test` (1,012 tests), and `git diff --check` passed.

</details>

<details>
<summary>Implementation notes</summary>

The `git:save-patch` handler distinguishes a plain backup from Trac and handoff destinations. `github:open-pr` uses the same applied-layer refusal before collecting or publishing files.

</details>

<details>
<summary>Screenshots or recording</summary>

Not captured. The visible warning and disabled destinations require manual verification using the steps above.

</details>
