### PR TITLE
Say how to step through a journey by hand, and correct how

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -19,7 +19,7 @@ npm run test:electron       # the fast suite again, on the Node that Electron bu
 npm run test:e2e:packaged   # the built artifact — needs a build first, see below
 ```
 
-To run one file: `node --test test/azure-sign.test.cjs`. To run one journey: `npx playwright test --project=journeys -g "switching back"`. A journey opens and closes the app as it goes; there is no headless mode and nothing to turn off.
+To run one file: `node --test test/azure-sign.test.cjs`. To run one journey: `npx playwright test --project=journeys -g "switching back"`. A journey opens and closes the app as it goes; there is no headless mode and nothing to turn off. To advance a journey a step at a time instead of letting it run, see [Stepping through a journey by hand](#stepping-through-a-journey-by-hand).
 
 ## The five layers
 
@@ -111,9 +111,38 @@ open /tmp/e2e-video/switching-back-to-a-ticket-restores-its-work-byte-for-byte.w
 
 One `.webm` per test, named after it; a test that closes and reopens the app records both launches as `-1` and `-2`. They run about a second and a half at 25 frames per second, so step through them rather than pressing play.
 
-`PWDEBUG=1` pauses before each action instead, and lets you advance the run yourself. It opens the Playwright Inspector, which is a browser window, so it needs `npx playwright install chromium` once — the only browser this repository ever wants, and nothing else here uses it. Without it the run pauses with no window to drive it from, which reads as a hang. The Inspector knows Playwright's actions and not the filesystem steps between them, so it has the same blind spot as the recording.
+To drive a run yourself rather than watch a recording of one, see [Stepping through a journey by hand](#stepping-through-a-journey-by-hand), below.
 
 </details>
+
+## Stepping through a journey by hand
+
+To advance a journey one action at a time, driving each step yourself:
+
+```
+npx playwright test --project=journeys -g "switching back" --debug
+```
+
+That opens the Playwright Inspector and pauses before the first action. `--debug` is a shorthand for `--headed --timeout=0 --workers=1 --max-failures=1` with `PWDEBUG=1` set, and **`--headed` is the load-bearing part here**: without it the Inspector never attaches to an Electron test and the run finishes at full speed, unpaused. `PWDEBUG=1` on its own — the incantation the Playwright documentation gives, and the one this file used to give — does nothing at all to a journey. Checked against Playwright 1.62.1 by running it both ways.
+
+To stop somewhere other than the first action, put a pause in the spec at the point you care about and run headed:
+
+```
+# in the spec:
+await page.pause();
+
+npx playwright test --project=journeys -g "switching back" --headed --timeout=0
+```
+
+Everything before the pause runs at full speed. `--headed` is required for the same reason as above, and `--timeout=0` because `playwright.config.js` sets a 60 second `timeout` that would otherwise end the session while you are reading it.
+
+Three things worth knowing before you do either:
+
+- **Name a single test.** With no `-g` you are hand-stepping every journey in the project, one after another.
+- **The Inspector is a browser window**, so it needs `npx playwright install chromium` once — the only browser this repository ever wants, and nothing else here uses it. Without it the run pauses with nothing to drive it from, which reads as a hang.
+- **The app window is real and yours to poke**, which cuts both ways: a click you make is a click the remaining assertions did not expect. Once you have driven it by hand, end the run rather than reading anything into what it does next.
+
+The Inspector has the same blind spot as a recording, and it is the one from the audit above: it knows Playwright's actions and nothing about the filesystem steps between them. A journey that edits a file, deletes another and reads the working tree back steps straight past all of it. Read the spec alongside.
 
 ## Reading a failure
 


### PR DESCRIPTION
## Why

There is no way to find out how to run a journey in "manual" mode — pausing between actions and advancing each step yourself — from TESTING.md. The instruction was there, as the last paragraph of a collapsed `<details>` block titled "Watching one run", which reads as being about video recording. Somebody looking for it under "What to run" or "Auditing an end-to-end test" does not find it.

Worse, what it said was wrong. It gave `PWDEBUG=1`, which is what Playwright's own documentation gives, and which does nothing to an Electron test: the run finishes at full speed, unpaused, and you are left assuming you held it wrong.

## What changes

`PWDEBUG=1` alone never pauses a journey. `--debug` does, because it also passes `--headed`, and `--headed` is the part that matters — Playwright only enables the debugger for a headful browser, and `_electron.launch()` is not headful unless asked. Same story for `page.pause()`: a silent no-op on a default run, a working breakpoint under `--headed`. All four combinations were run against Playwright 1.62.1 to establish this; see the collapsed notes below.

So the section now gives `--debug` for stepping from the first action, `page.pause()` plus `--headed --timeout=0` for stepping from a chosen one, and says plainly that the `PWDEBUG=1` everyone will reach for first does not work here.

It also moves out of the video block into its own section next to the audit instructions — both are "drive this yourself" workflows — with a pointer from "What to run", which is where you look first. Two things that were missing either way: name a single test with `-g`, or you are hand-stepping every journey in sequence; and `--timeout=0` is not optional, because `playwright.config.js` sets a 60 second `timeout` that ends the session while you are still reading it.

The video block keeps answering its own question and now points here.

## How to test this

Platforms: any. Docs only — nothing in the app changes, so the test is whether the commands in the new section do what it says.

**Starting state:** a clean checkout of this branch, dependencies installed, `npx playwright install chromium` done once.

1. Read `## Stepping through a journey by hand` in TESTING.md. It should be findable from the "What to run" section without opening a `<details>` block.
2. Run `npx playwright test --project=journeys -g "the app launches from source" --debug`. The Playwright Inspector window opens, the app opens, and the run stops before the first action and waits. Step it with the Inspector; end it with Ctrl-C.
3. Run the same test without `--debug`, as `PWDEBUG=1 npx playwright test --project=journeys -g "the app launches from source"`. It should pass in about five seconds without ever pausing — this is the behaviour the old text got wrong.
4. Put `await page.pause();` in `e2e/journeys/engine.spec.js` above the `toHaveTitle` assertion and run `npx playwright test --project=journeys -g "the app launches from source" --headed --timeout=0`. It pauses there with the Inspector open. Drop `--headed` and it does not pause at all. Revert the spec afterwards.

**What must not have happened:** no spec file is left modified — step 4 edits `e2e/journeys/engine.spec.js` and must be reverted. `git status` clean apart from TESTING.md. And nothing in `e2e/` or `src/` is touched by this branch: the diff is one file.

## Risks and limitations

The `--headed` explanation is behavioural, not mechanical. I verified what happens in all four combinations; I did not trace exactly which branch inside Playwright's `BrowserContext.initialize` an Electron context takes to get there. If a future Playwright release changes it, the recipe breaks silently and the file goes stale the same way the `PWDEBUG=1` line did — the version it was checked against is stated in the text for that reason.

## Related

Follow-up to #368, which added the video and `PWDEBUG=1` paragraph this corrects.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The obvious smaller change was to leave the paragraph where it was and add the `-g` and `--timeout=0` details to it. Running the command is what ruled that out — there was no point improving an instruction that does not work.

Recommending `--debug` rather than `--headed --timeout=0 PWDEBUG=1` spelled out: `--debug` is one flag, it is the documented Playwright entry point, and it sets `--workers=1 --max-failures=1` too, which are both right here. The longer form is given only for the `page.pause()` case, where you do not want to stop at the first action.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

`npm run lint` clean. `npm test` 1027 passing, 0 failing. Neither is affected by the change; both were run because the standard asks for the deterministic layer first.

2 findings, both `[fix here]`, both fixed before this PR was opened:

- 🔴 **tests** — the section as first written repeated the file's own `PWDEBUG=1` claim, which is false for Electron tests. Found by running it rather than reading it. Rewritten around `--debug`, with the four verifying runs described above.
- 🔵 **process** — the draft said "all fourteen journeys", and this file's own Conventions section forbids test counts in it, for exactly the reason that it goes stale unnoticed. Changed to "every journey in the project".

Nothing across architecture, security, performance or cross-platform: the diff is one Markdown file and touches no code.

One deviation from the procedure, stated because it changes how much the above is worth: the judgement pass was run in the session that wrote the change rather than dispatched to a fresh context, which the standard asks for and which this session was configured not to do. The two findings above came out of running the commands, not out of re-reading the prose, so a fresh reader may still find something in the wording.

</details>

<details>
<summary>Implementation notes</summary>

What was actually run, on macOS, Playwright 1.62.1, against `-g "the app launches from source"`:

| command | result |
| --- | --- |
| `PWDEBUG=1 …` | passed in 5.1s, never paused |
| `page.pause()` in the spec, default flags | passed in 8.6s, never paused |
| `… --debug` | paused; Inspector window up, still held after 50s |
| `page.pause()` + `--headed --timeout=0` | paused; Inspector window up, still held after 36s |

Separately, a 75 second hold (`await new Promise( ( r ) => setTimeout( r, 75000 ) )`) under `--timeout=0` passed at 1.3m, confirming the config's 60 second `timeout` is genuinely lifted rather than merely large.

`node_modules/playwright/lib/program.js:194` is where `--debug` is defined as `PWDEBUG=1` plus `--timeout=0 --max-failures=1 --headed --workers=1`, which is the source for that sentence in the new section.

</details>
