### PR TITLE
Fix line-ending compatibility without changing repository config

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -431,7 +431,7 @@ function buildPatchHtml(content) {
 // Returns the base commit alongside the files because the pull request needs it
 // as the commit's parent, and it is the same oid the diff was taken against.
 async function collectChangedFiles(dir, baseOid = null) {
-    await ensureAutocrlf(dir);
+    const gitFs = await ensureAutocrlf(dir) || fs;
     // The diff base is the branch point of whatever ticket is being worked on
     // (#108) — the trunk snapshot this branch was created from, passed in by the
     // caller from the site's registry entry.
@@ -455,9 +455,9 @@ async function collectChangedFiles(dir, baseOid = null) {
         // No branch point on record: a site still on trunk, or one adopted from
         // disk. HEAD is the trunk snapshot there, which is what this always used
         // to diff against.
-        try { base = await git.resolveRef({ fs, dir, ref: 'HEAD' }); } catch {}
+        try { base = await git.resolveRef({ fs: gitFs, dir, ref: 'HEAD' }); } catch {}
         if (!base) {
-            try { base = await git.resolveRef({ fs, dir, ref: 'refs/heads/trunk' }); } catch {}
+            try { base = await git.resolveRef({ fs: gitFs, dir, ref: 'refs/heads/trunk' }); } catch {}
         }
     }
 
@@ -468,13 +468,13 @@ async function collectChangedFiles(dir, baseOid = null) {
     // and never unstaged it (#85) — with the branch point as the base it earns
     // nothing, so it is gone. (`staleStagedPaths` in trunk-update.js stays: it
     // still has to clean up residue left in indexes by earlier versions.)
-    const matrix = await git.statusMatrix({ fs, dir, ref: base });
+    const matrix = await git.statusMatrix({ fs: gitFs, dir, ref: base });
     const changed = matrix.filter(([, head, workdir]) => head !== workdir);
     const files = [];
     for (const [filepath, head, workdir] of changed) {
         const abs = path.join(dir, filepath);
         const workBuf = workdir ? await fs.promises.readFile(abs).catch(() => null) : null;
-        const baseBlob = head && base ? await git.readBlob({ fs, dir, oid: base, filepath }).catch(() => null) : null;
+        const baseBlob = head && base ? await git.readBlob({ fs: gitFs, dir, oid: base, filepath }).catch(() => null) : null;
         files.push({
             path: filepath,
             // The status codes, not the buffers, are what say whether a file is

--- a/src/ticket-branches.js
+++ b/src/ticket-branches.js
@@ -106,11 +106,12 @@ async function listTicketBranches(dir) {
  * @param {Function} [onProgress] told how far the staging has got (#173)
  */
 async function stageWorktree(dir, matrix = null, onProgress = null) {
+	const gitFs = await ensureAutocrlf(dir);
 	// The caller has usually just scanned the worktree to decide whether there
 	// was anything to park. On wordpress-develop that scan hashes thousands of
 	// files on the main process's event loop, so it is passed in and reused
 	// rather than repeated.
-	if (!matrix) matrix = await git.statusMatrix({ fs, dir });
+	if (!matrix) matrix = await git.statusMatrix({ fs: gitFs, dir });
 	// The one stage of a park with a real total, and it comes free: the rows
 	// worth staging are known before any of them is written.
 	const pending = matrix.filter(([, head, workdir, stage]) => !(head === workdir && workdir === stage));
@@ -118,9 +119,9 @@ async function stageWorktree(dir, matrix = null, onProgress = null) {
 	for (const [filepath, , workdir] of pending) {
 		if (workdir === 0) {
 			// Gone from disk: drop it from the index, and from the next commit.
-			try { await git.remove({ fs, dir, filepath }); staged += 1; } catch {}
+			try { await git.remove({ fs: gitFs, dir, filepath }); staged += 1; } catch {}
 		} else {
-			try { await git.add({ fs, dir, filepath }); staged += 1; } catch {}
+			try { await git.add({ fs: gitFs, dir, filepath }); staged += 1; } catch {}
 		}
 		if (onProgress) onProgress({ stage: 'stage', loaded: staged, total: pending.length });
 	}
@@ -166,7 +167,8 @@ async function countChangesAgainst(dir, ref = 'HEAD') {
  * @param {string} [ref]
  */
 async function scanWorktree(dir, ref = 'HEAD') {
-	const matrix = await git.statusMatrix({ fs, dir, ref });
+	const gitFs = await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs: gitFs, dir, ref });
 	return { matrix, changed: matrix.some(([, head, workdir]) => head !== workdir) };
 }
 
@@ -186,7 +188,6 @@ async function scanWorktree(dir, ref = 'HEAD') {
  * @param {Function} [root0.onProgress] told which stage of the park is running (#173)
  */
 async function parkCurrentWork(dir, { baseOid, author = WIP_AUTHOR, onProgress = null } = {}) {
-	await ensureAutocrlf(dir);
 	const branch = await currentBranchName(dir);
 	if (!branch || branch === TRUNK) {
 		const error = new Error('Refusing to commit on trunk — it is the diff base for every ticket');
@@ -230,7 +231,6 @@ async function parkCurrentWork(dir, { baseOid, author = WIP_AUTHOR, onProgress =
  * @param {number|string} ticketId
  */
 async function startTicketBranch(dir, ticketId) {
-	await ensureAutocrlf(dir);
 	const ref = ticketBranchRef(ticketId);
 	const existing = await git.listBranches({ fs, dir });
 	if (existing.includes(ref)) {
@@ -269,7 +269,6 @@ async function startTicketBranch(dir, ticketId) {
  * @param {Function} [root0.onProgress] told which stage is running (#173)
  */
 async function switchToBranch(dir, ref, { baseOid, author = WIP_AUTHOR, onProgress = null } = {}) {
-	await ensureAutocrlf(dir);
 	const from = await currentBranchName(dir);
 	if (from === ref) return { switched: false, from, to: ref, parked: false };
 

--- a/src/trunk-update.js
+++ b/src/trunk-update.js
@@ -22,24 +22,77 @@ const {
 } = require('./git-update.cjs');
 
 /**
- * A site checked out by native git on Windows (default core.autocrlf=true,
- * set globally — which isomorphic-git never reads) has CRLF on disk while
- * wordpress-develop's blobs are LF-only. Without this, statusMatrix hashes
- * the raw CRLF bytes and reports every text file as modified (~5k phantom
- * changes; isomorphic-git#1275). Writing core.autocrlf into the site's LOCAL
- * config makes isomorphic-git strip CRLF before hashing workdir files. LF
- * checkouts are unaffected. Called before every status/patch/update git op
- * so pre-existing sites are covered, not just new clones.
+ * Give isomorphic-git a Windows-only, in-memory view of core.autocrlf=true
+ * when the repository has no explicit local value. Native Git may have
+ * checked the worktree out as CRLF because of the contributor's global config,
+ * which isomorphic-git does not read; without this view, statusMatrix reports
+ * roughly 5,000 phantom modifications (isomorphic-git#1275).
  *
- * @param {string} dir
+ * The wrapper intercepts only reads of Git's config file. It never writes the
+ * repository, and explicit local values (true, false, or input) pass through
+ * unchanged. Non-Windows platforms use the original filesystem untouched.
+ *
+ * @param {string}    dir
+ * @param {Object}    [options]
+ * @param {string}    [options.platform]
+ * @param {typeof fs} [options.fileSystem]
+ * @param {Function}  [options.onError]
+ * @return {typeof fs}
  */
-async function ensureAutocrlf(dir) {
-	try {
-		const current = await git.getConfig({ fs, dir, path: 'core.autocrlf' });
-		if (current !== 'true') {
-			await git.setConfig({ fs, dir, path: 'core.autocrlf', value: 'true' });
+function createCrlfCompatibleFs(dir, {
+	platform = process.platform,
+	fileSystem = fs,
+	onError = (error) => process.emitWarning(
+		`Could not provide CRLF compatibility for ${dir}: ${String(error && error.message ? error.message : error)}`,
+		{ code: 'WCT_CRLF_CONFIG' }
+	)
+} = {}) {
+	if (platform !== 'win32') return fileSystem;
+
+	const dotGitPath = path.resolve(dir, '.git');
+	let configPath = path.join(dotGitPath, 'config');
+	const promises = Object.create(fileSystem.promises);
+	Object.defineProperty(promises, 'readFile', {
+		enumerable: true,
+		value: async (filepath, options) => {
+			let content;
+			try {
+				content = await fileSystem.promises.readFile(filepath, options);
+			} catch (error) {
+				if (path.resolve(String(filepath)) === configPath) onError(error);
+				throw error;
+			}
+			const resolvedPath = path.resolve(String(filepath));
+			if (resolvedPath === dotGitPath) {
+				const gitdir = String(content).match(/^gitdir:\s*(.+)\s*$/im);
+				if (gitdir) configPath = path.resolve(dir, gitdir[1].trim(), 'config');
+				return content;
+			}
+			if (resolvedPath !== configPath) return content;
+
+			const text = Buffer.isBuffer(content) ? content.toString('utf8') : String(content);
+			let inCore = false;
+			const hasAutocrlf = text.split(/\r?\n/).some((line) => {
+				const section = line.match(/^\s*\[([^\]]+)\]\s*(?:[#;].*)?$/);
+				if (section) {
+					inCore = section[1].trim().toLowerCase() === 'core';
+					return false;
+				}
+				return inCore && /^\s*autocrlf\s*=/.test(line.toLowerCase());
+			});
+			if (hasAutocrlf) return content;
+
+			const compatible = `${text.replace(/\s*$/, '')}\n[core]\n\tautocrlf = true\n`;
+			return Buffer.isBuffer(content) ? Buffer.from(compatible, 'utf8') : compatible;
 		}
-	} catch {}
+	});
+	const compatibleFs = Object.create(fileSystem);
+	Object.defineProperty(compatibleFs, 'promises', { enumerable: true, value: promises });
+	return compatibleFs;
+}
+
+async function ensureAutocrlf(dir, options) {
+	return createCrlfCompatibleFs(dir, options);
 }
 
 /**
@@ -97,8 +150,8 @@ async function isCrlfOnlyChange(dir, headOid, filepath) {
  * @param {string} dir
  */
 async function collectDirtyFiles(dir) {
-	await ensureAutocrlf(dir);
-	const matrix = await git.statusMatrix({ fs, dir });
+	const gitFs = await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs: gitFs, dir });
 	let headOid = null;
 	try { headOid = await git.resolveRef({ fs, dir, ref: 'HEAD' }); } catch {}
 	const files = [];
@@ -123,18 +176,18 @@ async function collectDirtyFiles(dir) {
  * @param {string} dir
  */
 async function discardChanges(dir) {
-	await ensureAutocrlf(dir);
-	const matrix = await git.statusMatrix({ fs, dir });
+	const gitFs = await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs: gitFs, dir });
 	for (const [filepath, head, workdir] of matrix) {
 		if (head === 0) {
-			try { await git.remove({ fs, dir, filepath }); } catch {}
+			try { await git.remove({ fs: gitFs, dir, filepath }); } catch {}
 			if (workdir !== 0) {
 				try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
 			}
 		}
 	}
-	const ref = (await git.currentBranch({ fs, dir, fullname: false })) || 'trunk';
-	await git.checkout({ fs, dir, ref, force: true });
+	const ref = (await git.currentBranch({ fs: gitFs, dir, fullname: false })) || 'trunk';
+	await git.checkout({ fs: gitFs, dir, ref, force: true });
 }
 
 /**
@@ -157,32 +210,32 @@ async function discardChanges(dir) {
  * @param {string} baseOid The commit the modal diffed against — the branch point.
  */
 async function discardToBase(dir, baseOid) {
-	await ensureAutocrlf(dir);
-	const matrix = await git.statusMatrix({ fs, dir });
+	const gitFs = await ensureAutocrlf(dir);
+	const matrix = await git.statusMatrix({ fs: gitFs, dir });
 	for (const [filepath, head, workdir] of matrix) {
 		if (head === 0) {
-			try { await git.remove({ fs, dir, filepath }); } catch {}
+			try { await git.remove({ fs: gitFs, dir, filepath }); } catch {}
 			if (workdir !== 0) {
 				try { await fs.promises.unlink(path.join(dir, filepath)); } catch {}
 			}
 		}
 	}
-	const ref = (await git.currentBranch({ fs, dir, fullname: false })) || 'trunk';
+	const ref = (await git.currentBranch({ fs: gitFs, dir, fullname: false })) || 'trunk';
 	// Only rewind the ref when baseOid really is this branch's own history — its
 	// point off trunk. A caller can hand over a commit that is not an ancestor of
 	// HEAD; moving the ref onto it would
 	// orphan the branch's commits and re-point it at unrelated work. When it is
 	// not an ancestor, leave the ref alone and just reset the worktree to HEAD —
 	// the uncommitted-only discard, which never throws away committed work.
-	const head = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+	const head = await git.resolveRef({ fs: gitFs, dir, ref: 'HEAD' });
 	let rewind = false;
 	if (baseOid !== head) {
-		try { rewind = await git.isDescendent({ fs, dir, oid: head, ancestor: baseOid }); } catch { rewind = false; }
+		try { rewind = await git.isDescendent({ fs: gitFs, dir, oid: head, ancestor: baseOid }); } catch { rewind = false; }
 	}
 	if (rewind) {
-		await git.writeRef({ fs, dir, ref: `refs/heads/${ref}`, value: baseOid, force: true });
+		await git.writeRef({ fs: gitFs, dir, ref: `refs/heads/${ref}`, value: baseOid, force: true });
 	}
-	await git.checkout({ fs, dir, ref, force: true });
+	await git.checkout({ fs: gitFs, dir, ref, force: true });
 }
 
 /**
@@ -207,14 +260,14 @@ async function discardToBase(dir, baseOid) {
  * @param {Function} [root0.onLog]
  */
 async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
-	await ensureAutocrlf(dir);
+	const gitFs = await ensureAutocrlf(dir);
 	let stage = 'fetch';
 	let worktreeReset = false;
 	try {
-		const oldOid = await git.resolveRef({ fs, dir, ref: 'HEAD' });
+		const oldOid = await git.resolveRef({ fs: gitFs, dir, ref: 'HEAD' });
 		onLog('Fetching latest trunk…\n');
 		const fetchResult = await git.fetch({
-			fs, http, dir, url,
+			fs: gitFs, http, dir, url,
 			ref: 'trunk',
 			singleBranch: true,
 			depth: 1,
@@ -222,7 +275,7 @@ async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 			onProgress: (evt) => onLog(`${evt.phase || 'fetch'} ${evt.loaded || 0}/${evt.total || 0}\r`)
 		});
 		let newOid = fetchResult && fetchResult.fetchHead;
-		if (!newOid) newOid = await git.resolveRef({ fs, dir, ref: 'refs/remotes/origin/trunk' });
+		if (!newOid) newOid = await git.resolveRef({ fs: gitFs, dir, ref: 'refs/remotes/origin/trunk' });
 
 		if (newOid === oldOid) {
 			const { trunkDate } = await readTrunkInfo(dir);
@@ -241,19 +294,19 @@ async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 		// checkout({force}) deletes workdir files that are in the index but
 		// absent from the target tree, so drop those index entries first
 		// (index-only — the workdir files survive).
-		const matrix = await git.statusMatrix({ fs, dir });
+		const matrix = await git.statusMatrix({ fs: gitFs, dir });
 		for (const filepath of staleStagedPaths(matrix)) {
-			try { await git.remove({ fs, dir, filepath }); } catch {}
+			try { await git.remove({ fs: gitFs, dir, filepath }); } catch {}
 		}
 		onLog(`\nResetting to latest trunk (${newOid.slice(0, 7)})…\n`);
-		await git.writeRef({ fs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
+		await git.writeRef({ fs: gitFs, dir, ref: 'refs/heads/trunk', value: newOid, force: true });
 		// Everything above this line can fail with the working tree untouched —
 		// statusMatrix walks a 5k-file checkout and writeRef only moves a ref.
 		// From here on, files are being overwritten, so anything the tree used to
 		// hold (an applied patch) has to be assumed gone even if the call throws.
 		worktreeReset = true;
 		await git.checkout({
-			fs, dir, ref: 'trunk', force: true,
+			fs: gitFs, dir, ref: 'trunk', force: true,
 			onProgress: (evt) => onLog(`${evt.phase || 'checkout'} ${evt.loaded || 0}/${evt.total || 0}\r`)
 		});
 
@@ -271,6 +324,7 @@ async function updateToLatestTrunk({ dir, url, onLog = () => {} }) {
 
 module.exports = {
 	ensureAutocrlf,
+	createCrlfCompatibleFs,
 	readTrunkInfo,
 	collectDirtyFiles,
 	discardChanges,

--- a/test/trunk-update.integration.test.cjs
+++ b/test/trunk-update.integration.test.cjs
@@ -13,7 +13,13 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const git = require('isomorphic-git');
-const { collectDirtyFiles, discardChanges, discardToBase, readTrunkInfo } = require('../src/trunk-update.js');
+const {
+	collectDirtyFiles,
+	createCrlfCompatibleFs,
+	discardChanges,
+	discardToBase,
+	readTrunkInfo
+} = require('../src/trunk-update.js');
 
 const AUTHOR = { name: 'test', email: 'test@example.com' };
 
@@ -40,6 +46,99 @@ test('collectDirtyFiles: CRLF-smudged files, UTF-8 or not, are not dirty (issue 
 	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\r\nline2\r\n');
 	fs.writeFileSync(path.join(dir, 'big5.txt'), Buffer.from([0xa4, 0xa4, 0x0d, 0x0a, 0xa4, 0xe5, 0x0d, 0x0a]));
 	assert.deepStrictEqual(await collectDirtyFiles(dir), []);
+});
+
+for (const platform of ['darwin', 'linux']) {
+	test(`CRLF compatibility: ${platform} leaves an unset local core.autocrlf untouched (issue #341)`, async (t) => {
+		const dir = await makeRepo(t);
+		const compatibleFs = createCrlfCompatibleFs(dir, { platform });
+
+		assert.strictEqual(await git.getConfig({ fs: compatibleFs, dir, path: 'core.autocrlf' }), undefined);
+		assert.strictEqual(await git.getConfig({ fs, dir, path: 'core.autocrlf' }), undefined);
+	});
+}
+
+for (const value of [undefined, 'true', 'false', 'input']) {
+	test(`CRLF compatibility: Windows preserves local core.autocrlf=${value ?? 'unset'} (issue #341)`, async (t) => {
+		const dir = await makeRepo(t);
+		if (value !== undefined) {
+			await git.setConfig({ fs, dir, path: 'core.autocrlf', value });
+		}
+
+		const compatibleFs = createCrlfCompatibleFs(dir, { platform: 'win32' });
+		const visibleValue = await git.getConfig({ fs: compatibleFs, dir, path: 'core.autocrlf' });
+
+		assert.strictEqual(visibleValue, value ?? 'true');
+		assert.strictEqual(await git.getConfig({ fs, dir, path: 'core.autocrlf' }), value);
+	});
+}
+
+test('CRLF compatibility: Windows normalizes a CRLF checkout without persisting config (issue #341)', async (t) => {
+	const dir = await makeRepo(t);
+	fs.writeFileSync(path.join(dir, 'text.txt'), 'line1\r\nline2\r\n');
+	const compatibleFs = createCrlfCompatibleFs(dir, { platform: 'win32' });
+
+	const matrix = await git.statusMatrix({ fs: compatibleFs, dir });
+
+	assert.deepStrictEqual(matrix.find(([filepath]) => filepath === 'text.txt'), ['text.txt', 1, 1, 1]);
+	assert.strictEqual(await git.getConfig({ fs, dir, path: 'core.autocrlf' }), undefined);
+});
+
+test('CRLF compatibility: a worktree file named config is not altered in memory (issue #341)', async (t) => {
+	const dir = await makeRepo(t);
+	fs.writeFileSync(path.join(dir, 'config'), 'ordinary worktree content\n');
+	const compatibleFs = createCrlfCompatibleFs(dir, { platform: 'win32' });
+
+	assert.strictEqual(
+		await compatibleFs.promises.readFile(path.join(dir, 'config'), 'utf8'),
+		'ordinary worktree content\n'
+	);
+});
+
+test('CRLF compatibility: a gitdir file receives the same non-persistent view (issue #341)', async (t) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'autocrlf-gitdir-test-'));
+	t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+	const dir = path.join(root, 'worktree');
+	const gitdir = path.join(root, 'actual-git');
+	fs.mkdirSync(dir);
+	fs.mkdirSync(gitdir);
+	fs.writeFileSync(path.join(dir, '.git'), 'gitdir: ../actual-git\n');
+	fs.writeFileSync(path.join(gitdir, 'config'), '[core]\n\trepositoryformatversion = 0\n');
+	const compatibleFs = createCrlfCompatibleFs(dir, { platform: 'win32' });
+
+	await compatibleFs.promises.readFile(path.join(dir, '.git'), 'utf8');
+	const visibleConfig = await compatibleFs.promises.readFile(path.join(gitdir, 'config'), 'utf8');
+
+	assert.match(visibleConfig, /autocrlf = true/);
+	assert.doesNotMatch(fs.readFileSync(path.join(gitdir, 'config'), 'utf8'), /autocrlf/);
+});
+
+test('CRLF compatibility: config read failures are logged and remain failures (issue #341)', async (t) => {
+	const dir = await makeRepo(t);
+	const errors = [];
+	const failingFs = Object.create(fs);
+	const promises = Object.create(fs.promises);
+	promises.readFile = async (filepath, options) => {
+		if (path.resolve(filepath) === path.resolve(dir, '.git', 'config')) {
+			const error = new Error('config is unreadable');
+			error.code = 'EACCES';
+			throw error;
+		}
+		return fs.promises.readFile(filepath, options);
+	};
+	Object.defineProperty(failingFs, 'promises', { enumerable: true, value: promises });
+	const compatibleFs = createCrlfCompatibleFs(dir, {
+		platform: 'win32',
+		fileSystem: failingFs,
+		onError: (error) => errors.push(error)
+	});
+
+	await assert.rejects(
+		compatibleFs.promises.readFile(path.join(dir, '.git', 'config'), 'utf8'),
+		{ code: 'EACCES' }
+	);
+	assert.strictEqual(errors.length, 1);
+	assert.match(errors[0].message, /config is unreadable/);
 });
 
 test('collectDirtyFiles: real edits and untracked files are detected (issue #94)', async (t) => {


### PR DESCRIPTION
## Why

WordPress Contributor Toolkit RC2 writes `core.autocrlf=true` into every managed repository's local Git configuration, including on macOS/Linux and when a contributor explicitly chose `false` or `input`. The compatibility workaround is needed for native-Git CRLF checkouts on Windows, but it must not silently change persistent repository policy.

## What changes

`isomorphic-git` now receives a Windows-only, in-memory view of `core.autocrlf=true` when the local value is unset. Explicit local values pass through unchanged, non-Windows platforms use the original filesystem, and config-read failures emit a diagnostic instead of being swallowed.

Status, patch generation, ticket parking, discard, and trunk-update operations use that scoped filesystem view. Nothing writes `.git/config`.

## How to test this

**Platform: Windows 11.** Use the signed Buildkite artifact for the current PR head commit. The procedure uses only PowerShell and tools bundled with the app; Git, Node, npm, and Docker are not required on the host.

**Starting state:** A disposable site created by the toolkit with setup complete. From **Open directory in → File Explorer**, open PowerShell in the site's root. Confirm `Test-Path ".git\config"` and `Test-Path "src\wp-login.php"` both return `True`.

1. Back up `.git/config`, then remove only `autocrlf` from its `[core]` section:

   ```powershell
   $configPath = Join-Path $PWD ".git\config"
   $configBackup = Join-Path $env:TEMP "toolkit-git-config.backup"
   Copy-Item $configPath $configBackup -Force

   $lines = [IO.File]::ReadAllLines($configPath)
   $inCore = $false
   $filtered = foreach ($line in $lines) {
       if ($line -match '^\s*\[([^\]]+)\]\s*$') {
           $inCore = $Matches[1] -ieq 'core'
       }
       if ($inCore -and $line -match '^\s*autocrlf\s*=') {
           continue
       }
       $line
   }

   $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
   [IO.File]::WriteAllLines($configPath, $filtered, $utf8NoBom)
   Select-String -Path $configPath -Pattern '^\s*autocrlf\s*='
   ```

   Expected: `Select-String` prints nothing.

2. Convert one tracked WordPress file to CRLF without Git and record the configuration hash:

   ```powershell
   $target = Join-Path $PWD "src\wp-login.php"
   $targetBackup = Join-Path $env:TEMP "toolkit-wp-login.php.backup"
   Copy-Item $target $targetBackup -Force

   $content = [IO.File]::ReadAllText($target)
   $content = $content.Replace("`r`n", "`n").Replace("`n", "`r`n")
   [IO.File]::WriteAllText($target, $content, $utf8NoBom)

   ([IO.File]::ReadAllText($target)).Contains("`r`n")
   $configBefore = (Get-FileHash $configPath -Algorithm SHA256).Hash
   ```

   Expected: the line-ending check returns `True`.

3. Return focus to the toolkit and wait for status to refresh.

   Expected: the site remains clean. No unassigned-changes notice appears and there are no phantom modifications. Back in PowerShell, `(Get-FileHash $configPath -Algorithm SHA256).Hash -eq $configBefore` returns `True`.

4. Create one real file:

   ```powershell
   $testFile = Join-Path $PWD "src\autocrlf-toolkit-test.txt"
   [IO.File]::WriteAllText($testFile, "toolkit autocrlf test`r`n", $utf8NoBom)
   ```

5. Return focus to the toolkit and click **create and save a patch** in the one-change notice.

   Expected: **Review & submit changes** contains only `src/autocrlf-toolkit-test.txt` and `+toolkit autocrlf test`. `src/wp-login.php` and other CRLF-only files do not appear. Close the modal; the `.git/config` hash must still equal `$configBefore`.

6. Delete the real change with `Remove-Item $testFile`, return focus to the toolkit, and confirm the site becomes clean again. Keep `wp-login.php` in CRLF. Choose **More → Update to latest trunk**.

   Expected: the update starts without a dirty-tree warning and completes successfully. Dependencies remain unchanged; a rebuild may run if trunk changed.

7. Verify the final state:

   ```powershell
   $configAfterUpdate = (Get-FileHash $configPath -Algorithm SHA256).Hash
   $configBefore -eq $configAfterUpdate
   ([IO.File]::ReadAllText($target)).Contains("`r`n")
   ```

   Expected: both expressions return `True`.

   Do not restore the old `wp-login.php` backup after updating trunk because it may contain an earlier revision. Delete the disposable site through the app when finished.

**What must not have happened:** `.git/config` must not change; the patch must not contain CRLF-only WordPress files; status and patch checks must not remove or rebuild `node_modules`; the trunk update must not reinstall unchanged dependencies.

Automated checks:

- `npm run lint`
- `npm test` — 1,027 passed
- `npm run test:electron` — 1,027 passed

The automated suite also covers explicit `core.autocrlf` values `true`, `false`, and `input`, non-Windows behavior, config-read failures, and worktree-style `.git` files.

## Risks and limitations

Repositories already modified by RC2 retain `core.autocrlf=true`. The app cannot safely distinguish its historical write from a contributor's intentional value, so automatic cleanup is deliberately out of scope. There is no visible UI change.

The signed Windows artifact for commit `1957967` was tested manually on Windows 11. Status, patch generation, and trunk update all handled the CRLF fixture correctly; `.git/config` remained byte-for-byte unchanged and the update kept dependencies unchanged.

## Related

Fixes #341

---

<details>
<summary>Design decisions and alternatives considered</summary>

Temporarily writing and restoring `.git/config` was rejected because a crash or concurrent operation could leave the temporary value behind. The filesystem wrapper instead changes only what `isomorphic-git` sees for the duration of an operation.

Explicit `false` and `input` values are honored rather than virtually overridden. A checkout inconsistent with its explicit local policy may therefore appear dirty; preserving that policy is preferable to silently second-guessing it.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 `[fix here]` · 1 `[follow-up]`.

The follow-up is the known RC2 residue described under Risks and limitations. It is deferred because removing an existing `true` value could erase an intentional contributor setting. No new findings across architecture, security, performance, cross-platform, or tests.

</details>

<details>
<summary>Implementation notes</summary>

The wrapper supports both ordinary `.git/config` directories and worktree-style `.git` files. Tests inject Windows and non-Windows platforms from one machine and cover unset, `true`, `false`, `input`, config-read failures, and a worktree file named `config`.

</details>
