### PR TITLE
Cover what survives closing the app

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -6,8 +6,8 @@ test belongs. [CONTRIBUTING.md](CONTRIBUTING.md) points here rather than repeati
 ## What to run
 
 ```
-npm test                    # the fast suite — 1,027 tests, under three seconds
-npm run test:e2e            # the app, driven — 8 tests, seconds
+npm test                    # the fast suite — layers 1–3, under three seconds
+npm run test:e2e            # the app, driven — layer 4, seconds
 npm run lint                # ESLint over the whole repo
 ```
 
@@ -34,29 +34,28 @@ They are listed cheapest first, and that ordering is the rule: **write a test at
 that can still see the failure.** What each layer is blind to is the part worth reading — it is what
 sends a test one layer up, or down.
 
-**1. Unit** — 63 files in `test/`. Starts nothing; calls plain functions. Pure logic: parsing a
-ticket reference, deriving a status, building a command line. Blind to anything touching disk, a
-process or a window.
+**1. Unit** — `test/`. Starts nothing; calls plain functions. Pure logic: parsing a ticket
+reference, deriving a status, building a command line. Blind to anything touching disk, a process
+or a window.
 
-**2. Integration** — 6 files, 89 tests, named `*.integration.test.cjs`. Runs the real modules
-against real Git repositories in a temporary directory. Proves Git does what the code assumes when
-it switches a branch, applies a patch or updates trunk. Blind to everything above the module
-boundary.
+**2. Integration** — the files named `*.integration.test.cjs`. Runs the real modules against real
+Git repositories in a temporary directory. Proves Git does what the code assumes when it switches a
+branch, applies a patch or updates trunk. Blind to everything above the module boundary.
 
-**3. IPC wiring** — one file, `test/ipc-wiring.test.cjs`, 151 tests. Loads the real `src/main.js`
-with `electron` replaced by a double, and exercises the ~58 handlers: what each returns, what it
-rejects, what error it gives. Blind to the window, and its store is a stand-in rather than the real
-one.
+**3. IPC wiring** — one file, `test/ipc-wiring.test.cjs`. Loads the real `src/main.js` with
+`electron` replaced by a double, and exercises every handler: what each returns, what it rejects,
+what error it gives. Blind to the window, and its store is a stand-in rather than the real one.
 
-**4. Journeys** — `e2e/journeys/`, 8 tests. Starts the whole app, built from the source tree, and
-drives it. Asks the only question the other three cannot: can a contributor do their work without
-losing it. Blind to anything about packaging.
+**4. Journeys** — `e2e/journeys/`. Starts the whole app, built from the source tree, and drives
+it. Asks the only question the other three cannot: can a contributor do their work without losing
+it. Blind to anything about packaging.
 
-**5. Packaged smoke** — `e2e/packaged/`, 4 tests. Starts the built artifact — the `.app` or `.exe`
+**5. Packaged smoke** — `e2e/packaged/`. Starts the built artifact — the `.app` or `.exe`
 a user downloads — and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
 
-Layers 1–3 are `npm test`. Layers 4 and 5 are the two `test:e2e` commands. That proportion, a
-thousand cheap tests to a dozen expensive ones, is the shape to keep.
+Layers 1–3 are `npm test`. Layers 4 and 5 are the two `test:e2e` commands. That proportion — a
+great many cheap tests to a handful of expensive ones, orders of magnitude apart in what each
+costs — is the shape to keep.
 
 ## Where to put a new test
 
@@ -230,6 +229,10 @@ Every matrix uses `fail-fast: false`, so a Windows failure never hides the macOS
   bug; a red characterisation is a prompt to read it and update it deliberately.
 - A bugfix's test must fail on the old code. A test written after the fix pins whatever the current
   behaviour is, rather than the correction.
+- No test counts in this document. A number here is wrong the moment somebody adds a test, and
+  nothing makes it go red — this file already carried a stale one. Say what a layer covers and
+  roughly what it costs; `npm test` prints the total, and it is the only place that can be trusted
+  to.
 
 The full review standard, including what counts as a test-shaped finding, is in
 [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).

--- a/e2e/journeys/store-persistence.spec.js
+++ b/e2e/journeys/store-persistence.spec.js
@@ -1,0 +1,129 @@
+/**
+ * What survives closing the app (#361).
+ *
+ * The only test in the repository that exercises the real persistence layer.
+ * Everywhere else `electron-store` is a stand-in: the wiring tests hand the main
+ * process a fake, and the integration tests never reach it at all. So this is the
+ * only place that can tell "the app persisted this" from "the app still had it in
+ * memory", which is exactly the distinction a change to how state is stored
+ * breaks without anything else noticing.
+ *
+ * Each test does its work, closes the app, opens it again against the same
+ * profile untouched, and asks what came back. Assertions are marked INVARIANT or
+ * CHARACTERISATION; see ticket-branches.spec.js for why.
+ */
+
+const { test, expect } = require( '../helpers/app.cjs' );
+const {
+	makeSite,
+	makePatchFile,
+	read,
+	write,
+	currentBranch,
+	SUBSTRATE,
+	SUBSTRATE_CONTENT,
+	LOGIN,
+} = require( '../helpers/git-site.cjs' );
+
+const TRUNK_LOGIN = '<?php // trunk';
+const PATCHED_LOGIN = '<?php // fixed by the patch';
+const MY_EDIT = '<?php // my work on 60001\n';
+
+/**
+ * @param {Object} page
+ * @param {string} ticket
+ */
+async function linkTicket( page, ticket ) {
+	await page.getByLabel( 'Trac ticket number or URL' ).first().fill( ticket );
+	await page.getByRole( 'button', { name: 'Link ticket', exact: true } ).first().click();
+	await expect( page.getByText( `#${ ticket }`, { exact: true } ).first() ).toBeVisible( { timeout: 30_000 } );
+}
+
+test( 'the linked ticket and its work are still there after a restart', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+
+	await linkTicket( page, '60001' );
+	write( site.dir, LOGIN, MY_EDIT );
+
+	const { page: reopened } = await session.restart();
+
+	// INVARIANT — the app opens where the contributor left it. Coming back to a
+	// site that has forgotten which ticket it was on is the cheapest possible way
+	// to lose somebody's afternoon.
+	await expect( reopened.getByText( '#60001', { exact: true } ).first() ).toBeVisible( { timeout: 30_000 } );
+
+	// INVARIANT — and it did not touch the checkout on the way past. A restart is
+	// not a switch.
+	expect( await currentBranch( site.dir ) ).toBe( 'ticket/60001' );
+	expect( read( site.dir, LOGIN ) ).toBe( MY_EDIT );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+} );
+
+test( 'an applied patch is still applied after a restart, and still revertable', async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+	await linkTicket( page, '60001' );
+
+	const patch = makePatchFile( session, 'ticket-60001.patch', [
+		{ file: 'wp-login.php', from: TRUNK_LOGIN, to: PATCHED_LOGIN },
+	] );
+	await session.answerFileDialog( [ patch ] );
+	await page.getByRole( 'button', { name: 'or choose a .diff / .patch file…', exact: true } ).click();
+	await expect( page.getByText( 'src/wp-login.php', { exact: true } ) ).toBeVisible( { timeout: 30_000 } );
+	await page.getByRole( 'button', { name: 'Apply and rebuild', exact: true } ).click();
+	await expect( page.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toBeVisible( {
+		timeout: 60_000,
+	} );
+
+	const { page: reopened } = await session.restart();
+
+	// INVARIANT — the app still knows somebody else's work is on this checkout,
+	// and still offers to take it off. Forgetting that leaves a contributor
+	// unable to tell their own changes from the patch's, and about to submit
+	// both as theirs.
+	await expect( reopened.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toBeVisible( {
+		timeout: 30_000,
+	} );
+	expect( read( site.dir, LOGIN ) ).toBe( `${ PATCHED_LOGIN }\n` );
+
+	// INVARIANT — and the offer is real, not just rendered. Reverting after a
+	// restart puts the checkout back.
+	await reopened.getByRole( 'button', { name: 'Revert this patch', exact: true } ).click();
+	await expect( reopened.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toHaveCount( 0, {
+		timeout: 60_000,
+	} );
+	expect( read( site.dir, LOGIN ) ).toBe( `${ TRUNK_LOGIN }\n` );
+} );
+
+test( "a site's tickets survive a restart, with the base each patch is measured against", async ( { session } ) => {
+	const site = await makeSite( session );
+	const { page } = await session.start( site.settings );
+
+	await linkTicket( page, '60001' );
+	write( site.dir, LOGIN, MY_EDIT );
+	await page.getByRole( 'button', { name: 'Unlink', exact: true } ).click();
+	await expect( page.getByLabel( 'Trac ticket number or URL' ).first() ).toBeVisible();
+	await linkTicket( page, '60002' );
+
+	const { page: reopened } = await session.restart();
+
+	// INVARIANT — both tickets come back, and the parked one is still offered.
+	// A ticket that survives in Git but not in the app is work a contributor
+	// cannot reach from the interface.
+	await expect( reopened.getByText( '#60002', { exact: true } ).first() ).toBeVisible( { timeout: 30_000 } );
+	// Matched on the sentence rather than on a button label: the row for another
+	// ticket reads "Continue working on #N" when nothing is linked and "You also
+	// have work on #N — switch" when something is, and after this restart
+	// something is.
+	await expect( reopened.getByText( /You also have work on #60001/ ).first() ).toBeVisible( {
+		timeout: 30_000,
+	} );
+
+	// CHARACTERISATION — and each branch keeps the commit its patch is measured
+	// from. Losing this is what #317 was: a ticket whose base is unknown can no
+	// longer say what the contributor changed.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	expect( meta.branches[ 'ticket/60001' ].baseOid ).toBe( site.baseOid );
+	expect( meta.branches[ 'ticket/60002' ].baseOid ).toBe( site.baseOid );
+} );

--- a/e2e/packaged/smoke.spec.js
+++ b/e2e/packaged/smoke.spec.js
@@ -5,7 +5,7 @@
  * The failures it exists to catch — asar layout, native module rebuilds, bundled
  * CLI resolution — do not reproduce under `npm start`.
  *
- * Build it first (see docs/testing.md):
+ * Build it first (see TESTING.md):
  *   npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
  *
  * It writes no state, so it deliberately does not use the session helper the
@@ -127,7 +127,7 @@ const REQUIRED_MODULES = [ '@wp-playground/cli', 'fs-ext-extra-prebuilt' ];
  */
 function findPackagedBinary() {
 	if ( ! fs.existsSync( DIST ) ) {
-		throw new Error( `No ${ DIST } directory. Run \`npm run pack:dir\` first — see docs/testing.md.` );
+		throw new Error( `No ${ DIST } directory. Run \`npm run pack:dir\` first — see TESTING.md.` );
 	}
 
 	if ( process.platform === 'darwin' ) {
@@ -146,7 +146,7 @@ function findPackagedBinary() {
 	if ( process.platform === 'win32' ) {
 		const unpacked = path.join( DIST, 'win-unpacked' );
 		if ( ! fs.existsSync( unpacked ) ) {
-			throw new Error( `No ${ unpacked }. Run \`npm run pack:dir\` first — see docs/testing.md.` );
+			throw new Error( `No ${ unpacked }. Run \`npm run pack:dir\` first — see TESTING.md.` );
 		}
 		const exe = fs.readdirSync( unpacked ).find( ( f ) => f.endsWith( '.exe' ) );
 		if ( ! exe ) throw new Error( `No .exe in ${ unpacked }.` );


### PR DESCRIPTION
**Stacked on #369.** Review the ones below it first; this diff is one new journey file.

## Why

This is the only test in the repository that exercises the real persistence layer.

Everywhere else `electron-store` is a stand-in. The wiring tests load the real `src/main.js` but hand it a fake store; the integration tests never reach it at all. So nothing today can tell **"the app persisted this"** from **"the app still had it in memory"** — and that is precisely the distinction a change to how state is stored breaks while every other test stays green.

#350 changes what is stored and where. This is the test that notices.

## What changes

Three journeys. Each acts, **closes the app**, opens it again against the same profile untouched, and asks what came back.

- **The linked ticket and the work on it.** The app opens where the contributor left it, and the checkout is untouched on the way past — a restart is not a switch.
- **An applied patch, still applied and still revertable.** The revert is *performed* after the restart rather than merely offered, because a button that renders and does nothing is the failure worth catching. Forgetting an applied patch leaves a contributor unable to tell their own changes from somebody else's, about to submit both as theirs.
- **Every ticket on the site, including the parked one**, each keeping the commit its patch is measured from. Losing that is what #317 was: a ticket whose base is unknown can no longer say what the contributor changed.

With this, the baseline battery #361 asked for is complete: ticket branches (#363), applying and reverting a patch (#369), and what survives a restart.

## How to test this

Platforms: **any**.

**Starting state:** this branch, `npm ci` and `npm run build:once` done.

1. `npm run test:e2e`
   - Expected: **14 passed**, in under twenty seconds. Windows open and close more often than in the other journeys — each of these launches the app twice.
2. Watch the one that matters most:
   ```
   E2E_VIDEO=/tmp/e2e-video npx playwright test --project=journeys -g "still applied after a restart"
   open /tmp/e2e-video/
   ```
   - Expected: two recordings, `-1` and `-2`. In the first the patch is applied; in the second the app has reopened, still offers **Revert this patch**, and the revert is carried out.
3. Break the persistence invariant. In `e2e/journeys/store-persistence.spec.js`, change `expect( read( site.dir, LOGIN ) ).toBe( \`${ PATCHED_LOGIN }\n\` )` to any other string, then rerun.
   - Expected: "an applied patch is still applied after a restart" goes red. Put it back.
4. Prove the restart is real, not a reload. In `e2e/helpers/app.cjs`, make `restart()` return without closing anything — replace its body with `return { app: this.app, page: this.page }`.
   - Expected: the persistence journeys still pass, because nothing was ever persisted or re-read. That is the shape of the vacuous test this file exists to avoid, and it is worth seeing once. Put it back.
5. `npm test` and `npm run lint`.
   - Expected: 1027 passed, and clean.

**What must not have happened:**

- **Your real settings file must not have been touched.** These journeys write more to the store than any other, so if the guard were going to fail anywhere it would be here.
- **No Electron processes left running.** Twice the launches means twice the chances to leak one.

## Risks and limitations

- **Step 4 above is a real gap, and it is not automated.** Nothing in the suite proves `restart()` genuinely restarts; a change that turned it into a no-op would leave these three tests passing and meaningless. The check exists as a manual step because asserting on it would mean asserting on the harness rather than on the app, and the honest place for that is a reviewer's eyes.
- **Slower than the rest.** Two app launches each, so these three take about as long as the other eleven together. Worth it for the only coverage of the real store, but it is why the layer stays small.
- **The store is read as a file, not through the app.** The characterisation assertions parse the profile's `settings.json` directly. That is the point — it is what actually survived — but it means a change to the file's shape shows up here as a failure to interpret rather than as a clean statement of what moved.

## Related

Part of #359. **Closes #361.** Stacked on #369.
