### PR TITLE
Let a journey be watched, and say what its trace really holds

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -22,7 +22,8 @@ npm run test:e2e:packaged   # the built artifact — needs a build first, see be
 ```
 
 To run one file: `node --test test/azure-sign.test.cjs`. To run one journey:
-`npx playwright test --project=journeys -g "switching back"`, and add `--headed` to watch it happen.
+`npx playwright test --project=journeys -g "switching back"`. A journey opens and closes the app as
+it goes; there is no headless mode and nothing to turn off.
 
 ## The five layers
 
@@ -124,19 +125,80 @@ npm run test:e2e:packaged
 without it — and harmless everywhere else. The test tells you if you forgot the build.
 
 Neither end-to-end command downloads a browser. The only thing they launch is the Electron already in
-the tree, so there is no `playwright install` step anywhere.
+the tree, which is why CI has no `playwright install` step. The one exception is the Inspector, and
+it is opt-in — see above.
+
+## Auditing an end-to-end test
+
+A test that asserts nothing passes. For a suite whose entire content is tests, that is the risk that
+matters, and neither a green run nor a recording of one will tell you: both look identical whether
+the assertion is load-bearing or decorative.
+
+**The way to audit a journey is to break what it claims and confirm it goes red.** One assertion at
+a time. Worked example — "switching back to a ticket restores its work byte for byte" says the
+contributor's edit comes back, so make that false and see whether the test notices:
+
+```
+# in e2e/journeys/ticket-branches.spec.js, find the line asserting the edit came
+# back — it ends `.toBe( MY_EDIT );` — and swap MY_EDIT for any other string:
+#     .toBe( 'anything else' );
+
+npx playwright test --project=journeys -g "switching back"   # must FAIL, on that line
+git checkout e2e/journeys/ticket-branches.spec.js            # put it back
+```
+
+If it stays green, the assertion is not reaching what it says it is, and the test is decoration.
+Every invariant in these journeys was checked this way before its pull request was opened; each is
+worth rechecking after a change to the code beneath it.
+
+Two mistakes to avoid when doing this. Break **one** assertion per run, or a failure tells you
+nothing about which. And run the **single** test by name — the same expression often appears in more
+than one journey, and a mutation applied to the first occurrence while running a different test
+reports a green that means nothing.
+
+**The second half of an audit is reading the test.** Roughly half of each journey happens on disk
+with no interface: the test edits a file, deletes another, and then reads the working tree back.
+None of that is on screen, and none of it can be watched. The twenty lines of the test are the
+description of what it does; there is no substitute for them.
+
+<details>
+<summary>Watching one run, and when that helps</summary>
+
+Recording a run answers one narrow question — **is this driving the app, or passing through a shell
+that happens to satisfy its assertions?** — and helps with a CI failure on a platform you cannot
+reach. It does not tell you what a test does, for the reason above.
+
+```
+E2E_VIDEO=/tmp/e2e-video npm run test:e2e
+open /tmp/e2e-video/switching-back-to-a-ticket-restores-its-work-byte-for-byte.webm
+```
+
+One `.webm` per test, named after it; a test that closes and reopens the app records both launches
+as `-1` and `-2`. They run about a second and a half at 25 frames per second, so step through them
+rather than pressing play.
+
+`PWDEBUG=1` pauses before each action instead, and lets you advance the run yourself. It opens the
+Playwright Inspector, which is a browser window, so it needs `npx playwright install chromium` once
+— the only browser this repository ever wants, and nothing else here uses it. Without it the run
+pauses with no window to drive it from, which reads as a hang. The Inspector knows Playwright's
+actions and not the filesystem steps between them, so it has the same blind spot as the recording.
+
+</details>
 
 ## Reading a failure
 
-Every end-to-end failure keeps a Playwright trace. Replay it with:
+Every end-to-end failure keeps a Playwright trace:
 
 ```
 npx playwright show-trace test-results/<the failing test>/trace.zip
 ```
 
-A failing journey also attaches the screen and the state the app had persisted at that moment,
-because the interesting half of a failure in this app is usually on disk rather than on screen. In
-CI both come back as a workflow artifact.
+For an Electron test that trace is an action log rather than a replay: each step, its timing and the
+line of source it came from.
+
+A failing journey also attaches the screen at the moment it failed and the state the app had
+persisted, because the interesting half of a failure in this app is usually on disk rather than on
+screen. In CI both come back as a workflow artifact.
 
 ## What CI runs
 

--- a/e2e/helpers/app.cjs
+++ b/e2e/helpers/app.cjs
@@ -65,6 +65,13 @@ function samePath( a, b ) {
 const EMPTY_SETTINGS = Object.freeze( { sites: [], siteMeta: {}, preferences: {} } );
 
 /**
+ * Where to record each journey, so a person can watch what the test did:
+ * `E2E_VIDEO=/tmp/e2e-video npm run test:e2e`. Unset, nothing is recorded and
+ * the launch is exactly what it would otherwise be.
+ */
+const VIDEO_DIR = process.env.E2E_VIDEO || '';
+
+/**
  * A session of the app under test: one throwaway profile, one app at a time.
  *
  * Split into `new Session()` and `start()` on purpose. A spec usually has to build
@@ -79,6 +86,7 @@ class Session {
 		this.app = null;
 		this.page = null;
 		this.scratch = [];
+		this.videos = [];
 	}
 
 	/**
@@ -132,6 +140,11 @@ class Session {
 			// harness use.
 			executablePath: require( 'electron' ),
 			args: [ ...ELECTRON_SWITCHES, REPO_ROOT ],
+			// Watching a run is only ever a question of recording it. `_electron.launch`
+			// takes `recordVideo` but not `slowMo`, and Playwright drops launch options it
+			// does not recognise without a word — so a `slowMo` added here would leave the
+			// tests passing at full speed and look like it had worked.
+			...( VIDEO_DIR ? { recordVideo: { dir: VIDEO_DIR } } : {} ),
 			env: {
 				...process.env,
 				TZ: 'UTC',
@@ -142,6 +155,10 @@ class Session {
 			},
 		} );
 		this.page = await this.app.firstWindow();
+		if ( VIDEO_DIR ) {
+			const video = this.page.video();
+			if ( video ) this.videos.push( video );
+		}
 
 		// Belt and braces over the env var above. If the redirect hook ever stops
 		// firing — it is guarded by `!app.isPackaged` — every journey would start
@@ -245,6 +262,50 @@ class Session {
 		if ( proc && proc.exitCode === null ) proc.kill();
 	}
 
+	/**
+	 * Saves each recording under a name that says which test it came from, and
+	 * clears away everything else the recorder left behind.
+	 *
+	 * Playwright names a recording after the page that produced it — an opaque
+	 * hash — and writes one for every window the run opened, most of which are
+	 * empty or a fraction of a second long. A directory of twenty files called
+	 * `page@24b3324…webm`, three of which are worth opening, is not something to
+	 * hand a contributor and call a feature.
+	 *
+	 * Call after `close()`: the recording is only finished once the app is gone.
+	 *
+	 * @param {string} name Slug for the test, used as the file name.
+	 * @return {Promise<string[]>} The paths written.
+	 */
+	async saveVideos( name ) {
+		if ( ! VIDEO_DIR || ! this.videos.length ) return [];
+
+		const written = [];
+		for ( const [ i, video ] of this.videos.entries() ) {
+			// One per launch: a journey that closes and reopens the app to prove
+			// something persisted has two, and both are worth keeping.
+			const suffix = this.videos.length > 1 ? `-${ i + 1 }` : '';
+			const file = path.join( VIDEO_DIR, `${ name }${ suffix }.webm` );
+			try {
+				await video.saveAs( file );
+				written.push( file );
+			} catch {
+				// A window that closed before a single frame was captured has
+				// nothing to save. Not worth failing a passing test over.
+			}
+		}
+		this.videos = [];
+
+		// Whatever the recorder wrote under its own names is now duplicated under
+		// the names above, or was empty to begin with.
+		for ( const left of fs.readdirSync( VIDEO_DIR ) ) {
+			if ( left.startsWith( 'page@' ) && left.endsWith( '.webm' ) ) {
+				fs.rmSync( path.join( VIDEO_DIR, left ), { force: true } );
+			}
+		}
+		return written;
+	}
+
 	dispose() {
 		for ( const dir of this.scratch.splice( 0 ) ) {
 			fs.rmSync( dir, { recursive: true, force: true } );
@@ -275,6 +336,7 @@ const test = base.extend( {
 		}
 
 		await session.close();
+		await session.saveVideos( testInfo.title.replace( /[^a-z0-9]+/gi, '-' ).toLowerCase() );
 		session.dispose();
 	},
 } );


### PR DESCRIPTION
**Stacked on #365.** Review that one first; this diff is one line of code and a section of `TESTING.md`.

## Why

The journeys are over in eight seconds. That is what makes them worth running on every pull request, and it is useless when the question is the one that matters for a suite of tests: **is this driving the app, or passing through a shell that happens to satisfy its assertions?** A green run looks identical either way.

There was no way to look. This adds one, and corrects something the guide said about the other.

## What changes

**`E2E_VIDEO=<dir> npm run test:e2e` records every window**, and each recording is saved under the name of the test it came from:

```
E2E_VIDEO=/tmp/e2e-video npm run test:e2e
open /tmp/e2e-video/switching-back-to-a-ticket-restores-its-work-byte-for-byte.webm
```

Inert unless the variable is set — nothing changes for CI, or for anyone not asking to watch.

The naming is not a nicety. Playwright names a recording after the page that produced it, an opaque hash, and writes a file for every window the run opened — a full run left twenty of them, most empty or a fraction of a second long, three worth opening. The first person to try it opened a zero-byte one and got an error from their video player, which is the whole feature failing at the last step. Recordings are now saved by test name once the app has closed, and everything else the recorder left is cleared away. A test that closes and reopens the app keeps both launches, as `-1` and `-2`.

**The guide no longer claims the trace replays a failing run.** It does not, for an Electron test. Playwright collects screenshots and DOM snapshots through a browser context, and an Electron window is not one, so the trace carries the actions, their timings and their source lines — and no pictures at all. `TESTING.md` now says what is actually in there and points at the recording for the rest.

**`slowMo` is recorded as a trap, in the code rather than the guide.** This PR started as an attempt to add it. `_electron.launch` does not accept it, and Playwright drops launch options it does not recognise without a word — so a `slowMo` added there leaves the tests running at full speed while looking like it worked. That belongs beside the launch, where somebody would try to add it, and not in a guide for contributors. `--headed` is not mentioned anywhere: it is simply not applicable, with no silent failure to warn about.

## How to test this

Platforms: **any**.

**Starting state:** this branch, `npm ci` and `npm run build:once` done.

1. `E2E_VIDEO=/tmp/e2e-video npm run test:e2e`
   - Expected: 8 passed, and **9** `.webm` files in `/tmp/e2e-video`, every one named after its test. Nine rather than eight because the restart test records both launches. No file is empty, and nothing is left called `page@…`.
2. Open `switching-back-to-a-ticket-restores-its-work-byte-for-byte.webm`.
   - Expected: the app, being driven. A ticket number typed into the field, **Link ticket** clicked, the panel changing. This is the check the video exists for — if it did not look like the app doing the work, the test would be worth nothing and would still be green.
3. `npm run test:e2e` with no variable set.
   - Expected: 8 passed, and **no** video directory created anywhere. The option must be inert by default.
4. Read `## Reading a failure` in `TESTING.md`, then confirm it for yourself:
   ```
   npx playwright test --project=journeys -g "switching back" --trace on
   unzip -l test-results/*/trace.zip
   ```
   - Expected: three files, about 12 KB, and no images — exactly what the page now says. Before this PR it said the trace replays the run.
5. `npm run lint`.
   - Expected: clean.

**What must not have happened:**

- **No behaviour change with the variable unset.** That is step 3, and it is the one that matters: a recording option that quietly slowed or altered a CI run would be worse than no option.
- **No video files committed.** `test-results/` and `playwright-report/` are already ignored; a directory chosen with `E2E_VIDEO` is wherever you point it, so point it outside the repository.

## Risks and limitations

- **The video directory is not emptied between runs**, and a rerun overwrites a recording of the same name. Deliberate — the point is to keep them and watch them — but worth knowing before pointing it somewhere you forget about.
- **The cleanup removes every `page@*.webm` in that directory**, not only the ones this run wrote. That is safe because the journeys run on a single worker and each test tidies up after itself, and it is the reason to point `E2E_VIDEO` at a directory kept for the purpose rather than at somewhere with other files in it.
- **Some recordings are only a second long and a few kilobytes.** Those are tests that assert on state rather than on the screen, so there is genuinely little to see. They are kept rather than filtered by size, because "too small to matter" is a guess and a missing file is confusing.
- **Not wired into CI.** A failing journey already comes back with a screenshot and the persisted state attached, which has been enough so far. Recording every window on every run would upload a few hundred kilobytes per job for something nobody looks at when the run is green.
- **`PWDEBUG=1` needs a browser this repository otherwise never installs.** The Inspector is a Chromium window, and nothing else here downloads one — the suites and CI launch only the Electron already in the tree. It worked on the first machine it was tried on purely because that machine had a Playwright browser cached from another project. Pointed at an empty `PLAYWRIGHT_BROWSERS_PATH` it does not error: the run pauses and no window opens, which reads as a hang. `TESTING.md` states the one-time `npx playwright install chromium` and says what skipping it looks like.

## Related

Part of #359. Stacked on #365.


