### PR TITLE
Bump version to 1.0.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",


### PR DESCRIPTION
## Why

`v1.0.0-rc.1` shipped on 12 August. Twenty changes have since landed on `trunk`, including safer applied-patch handling, clearer stale-ticket guidance, fixes for missing linked pull requests and stalled Trac loads, and exclusion of local coding-agent files from generated patches.

This second release candidate carries those fixes, so the package version must move to `1.0.0-rc.2` before its tag and artifacts are created.

## What changes

Only `package.json` and `package-lock.json`: all three package-version fields move together from `1.0.0-rc.1` to `1.0.0-rc.2`. No dependency versions or application behavior change.

`electron-builder` derives artifact names from `package.json`, producing:

- `wordpress-contributor-toolkit-1.0.0-rc.2-mac-arm64.dmg`
- `wordpress-contributor-toolkit-1.0.0-rc.2-win-x64.exe`
- `wordpress-contributor-toolkit-1.0.0-rc.2-linux-x86_64.AppImage`

## How to test this

Platforms: any; this is package metadata and is platform-independent.

**Starting state:** this branch checked out with dependencies installed.

1. Run `node -p "require('./package.json').version"`.
   - Expected: `1.0.0-rc.2`.
2. Run `node -e "const p=require('./package-lock.json'); console.log(p.version, p.packages[''].version)"`.
   - Expected: `1.0.0-rc.2 1.0.0-rc.2`.
3. Run `npm run lint` and `npm test`.
   - Expected: lint succeeds and all 1,017 tests pass.

**What must not have happened:** dependency versions and resolved packages must remain unchanged; no source, documentation, workflow, or build configuration file should be in the diff.

## Risks and limitations

No user-visible behavior changed, so there is no desktop flow or screenshot to test by hand. The signed artifacts will only exist after this PR lands and the release build runs.

## Related

Follow-up to #296.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The version remains SemVer-shaped as `1.0.0-rc.2`, matching `1.0.0-rc.1` and keeping artifact names in one series. The release tag will add the conventional `v` prefix; package metadata does not.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`0 [fix here] · 0 [follow-up]`. No findings across architecture, security, performance, cross-platform, or tests. `npm run lint`, `npm test` (1,017/1,017), and `git diff --check` pass.

</details>

<details>
<summary>Implementation notes</summary>

npm's documented versioning behavior keeps `package.json`, the lockfile root version, and `packages[""]` synchronized. The diff was checked to confirm those are the only changed values.

</details>
