### PR TITLE
Update the repository name in user-facing links and user agents

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -64,7 +64,7 @@ body:
     id: existing
     attributes:
       label: Please confirm that you have searched existing issues in the repo.
-      description: You can do this by searching https://github.com/WordPress/experimental-wp-dev-env/issues
+      description: You can do this by searching https://github.com/WordPress/contributor-toolkit/issues
       options:
         - label: "Yes"
           required: true

--- a/.github/ISSUE_TEMPLATE/installation-bug.yml
+++ b/.github/ISSUE_TEMPLATE/installation-bug.yml
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Where did you download the app from?
       description: Please provide the exact URL or describe where you got it (e.g. GitHub Releases page, a blog post link, etc.).
-      placeholder: "e.g. https://github.com/WordPress/experimental-wp-dev-env/releases/tag/v1.0.0"
+      placeholder: "e.g. https://github.com/WordPress/contributor-toolkit/releases/tag/v1.0.0"
     validations:
       required: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@
 # site, with a maintainer at the keyboard. shots.cjs says which ones and why.
 #
 # The site base path is derived from the repository name at run time rather than hardcoded,
-# because a project Pages site lives under /<repo-name>/ and this repository is being renamed
-# (experimental-wp-dev-env → contributor-toolkit). Deriving it means the rename cannot break
-# every asset URL.
+# because a project Pages site lives under /<repo-name>/ and this repository has already been
+# renamed once (experimental-wp-dev-env → contributor-toolkit). Deriving it means another rename
+# cannot break every asset URL.
 #
 # Pull requests get a build-only job: a broken link or bad markdown fails before merge, and
 # the deploy job (which holds the OIDC token) never runs on PR code.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## WordPress Contributor Toolkit (Electron)
 
-[![Unit tests](https://github.com/WordPress/experimental-wp-dev-env/actions/workflows/unit-tests.yml/badge.svg?branch=trunk)](https://github.com/WordPress/experimental-wp-dev-env/actions/workflows/unit-tests.yml)
-[![Latest release](https://img.shields.io/github/v/release/WordPress/experimental-wp-dev-env)](https://github.com/WordPress/experimental-wp-dev-env/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/WordPress/experimental-wp-dev-env/total)](https://github.com/WordPress/experimental-wp-dev-env/releases)
+[![Unit tests](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml/badge.svg?branch=trunk)](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml)
+[![Latest release](https://img.shields.io/github/v/release/WordPress/contributor-toolkit)](https://github.com/WordPress/contributor-toolkit/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/WordPress/contributor-toolkit/total)](https://github.com/WordPress/contributor-toolkit/releases)
 
 The [WordPress Contributor Toolkit](https://make.wordpress.org/core/2026/04/16/wordpress-core-dev-environment-toolkit-a-faster-path-to-your-first-core-contribution/) is a desktop Electron application (macOS on Apple Silicon, Windows, and Linux) that sets up a full WordPress core development environment with zero prerequisites — no Git, Node.js, npm or Docker on the host.
 

--- a/STATS.md
+++ b/STATS.md
@@ -6,13 +6,13 @@ there is no npm install count, no Docker pull count, no telemetry in the app.
 GitHub reports a running total per release asset and keeps **no history**: the API returns the
 number as it stands today and nothing about how it got there. So a
 [weekly workflow](.github/workflows/download-stats.yml) records that total and commits it to
-[`metrics`](https://github.com/WordPress/experimental-wp-dev-env/tree/metrics), an orphan branch
+[`metrics`](https://github.com/WordPress/contributor-toolkit/tree/metrics), an orphan branch
 that shares no history with `trunk` and holds nothing but the data files.
 
 ### Reading the data
 
 In the browser:
-[downloads.csv](https://github.com/WordPress/experimental-wp-dev-env/blob/metrics/downloads.csv).
+[downloads.csv](https://github.com/WordPress/contributor-toolkit/blob/metrics/downloads.csv).
 
 Locally, without switching branches:
 

--- a/src/github-http.cjs
+++ b/src/github-http.cjs
@@ -28,7 +28,7 @@
 
 // GitHub rejects API requests with no User-Agent; an identifying one is also
 // the honest thing to send.
-const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/experimental-wp-dev-env)';
+const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/contributor-toolkit)';
 const REQUEST_TIMEOUT_MS = 15000;
 
 /**

--- a/src/trac-view.js
+++ b/src/trac-view.js
@@ -25,7 +25,7 @@ const { httpGet } = require('./github-prs');
 
 const TRAC_HOST = 'core.trac.wordpress.org';
 const TRAC_PARTITION = 'persist:trac';
-const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/experimental-wp-dev-env)';
+const USER_AGENT = 'WordPress-Contributor-Toolkit (+https://github.com/WordPress/contributor-toolkit)';
 // How long to wait for the ticket page to appear. The hashcash runs
 // automatically in a few seconds; the extra headroom covers the escalated
 // "I am human" checkbox, which needs a human click.


### PR DESCRIPTION
> **Stacked on #343.** Base branch is `juanmaguitar/Release-v1.0`, not `trunk`. Merge #343 first.

## Why

The repository was renamed from `experimental-wp-dev-env` to `contributor-toolkit`. GitHub redirects
the old URLs, so nothing is broken — which is exactly why the stale references survived. But they
are user-facing, and 1.0 is the release that gets read: the README badges are the first thing on the
repository page, and two of them are shields.io images built from the repository name rather than
plain links.

#343 fixed `package.json`. This is the rest of it.

## What changes

Nine occurrences across six files, all of them `WordPress/experimental-wp-dev-env` →
`WordPress/contributor-toolkit`:

- `README.md` — the unit-tests, latest-release and downloads badges (image source and link target).
- `STATS.md` — the two links to the `metrics` orphan branch and to `downloads.csv` on it.
- `.github/ISSUE_TEMPLATE/Bug_report.yml` — the "search existing issues" URL shown to a reporter.
- `.github/ISSUE_TEMPLATE/installation-bug.yml` — the download-source placeholder.
- `src/trac-view.js` and `src/github-http.cjs` — the `+https://…` project URL inside the
  `WordPress-Contributor-Toolkit` user agent sent to Trac and to the GitHub API. The identifying
  prefix is unchanged; only the URL a server operator would follow moves.

**Deliberately kept:** the old name in the comments at `docs/.vitepress/config.mjs:9` and
`.github/workflows/docs.yml:14`. Both describe the rename itself and explain why the Pages base path
is derived at run time rather than hardcoded, so the old name is the point of the sentence. The
workflow comment did still say the repository "is being renamed"; it now matches the VitePress one
and says the rename has already happened, which is also the accurate reason to keep deriving the
path — the next rename, not this one.

## How to test this

Platforms: any; this is text and metadata.

**Starting state:** this branch checked out with dependencies installed.

1. Run `grep -rn "experimental-wp-dev-env" . | grep -v node_modules | grep -v "^./.git"`.
   - Expected: exactly two hits, the two explanatory comments named above.
2. Open the rendered `README.md` on this branch and confirm all three badges load an image rather
   than a broken-image icon, and that clicking each lands on the `contributor-toolkit` repository.
3. Follow both links in `STATS.md` and confirm they reach the `metrics` branch and `downloads.csv`.
4. Open **New issue** on this branch's fork and confirm both templates render, with the corrected
   URL in the bug-report description and the corrected placeholder in the installation-bug form.
5. Run `npm run lint` and `npm test`.
   - Expected: lint succeeds and all 1,027 tests pass.

**What must not have happened:** the `WordPress-Contributor-Toolkit` prefix of either user agent must
be unchanged — `test/github-http.test.cjs:56` asserts on it, and Trac's proof-of-work session is
identified by it.

## Risks and limitations

The user-agent change is the only line that leaves the machine. Its value is not persisted, not used
as a cache key and not part of the Trac session partition (`persist:trac`), so an existing site's
cleared proof-of-work challenge survives the change.

Nothing here can be verified from the diff alone for the badges: shields.io builds them server-side
from the repository name, so they can only be confirmed on the rendered page.

## Related

Stacked on #343, which fixed the same stale name in `package.json` and added the missing
`repository` and `bugs` fields.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`0 [fix here] · 1 [follow-up, fixed here]`. No findings across architecture, security, performance,
cross-platform or tests. `npm run lint` and `npm test` (1,027/1,027) pass.

The follow-up was the tense of the `docs.yml` comment, which is in this PR's own subject matter and
so was fixed here rather than deferred.

Verified as part of the review: no test, fixture or snapshot pins the old user-agent string — the
only assertion is `test/github-http.test.cjs:56` on the `WordPress-Contributor-Toolkit` prefix, and
`test/trac-view.test.cjs:39` stubs `setUserAgent()` without inspecting its argument. Neither
constant is value-sensitive: `src/github-http.cjs:91` only sets a request header, and the Trac
partition is the literal `'persist:trac'` (`src/trac-view.js:27`), not derived from the user agent,
so no cleared proof-of-work session is orphaned. `download-stats.yml:68` already uses
`$GITHUB_REPOSITORY`, so the metrics branch keeps writing under whatever the repository is called.



</details>
