### PR TITLE
Cover applying and reverting a patch, through the app

### DIFF
--- a/e2e/helpers/app.cjs
+++ b/e2e/helpers/app.cjs
@@ -308,9 +308,34 @@ class Session {
 
 	dispose() {
 		for ( const dir of this.scratch.splice( 0 ) ) {
-			fs.rmSync( dir, { recursive: true, force: true } );
+			discard( dir );
 		}
-		fs.rmSync( this.userDataDir, { recursive: true, force: true } );
+		discard( this.userDataDir );
+	}
+}
+
+/**
+ * Removes a directory the app was using, without ever failing a passing test.
+ *
+ * `force: true` covers a directory that is already gone; it does nothing for one
+ * that is still being written to, which is what a just-closed app does to its
+ * profile — the process is gone, its last flush is not. That surfaces as
+ * `ENOTEMPTY` from `rmSync`, in teardown, on a test that passed. It appeared on
+ * a macOS CI runner and never once locally, which is the worst way to find out.
+ *
+ * `maxRetries` is the documented answer: Node retries `ENOTEMPTY`, `EBUSY` and
+ * `EPERM` on a backoff. The `catch` behind it is deliberate all the same. These
+ * live under the system temp directory, the operating system reaps them, and a
+ * suite that goes red because it could not tidy up is reporting on itself rather
+ * than on the app.
+ *
+ * @param {string} dir
+ */
+function discard( dir ) {
+	try {
+		fs.rmSync( dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } );
+	} catch {
+		// Left for the operating system.
 	}
 }
 

--- a/e2e/helpers/git-site.cjs
+++ b/e2e/helpers/git-site.cjs
@@ -30,10 +30,31 @@ const AUTHOR = { name: 'e2e', email: 'e2e@example.test' };
 const SUBSTRATE = path.join( 'node_modules', 'react', 'index.js' );
 const SUBSTRATE_CONTENT = 'expensive to reinstall\n';
 
+/**
+ * Where WordPress's own source lives in a `wordpress-develop` checkout.
+ *
+ * Not cosmetic. Patches from Trac are often written against the layout core had
+ * before everything moved under `src/`, so the app rewrites a path like
+ * `wp-login.php` to `src/wp-login.php` on the way in (see `src/patch-plan.cjs`).
+ * A fixture with its files at the root would have every patch land somewhere the
+ * test never looks, and the test would fail for a reason that is not a bug.
+ */
+const LOGIN = path.join( 'src', 'wp-login.php' );
+const DOOMED = path.join( 'src', 'doomed.php' );
+
 const TRUNK_FILES = {
 	'.gitignore': 'node_modules/\nbuild/\n',
-	'wp-login.php': '<?php // trunk\n',
-	'doomed.php': '<?php // to be deleted\n',
+	'src/wp-login.php': '<?php // trunk\n',
+	'src/doomed.php': '<?php // to be deleted\n',
+	// Applying a patch ends by rebuilding the site, the way it does in a real
+	// checkout. Without a `build` script the chain fails after the patch is
+	// already on disk, and a journey would be asserting on a half-finished
+	// flow. It does nothing; what matters is that it exits 0 quickly.
+	'package.json': JSON.stringify(
+		{ name: 'e2e-fixture-site', version: '1.0.0', private: true, scripts: { build: 'node -e ""' } },
+		null,
+		2
+	) + '\n',
 };
 
 /**
@@ -52,6 +73,7 @@ async function makeSite( session, { label = 'e2e-site' } = {} ) {
 	const dir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-site-' ) ) );
 
 	await git.init( { fs, dir, defaultBranch: TRUNK } );
+	fs.mkdirSync( path.join( dir, 'src' ), { recursive: true } );
 	for ( const [ file, content ] of Object.entries( TRUNK_FILES ) ) {
 		fs.writeFileSync( path.join( dir, file ), content );
 	}
@@ -135,8 +157,36 @@ const branches = ( dir ) => git.listBranches( { fs, dir } );
  */
 const currentBranch = ( dir ) => git.currentBranch( { fs, dir, fullname: false } );
 
+/**
+ * Writes a unified diff to a file the app's dialog can be pointed at.
+ *
+ * Hand-written rather than produced by a Git library: what the app parses is a
+ * patch file as it arrives from Trac or a pull request, and generating one with
+ * the same code the app reads back would prove less than it looks.
+ *
+ * @param {Object}                                          session The session that will clean the file up.
+ * @param {string}                                          name    File name, e.g. 'ticket-60001.patch'.
+ * @param {Array<{file: string, from: string, to: string}>} hunks   One whole-line replacement per
+ *                                                                  file: the line to find, and what
+ *                                                                  replaces it.
+ * @return {string} The path written.
+ */
+function makePatchFile( session, name, hunks ) {
+	const dir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-patch-' ) ) );
+	const body = hunks
+		.map(
+			( { file, from, to } ) =>
+				`--- a/${ file }\n+++ b/${ file }\n@@ -1 +1 @@\n-${ from }\n+${ to }\n`
+		)
+		.join( '' );
+	const file = path.join( dir, name );
+	fs.writeFileSync( file, body );
+	return file;
+}
+
 module.exports = {
 	makeSite,
+	makePatchFile,
 	settingsFor,
 	read,
 	write,
@@ -146,4 +196,6 @@ module.exports = {
 	TRUNK,
 	SUBSTRATE,
 	SUBSTRATE_CONTENT,
+	LOGIN,
+	DOOMED,
 };

--- a/e2e/journeys/patch-apply.spec.js
+++ b/e2e/journeys/patch-apply.spec.js
@@ -1,0 +1,170 @@
+/**
+ * Applying and reverting a patch, driven through the app (#361).
+ *
+ * The other half of a contributor's day: someone else's work arrives as a patch
+ * file or a pull request, and it has to go onto the checkout and come off again
+ * without taking anything of theirs with it. #350 changes what "applied" means —
+ * today it is a layer the app holds, afterwards it is a commit — so what is
+ * pinned here is the part that must survive either model.
+ *
+ * Assertions are marked INVARIANT or CHARACTERISATION; see ticket-branches.spec.js
+ * for what the distinction buys during that refactor.
+ *
+ * The patch arrives from a local file through the app's own file dialog, answered
+ * from the test. Nothing here fetches a pull request: that would put a third
+ * party in the path of a test that is about the checkout.
+ */
+
+const { test, expect } = require( '../helpers/app.cjs' );
+const {
+	makeSite,
+	makePatchFile,
+	read,
+	write,
+	SUBSTRATE,
+	SUBSTRATE_CONTENT,
+	LOGIN,
+	DOOMED,
+} = require( '../helpers/git-site.cjs' );
+
+const TRUNK_LOGIN = '<?php // trunk';
+const PATCHED_LOGIN = '<?php // fixed by the patch';
+
+/**
+ * @param {Object} page
+ * @param {string} ticket
+ */
+async function linkTicket( page, ticket ) {
+	await page.getByLabel( 'Trac ticket number or URL' ).first().fill( ticket );
+	await page.getByRole( 'button', { name: 'Link ticket', exact: true } ).first().click();
+	await expect( page.getByText( `#${ ticket }`, { exact: true } ).first() ).toBeVisible( { timeout: 30_000 } );
+}
+
+/**
+ * Chooses a patch file and confirms the preview the app shows before writing.
+ *
+ * @param {Object} session
+ * @param {string} patchFile
+ */
+async function applyPatchFile( session, patchFile ) {
+	const { page } = session;
+	await session.answerFileDialog( [ patchFile ] );
+	await page.getByRole( 'button', { name: 'or choose a .diff / .patch file…', exact: true } ).click();
+
+	// The preview is a gate, not a formality: it is the app saying what it is
+	// about to write, before anything is written. It names `src/wp-login.php`
+	// though the patch says `wp-login.php`, because the app rewrites paths
+	// written against core's pre-`src/` layout — see src/patch-plan.cjs.
+	await expect( page.getByText( 'src/wp-login.php', { exact: true } ) ).toBeVisible( { timeout: 30_000 } );
+	await page.getByRole( 'button', { name: 'Apply and rebuild', exact: true } ).click();
+}
+
+test( 'applying a patch file changes the checkout and records what was applied', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+	await linkTicket( page, '60001' );
+
+	const patch = makePatchFile( session, 'ticket-60001.patch', [
+		{ file: 'wp-login.php', from: TRUNK_LOGIN, to: PATCHED_LOGIN },
+	] );
+	await applyPatchFile( session, patch );
+
+	// The offer to undo is the app saying the apply finished, and it is on the
+	// same card. Waiting for it beats waiting for a rebuild that a slower runner
+	// may still be finishing.
+	await expect( page.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toBeVisible( {
+		timeout: 60_000,
+	} );
+
+	// INVARIANT — the patch is on disk, in the working tree, not merely recorded.
+	expect( read( site.dir, LOGIN ) ).toBe( `${ PATCHED_LOGIN }\n` );
+
+	// INVARIANT — and it wrote nothing else. The substrate is what a rebuild
+	// would be most likely to take with it.
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+	expect( read( site.dir, DOOMED ) ).toBe( '<?php // to be deleted\n' );
+
+	// CHARACTERISATION — today the applied patch is a record the app holds
+	// against the branch, naming the files it touched. After #350 it should be a
+	// commit; this assertion is the one that will say so.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	const applied = meta.branches[ 'ticket/60001' ].appliedPatch;
+	expect( applied.label ).toBe( 'ticket-60001.patch' );
+	// The rewritten path, not the one the patch named: what the record has to
+	// describe is what changed on disk.
+	expect( applied.files ).toEqual( [ 'src/wp-login.php' ] );
+} );
+
+test( 'reverting puts the checkout back and leaves unrelated work alone', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+	await linkTicket( page, '60001' );
+
+	// The contributor's own work, in a file the patch does not touch. Reverting
+	// somebody else's patch must not reach it.
+	write( site.dir, DOOMED, '<?php // my own work in progress\n' );
+
+	const patch = makePatchFile( session, 'ticket-60001.patch', [
+		{ file: 'wp-login.php', from: TRUNK_LOGIN, to: PATCHED_LOGIN },
+	] );
+	await applyPatchFile( session, patch );
+	const revert = page.getByRole( 'button', { name: 'Revert this patch', exact: true } );
+	await expect( revert ).toBeVisible( { timeout: 60_000 } );
+
+	await revert.click();
+	await expect( revert ).toHaveCount( 0, { timeout: 60_000 } );
+
+	// INVARIANT — the patched file is back, byte for byte.
+	expect( read( site.dir, LOGIN ) ).toBe( `${ TRUNK_LOGIN }\n` );
+
+	// INVARIANT — and the contributor's own edit survived both directions. This
+	// is the failure that costs somebody their afternoon and reports nothing.
+	expect( read( site.dir, DOOMED ) ).toBe( '<?php // my own work in progress\n' );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+
+	// CHARACTERISATION — the record goes with it.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	expect( meta.branches[ 'ticket/60001' ].appliedPatch ).toBeFalsy();
+} );
+
+test( 'a patch that does not fit is refused, and writes nothing', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+	await linkTicket( page, '60001' );
+
+	// The contributor has already edited the line the patch expects to find.
+	const mine = '<?php // I got here first\n';
+	write( site.dir, LOGIN, mine );
+
+	const patch = makePatchFile( session, 'ticket-60001.patch', [
+		{ file: 'wp-login.php', from: TRUNK_LOGIN, to: PATCHED_LOGIN },
+	] );
+	await session.answerFileDialog( [ patch ] );
+	await page.getByRole( 'button', { name: 'or choose a .diff / .patch file…', exact: true } ).click();
+	await expect( page.getByText( 'src/wp-login.php', { exact: true } ) ).toBeVisible( { timeout: 30_000 } );
+
+	// INVARIANT — the app warns before writing, not after. A contributor about
+	// to drop somebody else's patch onto their own edits is told so while they
+	// can still stop.
+	await expect(
+		page.getByRole( 'alert' ).filter( { hasText: 'You have your own edits to src/wp-login.php' } )
+	).toBeVisible();
+
+	await page.getByRole( 'button', { name: 'Apply and rebuild', exact: true } ).click();
+
+	// INVARIANT — the refusal says the checkout was not touched, names the file,
+	// and says how much of the patch failed. Asserted on the alert rather than on
+	// the page: the preview above is still on screen and already names the file,
+	// so a looser locator would pass whether or not the app reported anything.
+	const failure = page.getByRole( 'alert' ).filter( { hasText: 'The checkout was not changed' } );
+	await expect( failure ).toBeVisible( { timeout: 60_000 } );
+	await expect( failure ).toContainText( 'src/wp-login.php' );
+
+	// INVARIANT — all or nothing. A half-applied patch leaves a contributor with
+	// a tree neither they nor the app can explain.
+	expect( read( site.dir, LOGIN ) ).toBe( mine );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+
+	// INVARIANT — and nothing is offered to undo, because nothing was done.
+	await expect( page.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toHaveCount( 0 );
+} );

--- a/e2e/journeys/ticket-branches.spec.js
+++ b/e2e/journeys/ticket-branches.spec.js
@@ -35,6 +35,8 @@ const {
 	TRUNK,
 	SUBSTRATE,
 	SUBSTRATE_CONTENT,
+	LOGIN,
+	DOOMED,
 } = require( '../helpers/git-site.cjs' );
 
 const MY_EDIT = '<?php // my fix for 60001\n';
@@ -120,14 +122,14 @@ test( 'unlinking parks a ticket, and the next one starts from trunk', async ( { 
 	const { page } = await session.start( site.settings );
 
 	await linkTicket( page, '60001' );
-	write( site.dir, 'wp-login.php', MY_EDIT );
+	write( site.dir, LOGIN, MY_EDIT );
 
 	await linkTicket( page, '60002' );
 
 	// INVARIANT — the second ticket starts from trunk. Seeing the first ticket's
 	// edit here would mean two tickets' work ending up in one patch, which is
 	// the failure a contributor discovers only when a reviewer asks about it.
-	expect( read( site.dir, 'wp-login.php' ) ).toBe( '<?php // trunk\n' );
+	expect( read( site.dir, LOGIN ) ).toBe( '<?php // trunk\n' );
 	expect( await currentBranch( site.dir ) ).toBe( 'ticket/60002' );
 	expect( await branches( site.dir ) ).toEqual(
 		expect.arrayContaining( [ TRUNK, 'ticket/60001', 'ticket/60002' ] )
@@ -146,13 +148,13 @@ test( 'switching back to a ticket restores its work byte for byte', async ( { se
 	const { page } = await session.start( site.settings );
 
 	await linkTicket( page, '60001' );
-	write( site.dir, 'wp-login.php', MY_EDIT );
+	write( site.dir, LOGIN, MY_EDIT );
 	// A deletion too: an edit that comes back while a deletion does not is a
 	// partially restored tree, which is worse than an obvious failure.
-	remove( site.dir, 'doomed.php' );
+	remove( site.dir, DOOMED );
 
 	await linkTicket( page, '60002' );
-	expect( exists( site.dir, 'doomed.php' ) ).toBe( true );
+	expect( exists( site.dir, DOOMED ) ).toBe( true );
 
 	// Back to the first ticket, through the row the panel offers for it.
 	await page.getByRole( 'button', { name: 'switch', exact: true } ).click();
@@ -161,8 +163,8 @@ test( 'switching back to a ticket restores its work byte for byte', async ( { se
 		.toBe( 'ticket/60001' );
 
 	// INVARIANT — both halves of the work return: the edit and the deletion.
-	expect( read( site.dir, 'wp-login.php' ) ).toBe( MY_EDIT );
-	expect( exists( site.dir, 'doomed.php' ) ).toBe( false );
+	expect( read( site.dir, LOGIN ) ).toBe( MY_EDIT );
+	expect( exists( site.dir, DOOMED ) ).toBe( false );
 	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
 } );
 
@@ -172,7 +174,7 @@ test( "deleting a ticket's work removes only that ticket", async ( { session } )
 	const confirmsAnswered = await session.acceptConfirms();
 
 	await linkTicket( page, '60001' );
-	write( site.dir, 'wp-login.php', MY_EDIT );
+	write( site.dir, LOGIN, MY_EDIT );
 	await linkTicket( page, '60002' );
 
 	// Unlink first: the list of a site's tickets deliberately leaves out the one


### PR DESCRIPTION
**Stacked on #368.** Review the ones below it first; this diff is one new journey file, plus the seed repository it needed.

## Why

The other half of a contributor's day, and the half #350 changes most. Someone else's work arrives as a patch file or a pull request, goes onto the checkout, and has to come off again without taking anything of theirs with it.

Today "applied" is a layer the app holds. After #350 it is a commit. So what these journeys pin is the part that has to survive either model — and the part whose failure is silent, because a patch that half-applied or a revert that ate an unrelated edit produces no error at all.

## What changes

Three journeys.

- **A patch applies.** The file changes on disk, the gitignored substrate and the untouched files are left alone, and the app records what it applied.
- **A revert puts the checkout back**, byte for byte — and the contributor's own work in a file the patch never touched survives both directions.
- **A patch that does not fit is refused.** This is the one worth having. The app warns *before* writing that the patch is about to land on the contributor's own edits, while they can still stop; then it refuses, says the checkout was not changed, names the file, and says how much of the patch failed. Nothing is written and nothing is offered to undo.

**Two things about the app the fixture had wrong**, both found by running it rather than by reading:

- **Patches are rewritten onto core's modern layout.** A patch naming `wp-login.php`, which is how Trac patches are written, is applied to `src/wp-login.php` — see `src/patch-plan.cjs`, which exists because core moved everything under `src/` and old patches predate it. A fixture with its files at the repository root sends every patch somewhere the test never looks, and the test then fails for a reason that is not a bug. The seed repository now mirrors a real checkout.
- **Applying ends by rebuilding the site.** Without a `build` script the chain fails *after* the patch is already on disk, so the journey would be asserting on a half-finished flow. The seed repository has a `package.json` whose build does nothing and exits.

**One assertion is deliberately narrow.** The conflict is asserted against the alert, not the page. When an apply fails the preview stays on screen and already names the file, so `getByText('src/wp-login.php')` passes whether or not the app reported anything — green, and proving nothing.

## How to test this

Platforms: **any**. Windows is covered by CI.

**Starting state:** this branch, `npm ci` and `npm run build:once` done.

1. `npm run test:e2e`
   - Expected: **11 passed** — four from #362, four from #363, three here.
2. Watch the interesting one:
   ```
   E2E_VIDEO=/tmp/e2e-video npx playwright test --project=journeys -g "does not fit"
   open /tmp/e2e-video/a-patch-that-does-not-fit-is-refused-and-writes-nothing.webm
   ```
   - Expected: the app opens, a ticket is linked, a patch file is chosen, the preview lists `src/wp-login.php`, a warning appears about your own edits, **Apply and rebuild** is clicked, and the refusal appears. Nothing in the file changes.
3. Break the all-or-nothing invariant. In `e2e/journeys/patch-apply.spec.js`, change `expect( read( site.dir, LOGIN ) ).toBe( mine )` to any other string, then rerun.
   - Expected: "a patch that does not fit is refused, and writes nothing" goes red on that line. Put it back.
4. Break the path rewrite. In `e2e/helpers/git-site.cjs`, change `LOGIN` from `src/wp-login.php` to `wp-login.php`, then rerun.
   - Expected: the patch journeys go red — the patch is applied where the fixture is not looking. This is the trap the fixture layout exists to avoid. Put it back.
5. `npm test` and `npm run lint`.
   - Expected: 1027 passed, and clean.

**What must not have happened:**

- **The ticket-branch journeys must still pass.** This PR moves their fixture's files under `src/`, so all four are re-exercised by step 1. If only the patch journeys were run, that move would go unchecked.
- **No leftover directories.** Nothing matching `wpct-e2e-*` should remain in the system temp directory after a run.
- **Your real settings file must not have been touched.**

## Risks and limitations

- **Linking a ticket reads Trac.** Correcting something I wrote on #363: linking a ticket *by hand* auto-reads the ticket's own facts (#292), so these journeys do reach the network at that point, and on a machine where Trac's human-check appears a window may open. Nothing here asserts on it and no journey waits for it, so an offline or blocked runner does not fail these tests — but it happens, and #363 said it did not.
- **The patches are hand-written unified diffs**, one whole-line replacement per file. That is deliberate — generating them with the same code the app reads back would prove less than it looks — but it means the shapes core actually produces (renames, binary files, empty additions) are not exercised here. Those are covered a layer down, in `test/patch-apply.integration.test.cjs`.
- **The rebuild is a no-op.** The seed repository's `build` script exits immediately, so what these journeys prove about the rebuild is that the chain reaches it and survives it, not that a real build works.
- **Applying a pull request is not covered**, only a patch file. Fetching a PR puts GitHub in the path of a test about the checkout. The app treats both identically once the patch text is in hand, which is the point where these journeys join the flow.

## Related

Part of #359 and #361. Stacked on #368.
