### PR TITLE
Add an end-to-end engine that drives the app against throwaway state

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,124 @@
+# Launches the app on the two platforms it ships to.
+#
+# Two jobs, because there are two different apps under test and they cost very
+# different amounts:
+#
+#   journeys  drives the source tree through the flows a contributor performs by
+#             hand. No packaging, so it is quick, and it is the one that fails when
+#             a change loses somebody's work.
+#   packaged  builds an unsigned artifact and asks whether packaging worked at all.
+#             Several minutes per platform, and it catches failures — asar layout,
+#             native module rebuilds, bundled CLI resolution — that cannot happen
+#             from source.
+#
+# Neither needs a secret: nothing here is signed. Buildkite still owns the signed
+# builds (.buildkite/pipeline.yml).
+#
+# No `playwright install` step in either job. These tests launch Electron; no
+# browser is ever downloaded.
+
+name: E2E
+
+on:
+  pull_request:
+    # `ready_for_review` is not in the default set. Without it, a PR opened as a draft
+    # and later marked ready never runs this workflow at all — the draft guard below
+    # would skip the only run it ever gets.
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [trunk]
+
+permissions:
+  contents: read
+
+# A new push supersedes the previous run on the same ref.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  journeys:
+    name: Journeys (${{ matrix.os }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      # The journeys read the renderer the app actually loads, so it has to exist.
+      # `postinstall` builds it too; this is here so a change to that never leaves
+      # the suite asserting against a stale bundle.
+      - name: Build the renderer bundle
+        run: npm run build:once
+
+      - name: Run the journeys
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-journeys-${{ matrix.os }}
+          path: |
+            playwright-report
+            test-results
+          retention-days: 7
+
+  packaged:
+    name: Packaged smoke (${{ matrix.os }})
+    # Packaging takes several minutes per platform; don't spend it on drafts.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      # `postinstall` runs `electron-builder install-app-deps`, which is what
+      # rebuilds the native file-locking module against Electron's ABI.
+      - run: npm ci
+
+      - name: Build the renderer bundle
+        run: npm run build:once
+
+      - name: Package (unsigned, --dir)
+        # Mandatory on macOS: electron-builder signs during `--dir` otherwise.
+        # Harmless elsewhere. Windows signing already no-ops without the Azure
+        # env vars (scripts/azure-sign.cjs).
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: npm run pack:dir
+
+      - name: Run the packaged smoke test
+        run: npm run test:e2e:packaged
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-packaged-${{ matrix.os }}
+          path: |
+            playwright-report
+            test-results
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ docs/.vitepress/cache
 src/renderer/index.js
 src/renderer/index.css
 
+# Playwright output. Traces, screenshots and the HTML report are written per run and
+# uploaded as CI artifacts on failure; none of it is worth committing.
+playwright-report
+test-results
+
 # Files with potential secrets
 .env
 .codesigning/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,41 @@ system Node, and the two versions are set independently and have drifted before 
 both is how a drift gets caught before it ships. The matrix uses `fail-fast: false`, so a Windows
 failure never hides the macOS result — you always see both.
 
+### End-to-end tests — [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml)
+
+Two suites, both launching a real app on macOS and Windows for every pull request that is not a
+draft. They answer different questions, so they are separate jobs and separate commands.
+
+- `npm run test:e2e` — **the journeys**. Drives the app built from the source tree through the flows
+  a contributor performs by hand: linking a ticket, applying and reverting a patch, moving between
+  ticket branches. Each test gets its own throwaway application-data directory and its own Git
+  fixture, so nothing it does can reach the sites you actually work on — and the harness refuses to
+  start at all if it ever finds the app using a different profile. Nothing here touches the network.
+  Seconds to run.
+- `npm run test:e2e:packaged` — **the packaged smoke test**. Launches an unsigned
+  `electron-builder --dir` build and asks only whether packaging worked: it boots, the whole preload
+  bridge is exposed, and the modules that exist only if packaging succeeded do resolve. Build it
+  first, or the test will tell you to:
+
+  ```
+  npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
+  ```
+
+  That environment variable is mandatory on macOS — electron-builder signs during `--dir` without
+  it — and harmless everywhere else.
+
+Neither downloads a browser. The only thing they launch is the Electron already in the tree, so
+there is no `playwright install` step anywhere.
+
+When one fails, the run keeps the trace, and the journeys additionally attach the screen and the
+state the app had persisted at the moment it failed — the interesting half of a failure in this app
+is usually on disk rather than on screen. Locally, `npx playwright show-trace test-results/<the
+failing test>/trace.zip` replays it.
+
+`npm test` does not pick these up and never will: the unit runner only collects `test/`, and these
+live in `e2e/`. Keeping them out of `npm test` is deliberate — they need a built renderer and cost
+seconds each, and the unit suite has to stay something you run without thinking about it.
+
 ## The review standard, and who reads it
 
 There is **one** source of truth for how a change is reviewed:

--- a/e2e/helpers/app.cjs
+++ b/e2e/helpers/app.cjs
@@ -1,0 +1,256 @@
+'use strict';
+
+// The engine the journey specs are built on: launch the app from source against a
+// profile that is thrown away afterwards, drive it, and read back the state it
+// actually persisted.
+//
+// Three things this exists to guarantee, none of which a spec should have to
+// remember:
+//
+//   1. The app never touches the contributor's real site registry. Every launch
+//      goes through TOOLKIT_USER_DATA_DIR — the `!app.isPackaged` hook in
+//      src/main.js:137 — and `start()` refuses to launch without one.
+//   2. Teardown always terminates. `close()` is known to hang on Windows in
+//      Electron apps that keep child processes alive, which this one does.
+//   3. A failure leaves evidence. The trace is Playwright's; the screenshot and
+//      the persisted settings.json are attached here, because the interesting
+//      half of a failure in this app is what ended up on disk.
+//
+// The packaged smoke test does not use this: it launches a different binary and
+// deliberately writes no state at all.
+
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { test: base, _electron: electron } = require( '@playwright/test' );
+
+const REPO_ROOT = path.join( __dirname, '..', '..' );
+
+// DPR 1 and a fixed locale and timezone: selectors read the text the app renders,
+// and some of that text is dates. Without these, a retina laptop and a CI runner
+// disagree about what is on screen.
+const ELECTRON_SWITCHES = [ '--force-device-scale-factor=1', '--lang=en-GB' ];
+
+/**
+ * Whether two paths name the same directory.
+ *
+ * Not `path.resolve(a) === path.resolve(b)`, which is wrong on both platforms this
+ * app ships to and would fail the launch guard for a reason that has nothing to do
+ * with what it is guarding:
+ *
+ *   - macOS hands back `/var/folders/...` from `os.tmpdir()` and `/private/var/...`
+ *     from the app, because the first is a symlink to the second.
+ *   - Windows hands back a short `RUNNER~1`-style path in some environments and the
+ *     long one in others, and its filesystem is case-insensitive besides.
+ *
+ * `realpath` settles the first two; lowercasing settles the third, and only off
+ * POSIX, where two names differing in case really are two directories.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @return {boolean}
+ */
+function samePath( a, b ) {
+	const real = ( p ) => {
+		try {
+			return fs.realpathSync.native( p );
+		} catch {
+			return path.resolve( p );
+		}
+	};
+	const normalise = ( p ) => ( process.platform === 'linux' ? real( p ) : real( p ).toLowerCase() );
+	return normalise( a ) === normalise( b );
+}
+
+const EMPTY_SETTINGS = Object.freeze( { sites: [], siteMeta: {}, preferences: {} } );
+
+/**
+ * A session of the app under test: one throwaway profile, one app at a time.
+ *
+ * Split into `new Session()` and `start()` on purpose. A spec usually has to build
+ * its Git fixture *before* the app opens — the site list in settings.json has to
+ * name directories that already exist — and it needs to know the profile path to
+ * write that settings.json. So the directory exists from construction; the app
+ * starts when the spec says so.
+ */
+class Session {
+	constructor() {
+		this.userDataDir = fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-profile-' ) );
+		this.app = null;
+		this.page = null;
+		this.scratch = [];
+	}
+
+	/**
+	 * Registers a directory to delete once the app has stopped.
+	 *
+	 * Deleting it any earlier is a Windows problem waiting to happen: a test's
+	 * fake site is open in a process that is still running, and Windows refuses
+	 * to remove a directory something holds a handle on — so the cleanup fails
+	 * with EPERM rather than the test failing on its own merits. Teardown here
+	 * runs after `close()`.
+	 *
+	 * @param {string} dir
+	 * @return {string} The same path, so this can wrap a mkdtemp call.
+	 */
+	track( dir ) {
+		this.scratch.push( dir );
+		return dir;
+	}
+
+	/**
+	 * Seeds settings.json and launches the app.
+	 *
+	 * @param {Object} settings Initial electron-store contents. Defaults to a
+	 *                          first-launch app with no sites.
+	 * @return {Promise<{app: Object, page: Object}>} The Electron app and its first window.
+	 */
+	async start( settings = EMPTY_SETTINGS ) {
+		if ( this.app ) throw new Error( 'This session already has an app running; call restart() instead.' );
+		this.writeSettings( settings );
+		return this.#launch();
+	}
+
+	/**
+	 * Closes the app and opens it again against the same profile, untouched.
+	 *
+	 * This is the only way to prove the app *persisted* something rather than
+	 * merely holding it in memory, which is what a change to the storage layer
+	 * can break without any test noticing.
+	 *
+	 * @return {Promise<{app: Object, page: Object}>} The relaunched app and its first window.
+	 */
+	async restart() {
+		await this.close();
+		return this.#launch();
+	}
+
+	async #launch() {
+		this.app = await electron.launch( {
+			// From plain Node, require('electron') resolves to the binary's path —
+			// the same trick scripts/run-tests-electron.cjs and the screenshot
+			// harness use.
+			executablePath: require( 'electron' ),
+			args: [ ...ELECTRON_SWITCHES, REPO_ROOT ],
+			env: {
+				...process.env,
+				TZ: 'UTC',
+				// Last, and not overridable by the ambient environment: a
+				// TOOLKIT_USER_DATA_DIR exported in the shell must never be able to
+				// point a test at a profile somebody cares about.
+				TOOLKIT_USER_DATA_DIR: this.userDataDir,
+			},
+		} );
+		this.page = await this.app.firstWindow();
+
+		// Belt and braces over the env var above. If the redirect hook ever stops
+		// firing — it is guarded by `!app.isPackaged` — every journey would start
+		// editing the contributor's real site registry, silently and permanently.
+		const inUse = await this.app.evaluate( ( { app } ) => app.getPath( 'userData' ) );
+		if ( ! samePath( inUse, this.userDataDir ) ) {
+			await this.close();
+			throw new Error(
+				`The app is using ${ inUse } as its profile, not the throwaway ${ this.userDataDir }. ` +
+				'Refusing to run a test that would write to a real site registry.'
+			);
+		}
+
+		return { app: this.app, page: this.page };
+	}
+
+	/**
+	 * Replaces the persisted settings wholesale. Only meaningful before a launch.
+	 *
+	 * @param {Object} settings
+	 */
+	writeSettings( settings ) {
+		fs.writeFileSync(
+			path.join( this.userDataDir, 'settings.json' ),
+			JSON.stringify( settings, null, '\t' )
+		);
+	}
+
+	/**
+	 * Reads back what the app persisted.
+	 *
+	 * electron-store writes on a debounce, so call this after the app has closed
+	 * when the assertion is about persistence; mid-run it answers with whatever
+	 * has been flushed so far.
+	 *
+	 * @return {Object} The parsed settings.json, or an empty object if there is none.
+	 */
+	readSettings() {
+		const file = path.join( this.userDataDir, 'settings.json' );
+		if ( ! fs.existsSync( file ) ) return {};
+		return JSON.parse( fs.readFileSync( file, 'utf8' ) );
+	}
+
+	/**
+	 * Makes the next "choose a file" dialog answer with these paths, without a human.
+	 *
+	 * Stubbed at invoke time in the main process rather than built into the app:
+	 * main.js calls `dialog.showOpenDialog` when the handler runs, so replacing the
+	 * method afterwards is enough and nothing test-shaped ships in the app.
+	 *
+	 * @param {string[]} filePaths
+	 */
+	async answerFileDialog( filePaths ) {
+		await this.app.evaluate( ( { dialog }, paths ) => {
+			dialog.showOpenDialog = async () => ( { canceled: false, filePaths: paths } );
+			dialog.showOpenDialogSync = () => paths;
+		}, filePaths );
+	}
+
+	async close() {
+		if ( ! this.app ) return;
+		const app = this.app;
+		this.app = null;
+		this.page = null;
+
+		// Grab the handle before closing — `process()` throws once the connection
+		// to the app is gone.
+		const proc = app.process();
+		await Promise.race( [
+			app.close().catch( () => {} ),
+			new Promise( ( resolve ) => setTimeout( resolve, 5_000 ) ),
+		] );
+		if ( proc && proc.exitCode === null ) proc.kill();
+	}
+
+	dispose() {
+		for ( const dir of this.scratch.splice( 0 ) ) {
+			fs.rmSync( dir, { recursive: true, force: true } );
+		}
+		fs.rmSync( this.userDataDir, { recursive: true, force: true } );
+	}
+}
+
+/**
+ * `test` with a `session` fixture. Import this instead of @playwright/test in a journey.
+ */
+const test = base.extend( {
+	session: async ( {}, use, testInfo ) => {
+		const session = new Session();
+		await use( session );
+
+		if ( testInfo.status !== testInfo.expectedStatus && session.page ) {
+			// Attached before the app closes, because closing it is also how a
+			// hung app gets killed — and then there is nothing left to photograph.
+			await testInfo.attach( 'screen', {
+				body: await session.page.screenshot().catch( () => Buffer.alloc( 0 ) ),
+				contentType: 'image/png',
+			} );
+			await testInfo.attach( 'settings.json', {
+				body: JSON.stringify( session.readSettings(), null, '\t' ),
+				contentType: 'application/json',
+			} );
+		}
+
+		await session.close();
+		session.dispose();
+	},
+} );
+
+const { expect } = base;
+
+module.exports = { test, expect, Session, EMPTY_SETTINGS, REPO_ROOT };

--- a/e2e/journeys/engine.spec.js
+++ b/e2e/journeys/engine.spec.js
@@ -1,0 +1,137 @@
+/**
+ * The engine's own test (#360).
+ *
+ * Not a journey: it asserts nothing about ticket branches or patches. It asserts
+ * that the four things every journey depends on actually work, so that when a
+ * journey fails it is about the flow and not about the harness.
+ *
+ *   1. The app launches from the source tree and paints.
+ *   2. It uses the throwaway profile, and nothing else.
+ *   3. What it persists survives closing and reopening it.
+ *   4. A native file dialog can be answered from the test.
+ *
+ * If this file is red, no other journey's result means anything.
+ */
+
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { test, expect } = require( '../helpers/app.cjs' );
+
+// Directories made during a test, removed after it. The profile is the session
+// fixture's problem; these are the fake sites and patch files pointed at from it.
+// The site's name is on screen twice — the sidebar entry and the heading of the
+// open site — so neither can be reached by text alone. Roles tell them apart, and
+// say which half of the app the assertion is about.
+const sidebarEntry = ( page, label ) => page.getByRole( 'button', { name: label, exact: true } );
+const openSiteHeading = ( page, label ) => page.getByRole( 'heading', { name: label, exact: true } );
+
+const scratch = [];
+test.afterEach( () => {
+	while ( scratch.length ) fs.rmSync( scratch.pop(), { recursive: true, force: true } );
+} );
+
+/**
+ * A site directory the app can list without being able to read Git metadata from
+ * it. The renderer tolerates that — it shows the site with no snapshot date
+ * rather than crashing — which is enough for everything below. Journeys build a
+ * real repository instead.
+ *
+ * @param {Object} session The session that will list it, and clean it up.
+ * @param {string} label
+ * @return {{dir: string, settings: Object}} The directory, and settings that list it.
+ */
+function makeListedSite( session, label ) {
+	const yesterday = new Date( Date.now() - 24 * 60 * 60 * 1000 ).toISOString();
+	const dir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-site-' ) ) );
+	fs.mkdirSync( path.join( dir, 'wp-content' ), { recursive: true } );
+	return {
+		dir,
+		settings: {
+			sites: [ dir ],
+			siteMeta: {
+				[ dir ]: {
+					initialized: true,
+					createdAt: yesterday,
+					label,
+					// Relative to now, not a fixed date. The staleness dot appears
+					// once a snapshot is a fortnight old, and it joins the sidebar
+					// entry's accessible name when it does — so a hardcoded date
+					// would quietly change what the selectors below match, months
+					// after anyone touched this file.
+					trunkDate: yesterday,
+					skipInitWizard: true,
+				},
+			},
+			preferences: {},
+		},
+	};
+}
+
+test( 'the app launches from source and lists the site it was seeded with', async ( { session } ) => {
+	const site = makeListedSite( session, 'engine-check' );
+	const { page } = await session.start( site.settings );
+
+	await expect( page ).toHaveTitle( 'WordPress Contributor Toolkit' );
+	// #root is in the static HTML, so its presence proves nothing — its children do.
+	await expect( page.locator( '#root > *' ) ).not.toHaveCount( 0 );
+
+	// `exact`, because the sidebar heading "WordPress Core" is a substring of
+	// several button labels further down the page.
+	await expect( sidebarEntry( page, 'engine-check' ) ).toBeVisible();
+	await expect( page.getByText( 'No sites yet.', { exact: true } ) ).toHaveCount( 0 );
+} );
+
+test( 'the app writes to the throwaway profile and not to the real one', async ( { session } ) => {
+	const { app } = await session.start();
+
+	// The launch guard already refuses to proceed otherwise, so this is here to
+	// make the guarantee visible as a test rather than only as a helper's
+	// precondition — the whole suite is unsafe to run the day it stops holding.
+	const inUse = await app.evaluate( ( { app: electronApp } ) => electronApp.getPath( 'userData' ) );
+	expect( path.resolve( inUse ) ).toBe( path.resolve( session.userDataDir ) );
+
+	// And it is genuinely this app's store: the seeded file is the one it read.
+	expect( session.readSettings() ).toHaveProperty( 'sites' );
+} );
+
+test( 'state written by the app survives closing and reopening it', async ( { session } ) => {
+	const site = makeListedSite( session, 'before-restart' );
+	const { page } = await session.start( site.settings );
+	await expect( sidebarEntry( page, 'before-restart' ) ).toBeVisible();
+
+	// Renaming goes through the app's own persistence path, so this proves the
+	// round trip the journeys rely on: the app wrote it, the app read it back.
+	// Anything asserted only within one launch could be memory, not storage.
+	await page.evaluate(
+		( [ sitePath, label ] ) => window.api.setSiteLabel( sitePath, label ),
+		[ site.dir, 'after-restart' ]
+	);
+	// No assertion on the sidebar here, deliberately. The rename went straight to
+	// the main process, which does not push an update back to a renderer that did
+	// not ask for one — so the old name stays on screen until something reloads.
+	// That is the app's business; what this test is about is the write reaching
+	// disk, and the reader for that is the relaunch below.
+
+	const { page: reopened } = await session.restart();
+	await expect( sidebarEntry( reopened, 'after-restart' ) ).toBeVisible();
+	await expect( openSiteHeading( reopened, 'after-restart' ) ).toBeVisible();
+	expect( session.readSettings().siteMeta[ site.dir ].label ).toBe( 'after-restart' );
+} );
+
+test( 'a native file dialog can be answered from the test', async ( { session } ) => {
+	const patchDir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-patch-' ) ) );
+	const patchFile = path.join( patchDir, 'engine.patch' );
+	fs.writeFileSync( patchFile, '--- a/wp-login.php\n+++ b/wp-login.php\n' );
+
+	const { page } = await session.start();
+	await session.answerFileDialog( [ patchFile ] );
+
+	// Straight through the app's real handler, which opens the dialog, reads the
+	// file and returns its text — so this covers the whole path a journey uses to
+	// bring a patch in, not just that the stub was installed.
+	const chosen = await page.evaluate( () => window.api.choosePatchFile() );
+	expect( chosen.filePath ).toBe( patchFile );
+	expect( chosen.name ).toBe( 'engine.patch' );
+	expect( chosen.text ).toContain( 'wp-login.php' );
+} );

--- a/e2e/packaged/smoke.spec.js
+++ b/e2e/packaged/smoke.spec.js
@@ -1,0 +1,234 @@
+/**
+ * Smoke test for the packaged app.
+ *
+ * Runs against an unsigned `electron-builder --dir` build, not the source tree.
+ * The failures it exists to catch — asar layout, native module rebuilds, bundled
+ * CLI resolution — do not reproduce under `npm start`.
+ *
+ * Build it first (see docs/testing.md):
+ *   npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
+ *
+ * It writes no state, so it deliberately does not use the session helper the
+ * journeys are built on: there is no profile to seed and nothing to read back.
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { test, expect, _electron: electron } = require( '@playwright/test' );
+
+const REPO_ROOT = path.join( __dirname, '..', '..' );
+const DIST = path.join( REPO_ROOT, 'dist' );
+
+/**
+ * Every key exposed through `contextBridge` in src/preload.js.
+ *
+ * This repo has no typecheck, so nothing else catches an `ipcMain.handle` added
+ * in src/main.js and never bridged to the renderer. Adding an API means adding it
+ * here too — that is the point, the list is meant to be edited deliberately.
+ *
+ * Do not try to derive it by reading src/preload.js. Two of these keys
+ * (`signInToGithub`, `cancelGithubSignIn`) are spread in from an immediately
+ * invoked function that closes over a listener, so they exist only once the file
+ * has run. Anything that greps for the object's literal keys silently misses
+ * them — which is the same class of gap this assertion exists to close, one
+ * level up.
+ */
+const EXPECTED_API_KEYS = [
+	'addSite',
+	'applyPatch',
+	'cancelGithubSignIn',
+	'chooseDirectory',
+	'choosePatchFile',
+	'clearEmails',
+	'clearWpDebug',
+	'createPatchWindow',
+	'deleteBranch',
+	'deleteSite',
+	'discardChanges',
+	'discardToBase',
+	'fetchPrDiff',
+	'fetchTracAttachment',
+	'getEmails',
+	'getGithubAccount',
+	'getPatch',
+	'getProvenance',
+	'getSiteStatus',
+	'getSites',
+	'getSitesWithMeta',
+	'hasUnsubmittedWork',
+	'isWorktreeDirty',
+	'listBranches',
+	'listEditors',
+	'listTicketPatches',
+	'listTracAttachments',
+	'markSiteInitialized',
+	'markUpdateComplete',
+	'npmKill',
+	'onNewEmail',
+	'onSmtpStarted',
+	'openExternal',
+	'openInEditor',
+	'openPullRequest',
+	'platform',
+	'playgroundWebAvailable',
+	'previewPatch',
+	'revealWpDebug',
+	'runNpmInstall',
+	'runNpmScript',
+	'savePatch',
+	'setContributionEvent',
+	'setSiteLabel',
+	'setSiteTicket',
+	'setSkipInitWizard',
+	'setWporgHandle',
+	'setupWordPress',
+	'showSiteInFileManager',
+	'signInToGithub',
+	'signOutOfGithub',
+	'startPlaygroundWeb',
+	'startServer',
+	'startSmtp',
+	'startWpDebug',
+	'stopPlaygroundWeb',
+	'stopServer',
+	'stopSmtp',
+	'stopWpDebug',
+	'subscribeCarriedWork',
+	'subscribePullRequestProgress',
+	'subscribeSetupProgress',
+	'subscribeSetupStatus',
+	'subscribeSwitchProgress',
+	'switchBranch',
+	'updateTrunk',
+];
+
+/**
+ * Modules the app resolves at runtime that only exist if packaging worked.
+ *
+ * `fs-ext-extra-prebuilt` is the interesting one. It is a native module that the
+ * bundled PHP runtime requires for file locking, it ships prebuilt binaries, and
+ * it is listed in `allowScripts` because it still runs an install script to pick
+ * one. A binary that is missing or built against the wrong ABI surfaces here and
+ * nowhere else: `npm ci` exits 0 and packaging succeeds regardless.
+ *
+ * Asserted on both platforms, deliberately. An earlier draft of this test
+ * excluded Windows on the grounds that the Playground CLI guarded the import
+ * with a `win32` check — that guard is gone, the dependency is no longer
+ * optional, and the runtime now carries a Windows-specific file-lock path that
+ * requires it. Excluding Windows today would skip the one failure this
+ * assertion exists to catch, on the platform where it is most likely.
+ */
+const REQUIRED_MODULES = [ '@wp-playground/cli', 'fs-ext-extra-prebuilt' ];
+
+/**
+ * electron-builder names the output directory after the platform *and* arch, so
+ * the path differs between a CI runner and a contributor's laptop:
+ * macos-latest is arm64 (`dist/mac-arm64`), an Intel Mac is `dist/mac`.
+ */
+function findPackagedBinary() {
+	if ( ! fs.existsSync( DIST ) ) {
+		throw new Error( `No ${ DIST } directory. Run \`npm run pack:dir\` first — see docs/testing.md.` );
+	}
+
+	if ( process.platform === 'darwin' ) {
+		const macDirs = fs.readdirSync( DIST ).filter( ( d ) => d === 'mac' || d.startsWith( 'mac-' ) );
+		for ( const dir of macDirs ) {
+			const appDir = path.join( DIST, dir );
+			const app = fs.readdirSync( appDir ).find( ( d ) => d.endsWith( '.app' ) );
+			if ( ! app ) continue;
+			const macOsDir = path.join( appDir, app, 'Contents', 'MacOS' );
+			const [ binary ] = fs.readdirSync( macOsDir );
+			if ( binary ) return path.join( macOsDir, binary );
+		}
+		throw new Error( `No packaged .app under ${ DIST }. Looked in: ${ macDirs.join( ', ' ) || '(nothing)' }` );
+	}
+
+	if ( process.platform === 'win32' ) {
+		const unpacked = path.join( DIST, 'win-unpacked' );
+		if ( ! fs.existsSync( unpacked ) ) {
+			throw new Error( `No ${ unpacked }. Run \`npm run pack:dir\` first — see docs/testing.md.` );
+		}
+		const exe = fs.readdirSync( unpacked ).find( ( f ) => f.endsWith( '.exe' ) );
+		if ( ! exe ) throw new Error( `No .exe in ${ unpacked }.` );
+		return path.join( unpacked, exe );
+	}
+
+	throw new Error( `This smoke test only covers macOS and Windows, not ${ process.platform }.` );
+}
+
+let electronApp;
+let firstWindow;
+
+test.beforeAll( async () => {
+	electronApp = await electron.launch( { executablePath: findPackagedBinary() } );
+	firstWindow = await electronApp.firstWindow();
+} );
+
+test.afterAll( async () => {
+	if ( ! electronApp ) return;
+
+	// Grab the handle before closing — `process()` throws once the connection to
+	// the app is gone.
+	const proc = electronApp.process();
+
+	// `close()` is known to hang on Windows when the app keeps child processes
+	// alive, which this one does. Never let teardown wedge the run.
+	await Promise.race( [
+		electronApp.close().catch( () => {} ),
+		new Promise( ( resolve ) => setTimeout( resolve, 5_000 ) ),
+	] );
+
+	if ( proc && proc.exitCode === null ) proc.kill();
+} );
+
+test( 'the packaged app boots and paints its first window', async () => {
+	// Deliberately not asserting "no uncaught renderer errors": index.html installs
+	// its own error handlers, and a `pageerror` listener attaches too late to be
+	// reliable. A painted window covers the same failure class positively.
+	await expect( firstWindow ).toHaveTitle( 'WordPress Contributor Toolkit' );
+
+	// #root is in the static HTML, so its presence proves nothing — its children do.
+	await expect( firstWindow.locator( '#root > *' ) ).not.toHaveCount( 0 );
+	// `exact` matters: "WordPress Core" is also a substring of button labels and
+	// step descriptions further down the page.
+	await expect( firstWindow.getByText( 'WordPress Core', { exact: true } ) ).toBeVisible();
+} );
+
+test( 'the preload bridge exposes every expected key', async () => {
+	const exposed = await firstWindow.evaluate( () =>
+		( window.api ? Object.keys( window.api ) : [] ).sort()
+	);
+
+	expect( exposed ).toEqual( EXPECTED_API_KEYS );
+} );
+
+for ( const moduleName of REQUIRED_MODULES ) {
+	test( `the packaged app can resolve ${ moduleName }`, async () => {
+		const resolved = await electronApp.evaluate( ( { app }, name ) => {
+			// The `require` in scope here carries no `.resolve` — only a per-module
+			// require wrapper does. Build one anchored at the app's own package.json,
+			// inside app.asar, so resolution happens exactly where src/main.js would
+			// do it.
+			//
+			// Anchored there rather than at `process.mainModule.filename`, which is
+			// what an earlier draft used: Electron does not keep that pointed at the
+			// entry script, and partway through a run it reads back as the bare
+			// string 'electron'. The test then fails on the *first* module it checks
+			// and passes when run alone — a packaging test going red for a reason
+			// that has nothing to do with packaging, which is the worst kind.
+			const nodeRequire = process.mainModule ? process.mainModule.require : require;
+			const { createRequire } = nodeRequire( 'module' );
+			const { join } = nodeRequire( 'path' );
+			const req = createRequire( join( app.getAppPath(), 'package.json' ) );
+			try {
+				return { ok: true, path: req.resolve( name ), appPath: app.getAppPath() };
+			} catch ( error ) {
+				return { ok: false, error: String( error && error.message ), appPath: app.getAppPath() };
+			}
+		}, moduleName );
+
+		expect( resolved, `${ moduleName } failed to resolve from ${ resolved.appPath }: ${ resolved.error }` )
+			.toHaveProperty( 'ok', true );
+		expect( resolved.path ).toBeTruthy();
+	} );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,6 +100,21 @@ export default [
 	},
 
 	{
+		// End-to-end suite. Playwright's fixture API is `async ({ deps }, use) => {}`
+		// — the test framework calls `use()` to hand the fixture to the test and
+		// resumes afterwards for teardown. The React hooks rule sees a bare `use(...)`
+		// and reads it as React's `use` hook called outside a component. There is no
+		// React in this directory at all; the app under test is a separate process.
+		files: [ 'e2e/**/*.{js,cjs,mjs}' ],
+		languageOptions: {
+			globals: { ...globals.node },
+		},
+		rules: {
+			'react-hooks/rules-of-hooks': 'off',
+		},
+	},
+
+	{
 		// Files whose stdout *is* their interface, so `no-console` is simply wrong
 		// there. The runners are spawned as child processes (process.execPath +
 		// ELECTRON_RUN_AS_NODE=1) and main.js reads their stdout/stderr back and

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "xterm": "^5.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@wordpress/eslint-plugin": "^25.7.0",
         "concurrently": "^8.2.2",
         "electron": "^43.2.0",
@@ -4224,6 +4225,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -10039,6 +10056,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -15198,6 +15230,25 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
     "dist:win": "npm run build:once && electron-builder --win --publish never",
     "dist:win:arm64": "npm run build:once && electron-builder --win --arm64 --publish never",
     "dist": "npm run build:once && electron-builder --publish never",
+    "pack:dir": "electron-builder --dir --publish never",
     "test": "node --test",
     "test:electron": "node scripts/run-tests-electron.cjs",
+    "test:e2e": "playwright test --project=journeys",
+    "test:e2e:packaged": "playwright test --project=packaged",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "shots": "npm run build:once && node scripts/screenshots/capture.cjs",
@@ -94,6 +97,7 @@
     "xterm": "^5.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@wordpress/eslint-plugin": "^25.7.0",
     "concurrently": "^8.2.2",
     "electron": "^43.2.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,45 @@
+const { defineConfig } = require('@playwright/test');
+
+// Electron only — no browsers are downloaded or launched, so there is no
+// `projects` entry for a browser and no `npx playwright install` step anywhere.
+//
+// Two projects, because there are two different apps under test:
+//
+//   journeys  drives the *source tree* through the flows a contributor performs by
+//             hand — link a ticket, apply a patch, switch branches. Fast, offline,
+//             and it writes real state to a throwaway profile.
+//   packaged  launches the *packaged artifact* (`electron-builder --dir`) and only
+//             asks whether packaging worked. It writes no state.
+//
+// They are not interchangeable: the journeys mutate real Git repositories and need
+// to be quick enough to run in a loop, and the packaging failures — asar layout,
+// native module rebuilds, bundled CLI resolution — do not reproduce from source.
+module.exports = defineConfig({
+	testDir: 'e2e',
+	// Launching Electron is not safe to parallelise: workers would race over the
+	// same packaged binary and, in the journeys, over the same fixture roots.
+	workers: 1,
+	fullyParallel: false,
+	// Locally a retry hides a flake you want to see; in CI it stops one flake from
+	// blocking somebody else's pull request.
+	retries: process.env.CI ? 1 : 0,
+	timeout: 60_000,
+	expect: { timeout: 15_000 },
+	reporter: process.env.CI ? [ [ 'list' ], [ 'html', { open: 'never' } ] ] : 'list',
+	use: {
+		trace: 'retain-on-failure',
+	},
+	projects: [
+		{
+			name: 'journeys',
+			testDir: 'e2e/journeys',
+		},
+		{
+			name: 'packaged',
+			testDir: 'e2e/packaged',
+			// Cold-starting a packaged app on a Windows runner is slow enough to
+			// trip the default on its own, before any assertion runs.
+			timeout: 120_000,
+		},
+	],
+});


### PR DESCRIPTION
## Why

Nothing in the suite has ever launched the app. The Git modules are covered against real repositories and the IPC handlers against a loaded main process, but the flows a contributor actually performs — linking a ticket, applying a patch, moving between branches — are verified only by a person following a **How to test this** section by hand.

That matters now because of #350. The git-native refactor moves ticket branches, applied patches, conflicts and trunk updates all at once, and a characterisation suite written afterwards can only record the refactor. Written first, it says which of the old guarantees were quietly dropped — which is the failure mode here, since nearly every regression in this area is silent: work parked and never restored, a patch quietly missing a file, a ticket that forgets its base.

This PR is the engine. The journeys themselves are #361.

## What changes

Two suites, because there are two different apps under test and they answer different questions.

**`npm run test:e2e` — the journeys.** Drives the app built from the source tree and writes real state. Everything a journey needs before it can assert anything lives in one session helper, so no spec has to remember it:

- **It cannot reach your own sites.** Every launch goes through the development-only data-directory redirect, and then reads back the path the app actually chose and refuses to continue if it is any other one. The env var is set last and is not overridable by the ambient environment.
- **Teardown always terminates.** `close()` is raced against a timeout and the process killed after it — closing is known to hang on Windows in apps that keep child processes alive, which this one does constantly.
- **A failure leaves evidence.** The trace is Playwright's; the screen and the state the app had persisted are attached here, because the interesting half of a failure in this app is on disk rather than on screen.
- **It can relaunch against the same profile.** This is not a convenience. It is the only way to tell "the app persisted this" from "the app still had it in memory", and it is exactly what a change to the storage layer breaks without any other test noticing.

**`npm run test:e2e:packaged` — the packaged smoke test.** Launches an unsigned `--dir` build and asks only whether packaging worked. This is the test from the now-closed #70, **rebuilt rather than rebased** — see below.

Both run on macOS and Windows for every non-draft pull request, as two separate jobs so a five-second suite is not waiting behind a fifteen-minute one. Neither downloads a browser: the only thing launched is the Electron already in the tree, so there is no `playwright install` step anywhere.

**Deliberately not in this PR:** any journey. `e2e/journeys/engine.spec.js` asserts nothing about ticket branches or patches — it asserts that the four things every journey will depend on actually work, so that when a journey fails it is about the flow and not about the harness.

## How to test this

Platforms: **any** for the journeys. The packaged half is macOS or Windows only, and the point of the CI matrix is that Windows is the half nobody can check locally.

**Starting state:** a clean checkout of this branch, `npm ci` done. Note the modification time of your real settings file before you start — on macOS, `~/Library/Application Support/electron-setup-wordpress-core/settings.json`.

1. `npm run build:once && npm run test:e2e`
   - Expected: 4 passed, in a few seconds. A real Electron window opens and closes four times.
2. `npm test`
   - Expected: **1027 passed** — the same count as on `trunk`. The unit runner only collects `test/`, so it must not pick up anything added here.
3. `npm run lint`
   - Expected: clean. It is repo-wide.
4. `CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir && npm run test:e2e:packaged`
   - Expected: 4 passed. Skip this if you would rather read the CI result — it takes several minutes.
5. Break the guard on purpose: in `e2e/helpers/app.cjs`, change `TOOLKIT_USER_DATA_DIR: this.userDataDir` to `TOOLKIT_USER_DATA_DIR: undefined`, then `npm run test:e2e`.
   - Expected: all four tests fail, each saying the app is using your real profile and that it refuses to run. Put the line back.
6. Break an assertion on purpose: in `e2e/packaged/smoke.spec.js`, delete any one entry from `EXPECTED_API_KEYS`, then `npm run test:e2e:packaged`.
   - Expected: the bridge test fails and names the missing key. Put it back.

**What must not have happened:**

- **Your real settings file must not have been touched.** Compare its modification time with what you noted in the starting state. This is the whole reason step 5 exists: the guard is the only thing standing between a future change to the redirect hook and a suite that silently edits the site list you actually work on.
- **`npm test` must not have grown.** If the count moved off 1027, the unit runner started collecting end-to-end specs, and `npm test` stops being something you run without thinking.
- **No Electron processes left running** after any of the above. `ps aux | grep -i electron` on macOS, Task Manager on Windows.

## Risks and limitations

- **Windows is unverified by hand.** Everything above was run on macOS. Two of the four fixes in this branch are specifically about Windows behaviour I could not reproduce locally — path shapes and file handles — so the CI run on this PR is the first real evidence either way. That is the honest state of it.
- **CI time.** The packaged job packages on both platforms for every non-draft PR: roughly ten to fifteen minutes per platform. The journeys job takes seconds. If the feedback loop gets annoying, the packaging job is what to trim, not the journeys.
- **The trunk update cannot be driven from a journey at all**, on any platform. It reaches for a hardcoded clone URL rather than the checkout's own remote, so exercising it means cloning from the network — unacceptable in CI. Its two interesting cases stay in the integration suite, against a local server. Making the update read the remote is worth doing on its own merits and belongs in #350; I left a note there.
- The teardown's last-resort kill is a bare `kill()` rather than `src/kill-tree.js`. It only runs after `close()` has already had its timeout, and it is test code, but if orphaned Electron processes ever show up on the runners, that is where to look.

## Related

Part of #359. Closes #360. **Closes #67** — its three assertions ship here as the `packaged` project, on both platforms, documented in `CONTRIBUTING.md`, with Buildkite untouched. Replaces #70, which is closed. Unblocks #361, and #350 after it.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**`@playwright/test` rather than `node --test` with `playwright-core`.** The first draft went the other way, to keep one runner in the repo and add no dependency. Requiring the suite to run in CI on two platforms for every pull request inverted that: retries, per-test timeouts, traces, the HTML report and the reporting artifacts are all things I would otherwise have written and then maintained, badly. Two runners is not a defect here — `npm test` stays the fast offline suite and `npm run test:e2e` is the one that launches an app, and they are meant to be told apart.

The dependency cost turned out to be smaller than assumed: `@playwright/test` at this version has no install script and downloads no browser. I checked the published tarball rather than trusting the recollection — an older version of Playwright did download browsers on install, which is why `scripts/screenshots/capture.cjs` depends on `playwright-core` directly and says so in its header.

**A session object rather than a `page` fixture.** A journey has to build its Git fixture *before* the app opens, because the site list has to name directories that already exist, and it needs the profile path to write that list. A fixture that launches the app for you takes that away. So the profile directory exists from construction and the spec decides when to start.

**Rebuilt #70 rather than rebasing it.** Two of its three assertions had gone stale in ways that would fail on first run: the list of bridged keys had roughly half the entries the app exposes today, and the native module it probes is no longer optional and no longer absent on Windows — it is a hard dependency of the bundled PHP runtime with a Windows-specific file-lock path — so its documented Windows exclusion had turned from a decision into a hole. Its structure, its comments and its reasoning are otherwise carried over almost verbatim; the closing comment on #70 lists what came across.

**Not adding `data-testid` anywhere.** The selectors use the text and roles already on screen, which also pins the visible copy as a contract. Where a name appears twice — the sidebar entry and the heading of the open site — roles tell them apart, and the assertion says which half of the app it is about.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`2 [fix here] · 2 [follow-up]` — both `[fix here]` fixed before this was pushed.

**🔴 cross-platform · `[fix here]` — fixed.** The launch guard compared `path.resolve(a) !== path.resolve(b)`. That would have aborted every test on Windows, and possibly on macOS, for reasons unrelated to what it guards: macOS returns `/var/folders/…` from `os.tmpdir()` and `/private/var/…` from the app, since the first is a symlink to the second, and Windows returns short `RUNNER~1` names in some environments and long ones in others, on a case-insensitive filesystem. Replaced with a `samePath()` that resolves through `realpath` and lowercases off POSIX.

**🔴 cross-platform · `[fix here]` — fixed.** The fake site directories were removed in an `afterEach`, which Playwright runs *before* fixture teardown — with the app still alive and holding handles on them. On Windows that is `EPERM`, and a failure that is not the test's. Cleanup moved onto the session, which removes them after `close()`.

**🟡 tests · `[follow-up]`.** The teardown's last-resort `kill()` is not `src/kill-tree.js`. Noted in **Risks** above.

**🔵 performance · `[follow-up]`.** The packaging job's cost per pull request. Noted in **Risks** above.

No findings in architecture (nothing under `src/` changes), security (the file-dialog stub is installed at runtime from the test, so nothing test-shaped ships in the app), or the new-dependency rule (devDependency, no install script — verified against the published tarball — no native compilation, so no `allowScripts` entry is needed and the zero-prerequisite promise is untouched).

**One caveat.** The standard asks for this pass to run in fresh context rather than in the session that wrote the code. It did not: the session that wrote this reviewed it. Worth a second pass by someone who has not already decided it is correct.

</details>

<details>
<summary>Implementation notes</summary>

Two things surfaced only by running this against the current tree, neither of which #70 could have seen:

**`process.mainModule.filename` is not stable in Electron.** The module-resolution assertions anchored a `createRequire` there. Partway through a run it reads back as the bare string `'electron'`, so the first module checked failed and the same test passed when run alone — a packaging test going red for a reason that has nothing to do with packaging. Now anchored at `join(app.getAppPath(), 'package.json')`, which is deterministic and is inside the asar either way.

**Two bridged keys cannot be found by reading `src/preload.js`.** `signInToGithub` and `cancelGithubSignIn` are spread in from an immediately invoked function that closes over a listener, so they exist only once the file has run. Any attempt to derive the expected-keys list by grepping the object literal misses them — which is the same class of gap the assertion itself exists to close, one level up. There is a comment in the file saying so, because the next person to regenerate that list will otherwise reintroduce the same two-key error.

The `react-hooks/rules-of-hooks` override for `e2e/` is not a suppression of a real problem: Playwright's fixture API is `async ({ deps }, use) => {}`, and the rule reads a bare `use(...)` as React's `use` hook outside a component. There is no React in that directory; the app under test is a separate process.

</details>

