### PR TITLE
Update the guide for current ticket work

### DIFF
--- a/docs/guide/applying-patches.md
+++ b/docs/guide/applying-patches.md
@@ -17,7 +17,7 @@ There are three ways to get a patch into the panel:
 Nothing is changed yet. The panel first shows what the patch would do:
 
 - The list of files it changes.
-- A warning if you have your own edits to any of those files. The patch is applied on top of them: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy — see [Submitting your changes](submitting-changes).
+- A warning if this ticket already has work in any of those files, measured from the trunk snapshot the ticket started on. The warning names your own edits and changes from an applied patch separately; a file from an applied patch may contain your edits too. The new patch is applied on top of that work: it succeeds if the changes do not overlap, and fails without touching anything if they do. Save a patch of your work first if you want a copy — see [Submitting your changes](submitting-changes).
 - Which files are binary and will be skipped.
 - Whether it changes `package-lock.json`, in which case dependencies will be installed before the rebuild.
 
@@ -46,7 +46,11 @@ Every region carries an **anchor line taken from your own file** to search for. 
 
 ### For a pull request
 
-The regions belong to whoever updates the pull request, and that is its author, not you. So the notice names the situation and its scale — *this pull request was written against an older trunk and no longer fits it: 4 of its 20 changes, in 3 files, would need rework* — without the line-level detail, and points at the one act that is genuinely yours: telling the author. Leaving a comment asking for a rebase is a real contribution.
+The panel first separates two situations that need different next steps.
+
+If the failures are only in files this ticket has not changed, the pull request was written against an older trunk. The notice names the situation and its scale — *this pull request was written against an older trunk and no longer fits it: 4 of its 20 changes, in 3 files, would need rework* — without the line-level detail. Bringing it up to date is its author's work, so the useful contribution is to leave a comment asking for a rebase or for trunk to be merged in.
+
+If your ticket already has work in a failing file, the app does not blame the pull request's author. A file-level overlap cannot prove which exact lines caused the failure, so the notice says your work *may* be involved. Save a patch of your work, try the pull request on a clean ticket, and ask its author to update it only if it still fails there. When the file includes changes from a patch you already applied, the notice names that patch too rather than calling all of the file your own writing.
 
 A **closed** pull request is read differently, because on `wordpress-develop` "closed" is also what landing looks like — core commits go through SVN and the pull request is closed, never merged. If all its changes read back as already in trunk, the panel says it was likely committed to core and there is nothing left to apply. Otherwise it says nobody is coming back to update it, and offers **See why it was closed**.
 
@@ -56,15 +60,19 @@ When the ticket has other patches on it — another pull request, another attach
 
 ## Applied patches belong to a ticket
 
-What is applied is recorded against the ticket you are on, not against the site. Switch to another ticket and the green "applied" box goes with the first one; switch back and it is there again, describing the patch you actually applied on that ticket. See [Working on several tickets](ticket-branches).
+What is applied is recorded as a named layer on the ticket you are on, separate from your own edits. Switch to another ticket and the green "applied" box goes with the first one; switch back and it is there again, naming the patch, how many files it changed, and when it was applied. The preview and failure notices continue to distinguish that layer from your writing.
+
+A ticket holds one applied patch or pull request at a time. Revert it, or discard the ticket back to its base, before applying another. See [Working on several tickets](ticket-branches).
 
 ## Reverting an applied patch
 
-While a patch is applied, the panel shows it in a green box with a **Revert this patch** button. Reverting removes the patch's changes and rebuilds, again leaving your own edits alone.
+While the saved patch can still be removed cleanly, the panel shows it in a green box with a **Revert this patch** button. Reverting removes the patch's changes and rebuilds, again leaving your own edits alone.
 
-Very large patches cannot be undone automatically. The panel says so; use **Update to latest trunk** to reset the checkout instead — see [Staying up to date with trunk](trunk-updates).
+If you edit lines the patch brought in, it can no longer be lifted back out without also disturbing your work. A failed Revert changes the explanation accordingly: the patch is part of your changes now. Undo your edits on the named regions to make **Revert this patch** work again, or **Save a copy of your work** and **Discard this ticket to its base**.
 
-That escape hatch only resets a site sitting on trunk. On a ticket, an update parks your branch before it resets trunk and checks the branch back out afterwards — applied patch and all — so it leaves you where you were. On a ticket, the way to be rid of both the patch and the work under it is [deleting that ticket's work](ticket-branches).
+For very large patches, the app does not keep the copy it would need for an undo, so they never offer Revert. The amber box says so and offers the same copy-and-discard route. Until the ticket is reverted or discarded, the patch still occupies its one applied-patch slot.
+
+**Update to latest trunk** is not an escape hatch for a patch on a ticket. It parks the ticket branch, updates trunk, and checks the same branch back out afterwards — applied patch and all — so it leaves you where you were. See [Staying up to date with trunk](trunk-updates).
 
 ## Your own changes
 

--- a/docs/guide/ticket-branches.md
+++ b/docs/guide/ticket-branches.md
@@ -85,13 +85,35 @@ This counts the ticket's whole work — including everything parked when you las
 
 Under it is the reassurance that matters here: unlinking the ticket does not touch those changes. They stay attached to the ticket in this site, ready for when you link it again.
 
+Returning to a ticket does not make it clean or measure it from wherever trunk happens to be now.
+The same count and the same files return because the ticket is still measured from the trunk
+snapshot where its branch started. That baseline also drives the warning before applying another
+patch: work committed when you switched away is still named as work on this ticket.
+
+## When trunk has moved since the ticket started
+
+Updating the site moves its copy of trunk, but deliberately does not move existing ticket branches.
+When the app can see that the linked ticket started on an older trunk, the **Trac ticket** card says:
+
+> **Trunk has moved since this ticket started.** Newer patches may not apply cleanly.
+
+Nothing moves automatically. To start the ticket again from current trunk:
+
+1. Use **Review & submit changes** to save a patch of the ticket's work.
+2. Click **Unlink** so the ticket appears under **Your tickets on this site**.
+3. Click **Delete this ticket's work** on its row. This deletes the branch, not the patch you saved
+   outside the site.
+4. Link the same ticket again. Its new branch starts from current trunk.
+5. Apply the saved patch and check that the work still fits.
+
+The app stays silent when it cannot identify a ticket's original base; it does not substitute the
+current trunk and pretend the ticket is current.
+
 ## What a patch contains
 
 A patch is everything on the ticket's branch since the point it was created — only that ticket's work, never another's, and never a change that arrived from a trunk update.
 
-That last point has a consequence worth knowing. A ticket branch keeps the snapshot of trunk it was born on, even after you [update the site to the latest trunk](./trunk-updates). The patch stays correct against that snapshot, which is what keeps it free of upstream changes you did not write — but a branch you started weeks ago produces a patch that may no longer apply to today's trunk.
-
-The app has no way to replay an old ticket branch onto a newer trunk. Doing it by hand means, in order: [update the site to the latest trunk](./trunk-updates) so there is a newer snapshot to branch from; save the ticket's patch from **Review & submit changes**; **Unlink** the ticket, so its row appears on the tickets card and **Delete this ticket's work** becomes available for it — the card never offers to delete the ticket you are on; link the ticket again, which creates a fresh branch on the updated trunk; and [apply the saved patch](./applying-patches) to it.
+That last point has a consequence worth knowing. A ticket branch keeps the snapshot of trunk it was born on, even after you [update the site to the latest trunk](./trunk-updates). The patch stays correct against that snapshot, which is what keeps it free of upstream changes you did not write — but a branch you started weeks ago produces a patch that may no longer apply to today's trunk. Use the copy-and-restart path above when you need a fresh base; the app does not replay the branch onto it silently.
 
 ## Next steps
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -29,6 +29,36 @@ branch before any file moved. See [Working on several tickets](./ticket-branches
 The usual cause is a file held open by an editor or an antivirus scanner during the swap. Closing
 whatever had the checkout open before retrying makes a repeat less likely.
 
+## A patch or pull request will not apply
+
+An apply is all-or-nothing: if any part fails, the checkout is unchanged. The panel names how many
+changes failed and which files they are in.
+
+For a pull request, check whether the notice names work already on your ticket:
+
+- If it does, save a patch of your work and try the pull request on a clean ticket. The app knows
+  that both sets of work touch the file, but it cannot prove which exact lines caused the failure.
+  Ask the pull request's author for an update only if it still fails on the clean ticket.
+- If it does not, the pull request was written against an older trunk. Open it and let its author
+  know that it needs a rebase or trunk merged in.
+
+For a patch file or Trac attachment, there is no author the app can send you to. Expand the failing
+files in the panel: each region gives a line from your checkout to search for and says whether the
+surrounding code changed or the change appears to be present already. See
+[Applying patches and PRs](./applying-patches#when-a-patch-will-not-apply).
+
+## Work seems to have vanished after changing tickets or updating trunk
+
+Ticket work belongs to its ticket branch, not to the whole site. If the files look clean after you
+click **Unlink** or switch tickets, return to the original ticket under **Your tickets on this
+site**. Its edits and its applied patch return with it.
+
+A trunk update also leaves ticket branches on the trunk snapshot where they started. When you run
+one while a ticket is linked, the app parks the ticket, updates trunk, and checks the same ticket
+back out. If its work is missing after the update rather than merely hidden on another ticket, stop
+editing and report a problem with the app; an update must not discard it. See
+[Keeping a site up to date with trunk](./trunk-updates#updating-while-you-are-on-a-ticket).
+
 ## The dev server won't start
 
 Starting the server can legitimately take a while — booting WASM PHP on a slow machine can take

--- a/docs/guide/trunk-updates.md
+++ b/docs/guide/trunk-updates.md
@@ -37,7 +37,13 @@ An update moves trunk, and your ticket's work is not on trunk — so the app ste
 
 The dialog in step 1 only ever concerns edits that are loose in the working tree. Work already parked on a ticket branch is never what it is offering to save or discard.
 
-What an update does not move is the snapshot your ticket branch was created on. That is deliberate — it is what keeps your patch free of the upstream changes the update just brought in — but it means an old ticket's patch does not get any newer by updating the site. See [Working on several tickets](./ticket-branches#what-a-patch-contains).
+What an update does not move is the snapshot your ticket branch was created on. That is deliberate — it is what keeps your patch free of the upstream changes the update just brought in — but it means an old ticket's patch does not get any newer by updating the site. The same is true for every other ticket stored on the site: updating trunk does not rebase any of them.
+
+After the update, the **Trac ticket** card may say **Trunk has moved since this ticket started**.
+That is not an incomplete update: trunk is current and the ticket is still safely on its original
+base. To move the work forward, save its patch, unlink it, delete its branch, link the ticket again,
+and apply the saved patch. The app never changes a ticket's base without that explicit sequence.
+See [When trunk has moved since the ticket started](./ticket-branches#when-trunk-has-moved-since-the-ticket-started).
 
 ## Staleness dots and notices
 


### PR DESCRIPTION
## Why

The ticket-work batch changed how the app explains ticket bases, applied patches, pull request conflicts, and trunk updates. The guide still described the earlier behavior, which could send a contributor to ask a pull request author for a rebase when their own ticket work was in the way, or imply that updating trunk also refreshed an existing ticket. Fixes #314.

## What changes

The guide now distinguishes conflicts involving a contributor's ticket work from pull requests that no longer fit clean trunk. It also describes applied patches as named ticket layers, explains Revert and copy-and-discard recovery, and documents that trunk updates leave existing ticket bases unchanged until the contributor explicitly saves, unlinks, deletes, and relinks the ticket.

The troubleshooting page now gives the matching recovery steps for failed applies and work that appears to vanish after a switch or update. No application behavior or visible UI changed.

## How to test this

Platforms: any; these are documentation-only changes and the described behavior is platform-independent.

**Starting state:** A built site with two linked tickets, work on one ticket, and an open pull request that touches the same file.

1. Follow issue #309's ticket switch, patch preview, apply, Revert, and trunk update flow. Confirm each guide section describes the wording and next action shown by the app.
2. Preview a pull request against a file containing ticket work. Confirm the guide directs the contributor to save a copy and retry on a clean ticket before asking the author to update it.
3. Update trunk while an older ticket is linked. Confirm the guide explains that the ticket keeps its original base and documents the save → unlink → delete → relink path.
4. Run `npm run lint`, `npm test`, and `npm run docs:build`.

**What must not have happened:** No guide page should imply that switching loses ticket work, that updating trunk rebases ticket branches, or that every failed pull request needs action from its author.

## Risks and limitations

The wording was verified against the current source and behavior-defining tests, but the complete desktop workflow was not driven by hand against a signed artifact in this worktree. Existing screenshots were not retaken because none show the notices or recovery controls whose descriptions changed.

`npm ci` currently fails on `trunk` because `package.json` requests esbuild 0.27.7 while the root lockfile does not contain it. Validation used an untracked dependency install without rewriting the lockfile; the mismatch is outside this documentation change.

## Related

Fixes #314

---

<details>
<summary>Design decisions and alternatives considered</summary>

This updates only the four pages named in the issue. Existing correct material was retained, and screenshots were left alone where the visible surface did not change.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. No findings across architecture, security, performance, cross-platform, or tests.

Deterministic checks: ESLint passed; 1,010 tests passed; VitePress built successfully; `git diff --check` passed.

</details>

<details>
<summary>Implementation notes</summary>

The documentation was checked against the renderer decision modules and tests for issues #301, #303, #305, #306, and #308.

</details>
