### PR TITLE
Fix missing linked PRs and stalled Trac loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,10 @@ see [`CONTRIBUTING.md`](CONTRIBUTING.md). It points back here; it does not resta
 See `package.json` scripts. To run a single test file (not exposed as a script):
 `node --test test/azure-sign.test.cjs`.
 
+When writing manual test instructions, inspect the current renderer flow first and distinguish
+actions that happen automatically after linking a ticket from controls used only to retry or
+refresh them. Do not tell a tester to click a control when the app already starts that operation.
+
 ## Architecture notes (non-obvious)
 
 - **Child processes run on Electron's own Node, not the system Node.** `npm install`,

--- a/src/patch-sources.cjs
+++ b/src/patch-sources.cjs
@@ -55,9 +55,13 @@ function parsePrRef(input) {
 }
 
 /**
- * True when a PR body cites this exact ticket. The negative lookahead stops
- * `/ticket/6582` from matching inside `/ticket/65820`, and the host is required
- * so a bare "#65822" in prose does not count.
+ * True when a PR body cites this exact ticket. Current pull request templates
+ * use the full Trac URL; older ones used a labelled bare number (#327), so that
+ * explicitly labelled form counts too. An unlabelled number still does not:
+ * GitHub search can surface it from unrelated prose or comments.
+ *
+ * The negative lookaheads stop either accepted form from matching a longer
+ * ticket number that merely starts with the requested digits.
  *
  * @param {string}        body
  * @param {number|string} ticketId
@@ -68,7 +72,8 @@ function bodyCitesTicket(body, ticketId) {
 	const id = String(ticketId).replace(/[^0-9]/g, '');
 	if (!id) return false;
 	const re = new RegExp(`${TICKET_HOST.replace(/\./g, '\\.')}/ticket/${id}(?![0-9])`);
-	return re.test(body);
+	const labelledNumber = new RegExp(`(?:^|[\\r\\n])[ \\t]*Trac[ \\t]+ticket[ \\t]*:[ \\t]*#?${id}(?![0-9])`, 'i');
+	return re.test(body) || labelledNumber.test(body);
 }
 
 /**

--- a/src/trac-view.js
+++ b/src/trac-view.js
@@ -32,6 +32,25 @@ const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress
 const READY_TIMEOUT_MS = 90000;
 const POLL_MS = 800;
 
+/**
+ * Whether a promise resolves before an absolute deadline. Rejections remain
+ * rejections so the caller can report navigation failures separately from a
+ * page that simply never finishes loading.
+ *
+ * @param {Promise} promise
+ * @param {number}  deadline Unix time in milliseconds.
+ * @return {Promise<boolean>}
+ */
+function resolvesBy(promise, deadline) {
+	let timer;
+	return Promise.race([
+		Promise.resolve(promise).then(() => true),
+		new Promise((resolve) => {
+			timer = setTimeout(() => resolve(false), Math.max(0, deadline - Date.now()));
+		})
+	]).finally(() => clearTimeout(timer));
+}
+
 function ticketUrl(id) {
 	return `https://${TRAC_HOST}/ticket/${id}`;
 }
@@ -61,11 +80,14 @@ function pinToTrac(wc) {
  * challenge needs the user), scrapes the attachment list, and closes.
  *
  * @param {number|string} ticketId
+ * @param {Object}        [deps]
+ * @param {number}        [deps.readyTimeoutMs] Override for tests.
  * @return {Promise<{status: string, items: Array, error?: string}>}
  */
-async function openAndScrape(ticketId) {
+async function openAndScrape(ticketId, deps = {}) {
 	const id = String(ticketId).replace(/[^0-9]/g, '');
 	if (!id) return { status: 'error', items: [], error: 'No ticket number' };
+	const readyTimeoutMs = Number.isFinite(deps.readyTimeoutMs) ? Math.max(0, deps.readyTimeoutMs) : READY_TIMEOUT_MS;
 
 	const tracSession = session.fromPartition(TRAC_PARTITION);
 	const win = new BrowserWindow({
@@ -91,12 +113,17 @@ async function openAndScrape(ticketId) {
 	};
 
 	try {
-		await win.loadURL(ticketUrl(id));
+		// The deadline covers navigation as well as the challenge poll. Electron's
+		// loadURL promise resolves only after the page finishes loading, so putting
+		// the deadline after this await left a stalled navigation spinning forever
+		// (#327).
+		const deadline = Date.now() + readyTimeoutMs;
+		const loaded = await resolvesBy(win.loadURL(ticketUrl(id)), deadline);
+		if (!loaded) return { status: 'challenge-timeout', items: [] };
 
 		// Poll until the real ticket page is present. The challenge page has no
 		// #ticket; when the hashcash (or the user) clears it, Trac reloads to
 		// the real page and #ticket appears.
-		const deadline = Date.now() + READY_TIMEOUT_MS;
 		let ready = false;
 		while (Date.now() < deadline) {
 			if (win.isDestroyed()) return { status: 'closed', items: [] };

--- a/test/patch-sources.test.cjs
+++ b/test/patch-sources.test.cjs
@@ -18,11 +18,21 @@ function item(number, overrides = {}) {
 	};
 }
 
-test('bodyCitesTicket: the full ticket URL counts, a bare number does not (issue #11)', () => {
+test('bodyCitesTicket: the full ticket URL counts, an unlabelled bare number does not (issue #11)', () => {
 	assert.strictEqual(bodyCitesTicket('see https://core.trac.wordpress.org/ticket/62281 for context', 62281), true);
 	assert.strictEqual(bodyCitesTicket('this is about #62281 somewhere', 62281), false);
 	assert.strictEqual(bodyCitesTicket('', 62281), false);
 	assert.strictEqual(bodyCitesTicket(null, 62281), false);
+});
+
+// Older wordpress-develop pull request templates asked for a ticket number,
+// not its full URL. PR #3139 still follows that format and must not disappear
+// from ticket #56320 merely because today's template is stricter.
+test('bodyCitesTicket: a labelled bare ticket number counts (issue #327)', () => {
+	assert.strictEqual(bodyCitesTicket('Updated mediaelement.js\nTrac ticket: 56320', 56320), true);
+	assert.strictEqual(bodyCitesTicket('Trac ticket: #56320', 56320), true);
+	assert.strictEqual(bodyCitesTicket('unrelated work mentions 56320 in passing', 56320), false);
+	assert.strictEqual(bodyCitesTicket('Trac ticket: 563200', 56320), false);
 });
 
 // The precision bug the URL check exists to prevent: GitHub's tokeniser can

--- a/test/trac-view.test.cjs
+++ b/test/trac-view.test.cjs
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function loadTracView(electron) {
+	const originalLoad = Module._load;
+	Module._load = function (request, parent, isMain) {
+		if (request === 'electron') return electron;
+		return originalLoad.call(this, request, parent, isMain);
+	};
+	try {
+		delete require.cache[require.resolve('../src/trac-view.js')];
+		return require('../src/trac-view.js');
+	} finally {
+		Module._load = originalLoad;
+	}
+}
+
+test('openAndScrape: a navigation that never finishes still reaches the ready timeout (issue #327)', async () => {
+	let destroyed = false;
+	class BrowserWindowStub {
+		constructor() {
+			this.webContents = {
+				setWindowOpenHandler() {},
+				on() {},
+				executeJavaScript() { return Promise.resolve(false); }
+			};
+		}
+		loadURL() { return new Promise(() => {}); }
+		isDestroyed() { return destroyed; }
+		destroy() { destroyed = true; }
+		show() {}
+	}
+
+	const electron = {
+		BrowserWindow: BrowserWindowStub,
+		session: { fromPartition: () => ({ setUserAgent() {} }) }
+	};
+	const { openAndScrape } = loadTracView(electron);
+	const harnessTimeout = new Promise((resolve) => {
+		setTimeout(() => resolve({ status: 'test-harness-timeout' }), 50);
+	});
+
+	const result = await Promise.race([
+		openAndScrape(56320, { readyTimeoutMs: 5 }),
+		harnessTimeout
+	]);
+
+	assert.equal(result.status, 'challenge-timeout');
+	assert.equal(destroyed, true, 'the hidden Trac window is cleaned up after timing out');
+});


### PR DESCRIPTION
## Why

Ticket #56320 has an open WordPress/wordpress-develop pull request, but the toolkit reports that no pull requests cite it. The same ticket can also leave the automatic Trac patch load spinning indefinitely, making existing work look absent to a contributor.

## What changes

The GitHub result filter now accepts the historical, explicitly labelled `Trac ticket: 56320` citation format as well as the current full Trac URL, while continuing to reject incidental number mentions and longer ticket numbers.

The existing 90-second Trac deadline now covers the initial Electron navigation as well as the human-check polling. A navigation that never finishes therefore reaches the existing timeout state and cleans up its hidden window instead of leaving the renderer waiting forever.

## How to test this

Platforms: macOS was tested manually. Windows should also be checked because #327 was reported on Windows 11 and the timeout symptom occurred there.

**Starting state:** A configured site on the site view, with no Trac ticket linked.

1. Enter `56320` in **Trac ticket** and click **Link ticket**. The app automatically starts both the GitHub and Trac checks.
2. Confirm **Linked pull requests** shows **#3139 — Updated mediaelement.js to 5.0.5** instead of “No pull requests cite this ticket yet.”
3. Confirm the automatic **Opening the ticket on Trac…** operation completes and the spinner disappears. Complete the Trac human-check if it appears.
4. As a control, unlink the ticket, link `61330`, and confirm its two full-URL-citing pull requests still appear.
5. Run `npm test` and `npm run lint`. The regression tests for the historical citation and stalled navigation pass; the full suite reports 1,014 passing tests.

**What must not have happened:** An unrelated mention of `56320` must not be treated as a citation, ticket `563200` must not match, the Trac spinner must not remain indefinitely, and no site work or dependencies should be changed by linking either ticket.

## Risks and limitations

The exact never-settling navigation could not be staged manually; it is covered by a BrowserWindow regression test that fails against the old implementation. The shared 90-second budget now includes initial navigation, so an unusually slow navigation leaves less time for the subsequent human-check.

No UI layout changed, so there are no before/after screenshots.

## Related

Fixes #327

---

<details>
<summary>Design decisions and alternatives considered</summary>

The matcher was not broadened to accept any bare occurrence of the ticket number because GitHub search can return incidental mentions. Only a line explicitly labelled `Trac ticket:` is accepted.

The timeout retains the existing `challenge-timeout` result and UI instead of adding a second navigation-specific state. From the contributor's perspective the recovery is the same: retry the Trac load and complete the human-check if necessary.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. No findings across architecture, security, performance, cross-platform, or tests. `npm run lint`, `npm test` (1,014 tests), and `git diff --check` all passed.

</details>

<details>
<summary>Implementation notes</summary>

The Trac timeout uses one absolute deadline across `loadURL()` and the existing DOM poll. The test injects a short timeout and a BrowserWindow whose navigation promise never settles, then verifies both the timeout result and window cleanup.

The repository's manual-testing guidance was also clarified after testing confirmed that Trac patch loading starts automatically when a ticket is linked; the button is a retry/refresh path rather than the initial action.

</details>
