### PR TITLE
Move the testing detail out of CONTRIBUTING.md into TESTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,10 @@ see [`CONTRIBUTING.md`](CONTRIBUTING.md). It points back here; it does not resta
 See `package.json` scripts. To run a single test file (not exposed as a script):
 `node --test test/azure-sign.test.cjs`.
 
+**[TESTING.md](TESTING.md) is the canonical description of the suite** — the five layers it is made
+of, which one a new test belongs in, what each layer is blind to, and how to read a failure. Read it
+before adding or moving a test; do not restate it elsewhere.
+
 When writing manual test instructions, inspect the current renderer flow first and distinguish
 actions that happen automatically after linking a ticket from controls used only to retry or
 refresh them. Do not tell a tester to click a control when the app already starts that operation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ expected to do before opening a PR.
 
 ## Checks that run on every pull request
 
-Two GitHub Actions workflows run on every PR, and also on push to `trunk` so the default branch
+Three GitHub Actions workflows run on every PR, and also on push to `trunk` so the default branch
 carries a status a branch-protection rule can require. Neither needs secrets, and neither is
 credential-gated — everything here is safe to run on a public repository.
 
@@ -73,6 +73,92 @@ failing test>/trace.zip` replays it.
 `npm test` does not pick these up and never will: the unit runner only collects `test/`, and these
 live in `e2e/`. Keeping them out of `npm test` is deliberate — they need a built renderer and cost
 seconds each, and the unit suite has to stay something you run without thinking about it.
+
+## The test suite: five layers, and where a new test belongs
+
+The sections above say what CI runs. This one says what the suite *is*, because "add a test" is not
+a single instruction here — there are five places a test can go, and putting one in the wrong place
+is how a suite gets slow without getting better.
+
+They are listed cheapest first. That ordering is also the rule: **write a test at the highest layer
+that can still see the failure.** What each layer cannot see is the part worth reading — it is what
+sends a test one layer down, or up.
+
+**1. Unit** — 63 files. Starts nothing; calls plain functions. Pure logic: parsing a ticket
+reference, deriving a status, building a command line. Blind to anything touching disk, a process
+or a window.
+
+**2. Integration** — 6 files, 89 tests. Runs the real modules against real Git repositories in a
+temporary directory. Proves Git does what the code assumes when it switches a branch, applies a
+patch or updates trunk. Blind to everything above the module boundary.
+
+**3. IPC wiring** — one file, 151 tests. Loads the real `src/main.js` with `electron` replaced by
+a double, and exercises the ~58 handlers: what each returns, what it rejects, what error it gives.
+Blind to the window, and its store is a stand-in rather than the real one.
+
+**4. Journeys** — 8 tests. Starts the whole app, built from the source tree, and drives it. Asks
+the only question the other three cannot: can a contributor do their work without losing it. Blind
+to anything about packaging.
+
+**5. Packaged smoke** — 4 tests. Starts the built artifact, the `.app` or `.exe` a user downloads,
+and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
+
+Layers 1–3 are `npm test`: 1,027 tests in under three seconds, and nothing leaves the machine — the
+one suite that needs a Git remote serves it from a loopback server it starts itself. Layers 4 and 5
+are the two `test:e2e` commands. That proportion, a thousand cheap tests to a dozen expensive ones,
+is the shape to keep.
+
+### Why layers 4 and 5 are separate, and why both exist
+
+They test **the same source code in two different containers**, and each container has failures the
+other cannot have.
+
+Layer 4 runs the code the way `npm start` does: `src/main.js` on disk, `node_modules` beside it.
+Layer 5 runs the artifact `electron-builder` produces, where all of `src/` and every production
+dependency is compressed into a single `app.asar`, and native modules are pulled back out beside it
+because the operating system cannot load a binary from inside an archive. A path that resolves from
+a directory may not resolve from inside that archive; a native binary can be selected for the wrong
+runtime while `npm ci` and the packaging both exit 0 and the app still starts. Those failures do not
+exist in the source tree, because there is nothing packaged to get wrong.
+
+So layer 5 asks only whether the container is intact — it boots, the whole preload bridge is there,
+the modules that only resolve if packaging worked do resolve — and **writes no state at all**.
+
+That last part is not minimalism, it is a constraint. The app only honours a redirected
+application-data directory in development builds (`!app.isPackaged` in `src/main.js`); the packaged
+app always writes to the real site registry of whoever runs it. So a test that drives a *flow* —
+linking tickets, creating branches, applying patches — cannot run against the artifact without
+writing to somebody's actual sites. Layer 4 exists in the shape it does for that reason as much as
+for speed.
+
+**The gap this leaves**, stated plainly: a flow that behaves differently *because* of packaging
+would be caught by neither layer. Layer 5 covers it only indirectly — if the container is intact,
+the code inside it is the same code. Closing it properly would mean letting the packaged app accept
+a redirected data directory under a test-only condition, which is a seam in shipped software and is
+not worth opening until a failure of that shape actually escapes.
+
+### Where to put a new test
+
+- **A pure function, a derived string, a decision with branches** → layer 1. If it lives inside
+  `src/renderer/index.jsx` today, move it to a `src/renderer/*.cjs` module first: that component
+  mounts at module scope and nothing in the suite can load it, so a decision made there is
+  untestable by construction.
+- **Anything that asks Git a question** → layer 2, against a real repository. There is a local Git
+  server fixture in `test/trunk-update-fetch.integration.test.cjs` for the cases that need a remote,
+  because `isomorphic-git` has no `file://` transport.
+- **A new IPC handler** → layer 3, plus the `contextBridge` entry, which layer 5 checks is actually
+  exposed.
+- **A flow that spans the interface, the main process, Git and the store at once** → layer 4. Keep
+  this layer small on purpose: every test costs an app launch, and any assertion that does not need
+  a window belongs one layer down.
+- **Something that can only break during packaging** → layer 5.
+
+The failures worth layer 4 are the ones that fall *between* the other layers, where every piece
+works and the whole does not. One example, found while writing the first journeys: the integration
+tests prove branch switching restores work correctly, and the wiring tests prove the delete handler
+returns the checkout to trunk when the deleted branch was the current one — but the interface leaves
+the currently linked ticket out of the list it offers delete controls for, so that branch of the
+handler cannot be reached by a contributor at all. Three layers passing, one path dead.
 
 ## The review standard, and who reads it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ expected to do before opening a PR.
 ## Checks that run on every pull request
 
 Three GitHub Actions workflows run on every PR, and also on push to `trunk` so the default branch
-carries a status a branch-protection rule can require. Neither needs secrets, and neither is
+carries a status a branch-protection rule can require. None needs a secret, and none is
 credential-gated — everything here is safe to run on a public repository.
 
 ### Lint — [`.github/workflows/lint.yml`](.github/workflows/lint.yml)
@@ -26,139 +26,21 @@ executes the PR's code** (this repo's `postinstall` would otherwise pull the Ele
 the linter does not need). If ESLint flags something mechanical, `npm run lint:fix` handles it;
 check what it rewrote before committing, since it too is repo-wide.
 
-### Unit tests — [`.github/workflows/unit-tests.yml`](.github/workflows/unit-tests.yml)
+### Tests — [`unit-tests.yml`](.github/workflows/unit-tests.yml) and [`e2e.yml`](.github/workflows/e2e.yml)
 
-The unit suite runs on the **two platforms the app ships to — macOS and Windows** — and on each
-platform it runs **twice**:
+Everything runs on the **two platforms the app ships to, macOS and Windows**:
 
-- `npm test` — on the system Node pinned in `.nvmrc`.
-- `npm run test:electron` — on the Node that Electron bundles.
+- **The fast suite** (`npm test`) — and on each platform it runs **twice**, once on the system Node
+  pinned in `.nvmrc` and once on the Node that Electron bundles. That second pass is not redundant:
+  child processes in this app run on Electron's own Node, and the two versions are set independently
+  and have drifted before (#37/#46).
+- **The end-to-end suites** (`npm run test:e2e`, and the packaged one) — on every pull request that
+  is not a draft, as two jobs, because one takes seconds and the other packages the app first.
 
-That second pass is not redundant. Child processes in this app run on Electron's own Node, not the
-system Node, and the two versions are set independently and have drifted before (#37/#46). Running
-both is how a drift gets caught before it ships. The matrix uses `fail-fast: false`, so a Windows
-failure never hides the macOS result — you always see both.
+Every matrix uses `fail-fast: false`, so a Windows failure never hides the macOS result.
 
-### End-to-end tests — [`.github/workflows/e2e.yml`](.github/workflows/e2e.yml)
-
-Two suites, both launching a real app on macOS and Windows for every pull request that is not a
-draft. They answer different questions, so they are separate jobs and separate commands.
-
-- `npm run test:e2e` — **the journeys**. Drives the app built from the source tree through the flows
-  a contributor performs by hand: linking a ticket, applying and reverting a patch, moving between
-  ticket branches. Each test gets its own throwaway application-data directory and its own Git
-  fixture, so nothing it does can reach the sites you actually work on — and the harness refuses to
-  start at all if it ever finds the app using a different profile. Nothing here touches the network.
-  Seconds to run.
-- `npm run test:e2e:packaged` — **the packaged smoke test**. Launches an unsigned
-  `electron-builder --dir` build and asks only whether packaging worked: it boots, the whole preload
-  bridge is exposed, and the modules that exist only if packaging succeeded do resolve. Build it
-  first, or the test will tell you to:
-
-  ```
-  npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
-  ```
-
-  That environment variable is mandatory on macOS — electron-builder signs during `--dir` without
-  it — and harmless everywhere else.
-
-Neither downloads a browser. The only thing they launch is the Electron already in the tree, so
-there is no `playwright install` step anywhere.
-
-When one fails, the run keeps the trace, and the journeys additionally attach the screen and the
-state the app had persisted at the moment it failed — the interesting half of a failure in this app
-is usually on disk rather than on screen. Locally, `npx playwright show-trace test-results/<the
-failing test>/trace.zip` replays it.
-
-`npm test` does not pick these up and never will: the unit runner only collects `test/`, and these
-live in `e2e/`. Keeping them out of `npm test` is deliberate — they need a built renderer and cost
-seconds each, and the unit suite has to stay something you run without thinking about it.
-
-## The test suite: five layers, and where a new test belongs
-
-The sections above say what CI runs. This one says what the suite *is*, because "add a test" is not
-a single instruction here — there are five places a test can go, and putting one in the wrong place
-is how a suite gets slow without getting better.
-
-They are listed cheapest first. That ordering is also the rule: **write a test at the highest layer
-that can still see the failure.** What each layer cannot see is the part worth reading — it is what
-sends a test one layer down, or up.
-
-**1. Unit** — 63 files. Starts nothing; calls plain functions. Pure logic: parsing a ticket
-reference, deriving a status, building a command line. Blind to anything touching disk, a process
-or a window.
-
-**2. Integration** — 6 files, 89 tests. Runs the real modules against real Git repositories in a
-temporary directory. Proves Git does what the code assumes when it switches a branch, applies a
-patch or updates trunk. Blind to everything above the module boundary.
-
-**3. IPC wiring** — one file, 151 tests. Loads the real `src/main.js` with `electron` replaced by
-a double, and exercises the ~58 handlers: what each returns, what it rejects, what error it gives.
-Blind to the window, and its store is a stand-in rather than the real one.
-
-**4. Journeys** — 8 tests. Starts the whole app, built from the source tree, and drives it. Asks
-the only question the other three cannot: can a contributor do their work without losing it. Blind
-to anything about packaging.
-
-**5. Packaged smoke** — 4 tests. Starts the built artifact, the `.app` or `.exe` a user downloads,
-and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
-
-Layers 1–3 are `npm test`: 1,027 tests in under three seconds, and nothing leaves the machine — the
-one suite that needs a Git remote serves it from a loopback server it starts itself. Layers 4 and 5
-are the two `test:e2e` commands. That proportion, a thousand cheap tests to a dozen expensive ones,
-is the shape to keep.
-
-### Why layers 4 and 5 are separate, and why both exist
-
-They test **the same source code in two different containers**, and each container has failures the
-other cannot have.
-
-Layer 4 runs the code the way `npm start` does: `src/main.js` on disk, `node_modules` beside it.
-Layer 5 runs the artifact `electron-builder` produces, where all of `src/` and every production
-dependency is compressed into a single `app.asar`, and native modules are pulled back out beside it
-because the operating system cannot load a binary from inside an archive. A path that resolves from
-a directory may not resolve from inside that archive; a native binary can be selected for the wrong
-runtime while `npm ci` and the packaging both exit 0 and the app still starts. Those failures do not
-exist in the source tree, because there is nothing packaged to get wrong.
-
-So layer 5 asks only whether the container is intact — it boots, the whole preload bridge is there,
-the modules that only resolve if packaging worked do resolve — and **writes no state at all**.
-
-That last part is not minimalism, it is a constraint. The app only honours a redirected
-application-data directory in development builds (`!app.isPackaged` in `src/main.js`); the packaged
-app always writes to the real site registry of whoever runs it. So a test that drives a *flow* —
-linking tickets, creating branches, applying patches — cannot run against the artifact without
-writing to somebody's actual sites. Layer 4 exists in the shape it does for that reason as much as
-for speed.
-
-**The gap this leaves**, stated plainly: a flow that behaves differently *because* of packaging
-would be caught by neither layer. Layer 5 covers it only indirectly — if the container is intact,
-the code inside it is the same code. Closing it properly would mean letting the packaged app accept
-a redirected data directory under a test-only condition, which is a seam in shipped software and is
-not worth opening until a failure of that shape actually escapes.
-
-### Where to put a new test
-
-- **A pure function, a derived string, a decision with branches** → layer 1. If it lives inside
-  `src/renderer/index.jsx` today, move it to a `src/renderer/*.cjs` module first: that component
-  mounts at module scope and nothing in the suite can load it, so a decision made there is
-  untestable by construction.
-- **Anything that asks Git a question** → layer 2, against a real repository. There is a local Git
-  server fixture in `test/trunk-update-fetch.integration.test.cjs` for the cases that need a remote,
-  because `isomorphic-git` has no `file://` transport.
-- **A new IPC handler** → layer 3, plus the `contextBridge` entry, which layer 5 checks is actually
-  exposed.
-- **A flow that spans the interface, the main process, Git and the store at once** → layer 4. Keep
-  this layer small on purpose: every test costs an app launch, and any assertion that does not need
-  a window belongs one layer down.
-- **Something that can only break during packaging** → layer 5.
-
-The failures worth layer 4 are the ones that fall *between* the other layers, where every piece
-works and the whole does not. One example, found while writing the first journeys: the integration
-tests prove branch switching restores work correctly, and the wiring tests prove the delete handler
-returns the checkout to trunk when the deleted branch was the current one — but the interface leaves
-the currently linked ticket out of the list it offers delete controls for, so that branch of the
-handler cannot be reached by a contributor at all. Three layers passing, one path dead.
+**[TESTING.md](TESTING.md) is the full picture** — what to run locally, the five layers the suite is
+made of, where a new test belongs, and how to read a failure. Read it before adding a test.
 
 ## The review standard, and who reads it
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,173 @@
+# Testing
+
+Everything about tests in this repository: what to run, what the suite is made of, and where a new
+test belongs. [CONTRIBUTING.md](CONTRIBUTING.md) points here rather than repeating any of it.
+
+## What to run
+
+```
+npm test                    # the fast suite — 1,027 tests, under three seconds
+npm run test:e2e            # the app, driven — 8 tests, seconds
+npm run lint                # ESLint over the whole repo
+```
+
+`npm test` is the one to run without thinking about it. It touches no network: the single suite
+that needs a Git remote starts a loopback server and serves the repository to itself.
+
+Two more, for when you need them:
+
+```
+npm run test:electron       # the fast suite again, on the Node that Electron bundles
+npm run test:e2e:packaged   # the built artifact — needs a build first, see below
+```
+
+To run one file: `node --test test/azure-sign.test.cjs`. To run one journey:
+`npx playwright test --project=journeys -g "switching back"`, and add `--headed` to watch it happen.
+
+## The five layers
+
+"Add a test" is not a single instruction here. There are five places a test can go, and putting one
+in the wrong place is how a suite gets slow without getting better.
+
+They are listed cheapest first, and that ordering is the rule: **write a test at the highest layer
+that can still see the failure.** What each layer is blind to is the part worth reading — it is what
+sends a test one layer up, or down.
+
+**1. Unit** — 63 files in `test/`. Starts nothing; calls plain functions. Pure logic: parsing a
+ticket reference, deriving a status, building a command line. Blind to anything touching disk, a
+process or a window.
+
+**2. Integration** — 6 files, 89 tests, named `*.integration.test.cjs`. Runs the real modules
+against real Git repositories in a temporary directory. Proves Git does what the code assumes when
+it switches a branch, applies a patch or updates trunk. Blind to everything above the module
+boundary.
+
+**3. IPC wiring** — one file, `test/ipc-wiring.test.cjs`, 151 tests. Loads the real `src/main.js`
+with `electron` replaced by a double, and exercises the ~58 handlers: what each returns, what it
+rejects, what error it gives. Blind to the window, and its store is a stand-in rather than the real
+one.
+
+**4. Journeys** — `e2e/journeys/`, 8 tests. Starts the whole app, built from the source tree, and
+drives it. Asks the only question the other three cannot: can a contributor do their work without
+losing it. Blind to anything about packaging.
+
+**5. Packaged smoke** — `e2e/packaged/`, 4 tests. Starts the built artifact — the `.app` or `.exe`
+a user downloads — and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
+
+Layers 1–3 are `npm test`. Layers 4 and 5 are the two `test:e2e` commands. That proportion, a
+thousand cheap tests to a dozen expensive ones, is the shape to keep.
+
+## Where to put a new test
+
+- **A pure function, a derived string, a decision with branches** → layer 1. If it lives inside
+  `src/renderer/index.jsx` today, move it to a `src/renderer/*.cjs` module first: that component
+  mounts at module scope and nothing in the suite can load it, so a decision made there is
+  untestable by construction.
+- **Anything that asks Git a question** → layer 2, against a real repository. There is a local Git
+  server fixture in `test/trunk-update-fetch.integration.test.cjs` for cases that need a remote,
+  because `isomorphic-git` has no `file://` transport.
+- **A new IPC handler** → layer 3, plus the `contextBridge` entry in `src/preload.js`, which layer 5
+  checks is actually exposed.
+- **A flow that spans the interface, the main process, Git and the store at once** → layer 4.
+- **Something that can only break during packaging** → layer 5.
+
+Keep layer 4 small on purpose. Every test there costs an app launch, and any assertion that does not
+need a window belongs one layer down.
+
+The failures worth layer 4 are the ones that fall *between* the other layers, where every piece works
+and the whole does not. One example, found while writing the first journeys: the integration tests
+prove branch switching restores work correctly, and the wiring tests prove the delete handler returns
+the checkout to trunk when the deleted branch was the current one — but the interface leaves the
+currently linked ticket out of the list it offers delete controls for, so that branch of the handler
+cannot be reached by a contributor at all. Three layers passing, one path dead.
+
+## The two end-to-end layers, and why they are separate
+
+They run **the same source code in two different containers**, and each container has failures the
+other cannot have.
+
+Layer 4 runs the code the way `npm start` does: `src/main.js` on disk, `node_modules` beside it.
+Layer 5 runs what `electron-builder` produces, where all of `src/` and every production dependency is
+compressed into a single `app.asar`, and native modules are pulled back out beside it because the
+operating system cannot load a binary from inside an archive. A path that resolves from a directory
+may not resolve from inside that archive; a native binary can be selected for the wrong runtime while
+`npm ci` and the packaging both exit 0 and the app still starts. Those failures do not exist in the
+source tree, because there is nothing packaged to get wrong.
+
+So layer 5 asks only whether the container is intact, and **writes no state at all**.
+
+That last part is a constraint, not minimalism. The app only honours a redirected application-data
+directory in development builds (`!app.isPackaged` in `src/main.js`); the packaged app always writes
+to the real site registry of whoever runs it. So a test that drives a flow cannot run against the
+artifact without writing to somebody's actual sites.
+
+Layer 4 gets a throwaway application-data directory per test, and the harness reads back the path the
+app chose and **refuses to run** if it is not the throwaway one. Nothing a journey does can reach the
+sites you work on.
+
+**The gap this leaves**, stated plainly: a flow that behaves differently *because* of packaging is
+caught by neither layer. Layer 5 covers it only indirectly — if the container is intact, the code
+inside it is the same code. Closing it properly would mean letting the packaged app accept a
+redirected data directory under a test-only condition, which is a seam in shipped software and is not
+worth opening until a failure of that shape actually escapes.
+
+## Running the packaged smoke test
+
+It needs an artifact, so build one first:
+
+```
+npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
+npm run test:e2e:packaged
+```
+
+`CSC_IDENTITY_AUTO_DISCOVERY=false` is mandatory on macOS — electron-builder signs during `--dir`
+without it — and harmless everywhere else. The test tells you if you forgot the build.
+
+Neither end-to-end command downloads a browser. The only thing they launch is the Electron already in
+the tree, so there is no `playwright install` step anywhere.
+
+## Reading a failure
+
+Every end-to-end failure keeps a Playwright trace. Replay it with:
+
+```
+npx playwright show-trace test-results/<the failing test>/trace.zip
+```
+
+A failing journey also attaches the screen and the state the app had persisted at that moment,
+because the interesting half of a failure in this app is usually on disk rather than on screen. In
+CI both come back as a workflow artifact.
+
+## What CI runs
+
+Three workflows, on every pull request and on push to `trunk`. None needs a secret.
+
+**[`lint.yml`](.github/workflows/lint.yml)** — `eslint . --max-warnings=0` over the whole repo. It
+installs with `npm ci --ignore-scripts`, so linting never executes the pull request's code.
+
+**[`unit-tests.yml`](.github/workflows/unit-tests.yml)** — layers 1–3 on macOS and Windows, and on
+each platform **twice**: once on the system Node pinned in `.nvmrc`, once on the Node that Electron
+bundles. That second pass is not redundant. Child processes in this app run on Electron's own Node,
+and the two versions are set independently and have drifted before (#37/#46).
+
+**[`e2e.yml`](.github/workflows/e2e.yml)** — layers 4 and 5 on macOS and Windows, as two jobs for
+every pull request that is not a draft. They are separate because they cost very different amounts:
+the journeys take seconds, and packaging takes several minutes per platform.
+
+Every matrix uses `fail-fast: false`, so a Windows failure never hides the macOS result.
+
+## Conventions
+
+- `npm test` collects `test/` only, and never picks up `e2e/`. That is deliberate: end-to-end tests
+  need a built renderer and cost seconds each, and the fast suite has to stay something you run
+  without thinking.
+- End-to-end selectors read the text and roles already on screen. No `data-testid` — the visible copy
+  is the contract, and renaming a button is a change worth noticing.
+- Journeys mark each assertion as an **invariant** (must hold under any model of how work is stored)
+  or a **characterisation** (true because of how the app stores things today). A red invariant is a
+  bug; a red characterisation is a prompt to read it and update it deliberately.
+- A bugfix's test must fail on the old code. A test written after the fix pins whatever the current
+  behaviour is, rather than the correction.
+
+The full review standard, including what counts as a test-shaped finding, is in
+[`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).


### PR DESCRIPTION
**Stacked on #363.** Review that one first; this diff is `TESTING.md`, plus a much shorter testing section in `CONTRIBUTING.md`.

## Why

CONTRIBUTING.md is the map of this project's guardrails. Testing had grown to half of it — 134 of 271 lines describing five layers, two containers and a constraint in the packaged app — so a contributor arriving to ask "what will fail on my PR" had to read all of that first.

The detail is worth having. It just is not what belongs on that page.

The need for it surfaced in a plain question there was no good answer to: *shouldn't the unit tests cover the code, and the end-to-end tests cover the artifact built from it?* It is the natural reading, and answering it properly needs the whole map — which lived in nobody's head but the person who had just built the last two layers.

## What changes

**New `TESTING.md`** — the canonical description of the suite:

- **What to run.** Three commands at the top, then the two you need less often, then how to run a single file or a single journey.
- **The five layers**, cheapest first, each leading with **what it is blind to** — the fact that actually sends a test one layer up or down. Unit, integration against real Git repositories, IPC wiring with a stubbed Electron, journeys through the whole app, and the packaged smoke test.
- **Where a new test belongs**, by kind of change, with the rule the ordering implies: write it at the highest layer that can still see the failure.
- **Why the two end-to-end layers are separate.** They run the same source in two containers, and each container has failures the other cannot have.
- **How to read a failure**, what CI runs, and the conventions a new test is expected to follow.

**`CONTRIBUTING.md` keeps only what a reader needs at that point** — both platforms, the fast suite run twice per platform and why, the end-to-end suites as two jobs — and links to `TESTING.md` for the rest. It goes back to roughly the length it was before this stack started: 150 lines on `trunk`, 153 now, with the third workflow properly represented.

**`AGENTS.md` gets the same pointer.** An agent adding a test is exactly who needs to know which layer it belongs in.

This follows the rule the repository already uses for the review standard: one source of truth, everything else pointing at it rather than restating it, so nothing can drift.

Two things `TESTING.md` says out loud rather than implying:

**The end-to-end split is forced, not preferred.** The packaged app ignores a redirected application-data directory — `!app.isPackaged` in `src/main.js` — so it always writes to the real site registry of whoever runs it. A test that drives a flow therefore cannot run against the artifact without writing to somebody's actual sites. That constraint is why the packaged smoke test writes no state, and reading it as minimalism leads to the wrong conclusion about what belongs where.

**The gap that leaves.** A flow that behaves differently *because* of packaging is caught by neither layer. The page names it, says what closing it would cost — a test-only seam in shipped software — and says it is not worth opening until a failure of that shape actually escapes.

It also fixes the opening paragraph of the checks section, which said "Neither needs secrets" while listing three workflows.

## How to test this

Platforms: **any**. This is documentation; there is no user-visible surface.

1. Read `TESTING.md` top to bottom.
   - Expected: it answers "what do I run?" in the first ten lines and "where does my new test go?" without needing anything else open.
2. Read the `### Tests` section of `CONTRIBUTING.md`.
   - Expected: it tells you what CI will run against your PR and nothing more, and points at `TESTING.md` for the rest.
3. Check every number and command, because they date fast:
   ```
   ls test/*.test.cjs | grep -vc integration                                   # 63 unit files
   ls test/*.integration.test.cjs | wc -l                                      # 6 integration files
   for f in test/*.integration.test.cjs; do grep -cE '^(test|it)\(' $f; done | paste -sd+ - | bc   # 89
   grep -cE '^(test|it)\(' test/ipc-wiring.test.cjs                            # 151
   grep -c "ipcMain.handle(" src/main.js                                       # 58
   npm test                                                                    # 1027, ~2.7s
   ```
4. Follow the links. Every relative link in `TESTING.md`, `CONTRIBUTING.md` and `AGENTS.md` should resolve to a file that exists, and every `npm run …` it mentions should be a real script in `package.json`.
5. `npm run lint`.
   - Expected: clean.

**What must not have happened:** no code changed. `git diff --stat` against the base should show three Markdown files and nothing else.

## Risks and limitations

- **The counts go stale.** Six numbers in this section describe the repository as it is today, and nothing checks them. They are there because "63 files" and "8 tests" say something about proportion that "several" does not, and the proportion is the point of the section. The commands above regenerate all of them in a few seconds.
- **The five-layer count is a description, not a rule.** If a sixth kind of test earns its place, the section is where that argument gets made — it should not become a reason to squeeze a test into a layer it does not fit.
- This is one long section on a page that is already long. It sits after the CI checks because the first question a contributor has is "what will fail on my PR"; the second is "where does my test go".
- **Written as prose, not as a table.** The first draft used one, and it was wrong for this repository: no document here has a single Markdown table, every page is hard-wrapped at around 100 columns, and the table's rows ran to 236 characters — three times the width of anything else in the file. Rewritten as one paragraph per layer, wrapped like its neighbours. The longest line in the section is now 107, which is exactly the longest line already on the page.

## Related

Part of #359. Stacked on #363.


