### PR TITLE
Show the test layout in TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,19 @@ To run one file: `node --test tests/unit/azure-sign.test.cjs`. To run one journe
 
 ## The five layers
 
-"Add a test" is not a single instruction here. There are five places a test can go, and putting one in the wrong place is how a suite gets slow without getting better.
+"Add a test" is not a single instruction here. There are five places a test can go, and putting one in the wrong place is how a suite gets slow without getting better. All five are under `tests/`:
+
+```
+tests/
+  unit/            layers 1-3 — npm test — under three seconds
+    fixtures/      package.json trees the integration tests copy; not tests themselves
+  e2e/
+    journeys/      layer 4 — npm run test:e2e
+    packaged/      layer 5 — npm run test:e2e:packaged, and it needs a build first
+    helpers/       the app session fixture and the Git site builder; not tests either
+```
+
+Two directories, because the split that matters is what a test costs to run, not what it covers: everything in `unit/` is a function call, and everything in `e2e/` launches the app. The layers below subdivide that, and the file name says which — a layer-2 test is `*.integration.test.cjs`, and anything under `e2e/` is `*.spec.js`.
 
 They are listed cheapest first, and that ordering is the rule: **write a test at the highest layer that can still see the failure.** What each layer is blind to is the part worth reading — it is what sends a test one layer up, or down.
 


### PR DESCRIPTION
## Why

TESTING.md's five-layer section names a path per layer and never shows the tree. The shape of the suite is therefore something you assemble by reading five separate bullets and holding them in your head — and a reader arriving at that section is usually there for one reason, to find out where their new test goes. They want the map before the taxonomy.

This was worth doing anyway, but #377 is what made it obvious: that PR's whole argument was that the tree should say what the document says. It moved the tree. This finishes the sentence.

## What changes

One block at the top of **The five layers**, before the ordering rule and the numbered entries:

```
tests/
  unit/            layers 1-3 — npm test — under three seconds
    fixtures/      package.json trees the integration tests copy; not tests themselves
  e2e/
    journeys/      layer 4 — npm run test:e2e
    packaged/      layer 5 — npm run test:e2e:packaged, and it needs a build first
    helpers/       the app session fixture and the Git site builder; not tests either
```

Plus two sentences stating what the tree makes obvious once it is in front of you and was never written down: the two directories split on **what a test costs to run**, not on what it covers — everything in `unit/` is a function call, everything in `e2e/` launches the app. The five layers subdivide that, and the *file name* says which layer a file is (`*.integration.test.cjs` for layer 2, `*.spec.js` for anything end-to-end).

`fixtures/` and `helpers/` are labelled as not-tests deliberately. Both are directories full of `.cjs` and `.json` that a reader scanning for test files will otherwise count as tests, and `helpers/` in particular is where someone looking for "the e2e tests" lands first.

No path changed and no claim changed. This is the layout the parent PR produced, written down.

## How to test this

**Platforms: any.** Documentation only — no code, no config, nothing the suite can reach.

**Starting state:** this branch checked out.

1. `git diff juanmaguitar/tests-folder -- TESTING.md` → 13 added lines, 1 changed, all inside the **The five layers** section.
2. Read the tree against the repository: `find tests -maxdepth 2 -type d` → `tests/unit`, `tests/unit/fixtures`, `tests/e2e`, `tests/e2e/helpers`, `tests/e2e/journeys`, `tests/e2e/packaged`. Six directories, six lines in the block, no directory omitted and none invented.
3. Check the three commands named in the tree against `package.json` scripts — `npm test`, `npm run test:e2e`, `npm run test:e2e:packaged` all exist and map to the layer claimed.
4. `npm run lint` → exit 0 (nothing lints Markdown here; run for the sake of the branch being clean).

**What must not have happened:**

- **A test count.** TESTING.md's own Conventions section forbids numbers in this document — "a number here is wrong the moment somebody adds a test, and nothing makes it go red". The block gives commands and timings, never a count. Worth checking, because a directory tree is exactly the place the temptation shows up.
- **A second source of truth.** The tree must not restate what the numbered layer entries below it already say, or the two drift. It carries the *locations and costs*; the entries keep the "what each layer is blind to" reasoning, which is the part that actually decides where a test goes.
- **A claim about `fixtures/` or `helpers/` that is wrong.** Both are described by what they hold. `tests/unit/fixtures/` is `package.json` trees plus `.npmrc` files copied into a temp directory by `copyFixture()`; `tests/e2e/helpers/` is `app.cjs` (the session fixture) and `git-site.cjs` (the Git site builder). Neither contains an assertion.

## Risks and limitations

A hand-written tree in a document is a thing that can go stale, and nothing checks it. That is the honest cost of this PR. It is bounded — six directories that have been stable since the suite existed, and a wrong one is visible to anyone who runs `ls` — but it is a new claim in a file that previously made none.

Not done: no equivalent block in AGENTS.md or CONTRIBUTING.md. Both point at TESTING.md for exactly this, and a copy in either would be the drift this repository already avoids on the review standard.

## Related

Stacked on #377, which produced this layout. Base retargets to `trunk` automatically when that merges. Follow-up to #376.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Why in "The five layers" and not at the top of the file?** The opening section is **What to run** — commands, for someone who wants to run something now. A tree there answers a question that reader is not asking. The layer section is where the "where does this go" reader arrives, and the tree is the answer to their actual question.

**Why not one line per layer, matching the five entries below?** Because there are five layers and six directories, and they do not line up: layers 1-3 share `tests/unit/`, and `fixtures/` and `helpers/` belong to no layer at all. Forcing the tree into the taxonomy would have hidden precisely the two directories a newcomer most needs labelled.

**Why not annotate every file?** The suite is large and the file list changes weekly. Directories are stable; files are not. The Conventions section already rules out anything count-shaped for the same reason.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**No findings across the five dimensions.**

Deterministic layer: `npm run lint` exit 0. The test suites were not re-run for this PR and are unchanged by it — the diff is 14 lines of Markdown in one file, touching no code, no config and no path. They ran green on the parent commit in #377 (1027 unit on both runtimes, 14 journeys, 4 packaged).

The dimensions do not have much to bite on here: no code, so nothing to say about architecture, security, performance or cross-platform. Under **tests**, the standard's rule is that a change without a test is a finding — this is documentation with no user-visible surface and nothing `node --test` can assert about, which the standard explicitly allows for, and the manual verification above is what stands in its place.

The one thing worth flagging is in **Risks** rather than as a finding, because it is a property of the change rather than a defect: a hand-maintained tree can go stale and nothing in CI will notice.

**Process disclosure:** the judgement pass ran in the authoring session rather than a fresh subagent, because this session is configured not to dispatch them. Same disclosure as #376 and #377.

</details>
