### PR TITLE
Stop hard-wrapping prose in Markdown

### DIFF
--- a/.agents/skills/self-review/SKILL.md
+++ b/.agents/skills/self-review/SKILL.md
@@ -7,39 +7,22 @@ description: Review the current branch against this repo's architecture, securit
 
 Run the repo's review standard against the working branch, **before** the PR exists.
 
-Nothing runs this in CI. It is the only review a change gets before a human reads it, which is why
-it happens now rather than after: a finding fixed here costs one message, the same finding on the PR
-costs a review cycle.
+Nothing runs this in CI. It is the only review a change gets before a human reads it, which is why it happens now rather than after: a finding fixed here costs one message, the same finding on the PR costs a review cycle.
 
 ## Procedure
 
-**Read [`.github/instructions/code-review.instructions.md`](../../../.github/instructions/code-review.instructions.md)
-and follow it.** It is the specification for this task, not background reading — it carries the
-procedure (establish the diff, run `npm run lint` and `npm test`, then the five dimensions) as well
-as the invariants and the reporting bar. Do not restate it here; run it.
+**Read [`.github/instructions/code-review.instructions.md`](../../../.github/instructions/code-review.instructions.md) and follow it.** It is the specification for this task, not background reading — it carries the procedure (establish the diff, run `npm run lint` and `npm test`, then the five dimensions) as well as the invariants and the reporting bar. Do not restate it here; run it.
 
-That file is the single copy of the standard. It lives under `.github/instructions/` so Copilot code
-review picks it up natively; every other agent, this one included, reaches it from here. Changes to
-how reviews work go there, not into this wrapper.
+That file is the single copy of the standard. It lives under `.github/instructions/` so Copilot code review picks it up natively; every other agent, this one included, reaches it from here. Changes to how reviews work go there, not into this wrapper.
 
 Two things this skill adds on top, both agent-neutral — apply whichever your agent can:
 
-**Run the judgement pass in a fresh context.** The diff and the deterministic layer
-(`npm run lint`, `npm test`) run inline. The five dimensions should be reviewed by a context that
-did not write the change — a subagent, or a separate pass given only the diff and the instructions
-file. If the session that wrote the code also grades it, it reviews its own reasoning and finds it
-sound.
+**Run the judgement pass in a fresh context.** The diff and the deterministic layer (`npm run lint`, `npm test`) run inline. The five dimensions should be reviewed by a context that did not write the change — a subagent, or a separate pass given only the diff and the instructions file. If the session that wrote the code also grades it, it reviews its own reasoning and finds it sound.
 
-**Report, don't apply.** Surface findings in the chat. No GitHub comments, no files written — the PR
-does not exist yet. Then offer; the author decides what is a real finding.
+**Report, don't apply.** Surface findings in the chat. No GitHub comments, no files written — the PR does not exist yet. Then offer; the author decides what is a real finding.
 
 ## Notes
 
-- This is the same skill as [`.claude/skills/self-review/`](../../../.claude/skills/self-review/),
-  placed here because agents built on the Agent Skills open standard (Command Code and others)
-  discover skills under `.agents/skills/` rather than `.claude/skills/`. Both are thin wrappers over
-  the one instructions file — neither is a second copy of the standard.
-- The repo-specific knowledge this adds over a generic review: Electron's bundled Node,
-  `isomorphic-git`, `electron-store`, loopback binding, the Windows spawn shims.
-- If a finding reveals a rule the instructions file does not yet cover, say so. It is meant to
-  accumulate what the project learns.
+- This is the same skill as [`.claude/skills/self-review/`](../../../.claude/skills/self-review/), placed here because agents built on the Agent Skills open standard (Command Code and others) discover skills under `.agents/skills/` rather than `.claude/skills/`. Both are thin wrappers over the one instructions file — neither is a second copy of the standard.
+- The repo-specific knowledge this adds over a generic review: Electron's bundled Node, `isomorphic-git`, `electron-store`, loopback binding, the Windows spawn shims.
+- If a finding reveals a rule the instructions file does not yet cover, say so. It is meant to accumulate what the project learns.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -7,36 +7,21 @@ description: Review the current branch against this repo's architecture, securit
 
 Run the repo's review standard against the working branch, **before** the PR exists.
 
-Nothing runs this in CI. It is the only automated pass a change gets before a human reads it, which
-is why it happens now rather than after: a finding fixed here costs one message, the same finding on
-the PR costs a review cycle.
+Nothing runs this in CI. It is the only automated pass a change gets before a human reads it, which is why it happens now rather than after: a finding fixed here costs one message, the same finding on the PR costs a review cycle.
 
 ## Procedure
 
-**Read `.github/instructions/code-review.instructions.md` and follow it.** It is the specification
-for this task, not background reading — it carries the procedure (establish the diff, run
-`npm run lint` and `npm test`, then the five dimensions) as well as the invariants and the
-reporting bar. Do not restate it here; run it.
+**Read `.github/instructions/code-review.instructions.md` and follow it.** It is the specification for this task, not background reading — it carries the procedure (establish the diff, run `npm run lint` and `npm test`, then the five dimensions) as well as the invariants and the reporting bar. Do not restate it here; run it.
 
-That file sits under `.github/instructions/` so Copilot code review picks it up natively rather
-than needing a condensed second copy. It is the only copy of the standard; changes to how reviews
-work go there, not here.
+That file sits under `.github/instructions/` so Copilot code review picks it up natively rather than needing a condensed second copy. It is the only copy of the standard; changes to how reviews work go there, not here.
 
 Two things this skill adds on top:
 
-**Dispatch the judgement pass to a subagent.** Steps 1-2 of the procedure — the diff and the
-deterministic layer — run inline. Step 3, the five dimensions, goes to an `Explore` subagent given
-the diff and the instructions file, and nothing else from this conversation. If the session that
-wrote the code also reviews it, it reviews its own reasoning and finds it sound. Collect the
-subagent's findings and report them.
+**Dispatch the judgement pass to a subagent.** Steps 1-2 of the procedure — the diff and the deterministic layer — run inline. Step 3, the five dimensions, goes to an `Explore` subagent given the diff and the instructions file, and nothing else from this conversation. If the session that wrote the code also reviews it, it reviews its own reasoning and finds it sound. Collect the subagent's findings and report them.
 
-**Report in the chat and stop there.** No GitHub comments, no files written — the PR does not exist
-yet. Then offer; do not apply. The author decides what is a real finding.
+**Report in the chat and stop there.** No GitHub comments, no files written — the PR does not exist yet. Then offer; do not apply. The author decides what is a real finding.
 
 ## Notes
 
-- Complements the built-in `/code-review` and `/security-review`. What this adds is the
-  repo-specific knowledge: Electron's bundled Node, `isomorphic-git`, `electron-store`, loopback
-  binding, the Windows spawn shims.
-- If a finding reveals a rule the instructions file does not yet cover, say so. It is meant to
-  accumulate what the project learns.
+- Complements the built-in `/code-review` and `/security-review`. What this adds is the repo-specific knowledge: Electron's bundled Node, `isomorphic-git`, `electron-store`, loopback binding, the Windows spawn shims.
+- If a finding reveals a rule the instructions file does not yet cover, say so. It is meant to accumulate what the project learns.

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,5 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+# Prose is not wrapped here — one paragraph is one line. See AGENTS.md.
+max_line_length = off

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -4,23 +4,13 @@ applyTo: "**"
 
 # Automated review rules
 
-What an automated reviewer should look for in this repo, and how to run that review. Written to be
-read by any agent, not one in particular — this is the single source of truth for the review
-standard, and it is deliberately the only copy of it.
+What an automated reviewer should look for in this repo, and how to run that review. Written to be read by any agent, not one in particular — this is the single source of truth for the review standard, and it is deliberately the only copy of it.
 
-`AGENTS.md` and `.claude/skills/self-review/SKILL.md` point here rather than restate it. Copilot
-needs no pointer: it reads `.github/instructions/*.instructions.md` natively, selecting them by
-matching the `applyTo` glob above against the files in a pull request, so `**` means every PR gets
-this. That is the whole reason the file lives at this path and not somewhere better-named — a
-pointer would not have reached it, and a second condensed copy would have drifted.
+`AGENTS.md` and `.claude/skills/self-review/SKILL.md` point here rather than restate it. Copilot needs no pointer: it reads `.github/instructions/*.instructions.md` natively, selecting them by matching the `applyTo` glob above against the files in a pull request, so `**` means every PR gets this. That is the whole reason the file lives at this path and not somewhere better-named — a pointer would not have reached it, and a second condensed copy would have drifted.
 
-The procedure below assumes an agent that can run commands. Copilot cannot; it should skip to
-**Scope** and treat the rest as the standard to review against.
+The procedure below assumes an agent that can run commands. Copilot cannot; it should skip to **Scope** and treat the rest as the standard to review against.
 
-Nothing runs this automatically. It is the author's pass, before a human reads the diff — which is
-the point: a finding fixed now costs one message, the same finding on the PR costs a review cycle.
-The producer is responsible for handing over a reviewable change, not the reviewer for
-reconstructing the context.
+Nothing runs this automatically. It is the author's pass, before a human reads the diff — which is the point: a finding fixed now costs one message, the same finding on the PR costs a review cycle. The producer is responsible for handing over a reviewable change, not the reviewer for reconstructing the context.
 
 ## Running the review
 
@@ -32,8 +22,7 @@ git diff --stat origin/trunk...HEAD
 git diff origin/trunk...HEAD
 ```
 
-Include uncommitted work if there is any (`git status --short`, `git diff`) — the author is about
-to commit it, so it is in scope.
+Include uncommitted work if there is any (`git status --short`, `git diff`) — the author is about to commit it, so it is in scope.
 
 **2. Run the deterministic layer first**, so mechanical findings never reach the judgement pass:
 
@@ -42,229 +31,113 @@ npm run lint
 npm test
 ```
 
-Both are repo-wide and both are clean on `trunk` — the lint backlog was cleared in #117, which is
-why `lint.yml` runs `eslint .` rather than linting only the changed files. So any failure here
-belongs to the branch. Report both results plainly.
+Both are repo-wide and both are clean on `trunk` — the lint backlog was cleared in #117, which is why `lint.yml` runs `eslint .` rather than linting only the changed files. So any failure here belongs to the branch. Report both results plainly.
 
-If ESLint fails, `npm run lint:fix` handles the mechanical part. Check what it rewrote before
-committing: it is also repo-wide, so a rule that starts flagging untouched files would pull them
-into the diff. Do not hand-fix what the fixer handles.
+If ESLint fails, `npm run lint:fix` handles the mechanical part. Check what it rewrote before committing: it is also repo-wide, so a rule that starts flagging untouched files would pull them into the diff. Do not hand-fix what the fixer handles.
 
-**3. Review the five dimensions below.** Read the surrounding files, not just the diff — a diff
-rarely shows that a helper already handles the case, and the reporting bar requires verifying a
-finding before asserting it.
+**3. Review the five dimensions below.** Read the surrounding files, not just the diff — a diff rarely shows that a helper already handles the case, and the reporting bar requires verifying a finding before asserting it.
 
-Where the tool allows it, run this pass with fresh context — a subagent given the diff and this
-file, rather than the session that wrote the code. Nothing runs this review independently any more,
-so a reviewer that already believes the change is correct is the main way it stops working.
+Where the tool allows it, run this pass with fresh context — a subagent given the diff and this file, rather than the session that wrote the code. Nothing runs this review independently any more, so a reviewer that already believes the change is correct is the main way it stops working.
 
-**4. Report, then offer.** Format below. Ask before changing anything: the author decides what is a
-real finding, which is the whole reason this happens before the PR rather than after.
+**4. Report, then offer.** Format below. Ask before changing anything: the author decides what is a real finding, which is the whole reason this happens before the PR rather than after.
 
 ## Scope
 
-Review **judgement**, not style. ESLint (`eslint.config.mjs`, `npm run lint`) already covers
-formatting, unused variables, JSDoc, React hooks and the rest of the mechanical layer. Repeating
-those here buries the findings that matter. When style and process nits share space with
-substantive findings, authors learn to skim past them — and the substantive findings go with
-them.
+Review **judgement**, not style. ESLint (`eslint.config.mjs`, `npm run lint`) already covers formatting, unused variables, JSDoc, React hooks and the rest of the mechanical layer. Repeating those here buries the findings that matter. When style and process nits share space with substantive findings, authors learn to skim past them — and the substantive findings go with them.
 
-Five dimensions, in priority order: **architecture · security · performance · cross-platform ·
-tests**.
+Five dimensions, in priority order: **architecture · security · performance · cross-platform · tests**.
 
 ## What this app is
 
-An Electron app that sets up a `wordpress-develop` environment with **zero prerequisites** — no
-Git, Node, npm or Docker on the host. Everything runs as JS/WASM inside the Electron process. Its
-users are Contributor Day newcomers on macOS and Windows, often on locked-down machines.
+An Electron app that sets up a `wordpress-develop` environment with **zero prerequisites** — no Git, Node, npm or Docker on the host. Everything runs as JS/WASM inside the Electron process. Its users are Contributor Day newcomers on macOS and Windows, often on locked-down machines.
 
-That premise is what most of the rules below protect. A change that quietly reintroduces a host
-dependency defeats the entire point of the project.
+That premise is what most of the rules below protect. A change that quietly reintroduces a host dependency defeats the entire point of the project.
 
 ---
 
 ## 1. Architecture
 
-Invariants. Breaking one is a `[fix here]` finding even when the code works on the author's
-machine.
+Invariants. Breaking one is a `[fix here]` finding even when the code works on the author's machine.
 
-**Child processes run on Electron's bundled Node, never the host's.** Spawns go through
-`process.execPath` with `ELECTRON_RUN_AS_NODE=1` in the environment (see `runNpmWithEngineRetry`
-and the `playground:start` handler in `src/main.js`, and `buildChildEnv`). A bare `spawn('node')`
-or `spawn('npm')` assumes a host toolchain that is not there. On Windows child `npm` processes
-find a `node` at all only because of the `PATH` shim built by `ensureNodeShimDir` — new spawns
-must inherit that environment rather than build their own.
+**Child processes run on Electron's bundled Node, never the host's.** Spawns go through `process.execPath` with `ELECTRON_RUN_AS_NODE=1` in the environment (see `runNpmWithEngineRetry` and the `playground:start` handler in `src/main.js`, and `buildChildEnv`). A bare `spawn('node')` or `spawn('npm')` assumes a host toolchain that is not there. On Windows child `npm` processes find a `node` at all only because of the `PATH` shim built by `ensureNodeShimDir` — new spawns must inherit that environment rather than build their own.
 
-**Git never shells out.** All Git operations go through `isomorphic-git`. Patch and diff
-generation is hand-rolled in `src/main.js` (stage untracked files, diff working tree against
-`origin/trunk`) precisely because there is no `git` binary to call. Any `spawn('git')` or
-`exec('git ...')` is a regression.
+**Git never shells out.** All Git operations go through `isomorphic-git`. Patch and diff generation is hand-rolled in `src/main.js` (stage untracked files, diff working tree against `origin/trunk`) precisely because there is no `git` binary to call. Any `spawn('git')` or `exec('git ...')` is a regression.
 
-**`electron-store` is the only persistence layer.** No database, no sidecar JSON. It holds the
-site registry and per-site metadata and is the single source of truth for "known sites". A second
-store, a cache file, or state parked in a module-level variable that outlives a handler is
-architectural drift — flag it.
+**`electron-store` is the only persistence layer.** No database, no sidecar JSON. It holds the site registry and per-site metadata and is the single source of truth for "known sites". A second store, a cache file, or state parked in a module-level variable that outlives a handler is architectural drift — flag it.
 
-**Long-running output streams; it is not returned.** Installs, scripts and the Playground server
-push output to the renderer through correlated IDs (`installId`, `runId`, `sitePath`) over
-dedicated channels. See the handler pairs in `src/preload.js`. A new long-running operation that
-resolves its `invoke()` with accumulated output instead of streaming will look fine on a fast
-machine and hang the UI on a slow one.
+**Long-running output streams; it is not returned.** Installs, scripts and the Playground server push output to the renderer through correlated IDs (`installId`, `runId`, `sitePath`) over dedicated channels. See the handler pairs in `src/preload.js`. A new long-running operation that resolves its `invoke()` with accumulated output instead of streaming will look fine on a fast machine and hang the UI on a slow one.
 
-**The renderer↔main boundary is fixed.** New surface means a `contextBridge` entry in
-`src/preload.js` plus an `ipcMain.handle` in `src/main.js`. `contextIsolation: true` and
-`nodeIntegration: false` are set on every `BrowserWindow` — the main window and both patch
-windows — and are not negotiable. Flag any window created without them, and any attempt to widen
-the bridge by exposing `ipcRenderer` itself rather than named functions.
+**The renderer↔main boundary is fixed.** New surface means a `contextBridge` entry in `src/preload.js` plus an `ipcMain.handle` in `src/main.js`. `contextIsolation: true` and `nodeIntegration: false` are set on every `BrowserWindow` — the main window and both patch windows — and are not negotiable. Flag any window created without them, and any attempt to widen the bridge by exposing `ipcRenderer` itself rather than named functions.
 
-**Failure paths are part of the architecture.** The users cannot debug: a swallowed error is
-"the button did nothing" at a Contributor Day, with nobody able to diagnose it. Every spawn
-handles both `error` and `close` — Node documents that exit events "may or may not" follow a
-spawn failure, and `runNpmWithEngineRetry` in `src/main.js` shows the expected shape. No silent
-`catch`: an error that never reaches the renderer's log stream did not happen, from the user's
-chair. And a setup that dies halfway must leave the site registry consistent — no phantom site
-in `electron-store` for a directory that was never finished.
+**Failure paths are part of the architecture.** The users cannot debug: a swallowed error is "the button did nothing" at a Contributor Day, with nobody able to diagnose it. Every spawn handles both `error` and `close` — Node documents that exit events "may or may not" follow a spawn failure, and `runNpmWithEngineRetry` in `src/main.js` shows the expected shape. No silent `catch`: an error that never reaches the renderer's log stream did not happen, from the user's chair. And a setup that dies halfway must leave the site registry consistent — no phantom site in `electron-store` for a directory that was never finished.
 
-**Renderer decisions live in modules, not in `index.jsx`.** `src/renderer/index.jsx` mounts itself
-at module scope and cannot be loaded without a DOM, so nothing in the suite can reach it: a
-decision made there is untestable by construction. Anything with more than one branch — a string
-the user reads, a path joined, a status derived, a command parsed — belongs in a
-`src/renderer/*.cjs` module with its own test, leaving the component holding JSX, state
-assignments and the call. `site-folder.cjs` and `open-failure.cjs` are the shape.
+**Renderer decisions live in modules, not in `index.jsx`.** `src/renderer/index.jsx` mounts itself at module scope and cannot be loaded without a DOM, so nothing in the suite can reach it: a decision made there is untestable by construction. Anything with more than one branch — a string the user reads, a path joined, a status derived, a command parsed — belongs in a `src/renderer/*.cjs` module with its own test, leaving the component holding JSX, state assignments and the call. `site-folder.cjs` and `open-failure.cjs` are the shape.
 
-This is the direction chosen in #216 over building a DOM harness, which was judged too much setup
-for the coverage it buys against a 4000-line component. The consequence is that it is enforced
-here, by review, and nowhere else — `no-unused-vars` catches a module whose last call site is
-deleted, but nothing catches a second code path that answers the same question inline. That is
-exactly what #180 was. Reopen the harness question if a bug ever lands in the assignments the
-modules cannot absorb.
+This is the direction chosen in #216 over building a DOM harness, which was judged too much setup for the coverage it buys against a 4000-line component. The consequence is that it is enforced here, by review, and nowhere else — `no-unused-vars` catches a module whose last call site is deleted, but nothing catches a second code path that answers the same question inline. That is exactly what #180 was. Reopen the harness question if a bug ever lands in the assignments the modules cannot absorb.
 
-**New dependencies are findings by default.** Native compilation or a host binary breaks the
-zero-prerequisite promise on user machines. A dependency with lifecycle scripts also needs an
-`allowScripts` entry in `package.json` — the mechanism already exists, and a missing entry means
-its install scripts silently don't run.
+**New dependencies are findings by default.** Native compilation or a host binary breaks the zero-prerequisite promise on user machines. A dependency with lifecycle scripts also needs an `allowScripts` entry in `package.json` — the mechanism already exists, and a missing entry means its install scripts silently don't run.
 
-**Changing the shape of what `electron-store` holds needs a migration path.** Existing users
-have site registries on disk; a renamed or restructured key silently orphans their sites.
+**Changing the shape of what `electron-store` holds needs a migration path.** Existing users have site registries on disk; a renamed or restructured key silently orphans their sites.
 
 ## 2. Security
 
-The threat model is not a hostile user — it is a contributor's laptop on a conference or café
-network, running a WordPress with `admin`/`admin`.
+The threat model is not a hostile user — it is a contributor's laptop on a conference or café network, running a WordPress with `admin`/`admin`.
 
-**Validate what crosses IPC.** Every `ipcMain.handle` argument comes from the renderer and is
-untrusted input. Paths get used for file operations, URLs get opened.
+**Validate what crosses IPC.** Every `ipcMain.handle` argument comes from the renderer and is untrusted input. Paths get used for file operations, URLs get opened.
 
-> Worked example, kept because it shows the shape rather than a single bug: `url:open` in
-> `src/main.js` used to pass its argument straight to `shell.openExternal()`, so `file://` and
-> `javascript:` got through to the OS handler. It now goes through `src/external-url.js`, which
-> refuses anything outside an http/https allow-list and — the part that is easy to miss — hands
-> the OS the *parsed* address rather than the caller's string, because the URL parser strips
-> control characters and a validator that checks one string while the caller opens another has
-> not checked anything. Look for both halves in any new handler that takes a URL or a path.
+> Worked example, kept because it shows the shape rather than a single bug: `url:open` in `src/main.js` used to pass its argument straight to `shell.openExternal()`, so `file://` and `javascript:` got through to the OS handler. It now goes through `src/external-url.js`, which refuses anything outside an http/https allow-list and — the part that is easy to miss — hands the OS the *parsed* address rather than the caller's string, because the URL parser strips control characters and a validator that checks one string while the caller opens another has not checked anything. Look for both halves in any new handler that takes a URL or a path.
 
-**Servers stay on loopback.** `src/bind-loopback.js` patches `net.Server.prototype.listen` so
-Playground's servers bind to `127.0.0.1` instead of every interface. Any new listener that is
-created before that patch is applied, or that passes an explicit non-loopback host, exposes the
-contributor's site to the local network. This is what the file exists to prevent — read its
-header comment before deciding a change is safe.
+**Servers stay on loopback.** `src/bind-loopback.js` patches `net.Server.prototype.listen` so Playground's servers bind to `127.0.0.1` instead of every interface. Any new listener that is created before that patch is applied, or that passes an explicit non-loopback host, exposes the contributor's site to the local network. This is what the file exists to prevent — read its header comment before deciding a change is safe.
 
-**Never `shell: true`.** Existing spawns pass `shell: false` deliberately. A shell turns any
-path containing a space or a quote into a command-injection vector, and contributor directory
-names are user-chosen. The Windows `.cmd` shim path in `src/win-spawn-patch.js` is the one
-audited exception; new code should not add another.
+**Never `shell: true`.** Existing spawns pass `shell: false` deliberately. A shell turns any path containing a space or a quote into a command-injection vector, and contributor directory names are user-chosen. The Windows `.cmd` shim path in `src/win-spawn-patch.js` is the one audited exception; new code should not add another.
 
-**No secrets in the repo, and none in logs.** Pay particular attention to
-`scripts/azure-sign.cjs` and `fastlane/`. Signing credentials arrive as environment variables and
-must not be echoed into child-process output, which is streamed to the renderer and written to
-disk by `electron-log`.
+**No secrets in the repo, and none in logs.** Pay particular attention to `scripts/azure-sign.cjs` and `fastlane/`. Signing credentials arrive as environment variables and must not be echoed into child-process output, which is streamed to the renderer and written to disk by `electron-log`.
 
-**Untrusted archives and downloads.** Anything unzipped or fetched into a user directory should
-be checked for path traversal (`../` in archive entries) before extraction.
+**Untrusted archives and downloads.** Anything unzipped or fetched into a user directory should be checked for path traversal (`../` in archive entries) before extraction.
 
 ## 3. Performance
 
-**The main process must not block.** It runs the UI. Synchronous filesystem calls, large
-`JSON.parse`, or hashing on a path that a handler can reach will freeze the whole window. `fs`
-sync calls during startup or inside an `ipcMain.handle` deserve a flag; the same call in a
-one-shot build script does not.
+**The main process must not block.** It runs the UI. Synchronous filesystem calls, large `JSON.parse`, or hashing on a path that a handler can reach will freeze the whole window. `fs` sync calls during startup or inside an `ipcMain.handle` deserve a flag; the same call in a one-shot build script does not.
 
-**Log output is unbounded by nature.** `npm install` on `wordpress-develop` produces a lot of it.
-Watch for per-chunk work that is quadratic, and for buffers that accumulate the full output with
-no ceiling — see `src/log-lines.js` for how line splitting is done today.
+**Log output is unbounded by nature.** `npm install` on `wordpress-develop` produces a lot of it. Watch for per-chunk work that is quadratic, and for buffers that accumulate the full output with no ceiling — see `src/log-lines.js` for how line splitting is done today.
 
-**Work should not scale with the site registry.** Anything that walks every known site, or stats
-every directory, on each render or each IPC call will degrade as a contributor accumulates sites.
+**Work should not scale with the site registry.** Anything that walks every known site, or stats every directory, on each render or each IPC call will degrade as a contributor accumulates sites.
 
-Flag performance only where there is a plausible path to a user noticing it. Speculative
-micro-optimisation is noise.
+Flag performance only where there is a plausible path to a user noticing it. Speculative micro-optimisation is noise.
 
 ## 4. Cross-platform
 
-macOS and Windows are the primary targets; Linux artifacts are published too. CI runs the unit
-suite on macOS and Windows, but plenty gets past it.
+macOS and Windows are the primary targets; Linux artifacts are published too. CI runs the unit suite on macOS and Windows, but plenty gets past it.
 
-**Paths.** Compose with `path.join` / `path.resolve`, never string concatenation with `/`. Do not
-compare paths case-sensitively — Windows and default macOS filesystems are case-insensitive. Do
-not assume a path has no spaces; contributors pick their own directories.
+**Paths.** Compose with `path.join` / `path.resolve`, never string concatenation with `/`. Do not compare paths case-sensitively — Windows and default macOS filesystems are case-insensitive. Do not assume a path has no spaces; contributors pick their own directories.
 
-**Killing processes is platform-split.** POSIX relies on the child being a process-group leader
-(`detached: true`) so the whole tree can be signalled; Windows uses `taskkill /T`. Both live in
-`src/kill-tree.js`. A new spawn that does not set `detached` correctly, or that is terminated with
-a bare `child.kill()`, will leave orphaned processes on one platform or the other.
+**Killing processes is platform-split.** POSIX relies on the child being a process-group leader (`detached: true`) so the whole tree can be signalled; Windows uses `taskkill /T`. Both live in `src/kill-tree.js`. A new spawn that does not set `detached` correctly, or that is terminated with a bare `child.kill()`, will leave orphaned processes on one platform or the other.
 
-**Windows specifics.** Executables need their extension (`.cmd`, `.bat`, `.exe`) resolved; `EPERM`
-and `EINVAL` have Windows-specific causes. `src/win-spawn-patch.js` documents the traps that have
-already bitten — consult it rather than re-deriving them.
+**Windows specifics.** Executables need their extension (`.cmd`, `.bat`, `.exe`) resolved; `EPERM` and `EINVAL` have Windows-specific causes. `src/win-spawn-patch.js` documents the traps that have already bitten — consult it rather than re-deriving them.
 
-**`windowsHide: true` turns on the child's subsystem, not on whether anyone reads its output.**
-Node sets `CREATE_NO_WINDOW` and STARTUPINFO's "start hidden" together; which of the two the child
-honors is what differs. A console application takes the first and gets a console that is never
-displayed — the flashing fix, and why `src/kill-tree.js` sets it on `taskkill` even though nothing
-reads that output. A GUI application takes the second, and one that passes it through to its first
-window — Chromium does, so VS Code and Cursor both — launches invisible while the spawn still
-reports success (#181). So: set it on a console child; leave it off a child whose window is the
-point. `src/editor-launch.js` is the only case of the second kind.
+**`windowsHide: true` turns on the child's subsystem, not on whether anyone reads its output.** Node sets `CREATE_NO_WINDOW` and STARTUPINFO's "start hidden" together; which of the two the child honors is what differs. A console application takes the first and gets a console that is never displayed — the flashing fix, and why `src/kill-tree.js` sets it on `taskkill` even though nothing reads that output. A GUI application takes the second, and one that passes it through to its first window — Chromium does, so VS Code and Cursor both — launches invisible while the spawn still reports success (#181). So: set it on a console child; leave it off a child whose window is the point. `src/editor-launch.js` is the only case of the second kind.
 
 **Line endings** matter when generating patches, which are destined for Trac.
 
-**Electron's Node version is a real constraint.** It is set independently of `.nvmrc` and the two
-have drifted before (issues #37 / #46), which is why the suite runs twice. A change that depends
-on a newer Node API needs to hold on whichever of the two is older.
+**Electron's Node version is a real constraint.** It is set independently of `.nvmrc` and the two have drifted before (issues #37 / #46), which is why the suite runs twice. A change that depends on a newer Node API needs to hold on whichever of the two is older.
 
 ## 5. Tests
 
-**A new feature or bugfix without a test is a finding.** Not a suggestion in a footer — a
-finding, with the same severity-and-scope labelling as everything else. The suite is
-`node --test` over `test/*.test.cjs`; new tests follow the patterns already there.
+**A new feature or bugfix without a test is a finding.** Not a suggestion in a footer — a finding, with the same severity-and-scope labelling as everything else. The suite is `node --test` over `test/*.test.cjs`; new tests follow the patterns already there.
 
-**A bugfix's test must reproduce the bug**: fail on the old code, pass on the new. A test
-written after the fix that never saw the bug proves far less — it pins the current behaviour,
-whatever that is, rather than the correction. When reviewing a bugfix, check whether the test
-would actually have caught it.
+**A bugfix's test must reproduce the bug**: fail on the old code, pass on the new. A test written after the fix that never saw the bug proves far less — it pins the current behaviour, whatever that is, rather than the correction. When reviewing a bugfix, check whether the test would actually have caught it.
 
 **Watch for tests that are green while proving nothing.** The known shapes in this repo:
 
 - Mocking the very thing the test claims to verify.
-- Asserting implementation details — exact log strings, call order of internals — instead of
-  observable behaviour. These break on harmless refactors and survive real bugs.
-- Passing on only one of the two Node runtimes. CI runs the suite on `.nvmrc`'s Node *and* on
-  Electron's bundled Node because the two are set independently and have drifted; a test (or the
-  code under it) that assumes the newer of the two is broken on the other.
+- Asserting implementation details — exact log strings, call order of internals — instead of observable behaviour. These break on harmless refactors and survive real bugs.
+- Passing on only one of the two Node runtimes. CI runs the suite on `.nvmrc`'s Node *and* on Electron's bundled Node because the two are set independently and have drifted; a test (or the code under it) that assumes the newer of the two is broken on the other.
 
-**Platform-conditional code needs both branches tested — from one machine.** The house pattern
-is dependency injection, not skipping: `test/win-spawn-patch.test.cjs` exercises the Windows
-paths from macOS by injecting `platform`, lookup and env rather than reading `process.platform`.
-A new platform split tested with `it.skip` on the other OS is a coverage hole CI will never
-close, since the suite runs on both platforms but each skips the other's branch.
+**Platform-conditional code needs both branches tested — from one machine.** The house pattern is dependency injection, not skipping: `test/win-spawn-patch.test.cjs` exercises the Windows paths from macOS by injecting `platform`, lookup and env rather than reading `process.platform`. A new platform split tested with `it.skip` on the other OS is a coverage hole CI will never close, since the suite runs on both platforms but each skips the other's branch.
 
-**Renderer logic is tested through its module, so check it has one.** A PR that puts a branch
-inside `src/renderer/index.jsx` has written code the suite cannot reach — see the invariant in §1.
-The finding is the missing module, not the missing test.
+**Renderer logic is tested through its module, so check it has one.** A PR that puts a branch inside `src/renderer/index.jsx` has written code the suite cannot reach — see the invariant in §1. The finding is the missing module, not the missing test.
 
-**Scope stays proportional.** Missing tests on a touched line of legacy code is `[follow-up]`,
-not `[fix here]` — the strong rule applies to what the PR introduces, not to everything it
-brushes against.
+**Scope stays proportional.** Missing tests on a touched line of legacy code is `[follow-up]`, not `[fix here]` — the strong rule applies to what the PR introduces, not to everything it brushes against.
 
 ---
 
@@ -272,28 +145,17 @@ brushes against.
 
 **Every finding carries a dimension, a severity and a scope.**
 
-- Scope is `[fix here]` or `[follow-up]`. Use `[follow-up]` for cross-cutting refactors and
-  anything the PR did not introduce. This gives the author a defensible "noted, separate PR"
-  rather than a finding that looks ignored.
+- Scope is `[fix here]` or `[follow-up]`. Use `[follow-up]` for cross-cutting refactors and anything the PR did not introduce. This gives the author a defensible "noted, separate PR" rather than a finding that looks ignored.
 - Severity: 🔴 high, 🟡 medium, 🔵 low.
 
-**Structure**: counts first (`2 [fix here] · 1 [follow-up]`), then one finding per entry carrying
-its dimension, severity, scope, `file:line`, and what actually goes wrong. Style and process
-observations go last, grouped and brief — never mixed in among the findings.
+**Structure**: counts first (`2 [fix here] · 1 [follow-up]`), then one finding per entry carrying its dimension, severity, scope, `file:line`, and what actually goes wrong. Style and process observations go last, grouped and brief — never mixed in among the findings.
 
-Where this runs before the PR exists, that report goes in the chat: no GitHub comments, no files
-written. Where it runs on a PR, `[fix here]` findings become inline comments on the exact lines and
-the counts go in a single summary comment, with the style notes in a collapsed `<details>` block.
+Where this runs before the PR exists, that report goes in the chat: no GitHub comments, no files written. Where it runs on a PR, `[fix here]` findings become inline comments on the exact lines and the counts go in a single summary comment, with the style notes in a collapsed `<details>` block.
 
-**On a re-run, reconcile — do not re-review from scratch.** Mark each earlier finding resolved,
-still open, or obsolete. Re-asserting a fixed finding is the fastest way to get the whole review
-ignored.
+**On a re-run, reconcile — do not re-review from scratch.** Mark each earlier finding resolved, still open, or obsolete. Re-asserting a fixed finding is the fastest way to get the whole review ignored.
 
-**Say when there is nothing.** "No findings across the five dimensions" in one line is a good
-review. Do not pad. Do not restate what the PR does — the author knows.
+**Say when there is nothing.** "No findings across the five dimensions" in one line is a good review. Do not pad. Do not restate what the PR does — the author knows.
 
-**Verify before claiming.** Read the surrounding file before asserting an invariant is broken;
-the diff alone often does not show that a helper already handles the case. A confident wrong
-finding costs more than a missed one.
+**Verify before claiming.** Read the surrounding file before asserting an invariant is broken; the diff alone often does not show that a helper already handles the case. A confident wrong finding costs more than a missed one.
 
 **Never approve, request changes, or merge.** Post comments only. The human decides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,170 +1,98 @@
 # AGENTS.md
 
-Instructions for AI coding agents working in this repository. Tool-neutral and canonical —
-`CLAUDE.md` points here rather than repeating it.
+Instructions for AI coding agents working in this repository. Tool-neutral and canonical — `CLAUDE.md` points here rather than repeating it.
 
 ## Where things are, whatever agent you use
 
 Two files, and neither is specific to one tool despite what their paths suggest:
 
-**The review standard** —
-[`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).
-The five dimensions, this project's invariants, the procedure to run them, and the reporting
-format. Read it directly if your agent has not already.
+**The review standard** — [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md). The five dimensions, this project's invariants, the procedure to run them, and the reporting format. Read it directly if your agent has not already.
 
-It sits under `.github/instructions/` because Copilot code review reads that directory natively and
-follows no links out of it. Anywhere better-named would have meant maintaining a condensed second
-copy for Copilot, which would drift. Every other agent reaches it from here.
+It sits under `.github/instructions/` because Copilot code review reads that directory natively and follows no links out of it. Anywhere better-named would have meant maintaining a condensed second copy for Copilot, which would drift. Every other agent reaches it from here.
 
-**The review as a skill** — a thin `SKILL.md` wrapper over the file above, in two locations because
-no single skills directory is read by every agent:
+**The review as a skill** — a thin `SKILL.md` wrapper over the file above, in two locations because no single skills directory is read by every agent:
 
-- [`.claude/skills/self-review/`](.claude/skills/self-review/) — Claude Code and Copilot. In Claude
-  Code it is `/self-review`.
-- [`.agents/skills/self-review/`](.agents/skills/self-review/) — the Agent Skills open-standard path
-  that Command Code and others scan.
+- [`.claude/skills/self-review/`](.claude/skills/self-review/) — Claude Code and Copilot. In Claude Code it is `/self-review`.
+- [`.agents/skills/self-review/`](.agents/skills/self-review/) — the Agent Skills open-standard path that Command Code and others scan.
 
-Both are pointers to the one instructions file, not copies of the standard. If your agent looks
-somewhere else again (`.github/skills/`, `.cursor/skills/`, `.codex/skills/`, or its own
-convention), add a wrapper there or skip it entirely and follow the instructions file — that is
-where all the content lives. The wrapper only adds two things: run the judgement pass in a fresh
-context, and report without touching GitHub.
+Both are pointers to the one instructions file, not copies of the standard. If your agent looks somewhere else again (`.github/skills/`, `.cursor/skills/`, `.codex/skills/`, or its own convention), add a wrapper there or skip it entirely and follow the instructions file — that is where all the content lives. The wrapper only adds two things: run the judgement pass in a fresh context, and report without touching GitHub.
 
-In Codex, `/review` is the built-in user-facing review command. Whenever `/review` runs, read and
-follow [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md)
-in full as the review standard. `self-review` is the local skill name, not a Codex command; do not
-tell users to invoke `self-review`.
+In Codex, `/review` is the built-in user-facing review command. Whenever `/review` runs, read and follow [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md) in full as the review standard. `self-review` is the local skill name, not a Codex command; do not tell users to invoke `self-review`.
 
-There is deliberately no per-tool copy of the *standard*. A wrapper is a few lines that defer to it;
-duplicating the standard itself is the thing to avoid — if you find yourself doing that, fix the
-pointer, not the number of copies.
+There is deliberately no per-tool copy of the *standard*. A wrapper is a few lines that defer to it; duplicating the standard itself is the thing to avoid — if you find yourself doing that, fix the pointer, not the number of copies.
 
 ## What this is
 
-An Electron desktop app ("WordPress Contributor Toolkit") that sets up a full WordPress core
-(`wordpress-develop`) dev environment with zero prerequisites — no Git, Node, npm, or Docker
-required on the host. Everything is bundled and run as JS/WASM inside the Electron process. Built
-to fix a Contributor Day problem: newcomers burning the whole session on local setup instead of
-contributing. Still labeled "experimental."
+An Electron desktop app ("WordPress Contributor Toolkit") that sets up a full WordPress core (`wordpress-develop`) dev environment with zero prerequisites — no Git, Node, npm, or Docker required on the host. Everything is bundled and run as JS/WASM inside the Electron process. Built to fix a Contributor Day problem: newcomers burning the whole session on local setup instead of contributing. Still labeled "experimental."
 
 ## Before opening a pull request
 
-Run the review in `.github/instructions/code-review.instructions.md` against the branch, and fix or
-consciously defer every finding. Summarise the outcome in the pull request description — counts,
-what was fixed, what was left as a follow-up and why.
+Run the review in `.github/instructions/code-review.instructions.md` against the branch, and fix or consciously defer every finding. Summarise the outcome in the pull request description — counts, what was fixed, what was left as a follow-up and why.
 
-Before reporting a GitHub workflow complete, verify every requested final state on GitHub — for
-example, distinguish a merged pull request from one that is merely closed, and confirm that an
-issue was closed by the intended pull request rather than only by a comment.
+Before reporting a GitHub workflow complete, verify every requested final state on GitHub — for example, distinguish a merged pull request from one that is merely closed, and confirm that an issue was closed by the intended pull request rather than only by a comment.
 
-Nothing enforces this. There is no automated review on pull requests, by design: it would mean
-storing an AI provider credential as a secret in a public repository. This pass is what stands in
-its place, so skipping it means a human reviewer is the first reader of the diff.
+Nothing enforces this. There is no automated review on pull requests, by design: it would mean storing an AI provider credential as a secret in a public repository. This pass is what stands in its place, so skipping it means a human reviewer is the first reader of the diff.
 
-That file carries the procedure as well as the standard. Follow it rather than improvising a
-review.
+That file carries the procedure as well as the standard. Follow it rather than improvising a review.
 
 ### The pull request description follows the template
 
-[`.github/pull_request_template.md`](.github/pull_request_template.md) is the shape, and GitHub
-loads it into every new pull request automatically — including ones opened with `gh pr create`, as
-long as you do not pass a `--body` that replaces it. Fill it in rather than writing your own
-structure.
+[`.github/pull_request_template.md`](.github/pull_request_template.md) is the shape, and GitHub loads it into every new pull request automatically — including ones opened with `gh pr create`, as long as you do not pass a `--body` that replaces it. Fill it in rather than writing your own structure.
 
-The rule it is built around: **a reviewer understands the change in five minutes.** So what stays
-visible is Why, What changes, How to test this, Risks, Related — and everything else goes in a
-`<details>` block, collapsed by default. Depth is not the enemy of a readable PR; depth *in the way*
-is. Do not delete detail to hit the five minutes, move it.
+The rule it is built around: **a reviewer understands the change in five minutes.** So what stays visible is Why, What changes, How to test this, Risks, Related — and everything else goes in a `<details>` block, collapsed by default. Depth is not the enemy of a readable PR; depth *in the way* is. Do not delete detail to hit the five minutes, move it.
 
-**One template, not one per kind of change.** GitHub shows no picker when a pull request is opened —
-selecting among several requires appending `?template=name.md` to the URL, which nobody remembers,
-so the default loads anyway. The template is written to serve a fix, a feature and a process change
-equally, and calls out the three places where they genuinely differ: a fix names its root cause and
-the test that fails without it, a feature names what it deliberately leaves out and shows its
-surface, and either way the testing steps follow the path a contributor actually takes.
+**One template, not one per kind of change.** GitHub shows no picker when a pull request is opened — selecting among several requires appending `?template=name.md` to the URL, which nobody remembers, so the default loads anyway. The template is written to serve a fix, a feature and a process change equally, and calls out the three places where they genuinely differ: a fix names its root cause and the test that fails without it, a feature names what it deliberately leaves out and shows its surface, and either way the testing steps follow the path a contributor actually takes.
 
-That includes the review outcome AGENTS.md requires below: it lives in a collapsed block, with the
-headline count surfaced in **Risks and limitations** when it changes how the PR should be read.
+That includes the review outcome AGENTS.md requires below: it lives in a collapsed block, with the headline count surfaced in **Risks and limitations** when it changes how the PR should be read.
 
-Titles are `[Action] [what] [where or why]` — "Fix the patch panel's empty diff after a trunk
-update", not "Fix bug".
+Titles are `[Action] [what] [where or why]` — "Fix the patch panel's empty diff after a trunk update", not "Fix bug".
 
-If the diff is over ~800 lines, the first question is whether it should be two pull requests. A
-stacked pair reviews faster than one that nobody wants to start.
+If the diff is over ~800 lines, the first question is whether it should be two pull requests. A stacked pair reviews faster than one that nobody wants to start.
 
 ### Every pull request says how to test it by hand
 
-A **How to test this** section is required, not optional, and a green test suite does not replace
-it. This app's failures live where the unit tests cannot go: a real clone of `wordpress-develop`, a
-`node_modules` that takes minutes to install, an OS file dialog, a Windows path with a space in it.
-The suite proves the logic; only a person driving the app proves the feature.
+A **How to test this** section is required, not optional, and a green test suite does not replace it. This app's failures live where the unit tests cannot go: a real clone of `wordpress-develop`, a `node_modules` that takes minutes to install, an OS file dialog, a Windows path with a space in it. The suite proves the logic; only a person driving the app proves the feature.
 
 Write it for someone who did not write the change and does not know where the button is. That means:
 
-- **A starting state.** "A site with a linked ticket and an uncommitted edit", not "a site". Say how
-  to reach it if it is not the state the app opens in.
+- **A starting state.** "A site with a linked ticket and an uncommitted edit", not "a site". Say how to reach it if it is not the state the app opens in.
 - **Numbered steps naming what to click**, in the words on screen.
-- **The expected result after each step that has one**, stated so it can come out false. "The patch
-  contains only `wp-login.php`" — not "the patch looks right".
-- **What must NOT have happened.** Most of this project's regressions are silent: work quietly
-  discarded, `node_modules` quietly rebuilt, a patch quietly missing a file. Name the thing that
-  would be easy not to notice.
-- **The platforms it needs.** Default to "any" and say so; call out macOS or Windows explicitly when
-  the change touches paths, spawning, line endings, or signing. Buildkite builds signed artifacts
-  for every branch with an open PR, so a reviewer can test on a real machine without building —
-  check the build matches the current head commit, since force-pushing invalidates earlier ones.
-- **What cannot be tested by hand, and why.** An honest "the mid-switch recovery needs a checkout to
-  fail part-way, which I could not stage" is worth more than silence.
+- **The expected result after each step that has one**, stated so it can come out false. "The patch contains only `wp-login.php`" — not "the patch looks right".
+- **What must NOT have happened.** Most of this project's regressions are silent: work quietly discarded, `node_modules` quietly rebuilt, a patch quietly missing a file. Name the thing that would be easy not to notice.
+- **The platforms it needs.** Default to "any" and say so; call out macOS or Windows explicitly when the change touches paths, spawning, line endings, or signing. Buildkite builds signed artifacts for every branch with an open PR, so a reviewer can test on a real machine without building — check the build matches the current head commit, since force-pushing invalidates earlier ones.
+- **What cannot be tested by hand, and why.** An honest "the mid-switch recovery needs a checkout to fail part-way, which I could not stage" is worth more than silence.
 
-If a change genuinely has no user-visible surface — a refactor, a CI fix — say that, and give the
-command that demonstrates it instead. The section is never simply absent.
+If a change genuinely has no user-visible surface — a refactor, a CI fix — say that, and give the command that demonstrates it instead. The section is never simply absent.
 
-For the human-facing version of all this — the CI checks each PR runs and the guardrails in prose —
-see [`CONTRIBUTING.md`](CONTRIBUTING.md). It points back here; it does not restate the standard.
+For the human-facing version of all this — the CI checks each PR runs and the guardrails in prose — see [`CONTRIBUTING.md`](CONTRIBUTING.md). It points back here; it does not restate the standard.
+
+## Markdown in this repository
+
+**Do not hard-wrap prose. One paragraph is one line, however long.** Markdown imposes no line limit — a wrapped paragraph and a single long line render identically — so the wrapping is a convention, and this repository's convention is not to. Every `.md` here follows it: `README.md`, `docs/`, this file, `TESTING.md`, `CONTRIBUTING.md`, the review instructions and the templates.
+
+The reasons are editing, not rendering. A long line reflows to whatever width the reader's editor or screen has, it pastes into an issue or a chat without arriving pre-chopped, and a one-word edit does not reshuffle the six lines beneath it into a diff that claims they changed. The cost is a diff that marks the whole paragraph as changed; `git diff --word-diff`, and GitHub's own intra-line highlighting, both narrow that back down to the words.
+
+Line breaks still mean something everywhere else, and none of this touches them: list items, table rows, headings, fenced code, VitePress `:::` containers, YAML frontmatter and the body of an HTML comment all keep the shape they have.
 
 ## Commands
 
-See `package.json` scripts. To run a single test file (not exposed as a script):
-`node --test test/azure-sign.test.cjs`.
+See `package.json` scripts. To run a single test file (not exposed as a script): `node --test test/azure-sign.test.cjs`.
 
-**[TESTING.md](TESTING.md) is the canonical description of the suite** — the five layers it is made
-of, which one a new test belongs in, what each layer is blind to, and how to read a failure. Read it
-before adding or moving a test; do not restate it elsewhere.
+**[TESTING.md](TESTING.md) is the canonical description of the suite** — the five layers it is made of, which one a new test belongs in, what each layer is blind to, and how to read a failure. Read it before adding or moving a test; do not restate it elsewhere.
 
-When writing manual test instructions, inspect the current renderer flow first and distinguish
-actions that happen automatically after linking a ticket from controls used only to retry or
-refresh them. Do not tell a tester to click a control when the app already starts that operation.
+When writing manual test instructions, inspect the current renderer flow first and distinguish actions that happen automatically after linking a ticket from controls used only to retry or refresh them. Do not tell a tester to click a control when the app already starts that operation.
 
-When asked to add an existing pull request to an existing stack, preserve its commits and change
-its base to the head branch of the current top PR. Do not move commits into an earlier PR unless
-the user explicitly asks to rewrite the stack.
+When asked to add an existing pull request to an existing stack, preserve its commits and change its base to the head branch of the current top PR. Do not move commits into an earlier PR unless the user explicitly asks to rewrite the stack.
 
 ## Architecture notes (non-obvious)
 
-- **Child processes run on Electron's own Node, not the system Node.** `npm install`,
-  `npm run <script>`, and the Playground server are spawned via `process.execPath` +
-  `ELECTRON_RUN_AS_NODE=1` — this is the mechanism behind "zero prerequisites." On Windows this
-  requires shimming `node`/`npm`/`npx` into `PATH` so child `npm` processes can find a `node` binary
-  at all.
-- **Git has no system dependency** — all Git ops go through `isomorphic-git`, not a shelled-out
-  `git` binary. Patch/diff generation is done by hand in `main.js`, not `git diff`: one status scan
-  against the branch point each ticket recorded (#108), nothing staged, and `/dev/null` naming
-  whichever side of an addition or a deletion does not exist — the app reads its own patches back
-  when a mentor applies one, and that filename is the only thing its parser reads an add or a
-  delete from (#85).
-- **`electron-store` is the only persistence layer** — no separate DB. It holds the site registry
-  and per-site metadata; treat it as the single source of truth for "known sites."
-- Long-running child-process output (installs, scripts, server) is streamed to the renderer via
-  correlated IDs (`installId`/`runId`), not returned synchronously — expect async event handlers,
-  not return values, when tracing that flow.
+- **Child processes run on Electron's own Node, not the system Node.** `npm install`, `npm run <script>`, and the Playground server are spawned via `process.execPath` + `ELECTRON_RUN_AS_NODE=1` — this is the mechanism behind "zero prerequisites." On Windows this requires shimming `node`/`npm`/`npx` into `PATH` so child `npm` processes can find a `node` binary at all.
+- **Git has no system dependency** — all Git ops go through `isomorphic-git`, not a shelled-out `git` binary. Patch/diff generation is done by hand in `main.js`, not `git diff`: one status scan against the branch point each ticket recorded (#108), nothing staged, and `/dev/null` naming whichever side of an addition or a deletion does not exist — the app reads its own patches back when a mentor applies one, and that filename is the only thing its parser reads an add or a delete from (#85).
+- **`electron-store` is the only persistence layer** — no separate DB. It holds the site registry and per-site metadata; treat it as the single source of truth for "known sites."
+- Long-running child-process output (installs, scripts, server) is streamed to the renderer via correlated IDs (`installId`/`runId`), not returned synchronously — expect async event handlers, not return values, when tracing that flow.
 
 ## Signing & CI
 
-- **Buildkite builds signed Windows, Linux and macOS artifacts for every branch that has an open
-  PR.** So a branch is testable on a real machine without building locally — and for a stacked PR,
-  the artifact from the topmost branch exercises the whole stack. Force-pushing a branch invalidates
-  earlier artifacts: check the build corresponds to the current head commit before testing.
-- Windows signing (Azure Trusted Signing via `scripts/azure-sign.cjs`) is skipped automatically when
-  its required env vars aren't set — this is intentional for local dev, not a bug.
-- macOS signing/notarization uses fastlane + match against Automattic's Developer ID;
-  `verify_code_signing` lane must pass before shipping.
+- **Buildkite builds signed Windows, Linux and macOS artifacts for every branch that has an open PR.** So a branch is testable on a real machine without building locally — and for a stacked PR, the artifact from the topmost branch exercises the whole stack. Force-pushing a branch invalidates earlier artifacts: check the build corresponds to the current head commit before testing.
+- Windows signing (Azure Trusted Signing via `scripts/azure-sign.cjs`) is skipped automatically when its required env vars aren't set — this is intentional for local dev, not a bug.
+- macOS signing/notarization uses fastlane + match against Automattic's Developer ID; `verify_code_signing` lane must pass before shipping.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,7 @@
 # CLAUDE.md
 
-Read **[AGENTS.md](AGENTS.md)** — it holds the instructions for this repository, and is written to
-be read by any agent. Nothing that belongs there should be duplicated here.
+Read **[AGENTS.md](AGENTS.md)** — it holds the instructions for this repository, and is written to be read by any agent. Nothing that belongs there should be duplicated here.
 
 Claude Code specifics only:
 
-- `/self-review` (`.claude/skills/self-review/SKILL.md`) is the entry point for the pre-PR review
-  that AGENTS.md asks for. It runs the procedure in
-  `.github/instructions/code-review.instructions.md` and dispatches the judgement pass to a
-  subagent, so the session that wrote the change is not the one grading it.
+- `/self-review` (`.claude/skills/self-review/SKILL.md`) is the entry point for the pre-PR review that AGENTS.md asks for. It runs the procedure in `.github/instructions/code-review.instructions.md` and dispatches the judgement pass to a subagent, so the session that wrote the change is not the one grading it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,153 +1,85 @@
 # Contributing
 
-Much of the work on this project happens with the support of AI coding agents. The quality bar is
-not held by trusting the agent — it is held by a small set of guardrails, some
-automated on every pull request, some run by the author before the PR exists. This page is the map
-of them.
+Much of the work on this project happens with the support of AI coding agents. The quality bar is not held by trusting the agent — it is held by a small set of guardrails, some automated on every pull request, some run by the author before the PR exists. This page is the map of them.
 
-If you are an agent, start with **[AGENTS.md](AGENTS.md)** — it is the canonical, tool-neutral set
-of instructions. This file is the human-facing companion: what the guardrails are and what you are
-expected to do before opening a PR.
+If you are an agent, start with **[AGENTS.md](AGENTS.md)** — it is the canonical, tool-neutral set of instructions. This file is the human-facing companion: what the guardrails are and what you are expected to do before opening a PR.
 
 ## Checks that run on every pull request
 
-Three GitHub Actions workflows run on every PR, and also on push to `trunk` so the default branch
-carries a status a branch-protection rule can require. None needs a secret, and none is
-credential-gated — everything here is safe to run on a public repository.
+Three GitHub Actions workflows run on every PR, and also on push to `trunk` so the default branch carries a status a branch-protection rule can require. None needs a secret, and none is credential-gated — everything here is safe to run on a public repository.
 
 ### Lint — [`.github/workflows/lint.yml`](.github/workflows/lint.yml)
 
-ESLint over the **whole repo**: `eslint . --max-warnings=0`. A single warning fails the check. The
-backlog that once made a repo-wide run impractical was cleared (#117), so the check now covers
-every file rather than only the ones a PR touched.
+ESLint over the **whole repo**: `eslint . --max-warnings=0`. A single warning fails the check. The backlog that once made a repo-wide run impractical was cleared (#117), so the check now covers every file rather than only the ones a PR touched.
 
-It installs with `npm ci --ignore-scripts`, which skips lifecycle scripts — so linting **never
-executes the PR's code** (this repo's `postinstall` would otherwise pull the Electron binary, which
-the linter does not need). If ESLint flags something mechanical, `npm run lint:fix` handles it;
-check what it rewrote before committing, since it too is repo-wide.
+It installs with `npm ci --ignore-scripts`, which skips lifecycle scripts — so linting **never executes the PR's code** (this repo's `postinstall` would otherwise pull the Electron binary, which the linter does not need). If ESLint flags something mechanical, `npm run lint:fix` handles it; check what it rewrote before committing, since it too is repo-wide.
 
 ### Tests — [`unit-tests.yml`](.github/workflows/unit-tests.yml) and [`e2e.yml`](.github/workflows/e2e.yml)
 
 Everything runs on the **two platforms the app ships to, macOS and Windows**:
 
-- **The fast suite** (`npm test`) — and on each platform it runs **twice**, once on the system Node
-  pinned in `.nvmrc` and once on the Node that Electron bundles. That second pass is not redundant:
-  child processes in this app run on Electron's own Node, and the two versions are set independently
-  and have drifted before (#37/#46).
-- **The end-to-end suites** (`npm run test:e2e`, and the packaged one) — on every pull request that
-  is not a draft, as two jobs, because one takes seconds and the other packages the app first.
+- **The fast suite** (`npm test`) — and on each platform it runs **twice**, once on the system Node pinned in `.nvmrc` and once on the Node that Electron bundles. That second pass is not redundant: child processes in this app run on Electron's own Node, and the two versions are set independently and have drifted before (#37/#46).
+- **The end-to-end suites** (`npm run test:e2e`, and the packaged one) — on every pull request that is not a draft, as two jobs, because one takes seconds and the other packages the app first.
 
 Every matrix uses `fail-fast: false`, so a Windows failure never hides the macOS result.
 
-**[TESTING.md](TESTING.md) is the full picture** — what to run locally, the five layers the suite is
-made of, where a new test belongs, and how to read a failure. Read it before adding a test.
+**[TESTING.md](TESTING.md) is the full picture** — what to run locally, the five layers the suite is made of, where a new test belongs, and how to read a failure. Read it before adding a test.
 
 ## The review standard, and who reads it
 
-There is **one** source of truth for how a change is reviewed:
-**[`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md)**.
-It holds the five review dimensions (architecture, security, performance, cross-platform, tests),
-this project's specific invariants, and the procedure to run them. It is deliberately the only copy
-— everything else points at it rather than restating it, so nothing can drift.
+There is **one** source of truth for how a change is reviewed: **[`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md)**. It holds the five review dimensions (architecture, security, performance, cross-platform, tests), this project's specific invariants, and the procedure to run them. It is deliberately the only copy — everything else points at it rather than restating it, so nothing can drift.
 
 Two things consume that one file:
 
 ### Copilot code review — assign it to a PR
 
-Copilot code review reads `.github/instructions/*.instructions.md` **natively**, selecting files by
-their `applyTo` glob (this one is `**`, so it applies to every PR). That is the entire reason the
-standard lives at this path and not somewhere better-named — Copilot follows no links, so a pointer
-would not have reached it.
+Copilot code review reads `.github/instructions/*.instructions.md` **natively**, selecting files by their `applyTo` glob (this one is `**`, so it applies to every PR). That is the entire reason the standard lives at this path and not somewhere better-named — Copilot follows no links, so a pointer would not have reached it.
 
-Copilot is **assigned manually** as a reviewer on a pull request; it is **not** an automatic bot
-that fires on every PR. That is by design: an always-on AI review would mean storing an AI provider
-credential as a secret in a public repository, which this project will not do. What exists is the
-*capability* — assign Copilot and it reviews against the same standard the author already ran.
+Copilot is **assigned manually** as a reviewer on a pull request; it is **not** an automatic bot that fires on every PR. That is by design: an always-on AI review would mean storing an AI provider credential as a secret in a public repository, which this project will not do. What exists is the *capability* — assign Copilot and it reviews against the same standard the author already ran.
 
 ### The author's own pass — before you open the PR
 
-The author runs the review against their branch **before** the PR exists — because a finding fixed
-now costs one message, and the same finding on the PR costs a full review cycle. This means running
-`npm run lint` and `npm test`, then reviewing the five dimensions against the diff.
+The author runs the review against their branch **before** the PR exists — because a finding fixed now costs one message, and the same finding on the PR costs a full review cycle. This means running `npm run lint` and `npm test`, then reviewing the five dimensions against the diff.
 
 How you invoke it depends on your agent:
 
-- **Claude Code** ships this as the [`/self-review`](.claude/skills/self-review/) skill. It adds one
-  thing worth knowing: it hands the judgement pass to a **fresh subagent**, given only the diff and
-  the standard. If the session that wrote the code also grades it, it reviews its own reasoning and
-  finds it sound — so the review runs in a context that did not write the change. It reports in the
-  chat and touches nothing on GitHub; you decide what is a real finding.
-- **Open-standard agents** (Command Code and others that scan `.agents/skills/`) find the same
-  review as [`/self-review`](.agents/skills/self-review/), a wrapper mirroring the Claude Code one.
-- **Any other agent** — no wrapper sits on the path it reads, so there is no `/self-review` command
-  to find. Point it at
-  [`code-review.instructions.md`](.github/instructions/code-review.instructions.md) directly, or
-  just follow the standard yourself. That file is where all the content lives; the skill is only a
-  wrapper over it. If your agent reads a skills directory nobody has wrapped yet, adding a pointer
-  there is a few lines — see [AGENTS.md](AGENTS.md).
+- **Claude Code** ships this as the [`/self-review`](.claude/skills/self-review/) skill. It adds one thing worth knowing: it hands the judgement pass to a **fresh subagent**, given only the diff and the standard. If the session that wrote the code also grades it, it reviews its own reasoning and finds it sound — so the review runs in a context that did not write the change. It reports in the chat and touches nothing on GitHub; you decide what is a real finding.
+- **Open-standard agents** (Command Code and others that scan `.agents/skills/`) find the same review as [`/self-review`](.agents/skills/self-review/), a wrapper mirroring the Claude Code one.
+- **Any other agent** — no wrapper sits on the path it reads, so there is no `/self-review` command to find. Point it at [`code-review.instructions.md`](.github/instructions/code-review.instructions.md) directly, or just follow the standard yourself. That file is where all the content lives; the skill is only a wrapper over it. If your agent reads a skills directory nobody has wrapped yet, adding a pointer there is a few lines — see [AGENTS.md](AGENTS.md).
 
 ## What is *not* a PR gate
 
 Worth knowing so you don't wait on them:
 
-- **Buildkite signed builds** produce Windows, Linux, and macOS artifacts for every branch with an
-  open PR, so a change is testable on a real machine without a local build. Force-pushing a branch
-  invalidates earlier artifacts — check the build matches the current head commit before testing.
-- **Download stats** ([`download-stats.yml`](.github/workflows/download-stats.yml)) is a weekly cron
-  that records release-asset counts to a `metrics` branch. It is not related to PR quality.
+- **Buildkite signed builds** produce Windows, Linux, and macOS artifacts for every branch with an open PR, so a change is testable on a real machine without a local build. Force-pushing a branch invalidates earlier artifacts — check the build matches the current head commit before testing.
+- **Download stats** ([`download-stats.yml`](.github/workflows/download-stats.yml)) is a weekly cron that records release-asset counts to a `metrics` branch. It is not related to PR quality.
 
 ## Before you open a pull request
 
-In an agent-assisted change your agent runs steps 1–3 — it invokes the review, applies or defers the
-findings, and drafts the PR summary. Your job is to see that they happen and that the summary is
-honest; you own the result even though the agent produced it.
+In an agent-assisted change your agent runs steps 1–3 — it invokes the review, applies or defers the findings, and drafts the PR summary. Your job is to see that they happen and that the summary is honest; you own the result even though the agent produced it.
 
-1. **Run the review standard** against your branch —
-   [`code-review.instructions.md`](.github/instructions/code-review.instructions.md). In Claude Code
-   that is the `/self-review` skill; on any other agent, follow the file directly.
+1. **Run the review standard** against your branch — [`code-review.instructions.md`](.github/instructions/code-review.instructions.md). In Claude Code that is the `/self-review` skill; on any other agent, follow the file directly.
 2. **Fix or consciously defer** every finding — a deferral is a decision, not an omission.
-3. **Summarise the outcome in the PR description**: what the checks reported, what you fixed, and
-   what you left as a follow-up and why.
-4. **Write a "How to test this" section** — a starting state, numbered steps naming what to click,
-   the expected result of each, and what must *not* have happened. Required on every PR, including
-   ones with green tests: this app fails in places the suite cannot reach, and a reviewer should
-   never have to guess how to drive the change. The shape is spelled out in
-   [AGENTS.md](AGENTS.md#every-pull-request-says-how-to-test-it-by-hand).
+3. **Summarise the outcome in the PR description**: what the checks reported, what you fixed, and what you left as a follow-up and why.
+4. **Write a "How to test this" section** — a starting state, numbered steps naming what to click, the expected result of each, and what must *not* have happened. Required on every PR, including ones with green tests: this app fails in places the suite cannot reach, and a reviewer should never have to guess how to drive the change. The shape is spelled out in [AGENTS.md](AGENTS.md#every-pull-request-says-how-to-test-it-by-hand).
 5. Optionally **assign Copilot** as a second reader against the same standard.
 
-GitHub fills every new pull request with
-[the template](.github/pull_request_template.md); steps 3 and 4 have their place in it already.
-It is built so a reviewer gets the change in five minutes — Why, What changes, How to test this,
-Risks, Related stay visible and everything deeper goes in a collapsed `<details>` block. Move detail
-out of the way rather than dropping it. The same template covers a fix, a feature and a process
-change; it flags the few places where the three want different things.
+GitHub fills every new pull request with [the template](.github/pull_request_template.md); steps 3 and 4 have their place in it already. It is built so a reviewer gets the change in five minutes — Why, What changes, How to test this, Risks, Related stay visible and everything deeper goes in a collapsed `<details>` block. Move detail out of the way rather than dropping it. The same template covers a fix, a feature and a process change; it flags the few places where the three want different things.
 
-Nothing enforces steps 1–4. Skipping them means a human reviewer is the first person to read the
-diff — which is exactly the cost this process exists to avoid.
+Nothing enforces steps 1–4. Skipping them means a human reviewer is the first person to read the diff — which is exactly the cost this process exists to avoid.
 
 ## The documentation site
 
-The user guide under `docs/` is a VitePress site, deployed to GitHub Pages by
-`.github/workflows/docs.yml` on every push to trunk that touches it.
+The user guide under `docs/` is a VitePress site, deployed to GitHub Pages by `.github/workflows/docs.yml` on every push to trunk that touches it.
 
-It is a **separate npm package** with its own lockfile, so a root `npm ci` does not install it and
-the commands below fail with `vitepress: not found` until you run this once:
+It is a **separate npm package** with its own lockfile, so a root `npm ci` does not install it and the commands below fail with `vitepress: not found` until you run this once:
 
 ```bash
 npm ci --prefix docs
 ```
 
-- `npm run docs:dev` — live-reloading editing server. Pages are served at their `.html` paths
-  (`/guide/getting-started.html`); the bare directory URL the banner prints does not resolve in
-  dev, only in the built site.
+- `npm run docs:dev` — live-reloading editing server. Pages are served at their `.html` paths (`/guide/getting-started.html`); the bare directory URL the banner prints does not resolve in dev, only in the built site.
 - `npm run docs:build` — what CI runs. It fails on dead links, so run it before pushing.
-- `npm run docs:preview` — serves the built site exactly as GitHub Pages will, clean URLs and all.
-  This is the one to check a change against before opening a PR.
+- `npm run docs:preview` — serves the built site exactly as GitHub Pages will, clean URLs and all. This is the one to check a change against before opening a PR.
 
-Its screenshots are captured by `npm run shots` (see `scripts/screenshots/`), not by CI: the harness
-launches the app against a seeded, throwaway site registry and photographs each screen at a fixed
-size. **A PR that changes what a documented screen looks like re-runs `npm run shots` and commits
-the new images** — nothing automated catches a stale screenshot. Shots the fixture registry cannot
-reach (a running dev server, a real diff) are listed in the live tier: `npm run shots -- --tier=live`
-pauses per shot while you set the real screen up, and those images show real paths, so look at each
-one before committing it.
+Its screenshots are captured by `npm run shots` (see `scripts/screenshots/`), not by CI: the harness launches the app against a seeded, throwaway site registry and photographs each screen at a fixed size. **A PR that changes what a documented screen looks like re-runs `npm run shots` and commits the new images** — nothing automated catches a stale screenshot. Shots the fixture registry cannot reach (a running dev server, a real diff) are listed in the live tier: `npm run shots -- --tier=live` pauses per shot while you set the real screen up, and those images show real paths, so look at each one before committing it.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ## WordPress Contributor Toolkit (Electron)
 
-[![Unit tests](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml/badge.svg?branch=trunk)](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml)
-[![Latest release](https://img.shields.io/github/v/release/WordPress/contributor-toolkit)](https://github.com/WordPress/contributor-toolkit/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/WordPress/contributor-toolkit/total)](https://github.com/WordPress/contributor-toolkit/releases)
+[![Unit tests](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml/badge.svg?branch=trunk)](https://github.com/WordPress/contributor-toolkit/actions/workflows/unit-tests.yml) [![Latest release](https://img.shields.io/github/v/release/WordPress/contributor-toolkit)](https://github.com/WordPress/contributor-toolkit/releases/latest) [![Downloads](https://img.shields.io/github/downloads/WordPress/contributor-toolkit/total)](https://github.com/WordPress/contributor-toolkit/releases)
 
 The [WordPress Contributor Toolkit](https://make.wordpress.org/core/2026/04/16/wordpress-core-dev-environment-toolkit-a-faster-path-to-your-first-core-contribution/) is a desktop Electron application (macOS on Apple Silicon, Windows, and Linux) that takes a contributor from nothing to a working WordPress core development environment, lets them try the work that already exists on a Trac ticket, and lets them send their own change back — as a pull request, a Trac attachment, or a patch for a mentor. No Git, Node.js, npm or Docker on the host, and no push credential written to disk.
 
@@ -32,20 +30,13 @@ Each of these has a page in the user guide.
 
 ## Documentation
 
-**The user guide lives at <https://wordpress.github.io/contributor-toolkit/>** — installing
-the app, creating a site, working on a Trac ticket, applying patches and PRs, and submitting your
-changes as a pull request, a Trac attachment, or a patch for a mentor. What follows here is only
-what a contributor to *this repository* needs.
+**The user guide lives at <https://wordpress.github.io/contributor-toolkit/>** — installing the app, creating a site, working on a Trac ticket, applying patches and PRs, and submitting your changes as a pull request, a Trac attachment, or a patch for a mentor. What follows here is only what a contributor to *this repository* needs.
 
 ## Getting started
 
 ### Just using the app
 
-Download the latest packaged build from the
-[Releases page](https://github.com/WordPress/contributor-toolkit/releases/latest) and follow
-[Getting started](https://wordpress.github.io/contributor-toolkit/guide/getting-started) in
-the user guide — it covers picking the right file per platform, the macOS Gatekeeper notes, and
-the first-contribution walkthrough.
+Download the latest packaged build from the [Releases page](https://github.com/WordPress/contributor-toolkit/releases/latest) and follow [Getting started](https://wordpress.github.io/contributor-toolkit/guide/getting-started) in the user guide — it covers picking the right file per platform, the macOS Gatekeeper notes, and the first-contribution walkthrough.
 
 ### Build from source
 
@@ -76,9 +67,7 @@ Electron Builder picks these up via `build` configuration in `package.json`.
 
 ## Technical notes
 
-How the app works from a user's point of view — the toolchain it bundles, keeping a site up to
-date with trunk, what SQLite does and doesn't cover — is documented in the
-[user guide](https://wordpress.github.io/contributor-toolkit/), not here.
+How the app works from a user's point of view — the toolchain it bundles, keeping a site up to date with trunk, what SQLite does and doesn't cover — is documented in the [user guide](https://wordpress.github.io/contributor-toolkit/), not here.
 
 ### Why Electron?
 
@@ -95,17 +84,11 @@ date with trunk, what SQLite does and doesn't cover — is documented in the
 
 ### Download stats
 
-Release downloads are the only usage signal this project has, and GitHub keeps no history of
-them, so a weekly workflow records the counts to a `metrics` branch. See [STATS.md](STATS.md) for
-how to read them and what they do and don't measure.
+Release downloads are the only usage signal this project has, and GitHub keeps no history of them, so a weekly workflow records the counts to a `metrics` branch. See [STATS.md](STATS.md) for how to read them and what they do and don't measure.
 
 ### Contributing
 
-Much of the work here happens with the support of AI coding agents, and the quality bar is held by
-a set of guardrails rather than by trusting the agent. See [CONTRIBUTING.md](CONTRIBUTING.md) for
-what runs on every pull request (repo-wide lint, unit tests on macOS and Windows) and the single
-review standard to run yourself before opening one — as the `/self-review` skill in Claude Code, or
-by following the standard directly on any other agent.
+Much of the work here happens with the support of AI coding agents, and the quality bar is held by a set of guardrails rather than by trusting the agent. See [CONTRIBUTING.md](CONTRIBUTING.md) for what runs on every pull request (repo-wide lint, unit tests on macOS and Windows) and the single review standard to run yourself before opening one — as the `/self-review` skill in Claude Code, or by following the standard directly on any other agent.
 
 ### License
 

--- a/STATS.md
+++ b/STATS.md
@@ -1,18 +1,12 @@
 ## Download stats
 
-The app is distributed as release binaries, so downloads are the only usage signal there is —
-there is no npm install count, no Docker pull count, no telemetry in the app.
+The app is distributed as release binaries, so downloads are the only usage signal there is — there is no npm install count, no Docker pull count, no telemetry in the app.
 
-GitHub reports a running total per release asset and keeps **no history**: the API returns the
-number as it stands today and nothing about how it got there. So a
-[weekly workflow](.github/workflows/download-stats.yml) records that total and commits it to
-[`metrics`](https://github.com/WordPress/contributor-toolkit/tree/metrics), an orphan branch
-that shares no history with `trunk` and holds nothing but the data files.
+GitHub reports a running total per release asset and keeps **no history**: the API returns the number as it stands today and nothing about how it got there. So a [weekly workflow](.github/workflows/download-stats.yml) records that total and commits it to [`metrics`](https://github.com/WordPress/contributor-toolkit/tree/metrics), an orphan branch that shares no history with `trunk` and holds nothing but the data files.
 
 ### Reading the data
 
-In the browser:
-[downloads.csv](https://github.com/WordPress/contributor-toolkit/blob/metrics/downloads.csv).
+In the browser: [downloads.csv](https://github.com/WordPress/contributor-toolkit/blob/metrics/downloads.csv).
 
 Locally, without switching branches:
 
@@ -30,8 +24,7 @@ date,tag,asset,downloads
 2026-07-31,"v0.1.0","mac-release-arm64.dmg",47
 ```
 
-**The number is cumulative per asset, not per week.** Two consecutive rows for the same asset are
-running totals; subtract them to get the change between those dates.
+**The number is cumulative per asset, not per week.** Two consecutive rows for the same asset are running totals; subtract them to get the change between those dates.
 
 A few things the data answers directly:
 
@@ -44,22 +37,14 @@ git show metrics:downloads.csv | awk -F, -v d="$(git show metrics:downloads.csv 
 git show metrics:downloads.csv | grep 'mac-arm64.dmg'
 ```
 
-`badge.json`, on the same branch, holds the current total across every release in the format a
-[shields.io endpoint badge](https://shields.io/badges/endpoint-badge) reads.
+`badge.json`, on the same branch, holds the current total across every release in the format a [shields.io endpoint badge](https://shields.io/badges/endpoint-badge) reads.
 
 ### What the numbers are not
 
-**They count HTTP requests, not people.** A re-download, a `curl` in a CI script, a retry after a
-dropped connection and a bot crawling the releases page each add one. Treat them as an interest
-signal, not an install count.
+**They count HTTP requests, not people.** A re-download, a `curl` in a CI script, a retry after a dropped connection and a bot crawling the releases page each add one. Treat them as an interest signal, not an install count.
 
-**Source archives and clones are not included.** Only uploaded release assets are counted — the
-auto-generated `.zip`/`.tar.gz` and `git clone` are not.
+**Source archives and clones are not included.** Only uploaded release assets are counted — the auto-generated `.zip`/`.tar.gz` and `git clone` are not.
 
-**The counter belongs to the asset, not the release.** Deleting a release file and re-uploading it
-restarts that file at zero, which is part of why these snapshots exist: they are the only record
-that survives a rename. It has already happened once, to the three artifacts replaced on the
-v0.1.2 draft.
+**The counter belongs to the asset, not the release.** Deleting a release file and re-uploading it restarts that file at zero, which is part of why these snapshots exist: they are the only record that survives a rename. It has already happened once, to the three artifacts replaced on the v0.1.2 draft.
 
-**History starts when the workflow did.** Everything before the first snapshot is unrecoverable —
-GitHub never stored it.
+**History starts when the workflow did.** Everything before the first snapshot is unrecoverable — GitHub never stored it.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,7 +1,6 @@
 # Testing
 
-Everything about tests in this repository: what to run, what the suite is made of, and where a new
-test belongs. [CONTRIBUTING.md](CONTRIBUTING.md) points here rather than repeating any of it.
+Everything about tests in this repository: what to run, what the suite is made of, and where a new test belongs. [CONTRIBUTING.md](CONTRIBUTING.md) points here rather than repeating any of it.
 
 ## What to run
 
@@ -11,8 +10,7 @@ npm run test:e2e            # the app, driven — layer 4, seconds
 npm run lint                # ESLint over the whole repo
 ```
 
-`npm test` is the one to run without thinking about it. It touches no network: the single suite
-that needs a Git remote starts a loopback server and serves the repository to itself.
+`npm test` is the one to run without thinking about it. It touches no network: the single suite that needs a Git remote starts a loopback server and serves the repository to itself.
 
 Two more, for when you need them:
 
@@ -21,95 +19,51 @@ npm run test:electron       # the fast suite again, on the Node that Electron bu
 npm run test:e2e:packaged   # the built artifact — needs a build first, see below
 ```
 
-To run one file: `node --test test/azure-sign.test.cjs`. To run one journey:
-`npx playwright test --project=journeys -g "switching back"`. A journey opens and closes the app as
-it goes; there is no headless mode and nothing to turn off.
+To run one file: `node --test test/azure-sign.test.cjs`. To run one journey: `npx playwright test --project=journeys -g "switching back"`. A journey opens and closes the app as it goes; there is no headless mode and nothing to turn off.
 
 ## The five layers
 
-"Add a test" is not a single instruction here. There are five places a test can go, and putting one
-in the wrong place is how a suite gets slow without getting better.
+"Add a test" is not a single instruction here. There are five places a test can go, and putting one in the wrong place is how a suite gets slow without getting better.
 
-They are listed cheapest first, and that ordering is the rule: **write a test at the highest layer
-that can still see the failure.** What each layer is blind to is the part worth reading — it is what
-sends a test one layer up, or down.
+They are listed cheapest first, and that ordering is the rule: **write a test at the highest layer that can still see the failure.** What each layer is blind to is the part worth reading — it is what sends a test one layer up, or down.
 
-**1. Unit** — `test/`. Starts nothing; calls plain functions. Pure logic: parsing a ticket
-reference, deriving a status, building a command line. Blind to anything touching disk, a process
-or a window.
+**1. Unit** — `test/`. Starts nothing; calls plain functions. Pure logic: parsing a ticket reference, deriving a status, building a command line. Blind to anything touching disk, a process or a window.
 
-**2. Integration** — the files named `*.integration.test.cjs`. Runs the real modules against real
-Git repositories in a temporary directory. Proves Git does what the code assumes when it switches a
-branch, applies a patch or updates trunk. Blind to everything above the module boundary.
+**2. Integration** — the files named `*.integration.test.cjs`. Runs the real modules against real Git repositories in a temporary directory. Proves Git does what the code assumes when it switches a branch, applies a patch or updates trunk. Blind to everything above the module boundary.
 
-**3. IPC wiring** — one file, `test/ipc-wiring.test.cjs`. Loads the real `src/main.js` with
-`electron` replaced by a double, and exercises every handler: what each returns, what it rejects,
-what error it gives. Blind to the window, and its store is a stand-in rather than the real one.
+**3. IPC wiring** — one file, `test/ipc-wiring.test.cjs`. Loads the real `src/main.js` with `electron` replaced by a double, and exercises every handler: what each returns, what it rejects, what error it gives. Blind to the window, and its store is a stand-in rather than the real one.
 
-**4. Journeys** — `e2e/journeys/`. Starts the whole app, built from the source tree, and drives
-it. Asks the only question the other three cannot: can a contributor do their work without losing
-it. Blind to anything about packaging.
+**4. Journeys** — `e2e/journeys/`. Starts the whole app, built from the source tree, and drives it. Asks the only question the other three cannot: can a contributor do their work without losing it. Blind to anything about packaging.
 
-**5. Packaged smoke** — `e2e/packaged/`. Starts the built artifact — the `.app` or `.exe`
-a user downloads — and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
+**5. Packaged smoke** — `e2e/packaged/`. Starts the built artifact — the `.app` or `.exe` a user downloads — and asks whether it is whole. Blind to behaviour: it never gets as far as a flow.
 
-Layers 1–3 are `npm test`. Layers 4 and 5 are the two `test:e2e` commands. That proportion — a
-great many cheap tests to a handful of expensive ones, orders of magnitude apart in what each
-costs — is the shape to keep.
+Layers 1–3 are `npm test`. Layers 4 and 5 are the two `test:e2e` commands. That proportion — a great many cheap tests to a handful of expensive ones, orders of magnitude apart in what each costs — is the shape to keep.
 
 ## Where to put a new test
 
-- **A pure function, a derived string, a decision with branches** → layer 1. If it lives inside
-  `src/renderer/index.jsx` today, move it to a `src/renderer/*.cjs` module first: that component
-  mounts at module scope and nothing in the suite can load it, so a decision made there is
-  untestable by construction.
-- **Anything that asks Git a question** → layer 2, against a real repository. There is a local Git
-  server fixture in `test/trunk-update-fetch.integration.test.cjs` for cases that need a remote,
-  because `isomorphic-git` has no `file://` transport.
-- **A new IPC handler** → layer 3, plus the `contextBridge` entry in `src/preload.js`, which layer 5
-  checks is actually exposed.
+- **A pure function, a derived string, a decision with branches** → layer 1. If it lives inside `src/renderer/index.jsx` today, move it to a `src/renderer/*.cjs` module first: that component mounts at module scope and nothing in the suite can load it, so a decision made there is untestable by construction.
+- **Anything that asks Git a question** → layer 2, against a real repository. There is a local Git server fixture in `test/trunk-update-fetch.integration.test.cjs` for cases that need a remote, because `isomorphic-git` has no `file://` transport.
+- **A new IPC handler** → layer 3, plus the `contextBridge` entry in `src/preload.js`, which layer 5 checks is actually exposed.
 - **A flow that spans the interface, the main process, Git and the store at once** → layer 4.
 - **Something that can only break during packaging** → layer 5.
 
-Keep layer 4 small on purpose. Every test there costs an app launch, and any assertion that does not
-need a window belongs one layer down.
+Keep layer 4 small on purpose. Every test there costs an app launch, and any assertion that does not need a window belongs one layer down.
 
-The failures worth layer 4 are the ones that fall *between* the other layers, where every piece works
-and the whole does not. One example, found while writing the first journeys: the integration tests
-prove branch switching restores work correctly, and the wiring tests prove the delete handler returns
-the checkout to trunk when the deleted branch was the current one — but the interface leaves the
-currently linked ticket out of the list it offers delete controls for, so that branch of the handler
-cannot be reached by a contributor at all. Three layers passing, one path dead.
+The failures worth layer 4 are the ones that fall *between* the other layers, where every piece works and the whole does not. One example, found while writing the first journeys: the integration tests prove branch switching restores work correctly, and the wiring tests prove the delete handler returns the checkout to trunk when the deleted branch was the current one — but the interface leaves the currently linked ticket out of the list it offers delete controls for, so that branch of the handler cannot be reached by a contributor at all. Three layers passing, one path dead.
 
 ## The two end-to-end layers, and why they are separate
 
-They run **the same source code in two different containers**, and each container has failures the
-other cannot have.
+They run **the same source code in two different containers**, and each container has failures the other cannot have.
 
-Layer 4 runs the code the way `npm start` does: `src/main.js` on disk, `node_modules` beside it.
-Layer 5 runs what `electron-builder` produces, where all of `src/` and every production dependency is
-compressed into a single `app.asar`, and native modules are pulled back out beside it because the
-operating system cannot load a binary from inside an archive. A path that resolves from a directory
-may not resolve from inside that archive; a native binary can be selected for the wrong runtime while
-`npm ci` and the packaging both exit 0 and the app still starts. Those failures do not exist in the
-source tree, because there is nothing packaged to get wrong.
+Layer 4 runs the code the way `npm start` does: `src/main.js` on disk, `node_modules` beside it. Layer 5 runs what `electron-builder` produces, where all of `src/` and every production dependency is compressed into a single `app.asar`, and native modules are pulled back out beside it because the operating system cannot load a binary from inside an archive. A path that resolves from a directory may not resolve from inside that archive; a native binary can be selected for the wrong runtime while `npm ci` and the packaging both exit 0 and the app still starts. Those failures do not exist in the source tree, because there is nothing packaged to get wrong.
 
 So layer 5 asks only whether the container is intact, and **writes no state at all**.
 
-That last part is a constraint, not minimalism. The app only honours a redirected application-data
-directory in development builds (`!app.isPackaged` in `src/main.js`); the packaged app always writes
-to the real site registry of whoever runs it. So a test that drives a flow cannot run against the
-artifact without writing to somebody's actual sites.
+That last part is a constraint, not minimalism. The app only honours a redirected application-data directory in development builds (`!app.isPackaged` in `src/main.js`); the packaged app always writes to the real site registry of whoever runs it. So a test that drives a flow cannot run against the artifact without writing to somebody's actual sites.
 
-Layer 4 gets a throwaway application-data directory per test, and the harness reads back the path the
-app chose and **refuses to run** if it is not the throwaway one. Nothing a journey does can reach the
-sites you work on.
+Layer 4 gets a throwaway application-data directory per test, and the harness reads back the path the app chose and **refuses to run** if it is not the throwaway one. Nothing a journey does can reach the sites you work on.
 
-**The gap this leaves**, stated plainly: a flow that behaves differently *because* of packaging is
-caught by neither layer. Layer 5 covers it only indirectly — if the container is intact, the code
-inside it is the same code. Closing it properly would mean letting the packaged app accept a
-redirected data directory under a test-only condition, which is a seam in shipped software and is not
-worth opening until a failure of that shape actually escapes.
+**The gap this leaves**, stated plainly: a flow that behaves differently *because* of packaging is caught by neither layer. Layer 5 covers it only indirectly — if the container is intact, the code inside it is the same code. Closing it properly would mean letting the packaged app accept a redirected data directory under a test-only condition, which is a seam in shipped software and is not worth opening until a failure of that shape actually escapes.
 
 ## Running the packaged smoke test
 
@@ -120,22 +74,15 @@ npm run build:once && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
 npm run test:e2e:packaged
 ```
 
-`CSC_IDENTITY_AUTO_DISCOVERY=false` is mandatory on macOS — electron-builder signs during `--dir`
-without it — and harmless everywhere else. The test tells you if you forgot the build.
+`CSC_IDENTITY_AUTO_DISCOVERY=false` is mandatory on macOS — electron-builder signs during `--dir` without it — and harmless everywhere else. The test tells you if you forgot the build.
 
-Neither end-to-end command downloads a browser. The only thing they launch is the Electron already in
-the tree, which is why CI has no `playwright install` step. The one exception is the Inspector, and
-it is opt-in — see above.
+Neither end-to-end command downloads a browser. The only thing they launch is the Electron already in the tree, which is why CI has no `playwright install` step. The one exception is the Inspector, and it is opt-in — see above.
 
 ## Auditing an end-to-end test
 
-A test that asserts nothing passes. For a suite whose entire content is tests, that is the risk that
-matters, and neither a green run nor a recording of one will tell you: both look identical whether
-the assertion is load-bearing or decorative.
+A test that asserts nothing passes. For a suite whose entire content is tests, that is the risk that matters, and neither a green run nor a recording of one will tell you: both look identical whether the assertion is load-bearing or decorative.
 
-**The way to audit a journey is to break what it claims and confirm it goes red.** One assertion at
-a time. Worked example — "switching back to a ticket restores its work byte for byte" says the
-contributor's edit comes back, so make that false and see whether the test notices:
+**The way to audit a journey is to break what it claims and confirm it goes red.** One assertion at a time. Worked example — "switching back to a ticket restores its work byte for byte" says the contributor's edit comes back, so make that false and see whether the test notices:
 
 ```
 # in e2e/journeys/ticket-branches.spec.js, find the line asserting the edit came
@@ -146,41 +93,25 @@ npx playwright test --project=journeys -g "switching back"   # must FAIL, on tha
 git checkout e2e/journeys/ticket-branches.spec.js            # put it back
 ```
 
-If it stays green, the assertion is not reaching what it says it is, and the test is decoration.
-Every invariant in these journeys was checked this way before its pull request was opened; each is
-worth rechecking after a change to the code beneath it.
+If it stays green, the assertion is not reaching what it says it is, and the test is decoration. Every invariant in these journeys was checked this way before its pull request was opened; each is worth rechecking after a change to the code beneath it.
 
-Two mistakes to avoid when doing this. Break **one** assertion per run, or a failure tells you
-nothing about which. And run the **single** test by name — the same expression often appears in more
-than one journey, and a mutation applied to the first occurrence while running a different test
-reports a green that means nothing.
+Two mistakes to avoid when doing this. Break **one** assertion per run, or a failure tells you nothing about which. And run the **single** test by name — the same expression often appears in more than one journey, and a mutation applied to the first occurrence while running a different test reports a green that means nothing.
 
-**The second half of an audit is reading the test.** Roughly half of each journey happens on disk
-with no interface: the test edits a file, deletes another, and then reads the working tree back.
-None of that is on screen, and none of it can be watched. The twenty lines of the test are the
-description of what it does; there is no substitute for them.
+**The second half of an audit is reading the test.** Roughly half of each journey happens on disk with no interface: the test edits a file, deletes another, and then reads the working tree back. None of that is on screen, and none of it can be watched. The twenty lines of the test are the description of what it does; there is no substitute for them.
 
 <details>
 <summary>Watching one run, and when that helps</summary>
 
-Recording a run answers one narrow question — **is this driving the app, or passing through a shell
-that happens to satisfy its assertions?** — and helps with a CI failure on a platform you cannot
-reach. It does not tell you what a test does, for the reason above.
+Recording a run answers one narrow question — **is this driving the app, or passing through a shell that happens to satisfy its assertions?** — and helps with a CI failure on a platform you cannot reach. It does not tell you what a test does, for the reason above.
 
 ```
 E2E_VIDEO=/tmp/e2e-video npm run test:e2e
 open /tmp/e2e-video/switching-back-to-a-ticket-restores-its-work-byte-for-byte.webm
 ```
 
-One `.webm` per test, named after it; a test that closes and reopens the app records both launches
-as `-1` and `-2`. They run about a second and a half at 25 frames per second, so step through them
-rather than pressing play.
+One `.webm` per test, named after it; a test that closes and reopens the app records both launches as `-1` and `-2`. They run about a second and a half at 25 frames per second, so step through them rather than pressing play.
 
-`PWDEBUG=1` pauses before each action instead, and lets you advance the run yourself. It opens the
-Playwright Inspector, which is a browser window, so it needs `npx playwright install chromium` once
-— the only browser this repository ever wants, and nothing else here uses it. Without it the run
-pauses with no window to drive it from, which reads as a hang. The Inspector knows Playwright's
-actions and not the filesystem steps between them, so it has the same blind spot as the recording.
+`PWDEBUG=1` pauses before each action instead, and lets you advance the run yourself. It opens the Playwright Inspector, which is a browser window, so it needs `npx playwright install chromium` once — the only browser this repository ever wants, and nothing else here uses it. Without it the run pauses with no window to drive it from, which reads as a hang. The Inspector knows Playwright's actions and not the filesystem steps between them, so it has the same blind spot as the recording.
 
 </details>
 
@@ -192,47 +123,28 @@ Every end-to-end failure keeps a Playwright trace:
 npx playwright show-trace test-results/<the failing test>/trace.zip
 ```
 
-For an Electron test that trace is an action log rather than a replay: each step, its timing and the
-line of source it came from.
+For an Electron test that trace is an action log rather than a replay: each step, its timing and the line of source it came from.
 
-A failing journey also attaches the screen at the moment it failed and the state the app had
-persisted, because the interesting half of a failure in this app is usually on disk rather than on
-screen. In CI both come back as a workflow artifact.
+A failing journey also attaches the screen at the moment it failed and the state the app had persisted, because the interesting half of a failure in this app is usually on disk rather than on screen. In CI both come back as a workflow artifact.
 
 ## What CI runs
 
 Three workflows, on every pull request and on push to `trunk`. None needs a secret.
 
-**[`lint.yml`](.github/workflows/lint.yml)** — `eslint . --max-warnings=0` over the whole repo. It
-installs with `npm ci --ignore-scripts`, so linting never executes the pull request's code.
+**[`lint.yml`](.github/workflows/lint.yml)** — `eslint . --max-warnings=0` over the whole repo. It installs with `npm ci --ignore-scripts`, so linting never executes the pull request's code.
 
-**[`unit-tests.yml`](.github/workflows/unit-tests.yml)** — layers 1–3 on macOS and Windows, and on
-each platform **twice**: once on the system Node pinned in `.nvmrc`, once on the Node that Electron
-bundles. That second pass is not redundant. Child processes in this app run on Electron's own Node,
-and the two versions are set independently and have drifted before (#37/#46).
+**[`unit-tests.yml`](.github/workflows/unit-tests.yml)** — layers 1–3 on macOS and Windows, and on each platform **twice**: once on the system Node pinned in `.nvmrc`, once on the Node that Electron bundles. That second pass is not redundant. Child processes in this app run on Electron's own Node, and the two versions are set independently and have drifted before (#37/#46).
 
-**[`e2e.yml`](.github/workflows/e2e.yml)** — layers 4 and 5 on macOS and Windows, as two jobs for
-every pull request that is not a draft. They are separate because they cost very different amounts:
-the journeys take seconds, and packaging takes several minutes per platform.
+**[`e2e.yml`](.github/workflows/e2e.yml)** — layers 4 and 5 on macOS and Windows, as two jobs for every pull request that is not a draft. They are separate because they cost very different amounts: the journeys take seconds, and packaging takes several minutes per platform.
 
 Every matrix uses `fail-fast: false`, so a Windows failure never hides the macOS result.
 
 ## Conventions
 
-- `npm test` collects `test/` only, and never picks up `e2e/`. That is deliberate: end-to-end tests
-  need a built renderer and cost seconds each, and the fast suite has to stay something you run
-  without thinking.
-- End-to-end selectors read the text and roles already on screen. No `data-testid` — the visible copy
-  is the contract, and renaming a button is a change worth noticing.
-- Journeys mark each assertion as an **invariant** (must hold under any model of how work is stored)
-  or a **characterisation** (true because of how the app stores things today). A red invariant is a
-  bug; a red characterisation is a prompt to read it and update it deliberately.
-- A bugfix's test must fail on the old code. A test written after the fix pins whatever the current
-  behaviour is, rather than the correction.
-- No test counts in this document. A number here is wrong the moment somebody adds a test, and
-  nothing makes it go red — this file already carried a stale one. Say what a layer covers and
-  roughly what it costs; `npm test` prints the total, and it is the only place that can be trusted
-  to.
+- `npm test` collects `test/` only, and never picks up `e2e/`. That is deliberate: end-to-end tests need a built renderer and cost seconds each, and the fast suite has to stay something you run without thinking.
+- End-to-end selectors read the text and roles already on screen. No `data-testid` — the visible copy is the contract, and renaming a button is a change worth noticing.
+- Journeys mark each assertion as an **invariant** (must hold under any model of how work is stored) or a **characterisation** (true because of how the app stores things today). A red invariant is a bug; a red characterisation is a prompt to read it and update it deliberately.
+- A bugfix's test must fail on the old code. A test written after the fix pins whatever the current behaviour is, rather than the correction.
+- No test counts in this document. A number here is wrong the moment somebody adds a test, and nothing makes it go red — this file already carried a stale one. Say what a layer covers and roughly what it costs; `npm test` prints the total, and it is the only place that can be trusted to.
 
-The full review standard, including what counts as a test-shaped finding, is in
-[`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).
+The full review standard, including what counts as a test-shaped finding, is in [`.github/instructions/code-review.instructions.md`](.github/instructions/code-review.instructions.md).

--- a/docs/guide/creating-a-site.md
+++ b/docs/guide/creating-a-site.md
@@ -27,9 +27,7 @@ While the clone runs, the site view shows a **Setting up new site…** card with
 
 The clone is the first step of the [initial setup checklist](./setup-wizard); the remaining steps stay locked until it finishes. Then the app carries on by itself — installing the dependencies and running the first build without waiting for you — so the only step left to click is starting the dev server.
 
-If setup fails, the half-created site is removed from the list — the row simply disappears. The
-reason goes to the application log rather than to a dialog, so **Help → Open App Log** is where
-to look when a site never finishes.
+If setup fails, the half-created site is removed from the list — the row simply disappears. The reason goes to the application log rather than to a dialog, so **Help → Open App Log** is where to look when a site never finishes.
 
 ## Where sites live on disk
 

--- a/docs/guide/database.md
+++ b/docs/guide/database.md
@@ -1,39 +1,25 @@
 # Browsing the database
 
-The dev server runs WordPress on SQLite, and the app bundles [Adminer](https://www.adminer.org/)
-so you can look inside that database from your browser.
+The dev server runs WordPress on SQLite, and the app bundles [Adminer](https://www.adminer.org/) so you can look inside that database from your browser.
 
 ## Opening Adminer
 
-While the dev server is running, a **DB inspect (Adminer)** link appears beside the server URL in
-the site view, after **wp-admin**. Clicking it opens Adminer in your browser, already logged into the site's
-SQLite database — no credentials to enter. From there you can browse tables, inspect rows, and run
-SQL, the same way you would against a MySQL-backed install.
+While the dev server is running, a **DB inspect (Adminer)** link appears beside the server URL in the site view, after **wp-admin**. Clicking it opens Adminer in your browser, already logged into the site's SQLite database — no credentials to enter. From there you can browse tables, inspect rows, and run SQL, the same way you would against a MySQL-backed install.
 
-The database file itself lives inside the Playground environment at
-`/wordpress/wp-content/database/.ht.sqlite`. It is not a file you can open directly on disk; go
-through Adminer.
+The database file itself lives inside the Playground environment at `/wordpress/wp-content/database/.ht.sqlite`. It is not a file you can open directly on disk; go through Adminer.
 
-Adminer is only reachable while the dev server runs — the link disappears when the server
-stops, and so does the page it opened.
+Adminer is only reachable while the dev server runs — the link disappears when the server stops, and so does the page it opened.
 
 ## Is SQLite enough for core development?
 
-For most new contributors, yes. WordPress's SQLite support has matured considerably: most plugins
-and most core unit tests work, and thanks to the query parser, remaining gaps are tracked and
-steadily closed.
+For most new contributors, yes. WordPress's SQLite support has matured considerably: most plugins and most core unit tests work, and thanks to the query parser, remaining gaps are tracked and steadily closed.
 
 It is not a complete substitute for MySQL, though. Be aware of the limits:
 
-- Some queries and features behave differently on SQLite than on MySQL, and a small number do not
-  work at all.
-- If your contribution touches the database layer itself — `wpdb`, schema changes, MySQL-specific
-  SQL — you should verify it against a real MySQL install before submitting. The toolkit cannot
-  do that for you: WordPress Playground can work with MySQL, but this app does not ship a MySQL
-  server.
+- Some queries and features behave differently on SQLite than on MySQL, and a small number do not work at all.
+- If your contribution touches the database layer itself — `wpdb`, schema changes, MySQL-specific SQL — you should verify it against a real MySQL install before submitting. The toolkit cannot do that for you: WordPress Playground can work with MySQL, but this app does not ship a MySQL server.
 
-For the typical first contribution — a fix in PHP, JavaScript, or CSS that reads and writes
-ordinary posts, options, and users — the difference will not affect you.
+For the typical first contribution — a fix in PHP, JavaScript, or CSS that reads and writes ordinary posts, options, and users — the difference will not affect you.
 
 ## Related pages
 

--- a/docs/guide/logs-and-debugging.md
+++ b/docs/guide/logs-and-debugging.md
@@ -2,30 +2,19 @@
 
 The **Logs** section of the site view has three tabs:
 
-- **Server** — the dev server's own output: everything the Playground server prints while
-  starting and running.
-- **Build watcher** — the [build watch](./running-the-site#the-build-watch)'s output. The tab title
-  carries its state while it is doing something: *Build watcher (watching)*, *(building)*,
-  *(paused)*, or *(exited 1)* when it stopped on its own. Stop it yourself and the title goes back
-  to a plain *Build watcher*.
+- **Server** — the dev server's own output: everything the Playground server prints while starting and running.
+- **Build watcher** — the [build watch](./running-the-site#the-build-watch)'s output. The tab title carries its state while it is doing something: *Build watcher (watching)*, *(building)*, *(paused)*, or *(exited 1)* when it stopped on its own. Stop it yourself and the title goes back to a plain *Build watcher*.
 - **debug.log** — WordPress's PHP log for this site, streamed live while the dev server runs.
 
 Output from `npm install` and `npm run` commands appears in the [Terminal](./terminal), not here.
 
-All three panes read in the terminal's own monospace font, so the columns of a PHP stack trace line
-up, and each line is coloured by what it is: a fatal, a warning, a deprecation, a notice, a stack
-trace frame, or the `Ready! WordPress is running on …` line you are actually waiting for. The
-`[11-Aug-2026 …]` timestamp at the head of a `debug.log` line is dimmed, so 26 identical characters
-per line recede instead of competing with the message.
+All three panes read in the terminal's own monospace font, so the columns of a PHP stack trace line up, and each line is coloured by what it is: a fatal, a warning, a deprecation, a notice, a stack trace frame, or the `Ready! WordPress is running on …` line you are actually waiting for. The `[11-Aug-2026 …]` timestamp at the head of a `debug.log` line is dimmed, so 26 identical characters per line recede instead of competing with the message.
 
 ![The debug.log tab showing PHP notices](/screenshots/debug-log.png)
 
 ## The debug.log tab
 
-Anything WordPress or your code writes to the PHP error log — `error_log()` calls, notices,
-warnings, deprecations, `_doing_it_wrong()`, fatals — appears here while the dev server runs.
-This works because every site is booted with WordPress's debug constants already set. They are
-not configurable:
+Anything WordPress or your code writes to the PHP error log — `error_log()` calls, notices, warnings, deprecations, `_doing_it_wrong()`, fatals — appears here while the dev server runs. This works because every site is booted with WordPress's debug constants already set. They are not configurable:
 
 | Constant | Value | Effect |
 | --- | --- | --- |
@@ -36,27 +25,17 @@ not configurable:
 | `WP_DISABLE_FATAL_ERROR_HANDLER` | `true` | A fatal shows the actual error instead of WordPress's "critical error" recovery screen. |
 | `AUTOMATIC_UPDATER_DISABLED` | `true` | Core's automatic updater does not run (and does not fill the log with its own messages). |
 
-Note that `WP_DEBUG_DISPLAY` has a known cost: a notice fired during a REST or AJAX request is
-printed into the response and can corrupt the JSON it expects. That trade is made deliberately —
-seeing the error beats a silent blank page for a newcomer.
+Note that `WP_DEBUG_DISPLAY` has a known cost: a notice fired during a REST or AJAX request is printed into the response and can corrupt the JSON it expects. That trade is made deliberately — seeing the error beats a silent blank page for a newcomer.
 
-While you are reading another tab, the **debug.log** tab shows an unread count, for example
-**debug.log (3)**, so a notice landing while you watch the server output does not go unseen.
-Selecting the tab resets the count. The panel keeps the most recent 512&nbsp;KB of the log.
+While you are reading another tab, the **debug.log** tab shows an unread count, for example **debug.log (3)**, so a notice landing while you watch the server output does not go unseen. Selecting the tab resets the count. The panel keeps the most recent 512&nbsp;KB of the log.
 
 Under the pane:
 
-- The full path to the log file (inside the site's `build/wp-content/` directory) is shown and can
-  be selected and copied — useful for tailing it in a real terminal or attaching it to a ticket.
+- The full path to the log file (inside the site's `build/wp-content/` directory) is shown and can be selected and copied — useful for tailing it in a real terminal or attaching it to a ticket.
 - **Show in folder** reveals the file in your file manager.
-- **Copy** puts the panel's contents on the clipboard, ready to paste into a Trac ticket or a pull
-  request comment.
-- **Clear** empties both the panel and the file on disk. If the file cannot be cleared, the panel
-  says so — otherwise the same lines would replay the next time the server starts.
+- **Copy** puts the panel's contents on the clipboard, ready to paste into a Trac ticket or a pull request comment.
+- **Clear** empties both the panel and the file on disk. If the file cannot be cleared, the panel says so — otherwise the same lines would replay the next time the server starts.
 
 ## The app's own log
 
-The application keeps a separate log of its own activity — server starts, installs, errors. Do not
-confuse it with the site's debug.log. Open it from the menu: **Help → Open App Log**, or
-**Help → Show Logs Folder** to reveal the directory. This is the file to attach when
-[reporting a problem with the app itself](./troubleshooting).
+The application keeps a separate log of its own activity — server starts, installs, errors. Do not confuse it with the site's debug.log. Open it from the menu: **Help → Open App Log**, or **Help → Show Logs Folder** to reveal the directory. This is the file to attach when [reporting a problem with the app itself](./troubleshooting).

--- a/docs/guide/mail.md
+++ b/docs/guide/mail.md
@@ -1,38 +1,24 @@
 # The Mail panel
 
-WordPress sends email constantly — new user notifications, password resets, comment moderation.
-On a development site none of that should reach a real inbox, and with this app none of it can:
-each site gets its own built-in SMTP catcher, listening only on `127.0.0.1`. WordPress's
-`wp_mail()` is pointed at it, so every email the site sends lands in the **Mail** panel instead
-of leaving your machine.
+WordPress sends email constantly — new user notifications, password resets, comment moderation. On a development site none of that should reach a real inbox, and with this app none of it can: each site gets its own built-in SMTP catcher, listening only on `127.0.0.1`. WordPress's `wp_mail()` is pointed at it, so every email the site sends lands in the **Mail** panel instead of leaving your machine.
 
 ![A captured email with its time, sender, and subject](/screenshots/mail-panel.png)
 
 ## How it works
 
-The SMTP catcher starts and stops together with the dev server. While the server is running, the
-panel shows the address it listens on, for example `SMTP listening on 127.0.0.1:54321` — the port
-is assigned by the operating system, so it varies. Before the server has started, the panel says
-`SMTP will start with the dev server.`
+The SMTP catcher starts and stops together with the dev server. While the server is running, the panel shows the address it listens on, for example `SMTP listening on 127.0.0.1:54321` — the port is assigned by the operating system, so it varies. Before the server has started, the panel says `SMTP will start with the dev server.`
 
-No configuration is needed on the WordPress side: the app installs a small must-use plugin in the
-Playground environment that routes `wp_mail()` through SMTP to the catcher.
+No configuration is needed on the WordPress side: the app installs a small must-use plugin in the Playground environment that routes `wp_mail()` through SMTP to the catcher.
 
 ## Reading emails
 
-Captured emails appear in a list showing the date, the sender, and the subject. Click an email
-(or press Enter on it) to open it in a full-screen viewer with the **From**, **To**, **CC**, and
-**Date** headers and two tabs:
+Captured emails appear in a list showing the date, the sender, and the subject. Click an email (or press Enter on it) to open it in a full-screen viewer with the **From**, **To**, **CC**, and **Date** headers and two tabs:
 
-- **Rendered** — the HTML body as a mail client would show it, or the plain-text body if the
-  email has no HTML part.
-- **Raw** — the raw message source, headers and all. Useful when the bug you are chasing is in
-  how core builds the email itself.
+- **Rendered** — the HTML body as a mail client would show it, or the plain-text body if the email has no HTML part.
+- **Raw** — the raw message source, headers and all. Useful when the bug you are chasing is in how core builds the email itself.
 
 **Clear emails** deletes all captured emails for the site.
 
 ## Trying it out
 
-Trigger any email-sending flow on the dev site — the password reset form at `/wp-login.php?action=lostpassword`
-is the quickest — and the email appears in the panel. See [Running the site](./running-the-site)
-for starting the server.
+Trigger any email-sending flow on the dev site — the password reset form at `/wp-login.php?action=lostpassword` is the quickest — and the email appears in the panel. See [Running the site](./running-the-site) for starting the server.

--- a/docs/guide/managing-sites.md
+++ b/docs/guide/managing-sites.md
@@ -1,55 +1,35 @@
 # Managing sites
 
-Everything about a site's identity and lifecycle lives in its header: the name, a few status
-badges, the path, and the **More** menu (☰) at the top right.
+Everything about a site's identity and lifecycle lives in its header: the name, a few status badges, the path, and the **More** menu (☰) at the top right.
 
 ![The site header with the More menu open](/screenshots/site-menu.png)
 
 ## The site header
 
-- **Rename** — click the pencil icon next to the site title to give the site a different display
-  name. This changes the label in the app only; the directory on disk keeps its name.
-- **Status badge** — **INITIALIZED** once the repository is cloned; **UNINITIALIZED** before
-  that.
+- **Rename** — click the pencil icon next to the site title to give the site a different display name. This changes the label in the app only; the directory on disk keeps its name.
+- **Status badge** — **INITIALIZED** once the repository is cloned; **UNINITIALIZED** before that.
 - **Created date** — when the site was created.
-- **Trunk age** — how old the site's snapshot of `wordpress-develop` trunk is. When the snapshot
-  gets stale, an amber dot appears next to the label; hover it to see the age in days. See
-  [Staying up to date with trunk](./trunk-updates).
-- **Path** — the site's directory, with a copy button next to it. The **Open directory in** menu
-  underneath opens it in your file manager or an editor; see [Editors](./editors).
+- **Trunk age** — how old the site's snapshot of `wordpress-develop` trunk is. When the snapshot gets stale, an amber dot appears next to the label; hover it to see the age in days. See [Staying up to date with trunk](./trunk-updates).
+- **Path** — the site's directory, with a copy button next to it. The **Open directory in** menu underneath opens it in your file manager or an editor; see [Editors](./editors).
 
 ## The More menu
 
 The ☰ menu at the top right of the site view contains:
 
 - **Copy path** — puts the site's directory path on the clipboard.
-- **Show in Finder** (macOS) / **Show in Explorer** (Windows) — reveals the directory in
-  your file manager.
-- **Update to latest trunk** — fetches the latest `wordpress-develop` trunk and rebuilds. Also
-  reachable from the staleness notice; on an already-fresh site it just prints "Already up to
-  date." See [Staying up to date with trunk](./trunk-updates).
-- **Delete this site** — removes the site from the list **and deletes its directory from disk**.
-  This cannot be undone. The app will only ever delete a directory it has on record as a site —
-  never an arbitrary path. It takes every ticket's work in the site with it; to throw away one
-  ticket and keep the rest, use **Delete this ticket's work** on the tickets card instead — see
-  [Working on several tickets](./ticket-branches#deleting-a-ticket-s-work).
+- **Show in Finder** (macOS) / **Show in Explorer** (Windows) — reveals the directory in your file manager.
+- **Update to latest trunk** — fetches the latest `wordpress-develop` trunk and rebuilds. Also reachable from the staleness notice; on an already-fresh site it just prints "Already up to date." See [Staying up to date with trunk](./trunk-updates).
+- **Delete this site** — removes the site from the list **and deletes its directory from disk**. This cannot be undone. The app will only ever delete a directory it has on record as a site — never an arbitrary path. It takes every ticket's work in the site with it; to throw away one ticket and keep the rest, use **Delete this ticket's work** on the tickets card instead — see [Working on several tickets](./ticket-branches#deleting-a-ticket-s-work).
 
 **Delete** asks for confirmation first.
 
 ## Updating with uncommitted changes
 
-If you start **Update to latest trunk** while the site has edits loose in the working tree, the app
-does not silently throw them away. A dialog titled **Update to latest trunk?** lists every changed
-file and offers two choices:
+If you start **Update to latest trunk** while the site has edits loose in the working tree, the app does not silently throw them away. A dialog titled **Update to latest trunk?** lists every changed file and offers two choices:
 
-- **Save them as a patch first (as a local file)** — writes a `.diff` to your machine, then
-  updates. Nothing is sent to Trac.
+- **Save them as a patch first (as a local file)** — writes a `.diff` to your machine, then updates. Nothing is sent to Trac.
 - **Discard them** — your changes are lost; this cannot be undone.
 
-Confirm with **Save patch & update** or **Discard & update**, or **Cancel** to keep everything as
-it is. If you meant to keep the changes as a contribution instead, see
-[Submitting your changes](./submitting-changes).
+Confirm with **Save patch & update** or **Discard & update**, or **Cancel** to keep everything as it is. If you meant to keep the changes as a contribution instead, see [Submitting your changes](./submitting-changes).
 
-Work that is already parked on a ticket branch is never what this dialog is offering to discard —
-the update carries it across untouched. See
-[Updating while you are on a ticket](./trunk-updates#updating-while-you-are-on-a-ticket).
+Work that is already parked on a ticket branch is never what this dialog is offering to discard — the update carries it across untouched. See [Updating while you are on a ticket](./trunk-updates#updating-while-you-are-on-a-ticket).

--- a/docs/guide/terminal.md
+++ b/docs/guide/terminal.md
@@ -1,9 +1,6 @@
 # The Terminal panel
 
-Each site view includes an embedded terminal. It is not a general-purpose shell: it accepts a
-small, fixed set of commands, all of which run in the site's directory using the Node.js runtime
-bundled with the app. This is enough to rebuild the site after editing code — the reason the panel
-exists — without requiring Node or npm on your machine.
+Each site view includes an embedded terminal. It is not a general-purpose shell: it accepts a small, fixed set of commands, all of which run in the site's directory using the Node.js runtime bundled with the app. This is enough to rebuild the site after editing code — the reason the panel exists — without requiring Node or npm on your machine.
 
 ![The Terminal panel with the command hints below it](/screenshots/terminal.png)
 
@@ -17,30 +14,21 @@ Type `help` to see the list at any time:
 | `npm install` | Runs `npm install` in the site directory. `npm i` and `install` work too. |
 | `npm run <script>` | Runs one of the allowed scripts: `build`, `build:dev`, `dev`, `test`, `watch`, `grunt`. |
 
-Any other script name is refused with a message listing the allowed scripts. Only one command runs
-at a time; if one is already running, the terminal tells you to stop it first.
+Any other script name is refused with a message listing the allowed scripts. Only one command runs at a time; if one is already running, the terminal tells you to stop it first.
 
-Press **Ctrl+C** to stop the running command. The Up and Down arrow keys move through your command
-history.
+Press **Ctrl+C** to stop the running command. The Up and Down arrow keys move through your command history.
 
 ## When to use it
 
-The [setup wizard](./setup-wizard) runs `npm install` and `npm run build` once, when the site is
-created. After that, keeping the built site in sync with your edits is up to you:
+The [setup wizard](./setup-wizard) runs `npm install` and `npm run build` once, when the site is created. After that, keeping the built site in sync with your edits is up to you:
 
 - **Edited files in `src/`?** Run `npm run build` so the site picks them up.
 - **Added a dependency to `package.json`?** Run `npm install`.
 
-Once the site has been built, these two hints appear directly under the terminal. The command in
-each hint is a link: clicking it types the command into the terminal for you, ready to run — it
-does not execute it. While a command is running the hints stop being links and show as plain text,
-so there is nothing to click until it finishes.
+Once the site has been built, these two hints appear directly under the terminal. The command in each hint is a link: clicking it types the command into the terminal for you, ready to run — it does not execute it. While a command is running the hints stop being links and show as plain text, so there is nothing to click until it finishes.
 
 ::: warning Do not run `npm run watch`
-It looks like the way to rebuild continuously, and it is a trap. `wordpress-develop`'s Gruntfile
-renames the real watch task to `_watch` and leaves a `watch` wrapper that runs a **full production
-build first** — tens of minutes with nothing to show for it, and 30+ on a Windows VM.
+It looks like the way to rebuild continuously, and it is a trap. `wordpress-develop`'s Gruntfile renames the real watch task to `_watch` and leaves a `watch` wrapper that runs a **full production build first** — tens of minutes with nothing to show for it, and 30+ on a Windows VM.
 
-You do not need it anyway: [starting the dev server](./running-the-site) already starts the real
-watcher for you, as `grunt -- _watch`.
+You do not need it anyway: [starting the dev server](./running-the-site) already starts the real watcher for you, as `grunt -- _watch`.
 :::

--- a/docs/guide/ticket-branches.md
+++ b/docs/guide/ticket-branches.md
@@ -85,15 +85,11 @@ This counts the ticket's whole work — including everything parked when you las
 
 Under it is the reassurance that matters here: unlinking the ticket does not touch those changes. They stay attached to the ticket in this site, ready for when you link it again.
 
-Returning to a ticket does not make it clean or measure it from wherever trunk happens to be now.
-The same count and the same files return because the ticket is still measured from the trunk
-snapshot where its branch started. That baseline also drives the warning before applying another
-patch: work committed when you switched away is still named as work on this ticket.
+Returning to a ticket does not make it clean or measure it from wherever trunk happens to be now. The same count and the same files return because the ticket is still measured from the trunk snapshot where its branch started. That baseline also drives the warning before applying another patch: work committed when you switched away is still named as work on this ticket.
 
 ## When trunk has moved since the ticket started
 
-Updating the site moves its copy of trunk, but deliberately does not move existing ticket branches.
-When the app can see that the linked ticket started on an older trunk, the **Trac ticket** card says:
+Updating the site moves its copy of trunk, but deliberately does not move existing ticket branches. When the app can see that the linked ticket started on an older trunk, the **Trac ticket** card says:
 
 > **Trunk has moved since this ticket started.** Newer patches may not apply cleanly.
 
@@ -101,13 +97,11 @@ Nothing moves automatically. To start the ticket again from current trunk:
 
 1. Use **Review & submit changes** to save a patch of the ticket's work.
 2. Click **Unlink** so the ticket appears under **Your tickets on this site**.
-3. Click **Delete this ticket's work** on its row. This deletes the branch, not the patch you saved
-   outside the site.
+3. Click **Delete this ticket's work** on its row. This deletes the branch, not the patch you saved outside the site.
 4. Link the same ticket again. Its new branch starts from current trunk.
 5. Apply the saved patch and check that the work still fits.
 
-The app stays silent when it cannot identify a ticket's original base; it does not substitute the
-current trunk and pretend the ticket is current.
+The app stays silent when it cannot identify a ticket's original base; it does not substitute the current trunk and pretend the ticket is current.
 
 ## What a patch contains
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,94 +2,57 @@
 
 ## macOS blocks the app from opening
 
-The app is signed and notarized, but Gatekeeper can still block a freshly downloaded copy.
-Right-click the app and choose **Open**, or remove the quarantine attribute — the exact steps,
-including the `xattr` command and its one pitfall, are in
-[Getting started](./getting-started#if-macos-blocks-the-app).
+The app is signed and notarized, but Gatekeeper can still block a freshly downloaded copy. Right-click the app and choose **Open**, or remove the quarantine attribute — the exact steps, including the `xattr` command and its one pitfall, are in [Getting started](./getting-started#if-macos-blocks-the-app).
 
 ## "Update incomplete" after a trunk update
 
-If a [trunk update](./trunk-updates) fetches new code but the install or build step fails, the
-site shows a red **Update incomplete** notice: the code is new but the built assets are old, and
-the site may not run correctly until install and build succeed. Click **Retry install & build**
-in the notice. If it fails again, the reason is in the [Terminal](./terminal) output — a network
-drop during `npm install` is the most common cause.
+If a [trunk update](./trunk-updates) fetches new code but the install or build step fails, the site shows a red **Update incomplete** notice: the code is new but the built assets are old, and the site may not run correctly until install and build succeed. Click **Retry install & build** in the notice. If it fails again, the reason is in the [Terminal](./terminal) output — a network drop during `npm install` is the most common cause.
 
 ![The Update incomplete notice with its Retry install and build button](/screenshots/update-incomplete.png)
 
 ## "A previous switch … did not finish"
 
-A ticket switch whose file swap died part-way leaves the checkout half of one ticket and half of
-the other, so the app refuses further ticket actions rather than committing the mixture:
-**A previous switch from … to … did not finish. Retry it before making other changes.**
+A ticket switch whose file swap died part-way leaves the checkout half of one ticket and half of the other, so the app refuses further ticket actions rather than committing the mixture: **A previous switch from … to … did not finish. Retry it before making other changes.**
 
-The refusal covers switching too, so the way out is **Unlink** on the **Trac ticket** panel — the
-one action it still allows. That puts the site back on trunk, and you can link the ticket you
-wanted from there. Nothing is lost: the work on the ticket you were leaving was committed to its
-branch before any file moved. See [Working on several tickets](./ticket-branches).
+The refusal covers switching too, so the way out is **Unlink** on the **Trac ticket** panel — the one action it still allows. That puts the site back on trunk, and you can link the ticket you wanted from there. Nothing is lost: the work on the ticket you were leaving was committed to its branch before any file moved. See [Working on several tickets](./ticket-branches).
 
-The usual cause is a file held open by an editor or an antivirus scanner during the swap. Closing
-whatever had the checkout open before retrying makes a repeat less likely.
+The usual cause is a file held open by an editor or an antivirus scanner during the swap. Closing whatever had the checkout open before retrying makes a repeat less likely.
 
 ## A patch or pull request will not apply
 
-An apply is all-or-nothing: if any part fails, the checkout is unchanged. The panel names how many
-changes failed and which files they are in.
+An apply is all-or-nothing: if any part fails, the checkout is unchanged. The panel names how many changes failed and which files they are in.
 
 For a pull request, check whether the notice names work already on your ticket:
 
-- If it does, save a patch of your work and try the pull request on a clean ticket. The app knows
-  that both sets of work touch the file, but it cannot prove which exact lines caused the failure.
-  Ask the pull request's author for an update only if it still fails on the clean ticket.
-- If it does not, the pull request was written against an older trunk. Open it and let its author
-  know that it needs a rebase or trunk merged in.
+- If it does, save a patch of your work and try the pull request on a clean ticket. The app knows that both sets of work touch the file, but it cannot prove which exact lines caused the failure. Ask the pull request's author for an update only if it still fails on the clean ticket.
+- If it does not, the pull request was written against an older trunk. Open it and let its author know that it needs a rebase or trunk merged in.
 
-For a patch file or Trac attachment, there is no author the app can send you to. Expand the failing
-files in the panel: each region gives a line from your checkout to search for and says whether the
-surrounding code changed or the change appears to be present already. See
-[Applying patches and PRs](./applying-patches#when-a-patch-will-not-apply).
+For a patch file or Trac attachment, there is no author the app can send you to. Expand the failing files in the panel: each region gives a line from your checkout to search for and says whether the surrounding code changed or the change appears to be present already. See [Applying patches and PRs](./applying-patches#when-a-patch-will-not-apply).
 
 ## Work seems to have vanished after changing tickets or updating trunk
 
-Ticket work belongs to its ticket branch, not to the whole site. If the files look clean after you
-click **Unlink** or switch tickets, return to the original ticket under **Your tickets on this
-site**. Its edits and its applied patch return with it.
+Ticket work belongs to its ticket branch, not to the whole site. If the files look clean after you click **Unlink** or switch tickets, return to the original ticket under **Your tickets on this site**. Its edits and its applied patch return with it.
 
-A trunk update also leaves ticket branches on the trunk snapshot where they started. When you run
-one while a ticket is linked, the app parks the ticket, updates trunk, and checks the same ticket
-back out. If its work is missing after the update rather than merely hidden on another ticket, stop
-editing and report a problem with the app; an update must not discard it. See
-[Keeping a site up to date with trunk](./trunk-updates#updating-while-you-are-on-a-ticket).
+A trunk update also leaves ticket branches on the trunk snapshot where they started. When you run one while a ticket is linked, the app parks the ticket, updates trunk, and checks the same ticket back out. If its work is missing after the update rather than merely hidden on another ticket, stop editing and report a problem with the app; an update must not discard it. See [Keeping a site up to date with trunk](./trunk-updates#updating-while-you-are-on-a-ticket).
 
 ## The dev server won't start
 
-Starting the server can legitimately take a while — booting WASM PHP on a slow machine can take
-tens of seconds. The app waits up to 120 seconds; after that it gives up and reports the failure
-instead of hanging.
+Starting the server can legitimately take a while — booting WASM PHP on a slow machine can take tens of seconds. The app waits up to 120 seconds; after that it gives up and reports the failure instead of hanging.
 
 If the start fails:
 
 1. Open the **Server** tab under **Logs** — the server's own output usually names the problem.
 2. If the server exited before reporting a URL, the error message includes its exit code.
-3. Make sure the site has actually been [built](./setup-wizard); a site whose build was
-   interrupted shows the **Update incomplete** notice described above.
-4. Stop and start the server once more — a previous instance that did not shut down cleanly can
-   hold on to resources until it is killed.
+3. Make sure the site has actually been [built](./setup-wizard); a site whose build was interrupted shows the **Update incomplete** notice described above.
+4. Stop and start the server once more — a previous instance that did not shut down cleanly can hold on to resources until it is killed.
 
 ## Where the logs live
 
 Two different logs, two different problems:
 
-- **The site's PHP log** — the **debug.log** tab in the site view. PHP notices, warnings, and
-  fatals from WordPress and your code. See [Logs and debugging](./logs-and-debugging).
-- **The app's own log** — menu **Help → Open App Log**, or **Help → Show Logs Folder** to reveal
-  the directory. Server starts, installs, git operations, and app errors. When reporting a bug in
-  the app, attach this file.
+- **The site's PHP log** — the **debug.log** tab in the site view. PHP notices, warnings, and fatals from WordPress and your code. See [Logs and debugging](./logs-and-debugging).
+- **The app's own log** — menu **Help → Open App Log**, or **Help → Show Logs Folder** to reveal the directory. Server starts, installs, git operations, and app errors. When reporting a bug in the app, attach this file.
 
 ## Reporting a problem
 
-The **Share feedback** button at the top of the sidebar opens a short form. Responses go into a
-shared form the team reviews regularly, and submissions are anonymous unless you add your email.
-For bugs, the [GitHub issue tracker](https://github.com/WordPress/contributor-toolkit/issues)
-works too — include the app log and, for site problems, the debug.log contents (the **Copy**
-button under the pane exists for exactly this).
+The **Share feedback** button at the top of the sidebar opens a short form. Responses go into a shared form the team reviews regularly, and submissions are anonymous unless you add your email. For bugs, the [GitHub issue tracker](https://github.com/WordPress/contributor-toolkit/issues) works too — include the app log and, for site problems, the debug.log contents (the **Copy** button under the pane exists for exactly this).

--- a/docs/guide/trunk-updates.md
+++ b/docs/guide/trunk-updates.md
@@ -14,18 +14,13 @@ This option is always there — on every site, at any time, no matter how old or
 
 You no longer have to stop the dev server first. The update pauses the [build watch](./running-the-site#the-build-watch) for the rebuild and resumes it afterwards, and the PHP server keeps serving throughout.
 
-What it will not run alongside is another install or build. The **Update to latest trunk** button in
-the staleness notice is disabled while one is running — but the ☰ menu entry is not, and clicking it
-in that state simply does nothing, with no message to say why.
+What it will not run alongside is another install or build. The **Update to latest trunk** button in the staleness notice is disabled while one is running — but the ☰ menu entry is not, and clicking it in that state simply does nothing, with no message to say why.
 
 ## What an update runs
 
 The update always shows the same three steps in a progress card, with a "step N of 3" counter:
 
-1. **Fetch and reset to trunk** — pull the newest commits and reset the checkout to them. If you
-   have uncommitted changes the app stops and asks first, offering **Save them as a patch first
-   (as a local file)** or **Discard them** — the second loses the work and cannot be undone. When
-   you choose to save, the summary afterwards tells you where the patch went.
+1. **Fetch and reset to trunk** — pull the newest commits and reset the checkout to them. If you have uncommitted changes the app stops and asks first, offering **Save them as a patch first (as a local file)** or **Discard them** — the second loses the work and cannot be undone. When you choose to save, the summary afterwards tells you where the patch went.
 2. **Install dependencies** — runs only if `package-lock.json` changed between the old and new trunk; otherwise the step is shown as "Dependencies unchanged — skipping npm install". When it does run, most packages are already cached, so it downloads the difference, not the whole tree.
 3. **Rebuild** — rebuild the `build/` directory so it matches the new source.
 
@@ -41,11 +36,7 @@ The dialog in step 1 only ever concerns edits that are loose in the working tree
 
 What an update does not move is the snapshot your ticket branch was created on. That is deliberate — it is what keeps your patch free of the upstream changes the update just brought in — but it means an old ticket's patch does not get any newer by updating the site. The same is true for every other ticket stored on the site: updating trunk does not rebase any of them.
 
-After the update, the **Trac ticket** card may say **Trunk has moved since this ticket started**.
-That is not an incomplete update: trunk is current and the ticket is still safely on its original
-base. To move the work forward, save its patch, unlink it, delete its branch, link the ticket again,
-and apply the saved patch. The app never changes a ticket's base without that explicit sequence.
-See [When trunk has moved since the ticket started](./ticket-branches#when-trunk-has-moved-since-the-ticket-started).
+After the update, the **Trac ticket** card may say **Trunk has moved since this ticket started**. That is not an incomplete update: trunk is current and the ticket is still safely on its original base. To move the work forward, save its patch, unlink it, delete its branch, link the ticket again, and apply the saved patch. The app never changes a ticket's base without that explicit sequence. See [When trunk has moved since the ticket started](./ticket-branches#when-trunk-has-moved-since-the-ticket-started).
 
 ## Staleness dots and notices
 


### PR DESCRIPTION
## Why

Every `.md` file that carries repository instructions was hard-wrapped at roughly 100 columns, while `README.md` and the whole of `docs/` were not. Nothing wrote either convention down, so each new paragraph was a guess, and the guess kept landing on the wrapped side. Markdown imposes no line limit — a wrapped paragraph and a single long line render identically — so this was never a rule, only a habit that half the tree had.

The habit has a cost the other half does not pay: text arrives pre-chopped when it is pasted into an issue or a chat, it does not reflow to the reader's width, and a one-word edit reshuffles every line beneath it into a diff that claims they changed.

## What changes

Prose is no longer wrapped anywhere: one paragraph is one line, however long. That is the convention `README.md` and `docs/` already followed, now applied to the remaining 18 files, and written down in `AGENTS.md` so it stops being a guess.

Line breaks that mean something are untouched — list items, table rows, headings, fenced code, VitePress `:::` containers, YAML frontmatter, and the body of an HTML comment all keep their shape. `.editorconfig` gains `max_line_length = off` for `[*.md]`, so an editor configured from it does not re-wrap on save.

No prose was rewritten. The only content change in the whole diff is that a blockquote spanning several wrapped lines now carries one `>` instead of one per line.

## How to test this

Platforms: any — nothing here is platform-specific, and no shipped code changed.

**Starting state:** trunk checked out, `npm ci` done.

1. `npm run docs:build` — the user guide builds. Compare against a build of trunk: the rendered HTML is byte-identical on all 21 pages once VitePress's content hashes are normalised away.
2. Open any changed file and confirm no paragraph is split across lines, and that tables, lists, code blocks and the `:::` blocks in `docs/guide/getting-started.md` and `docs/guide/terminal.md` are intact.
3. `npm test` and `npm run lint` — both green, and both untouched by this.

**What must not have happened:** a word lost, gained or reordered anywhere. That is the whole risk of a mechanical rewrite, and it is silent: nothing fails, the text is just quietly wrong. Verified by comparing every file against its `HEAD` version with all whitespace collapsed — identical, except the blockquote markers noted above — and by counting headings, list markers, table rows, code fences and `:::` lines per file before and after: unchanged in every file.

Also: no VitePress container left broken. An earlier pass of this change joined a closing `:::` into the paragraph above it, which silently swallowed the title of four tips and a warning. The rendered-HTML comparison in step 1 is what caught it.

## Risks and limitations

Diffs on documentation get coarser: change one word and GitHub marks the paragraph. `git diff --word-diff`, and GitHub's own intra-line highlighting, narrow it back down. This is the trade the convention accepts, and it is stated in `AGENTS.md`.

The README's three release badges are now on one line rather than three. They render the same — they were always one paragraph — but adding a fourth badge means editing a long line.

Nothing enforces the convention automatically. `.editorconfig` steers editors and `AGENTS.md` states the rule; neither fails CI. A markdownlint rule would, and is not worth a CI job for this.

## Related

Follow-up to a review comment rather than an issue: the convention was noticed by its absence, not filed.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Wrap at a fixed width instead.** The obvious reading of the problem was "TESTING.md exceeds 100 columns in 16 places", and the obvious fix was to re-wrap it to 100. That takes the habit as given. Since Markdown does not care, the question is which convention serves editing better, and the unwrapped half of the tree was already the answer.

**Semantic line breaks** (one line per sentence or clause) keeps diffs narrow and lines short. It also asks every author to make a judgement call on every sentence, which is exactly the kind of rule that decays — and it still chops text on paste.

**Leave `AGENTS.md` and `CONTRIBUTING.md` wrapped**, as the files most often reviewed line by line. Rejected: two conventions in one repository is what produced this in the first place.

**A markdownlint check in CI.** It is the only thing that would actually enforce this, but it means a workflow, a config, and an exception list for long link targets — for a rule that costs nothing when it is broken.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

1 `[fix here]` — found and fixed before this PR existed.

The finding: closing `:::` lines of VitePress containers were being joined into the paragraph above, breaking four tips in `docs/guide/getting-started.md` and one warning in `docs/guide/terminal.md`. The containers still rendered, so the page did not error — the title line was simply absorbed into the body text. Fixed by treating `:::` as a block boundary, and confirmed by the rendered-HTML comparison, which now reports zero differing pages.

Two smaller ones caught the same way, in the same pass: empty numbered list items (`1.` with nothing after it, in the PR template) were treated as prose and merged onto one line, and HTML comment bodies were being re-flowed, which mangled the templates a contributor reads while filling them in. Both fixed — empty list markers are list items, comment bodies are verbatim.

The judgement pass was run in this session rather than dispatched to a subagent. For a mechanical rewrite whose correctness is decided by a byte-for-byte comparison of the rendered output, the check that matters is the comparison, and it is reproducible from step 1 above.

</details>

<details>
<summary>Implementation notes</summary>

The rewrite was done by a throwaway script, not by hand, so that the transformation was uniform and could be re-run after each fix. It is not checked in: it has served its purpose, and a one-shot migration tool in the repository invites someone to run it again.

What it treats as verbatim, and therefore never joins: YAML frontmatter, fenced code, table rows, headings, thematic breaks, HTML blocks, HTML comment bodies, link reference definitions, `:::` container markers, and any line ending in a hard break (two trailing spaces or a backslash — this tree has none). List items start a new line, including empty ones; a list item's continuation lines join into it. Consecutive blockquote lines join into a single `>` line.

Three checks were run over every tracked `.md`, before and after:

- whitespace-collapsed content identical (ignoring `>` markers),
- per-file counts of headings, list markers, table rows, code fences and `:::` lines identical,
- for `docs/`, a full VitePress build compared page by page against a build of `HEAD`, with content hashes normalised — 21 pages, zero differences.

</details>
