### PR TITLE
Bump version to 1.0.0 and point homepage at the docs site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",
-  "homepage": "https://github.com/WordPress/experimental-wp-dev-env",
+  "homepage": "https://wordpress.github.io/contributor-toolkit/",
   "main": "src/main.js",
   "scripts": {
     "start": "npm run build:once && concurrently -k \"npm:build:watch\" \"electron .\"",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",
   "homepage": "https://wordpress.github.io/contributor-toolkit/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/WordPress/contributor-toolkit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/WordPress/contributor-toolkit/issues"
+  },
   "main": "src/main.js",
   "scripts": {
     "start": "npm run build:once && concurrently -k \"npm:build:watch\" \"electron .\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Electron app to setup WordPress develop structure and run npm install",


### PR DESCRIPTION
## Why

`v1.0.0-rc.2` shipped on 13 August as the second release candidate. Testing it on Windows found one
behaviour bug, now fixed on `trunk` (#342: the CRLF workaround wrote `core.autocrlf` into every
managed repository's config, on every platform). The other four commits since that tag are
documentation and guide screenshots (#336, #337, #339).

Nothing else is outstanding, so the next version is the stable `1.0.0`. The package version must
move before its tag and artifacts are created, because `electron-builder` derives artifact names
from `package.json`.

Two metadata corrections, no application behavior change.

## What changes

**The version.** All three package-version fields in `package.json` and `package-lock.json` move
together from `1.0.0-rc.2` to `1.0.0`. No dependency versions change.

**`homepage`.** It still pointed at `https://github.com/WordPress/experimental-wp-dev-env`, the
repository's name before the rename, and it pointed at a repository rather than at a place a
contributor would want to land. It now points at the documentation site,
`https://wordpress.github.io/contributor-toolkit/` — the Pages deployment
`docs/.vitepress/config.mjs` builds with `base: '/contributor-toolkit/'`. Shipping a 1.0 whose
package metadata names the old repository is the reason to fix it now rather than later.

**`repository` and `bugs`, which did not exist.** `homepage` was the only field naming the
repository, so pointing it at the documentation site would have left the package metadata with no
reference to the repository at all. Both fields are now present and name `contributor-toolkit`,
which is where that information belongs.

`electron-builder` derives artifact names from `package.json`, producing:

- `wordpress-contributor-toolkit-1.0.0-mac-arm64.dmg`
- `wordpress-contributor-toolkit-1.0.0-win-x64.exe`
- `wordpress-contributor-toolkit-1.0.0-linux-x86_64.AppImage`

## How to test this

Platforms: any; this is package metadata and is platform-independent.

**Starting state:** this branch checked out with dependencies installed.

1. Run `node -p "require('./package.json').version"`.
   - Expected: `1.0.0`.
2. Run `node -e "const p=require('./package-lock.json'); console.log(p.version, p.packages[''].version)"`.
   - Expected: `1.0.0 1.0.0`.
3. Run `node -p "require('./package.json').homepage"`.
   - Expected: `https://wordpress.github.io/contributor-toolkit/`, and opening it in a browser
     reaches the toolkit's documentation site rather than a 404.
4. Run `npm run lint` and `npm test`.
   - Expected: lint succeeds and all 1,027 tests pass.

**What must not have happened:** dependency versions and resolved packages must remain unchanged; no
source, documentation, workflow, or build configuration file should be in the diff.

## Risks and limitations

No user-visible behavior changed, so there is no desktop flow or screenshot to test by hand. The
signed artifacts will only exist after this PR lands and the release build runs.

Dropping the pre-release suffix means the resulting GitHub release is the first one to take the
**Latest** badge from `v0.1.2`.

## Related

Follow-up to #335. Ships the fixes in #342, #336, #337 and #339 as the stable 1.0.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The version goes straight to `1.0.0` rather than to a third release candidate: the only behaviour
change since rc.2 is #342, which was itself the finding rc.2 existed to surface, and it has been
verified on Windows. The release tag will add the conventional `v` prefix; package metadata does
not.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`0 [fix here] · 0 [follow-up]`. No findings across architecture, security, performance,
cross-platform, or tests. `npm run lint`, `npm test` (1,027/1,027), and `git diff --check` pass.
The stale `homepage` was itself the review's one observation, and is fixed in this PR.

Nothing reads `homepage` at runtime, and `electron-builder` has no `publish` block that would
derive an update feed from it, so the change is metadata only.

Verified as part of the review: no source, script, docs, `.buildkite/` or workflow file embeds the
app version (`src/logging.js:78` reads it via `app.getVersion()`); the lockfile diff carries no
dependency or integrity churn; `electron-builder` is prerelease-agnostic — the artifact template at
`package.json:30` is `…-${version}-${os}-${arch}.${ext}` and the repo has no `publish` block, no
channel and no auto-updater, so dropping the suffix only shortens the filenames; and nothing in CI
keys off a tag or version pattern.

One consequence worth stating: `docs/.vitepress/theme/DownloadButton.vue` resolves
`releases/latest`, which the GitHub API defines as excluding pre-releases. Since `v0.1.2` the button
has been falling back to the Releases page for everyone. Publishing 1.0.0 as a non-prerelease is
what makes it resolve a real asset again.



</details>

<details>
<summary>Implementation notes</summary>

`npm version 1.0.0 --no-git-tag-version` keeps `package.json`, the lockfile root `version` and
`packages[""].version` synchronized. The diff was checked to confirm those are the only changed
values.

</details>
