### PR TITLE
Cover ticket branches end to end, through the app

### DIFF
--- a/e2e/helpers/app.cjs
+++ b/e2e/helpers/app.cjs
@@ -201,6 +201,34 @@ class Session {
 		}, filePaths );
 	}
 
+	/**
+	 * Answers yes to every `window.confirm` the app raises, for the life of this
+	 * window. Returns the number of prompts answered so far, so a test can assert
+	 * that a destructive action did ask before doing anything.
+	 *
+	 * Replaces `window.confirm` in the page rather than handling Playwright's
+	 * `dialog` event. Electron implements the JavaScript dialogs natively and
+	 * blocks the renderer on them, so the `dialog` event a browser would emit
+	 * does not arrive — a test relying on it clicks "Delete this ticket's work",
+	 * watches nothing happen, and fails on an assertion that had nothing to do
+	 * with the bug. (Confirmed the hard way; the listener is kept alongside for
+	 * anything that does surface as a real dialog.)
+	 *
+	 * @return {Promise<() => Promise<number>>} Reads back how many confirmations
+	 *                                          have been answered.
+	 */
+	async acceptConfirms() {
+		this.page.on( 'dialog', ( dialog ) => dialog.accept() );
+		await this.page.evaluate( () => {
+			window.__e2eConfirmCount = 0;
+			window.confirm = () => {
+				window.__e2eConfirmCount += 1;
+				return true;
+			};
+		} );
+		return () => this.page.evaluate( () => window.__e2eConfirmCount );
+	}
+
 	async close() {
 		if ( ! this.app ) return;
 		const app = this.app;

--- a/e2e/helpers/git-site.cjs
+++ b/e2e/helpers/git-site.cjs
@@ -1,0 +1,149 @@
+'use strict';
+
+// A site the app will treat as a finished, working checkout — built as a real Git
+// repository on disk, because the flows these journeys cover are Git operations
+// and a stub would only prove the app can talk to a stub.
+//
+// The shape mirrors the fixture the integration suite uses
+// (test/ticket-branches.integration.test.cjs), one level up: same trunk branch,
+// same three tracked files, and the same gitignored `node_modules` standing in for
+// the expensive substrate. That substrate is the point of half these assertions —
+// reinstalling it costs a contributor minutes, so a ticket switch that quietly
+// removes it is a regression the app would never report.
+//
+// Small enough that every test builds its own from scratch: nothing here is shared
+// between tests, so no journey can be affected by the order it runs in.
+
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const git = require( 'isomorphic-git' );
+
+const TRUNK = 'trunk';
+const AUTHOR = { name: 'e2e', email: 'e2e@example.test' };
+
+/**
+ * The substrate: gitignored, expensive to rebuild, and must survive everything.
+ * A journey asserts on this file's contents, not merely on the directory existing,
+ * so a checkout that deletes and recreates it still counts as a loss.
+ */
+const SUBSTRATE = path.join( 'node_modules', 'react', 'index.js' );
+const SUBSTRATE_CONTENT = 'expensive to reinstall\n';
+
+const TRUNK_FILES = {
+	'.gitignore': 'node_modules/\nbuild/\n',
+	'wp-login.php': '<?php // trunk\n',
+	'doomed.php': '<?php // to be deleted\n',
+};
+
+/**
+ * Creates a repository the app will list, open, and consider ready to work in.
+ *
+ * @param {Object} session         A Session from ./app.cjs. The directory is
+ *                                 registered with it, so it is removed after the
+ *                                 app has stopped — doing it earlier fails on
+ *                                 Windows, where a directory with open handles
+ *                                 cannot be deleted.
+ * @param {Object} [options]
+ * @param {string} [options.label] The name shown in the sidebar.
+ * @return {Promise<{dir: string, baseOid: string, settings: Object}>}
+ */
+async function makeSite( session, { label = 'e2e-site' } = {} ) {
+	const dir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-site-' ) ) );
+
+	await git.init( { fs, dir, defaultBranch: TRUNK } );
+	for ( const [ file, content ] of Object.entries( TRUNK_FILES ) ) {
+		fs.writeFileSync( path.join( dir, file ), content );
+	}
+	await git.add( { fs, dir, filepath: Object.keys( TRUNK_FILES ) } );
+	const baseOid = await git.commit( { fs, dir, message: 'trunk', author: AUTHOR } );
+
+	fs.mkdirSync( path.join( dir, 'node_modules', 'react' ), { recursive: true } );
+	fs.writeFileSync( path.join( dir, SUBSTRATE ), SUBSTRATE_CONTENT );
+
+	// What `site:status` reads to decide the site is installed and built, so the
+	// app opens the working views instead of the setup wizard. The directory is
+	// what is checked, not its contents.
+	fs.mkdirSync( path.join( dir, 'build', 'wp-includes', 'js', 'dist' ), { recursive: true } );
+
+	return { dir, baseOid, settings: settingsFor( dir, label ) };
+}
+
+/**
+ * The store contents that make the app open on this site with nothing in the way.
+ *
+ * Dates are relative to now rather than fixed: the staleness dot appears once a
+ * snapshot is a fortnight old and joins the sidebar entry's accessible name when
+ * it does, so a hardcoded date would quietly change what the selectors match,
+ * months after anyone last read this file.
+ *
+ * @param {string} dir
+ * @param {string} label
+ * @return {Object}
+ */
+function settingsFor( dir, label ) {
+	const yesterday = new Date( Date.now() - 24 * 60 * 60 * 1000 ).toISOString();
+	return {
+		sites: [ dir ],
+		siteMeta: {
+			[ dir ]: {
+				initialized: true,
+				createdAt: yesterday,
+				label,
+				trunkDate: yesterday,
+				skipInitWizard: true,
+			},
+		},
+		preferences: {},
+	};
+}
+
+/**
+ * @param {string} dir
+ * @param {string} file
+ * @return {string}
+ */
+const read = ( dir, file ) => fs.readFileSync( path.join( dir, file ), 'utf8' );
+
+/**
+ * @param {string} dir
+ * @param {string} file
+ * @return {boolean}
+ */
+const exists = ( dir, file ) => fs.existsSync( path.join( dir, file ) );
+
+/**
+ * @param {string} dir
+ * @param {string} file
+ * @param {string} content
+ */
+const write = ( dir, file, content ) => fs.writeFileSync( path.join( dir, file ), content );
+
+/**
+ * The branches that exist in the repository, read from disk rather than from the
+ * app — so an assertion about a branch is about Git, not about what the app
+ * believes.
+ *
+ * @param {string} dir
+ * @return {Promise<string[]>}
+ */
+const branches = ( dir ) => git.listBranches( { fs, dir } );
+
+/**
+ * @param {string} dir
+ * @return {Promise<string>}
+ */
+const currentBranch = ( dir ) => git.currentBranch( { fs, dir, fullname: false } );
+
+module.exports = {
+	makeSite,
+	settingsFor,
+	read,
+	write,
+	exists,
+	branches,
+	currentBranch,
+	TRUNK,
+	SUBSTRATE,
+	SUBSTRATE_CONTENT,
+};

--- a/e2e/journeys/ticket-branches.spec.js
+++ b/e2e/journeys/ticket-branches.spec.js
@@ -1,0 +1,217 @@
+/**
+ * Ticket branches, driven through the app (#361).
+ *
+ * The flow a contributor performs by hand at a Contributor Day: link a ticket,
+ * edit something, link a second ticket, come back to the first. It is the flow
+ * #350 moves wholesale, and the one whose failures are silent — the app does not
+ * report work it quietly failed to restore.
+ *
+ * Assertions are marked as one of two kinds, and the distinction is the point of
+ * the file:
+ *
+ *   INVARIANT      must hold under any model of how the app stores work. If one
+ *                  of these goes red during #350, something is broken.
+ *   CHARACTERISATION  true because of how the app stores things today. If one of
+ *                  these goes red during #350, read it, decide whether the new
+ *                  model is what you meant, and update it deliberately.
+ *
+ * Nothing here asserts on the ticket's Trac or pull-request panels. Linking a
+ * ticket does start a GitHub lookup for its pull requests, so the app really
+ * does reach the network at that moment — but an assertion that depends on a
+ * third party being reachable is a flake waiting for a Monday morning, and none
+ * of these need one. Trac itself is only read when the contributor asks for it.
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { test, expect } = require( '../helpers/app.cjs' );
+const {
+	makeSite,
+	read,
+	write,
+	exists,
+	branches,
+	currentBranch,
+	TRUNK,
+	SUBSTRATE,
+	SUBSTRATE_CONTENT,
+} = require( '../helpers/git-site.cjs' );
+
+const MY_EDIT = '<?php // my fix for 60001\n';
+
+/**
+ * @param {string} dir
+ * @param {string} file
+ */
+const remove = ( dir, file ) => fs.unlinkSync( path.join( dir, file ) );
+
+/**
+ * The panel row for one ticket, in the list of a site's tickets.
+ *
+ * Addressed by the ticket it offers to continue rather than by position. Every
+ * row carries an identically labelled delete control, and the list is ordered by
+ * how recently each ticket was used — so `.first()` picks whichever ticket the
+ * app most recently touched, which is a different one depending on how far the
+ * render has got. That is a test that deletes the wrong branch and then fails
+ * somewhere else entirely.
+ *
+ * @param {Object} page
+ * @param {string} ticket
+ * @return {Object} The row locator.
+ */
+const ticketRow = ( page, ticket ) =>
+	page
+		.locator( 'div' )
+		.filter( { has: page.getByRole( 'button', { name: `Continue working on #${ ticket }`, exact: true } ) } )
+		.filter( { has: page.getByRole( 'button', { name: "Delete this ticket's work", exact: true } ) } )
+		.last();
+
+/**
+ * Links a ticket through the panel, the way a contributor does.
+ *
+ * Unlinks first when something is already linked, because that is the only route
+ * the app offers: once a ticket is linked its card shows that ticket's pull
+ * requests and attachments, and the "Trac ticket number or URL" field is not on
+ * screen at all. Unlinking is not throwing the ticket away — it parks the work
+ * on its branch and returns the checkout to trunk — but it is a step, and a test
+ * that skipped it would be testing a path no contributor can take.
+ *
+ * @param {Object} page
+ * @param {string} ticket
+ */
+async function linkTicket( page, ticket ) {
+	const unlink = page.getByRole( 'button', { name: 'Unlink', exact: true } );
+	if ( await unlink.isVisible().catch( () => false ) ) {
+		await unlink.click();
+		await expect( page.getByLabel( 'Trac ticket number or URL' ).first() ).toBeVisible();
+	}
+	await page.getByLabel( 'Trac ticket number or URL' ).first().fill( ticket );
+	await page.getByRole( 'button', { name: 'Link ticket', exact: true } ).first().click();
+	// The ticket number rendered as the panel's subject is the app saying it
+	// finished. Waiting on it rather than on a timeout is what keeps this honest
+	// on a Windows runner, where the checkout takes noticeably longer.
+	await expect( page.getByText( `#${ ticket }`, { exact: true } ).first() ).toBeVisible( { timeout: 30_000 } );
+}
+
+test( 'linking a ticket creates its branch and leaves trunk alone', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+
+	await linkTicket( page, '60001' );
+
+	// INVARIANT — the ticket is a branch in the repository, and it is the one
+	// checked out. Whatever the app records about it is secondary to this.
+	expect( await branches( site.dir ) ).toContain( 'ticket/60001' );
+	expect( await currentBranch( site.dir ) ).toBe( 'ticket/60001' );
+
+	// INVARIANT — the substrate survives. Reinstalling it costs a contributor
+	// minutes, and nothing in the app would report that it had gone.
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+
+	// CHARACTERISATION — the linked ticket and the branch it maps to are held in
+	// the store, per site.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	expect( meta.tracTicket ).toBe( 60001 );
+	expect( meta.currentBranch ).toBe( 'ticket/60001' );
+} );
+
+test( 'unlinking parks a ticket, and the next one starts from trunk', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+
+	await linkTicket( page, '60001' );
+	write( site.dir, 'wp-login.php', MY_EDIT );
+
+	await linkTicket( page, '60002' );
+
+	// INVARIANT — the second ticket starts from trunk. Seeing the first ticket's
+	// edit here would mean two tickets' work ending up in one patch, which is
+	// the failure a contributor discovers only when a reviewer asks about it.
+	expect( read( site.dir, 'wp-login.php' ) ).toBe( '<?php // trunk\n' );
+	expect( await currentBranch( site.dir ) ).toBe( 'ticket/60002' );
+	expect( await branches( site.dir ) ).toEqual(
+		expect.arrayContaining( [ TRUNK, 'ticket/60001', 'ticket/60002' ] )
+	);
+
+	// INVARIANT — still there, after a second checkout of the same directory.
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+
+	// INVARIANT — both tickets are offered in the panel, so the parked one is
+	// reachable rather than merely present in the repository.
+	await expect( page.getByText( '#60001', { exact: false } ).first() ).toBeVisible();
+} );
+
+test( 'switching back to a ticket restores its work byte for byte', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+
+	await linkTicket( page, '60001' );
+	write( site.dir, 'wp-login.php', MY_EDIT );
+	// A deletion too: an edit that comes back while a deletion does not is a
+	// partially restored tree, which is worse than an obvious failure.
+	remove( site.dir, 'doomed.php' );
+
+	await linkTicket( page, '60002' );
+	expect( exists( site.dir, 'doomed.php' ) ).toBe( true );
+
+	// Back to the first ticket, through the row the panel offers for it.
+	await page.getByRole( 'button', { name: 'switch', exact: true } ).click();
+	await expect
+		.poll( () => currentBranch( site.dir ), { timeout: 20_000 } )
+		.toBe( 'ticket/60001' );
+
+	// INVARIANT — both halves of the work return: the edit and the deletion.
+	expect( read( site.dir, 'wp-login.php' ) ).toBe( MY_EDIT );
+	expect( exists( site.dir, 'doomed.php' ) ).toBe( false );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+} );
+
+test( "deleting a ticket's work removes only that ticket", async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+	const confirmsAnswered = await session.acceptConfirms();
+
+	await linkTicket( page, '60001' );
+	write( site.dir, 'wp-login.php', MY_EDIT );
+	await linkTicket( page, '60002' );
+
+	// Unlink first: the list of a site's tickets deliberately leaves out the one
+	// currently linked — its card is the panel above — so the delete control for
+	// a ticket only exists once you are not on it. A contributor deleting the
+	// ticket they are working on takes this same route.
+	await page.getByRole( 'button', { name: 'Unlink', exact: true } ).click();
+
+	const row = ticketRow( page, '60002' );
+	await expect( row ).toBeVisible();
+	await row.getByRole( 'button', { name: "Delete this ticket's work", exact: true } ).click();
+
+	await expect
+		.poll( () => branches( site.dir ), { timeout: 30_000 } )
+		.not.toContain( 'ticket/60002' );
+
+	// INVARIANT — it deletes only what was asked for. The other ticket's work is
+	// untouched, the checkout is on trunk, and the substrate is still there.
+	expect( await branches( site.dir ) ).toContain( 'ticket/60001' );
+	expect( await currentBranch( site.dir ) ).toBe( TRUNK );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+
+	// INVARIANT — and the deleted ticket is gone from the panel, not merely from
+	// the repository. A row still offering to continue work that no longer
+	// exists is a dead end.
+	await expect(
+		page.getByRole( 'button', { name: 'Continue working on #60002', exact: true } )
+	).toHaveCount( 0 );
+	await expect(
+		page.getByRole( 'button', { name: 'Continue working on #60001', exact: true } )
+	).toBeVisible();
+
+	// INVARIANT — it asked first. A destructive action that skips the
+	// confirmation is a bug even when it deletes the right thing.
+	expect( await confirmsAnswered() ).toBe( 1 );
+
+	// CHARACTERISATION — the store drops the branch's record with it, and keeps
+	// the other one, including the base commit its patch is measured against.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	expect( Object.keys( meta.branches ) ).toEqual( [ 'ticket/60001' ] );
+	expect( meta.branches[ 'ticket/60001' ].baseOid ).toBe( site.baseOid );
+} );


### PR DESCRIPTION
**Stacked on #362.** Review that one first; this diff is only the three files under `e2e/` that this PR adds.

## Why

#362 built an engine and proved it works. This is the first thing it was built for: the ticket-branch flow, driven through the app rather than through a module.

That flow is what a contributor spends a Contributor Day inside — link a ticket, edit a file, realise it belongs to another ticket, come back later — and it is the flow #350 moves wholesale. Today it is verified by a person following a **How to test this** section. After this, it is verified on macOS and Windows on every pull request.

It is also the flow whose failures are silent. Work that is not restored produces no error; the app shows a clean tree and the contributor discovers the loss when a reviewer asks where the change went.

## What changes

Four journeys, and one addition to the engine.

- **Linking a ticket** creates its branch, checks it out, and leaves the gitignored substrate alone.
- **Unlinking parks the work**, and the next ticket starts from trunk with none of the first one's edits.
- **Switching back restores the work byte for byte** — the edit *and* the deletion. An edit that returns while a deletion does not is a half-restored tree, which is worse than an obvious failure.
- **Deleting a ticket's work** removes that branch and only that branch, after asking.

**Every assertion is marked `INVARIANT` or `CHARACTERISATION`,** and that is the point of the file rather than decoration. An invariant must hold under any model of how work is stored; a characterisation is true because of how the app stores things today. During #350, a red invariant is a bug and a red characterisation is a prompt to read it, decide whether the new model is what you meant, and update it on purpose. Without the distinction every failure looks the same, and the suite becomes noise at exactly the moment it is supposed to be useful.

**Two things the app does turned out not to match how the flow reads from the outside.** The tests follow the app:

- Linking a second ticket means unlinking the first. Once a ticket is linked, its card shows that ticket's pull requests and attachments and the ticket-number field is not on screen at all. Unlinking is not throwing the ticket away — it parks the work on its branch and returns the checkout to trunk — but it is a step, and a test that skipped it would exercise a path no contributor can take.
- A ticket cannot be deleted while it is the linked one, because the list of a site's tickets deliberately leaves out the current one. So the `wasActive` branch in the delete handler — the one that returns the checkout to trunk and clears the link — appears to be unreachable from the interface. Left alone here; noting it because it is the kind of thing worth knowing before #350 rewrites around it.

**The engine grows one thing: answering `window.confirm`.** Electron implements the JavaScript dialogs natively and blocks the renderer on them, so Playwright's `dialog` event never arrives — a test relying on it clicks "Delete this ticket's work" and watches nothing happen. Replacing `window.confirm` in the page works, and counting the calls lets a test assert that the app *asked* before it deleted anything.

**Deliberately not in this PR:** applying and reverting patches, and what survives a restart. Those are the next two in the stack.

## How to test this

Platforms: **any**. Windows is covered by CI, which is where the interesting half is.

**Starting state:** this branch, `npm ci` done, `npm run build:once` run once.

1. `npm run test:e2e`
   - Expected: 8 passed in under ten seconds — the four from #362 and the four here. Electron windows open and close as it goes.
2. Watch one of them rather than trusting the count: `npx playwright test --project=journeys -g "switching back" --headed`
   - Expected: the app opens, a ticket is linked, another, and the panel switches back. Nothing is typed by a human.
3. Break an invariant on purpose. In `e2e/journeys/ticket-branches.spec.js`, change `expect( read( site.dir, 'wp-login.php' ) ).toBe( MY_EDIT )` to any other string, then rerun.
   - Expected: "switching back to a ticket restores its work byte for byte" goes red on that line. Put it back.
4. Break the substrate on purpose. In `e2e/helpers/git-site.cjs`, delete the line that writes `SUBSTRATE_CONTENT`, then rerun.
   - Expected: every ticket-branch journey goes red. Put it back. This is the assertion that stands in for "a switch did not silently wipe `node_modules`".
5. `npm test` and `npm run lint`.
   - Expected: 1027 passed, and clean.

**What must not have happened:**

- **Your real settings file must not have been touched** — the guard from #362 covers this, and it is worth confirming once more now that the journeys write far more state than the engine test did.
- **No leftover directories.** Each journey builds a real repository under the system temp directory and removes it after the app stops. After a run, nothing matching `wpct-e2e-*` should remain.
- **No Electron processes still running.**

## Risks and limitations

- **Linking a ticket reaches the network, twice.** The app starts a GitHub lookup for the ticket's pull requests, and — because the ticket was linked by hand rather than restored on mount — it also auto-reads the ticket's own facts from Trac (#292). Nothing here asserts on either, and no journey waits for them, so an offline or rate-limited runner does not fail these tests. But both calls happen, and on a machine where Trac's human-check appears a window may open. An earlier version of this section said Trac is only read on request; that is true on mount and re-activation, and not true of a hand-linked ticket, which is what every journey here does.
- **Selectors read the visible copy.** Renaming "Link ticket" or "Delete this ticket's work" breaks these tests. That is deliberate — it makes the copy a contract — but it is a maintenance cost, and worth saying out loud rather than discovering in a rename.
- **Timing is waited for, never slept through.** Every step waits on something the app renders or on the state of the repository on disk. There is no `waitForTimeout` in the journeys, because a sleep tuned on a laptop is a flake on a Windows runner.
- The row for a ticket is addressed by the ticket it names, not by position: the list is ordered by how recently each ticket was used, so `.first()` picks a different branch depending on how far the render has got. That cost a wrong-branch deletion during development, which is why it is called out in a comment in the file.

## Related

Part of #359 and #361. Stacked on #362, which closes #360.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**A real repository per test, built from scratch.** These are Git operations; a stub would only prove the app can talk to a stub. The fixture mirrors the one the integration suite already uses one level down — same trunk branch, same three tracked files, same gitignored `node_modules` — so the two levels describe the same site and a failure at one level can be read against the other.

**Nothing is shared between tests.** Each builds its own repository and its own profile, so no journey can be affected by the order it runs in. It costs about a second per test, which is the right trade at this size.

**Assertions read the repository, not the app.** Whether a branch exists is asked of `isomorphic-git` against the directory on disk, not of the app that just claimed to have made it. An assertion that asks the app to confirm its own work is the "mocking the thing under test" shape from the review standard, one level up.

**Marking assertions rather than splitting the files.** An alternative was two files per flow, invariants in one and characterisations in the other. Rejected because the reason a characterisation exists is the invariant next to it — reading "the applied patch is a record in the store" is only useful beside "the contributor's edit comes back". Splitting them would put the two halves of one argument in different files.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`0 [fix here] · 1 [follow-up]`.

**🔵 architecture · `[follow-up]` — not this PR's to fix.** The `wasActive` branch of `branches:delete` in `src/main.js` returns the checkout to trunk and clears the link when the deleted ticket is the current one. The panel excludes the current ticket from the list it offers delete controls for, so that branch appears unreachable from the interface. Not touched here; worth confirming before #350 rewrites around it.

No findings in architecture (nothing under `src/` changes), security, performance, or cross-platform. The two cross-platform traps in this diff — path comparison and deleting directories the app still holds open — were fixed in #362 and are reused here rather than re-solved.

**Tests:** every invariant in this PR was verified by mutating it and confirming the test goes red. Seven mutations, seven reds:

| Mutated assertion | Result |
| --- | --- |
| the store records the linked ticket | red |
| the second ticket is the one checked out | red |
| the edit comes back on switch | red |
| the deletion comes back on switch | red |
| delete leaves the other ticket alone | red |
| delete asked for confirmation | red |
| the substrate survives a switch | red |

**Same caveat as #362:** this pass ran in the session that wrote the code, not in fresh context as the standard asks for.

</details>

