### PR TITLE
[Recommend] preparing sites before Contributor Day

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,10 @@ When writing manual test instructions, inspect the current renderer flow first a
 actions that happen automatically after linking a ticket from controls used only to retry or
 refresh them. Do not tell a tester to click a control when the app already starts that operation.
 
+When asked to add an existing pull request to an existing stack, preserve its commits and change
+its base to the head branch of the current top PR. Do not move commits into an earlier PR unless
+the user explicitly asks to rewrite the stack.
+
 ## Architecture notes (non-obvious)
 
 - **Child processes run on Electron's own Node, not the system Node.** `npm install`,

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,6 +10,12 @@ You install it, choose a directory for `wordpress-develop`, click a button, and 
 
 No Git, no Node.js, no npm, no Docker needed. Everything is bundled inside the application as JavaScript/WASM, powered by [WordPress Playground](https://wordpress.github.io/wordpress-playground/).
 
+::: tip Prepare at home before Contributor Day
+Creating your first site downloads the full `wordpress-develop` repository, installs its dependencies, and runs the first build. That means downloading a lot of files, so we recommend having at least one site fully set up a day or a few days before the event.
+
+On Contributor Day, open that site and run [**Update to latest trunk**](./trunk-updates). The app fetches the changes made since your initial setup and only reinstalls dependencies if they changed. Most packages will already be cached, which uses far less of the venue's shared bandwidth than starting from scratch.
+:::
+
 ## Install the app
 
 <DownloadButton />

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,9 @@ features:
   - title: A full core environment in one click
     details: The app clones wordpress-develop, installs dependencies, builds, and starts a dev server — the whole toolchain ships inside the app as JavaScript and WASM.
   - title: Made for Contributor Days
-    details: First-time contributors often spend a whole session fighting their local setup. The Toolkit removes that step so the day is spent contributing.
+    details: Create your first site at home a day or two before the event. On Contributor Day, update it to download the recent changes instead of the full repository and all its dependencies.
+    link: /guide/trunk-updates
+    linkText: Update to latest trunk
   - title: From code change to contribution
     details: Link a Trac ticket, apply an existing patch or PR, and submit your own changes as a pull request, a Trac attachment, or a patch for your mentor.
   - title: One site, as many tickets as you like


### PR DESCRIPTION
## Why

Creating a WordPress core development site downloads the repository, installs its dependencies, and runs a full build. Doing that for every participant at the start of a Contributor Day puts unnecessary pressure on the venue's shared connection and delays contributions.

## What changes

The landing page now recommends creating the first site at home before the event and links directly to **Update to latest trunk**. The Getting Started guide explains why the initial setup downloads many files and how arriving with one prepared site lets contributors fetch only recent changes, reusing cached packages where possible.

## How to test this

Platforms: any. This changes only the documentation site.

**Starting state:** this branch checked out with the `docs/` dependencies installed.

1. Run `npm run docs:dev` and open the landing page.
2. Find **Made for Contributor Days**. Expect it to recommend creating a site before the event.
3. Click **Update to latest trunk**. Expect the trunk-update guide to open.
4. Open **Getting started**. Expect a **Prepare at home before Contributor Day** tip before **Install the app**.
5. Follow the link in that tip. Expect the same trunk-update guide to open.
6. Run `npm run docs:build`. Expect the production build to finish without errors.

**What must not have happened:** the landing page must not display Markdown brackets as literal text, and the copy must not claim that a trunk update can never reinstall dependencies.

## Risks and limitations

The exact download savings depend on how much trunk and `package-lock.json` changed since setup. The copy says dependencies are reinstalled when needed and packages are generally reused from the cache; it does not promise a fixed download size.

Self-review: 0 `[fix here]` · 0 `[follow-up]`.

## Related

Stacked on #337, with #336 as the first PR in the stack.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The recommendation appears as a short linked feature on the landing page and a fuller tip in Getting Started. VitePress does not parse Markdown inside a home feature's `details` field, so the feature uses the supported `link` and `linkText` fields instead.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 `[fix here]` · 0 `[follow-up]`.

No findings across architecture, security, performance, cross-platform, or tests. The reviewer also verified that the wording matches the app's shallow clone, conditional dependency installation, package cache, and trunk-update behavior.

</details>

<details>
<summary>Implementation notes</summary>

Verification passed: ESLint, 1,017 Node tests, VitePress production build, `git diff --check`, and inspection of the generated internal links.

</details>

