### PR TITLE
Do not merge — spike #364: ship the Git the app runs on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@wp-playground/cli": "^3.1.47",
         "@xterm/xterm": "^5.5.0",
         "diff": "^5.2.0",
+        "dugite": "^3.2.3",
         "electron-log": "^5.4.4",
         "electron-store": "^10.0.1",
         "extract-zip": "^2.0.1",
@@ -6825,6 +6826,100 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -8143,6 +8238,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dugite": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dugite/-/dugite-3.2.3.tgz",
+      "integrity": "sha512-kPBJ0uevCPY4pcGl0R0+dgC/prPBvnHN9109ZUUWDttkWHz4HqFGwyFri9Btmd2YucAXIJTYMGECh/Q5VAfpfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "tar-stream": "^3.1.7"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/dunder-proto": {
@@ -9618,6 +9727,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -9718,6 +9836,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -15388,7 +15512,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -16577,6 +16700,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -16855,6 +16989,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -16863,6 +17023,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp": {
@@ -16904,6 +17073,29 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/tiny-async-pool": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,17 @@
       "buildResources": "build"
     },
     "files": [
-      "!vendor{,/**/*}"
+      "!vendor{,/**/*}",
+      "!node_modules/dugite/git/libexec/git-core/*.dll",
+      "!node_modules/dugite/git/libexec/git-core/*.dylib",
+      "!node_modules/dugite/git/libexec/git-core/*.json",
+      "!node_modules/dugite/git/libexec/git-core/git-credential-manager",
+      "!node_modules/dugite/git/libexec/git-core/git-lfs",
+      "!node_modules/dugite/git/libexec/git-core/createdump",
+      "!node_modules/dugite/git/libexec/git-core/{cs,de,es,fr,it,ja,ko,pl,pt-BR,ru,tr,zh-Hans,zh-Hant}{,/**/*}"
+    ],
+    "asarUnpack": [
+      "node_modules/dugite/git/**"
     ],
     "icon": "build/icon.png",
     "linux": {
@@ -84,6 +94,7 @@
     "@wp-playground/cli": "^3.1.47",
     "@xterm/xterm": "^5.5.0",
     "diff": "^5.2.0",
+    "dugite": "^3.2.3",
     "electron-log": "^5.4.4",
     "electron-store": "^10.0.1",
     "extract-zip": "^2.0.1",
@@ -107,8 +118,9 @@
     "playwright-core": "^1.62.1"
   },
   "allowScripts": {
-    "electron@43.2.0": true,
+    "dugite@3.2.3": true,
     "electron-winstaller@5.4.0": true,
+    "electron@43.2.0": true,
     "esbuild@0.23.1": true,
     "fs-ext-extra-prebuilt@2.2.7": true
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
       "!node_modules/dugite/git/libexec/git-core/git-credential-manager",
       "!node_modules/dugite/git/libexec/git-core/git-lfs",
       "!node_modules/dugite/git/libexec/git-core/createdump",
-      "!node_modules/dugite/git/libexec/git-core/{cs,de,es,fr,it,ja,ko,pl,pt-BR,ru,tr,zh-Hans,zh-Hant}{,/**/*}"
+      "!node_modules/dugite/git/libexec/git-core/{cs,de,es,fr,it,ja,ko,pl,pt-BR,ru,tr,zh-Hans,zh-Hant}{,/**/*}",
+      "!node_modules/dugite/git/{mingw64,clangarm64}/libexec/git-core/git-credential-manager*",
+      "!node_modules/dugite/git/{mingw64,clangarm64}/libexec/git-core/git-lfs.exe",
+      "!node_modules/dugite/git/{mingw64,clangarm64}/bin/git-lfs.exe"
     ],
     "asarUnpack": [
       "node_modules/dugite/git/**"

--- a/scripts/spike-364/git-env.cjs
+++ b/scripts/spike-364/git-env.cjs
@@ -2,56 +2,58 @@
 /**
  * Spike #364 — resolving the bundled Git, in development and packaged.
  *
- * Throwaway. Nothing here is meant to land: it exists so the probes can find
- * the binary the same way `src/main.js` would have to, and so the environment
- * question is answered explicitly rather than inherited from the host.
+ * Throwaway. It delegates to dugite rather than joining paths by hand, which is
+ * a finding rather than a convenience: the layout differs per platform in three
+ * places at once. On Windows the binary is `git/cmd/git.exe` and not
+ * `git/bin/git`, the exec path is under `git/mingw64/libexec/git-core`, and
+ * `PATH` has to carry `mingw64/bin` and `mingw64/usr/bin` or the helpers Git
+ * shells out to are not found. A first pass at this spike hand-rolled the macOS
+ * layout, and every Windows check failed on that alone.
  */
 
 const fs = require( 'node:fs' );
 const path = require( 'node:path' );
+const dugite = require( 'dugite' );
 
 /**
- * dugite lands in node_modules, so in a packaged app its tree is inside
- * app.asar and cannot be executed from there. `asarUnpack` puts it in
- * app.asar.unpacked; this is the resolution that goes with it.
+ * dugite already rewrites `app.asar` to `app.asar.unpacked`, which is the
+ * resolution that goes with the `asarUnpack` rule this spike adds. Nothing here
+ * has to know about packaging.
  */
 function resolveGitRoot() {
-	const fromDugite = path.join( require.resolve( 'dugite' ), '..', '..', '..', 'git' );
-	const unpacked = fromDugite.replace( `app.asar${ path.sep }`, `app.asar.unpacked${ path.sep }` );
-	if ( fs.existsSync( path.join( unpacked, 'bin' ) ) ) return unpacked;
-	return fromDugite;
+	return dugite.resolveGitDir();
 }
 
-function gitBinary( root = resolveGitRoot() ) {
-	return path.join( root, 'bin', process.platform === 'win32' ? 'git.exe' : 'git' );
+function gitBinary() {
+	return dugite.setupEnvironment( {} ).gitLocation;
 }
 
 /**
  * Everything the bundled Git must be told, and nothing it should inherit.
  *
- * `--exec-path` resolves to `//libexec/git-core` when GIT_EXEC_PATH is unset,
- * so it is not optional. The rest is the second invariant of #350 read
- * forwards: a Git that picks up the host's global or system config is a Git
- * whose behaviour the app cannot predict.
+ * `setupEnvironment` covers the layout: GIT_EXEC_PATH (without which
+ * `--exec-path` reads `//libexec/git-core`), the Windows PATH prefix, the
+ * template dir, and dugite's own system gitconfig on macOS and Linux.
+ *
+ * The rest is #350's second invariant read forwards: a Git that picks up the
+ * host's global config, or asks a human for credentials, is a Git whose
+ * behaviour the app cannot predict. Every fetch this app makes is anonymous
+ * over public HTTPS, so there is nothing to authenticate and nothing to prompt
+ * for.
  */
-function gitEnv( root = resolveGitRoot(), extra = {} ) {
-	const env = {
-		...process.env,
-		GIT_EXEC_PATH: path.join( root, 'libexec', 'git-core' ),
-		GIT_TEMPLATE_DIR: path.join( root, 'share', 'git-core', 'templates' ),
+function gitEnv( extra = {} ) {
+	const { env } = dugite.setupEnvironment( {
+		// dugite's own system gitconfig `include`s the host's /etc/gitconfig, so
+		// without this the app would inherit whatever a mentor's machine sets.
 		GIT_CONFIG_NOSYSTEM: '1',
 		GIT_TERMINAL_PROMPT: '0',
 		GIT_ASKPASS: '',
-		// No interactive credential helper, ever: every fetch the app makes is
-		// anonymous over public HTTPS.
 		GIT_CONFIG_COUNT: '1',
 		GIT_CONFIG_KEY_0: 'credential.helper',
 		GIT_CONFIG_VALUE_0: '',
 		...extra,
-	};
-	const caBundle = path.join( root, 'etc', 'ssl', 'cert.pem' );
-	if ( fs.existsSync( caBundle ) ) env.GIT_SSL_CAINFO = caBundle;
+	} );
 	return env;
 }
 
-module.exports = { resolveGitRoot, gitBinary, gitEnv };
+module.exports = { resolveGitRoot, gitBinary, gitEnv, dugite, fs, path };

--- a/scripts/spike-364/git-env.cjs
+++ b/scripts/spike-364/git-env.cjs
@@ -1,0 +1,57 @@
+/* eslint-disable -- Spike #364 scaffolding. Thrown away with the branch; not held to the repo's style. */
+/**
+ * Spike #364 — resolving the bundled Git, in development and packaged.
+ *
+ * Throwaway. Nothing here is meant to land: it exists so the probes can find
+ * the binary the same way `src/main.js` would have to, and so the environment
+ * question is answered explicitly rather than inherited from the host.
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+
+/**
+ * dugite lands in node_modules, so in a packaged app its tree is inside
+ * app.asar and cannot be executed from there. `asarUnpack` puts it in
+ * app.asar.unpacked; this is the resolution that goes with it.
+ */
+function resolveGitRoot() {
+	const fromDugite = path.join( require.resolve( 'dugite' ), '..', '..', '..', 'git' );
+	const unpacked = fromDugite.replace( `app.asar${ path.sep }`, `app.asar.unpacked${ path.sep }` );
+	if ( fs.existsSync( path.join( unpacked, 'bin' ) ) ) return unpacked;
+	return fromDugite;
+}
+
+function gitBinary( root = resolveGitRoot() ) {
+	return path.join( root, 'bin', process.platform === 'win32' ? 'git.exe' : 'git' );
+}
+
+/**
+ * Everything the bundled Git must be told, and nothing it should inherit.
+ *
+ * `--exec-path` resolves to `//libexec/git-core` when GIT_EXEC_PATH is unset,
+ * so it is not optional. The rest is the second invariant of #350 read
+ * forwards: a Git that picks up the host's global or system config is a Git
+ * whose behaviour the app cannot predict.
+ */
+function gitEnv( root = resolveGitRoot(), extra = {} ) {
+	const env = {
+		...process.env,
+		GIT_EXEC_PATH: path.join( root, 'libexec', 'git-core' ),
+		GIT_TEMPLATE_DIR: path.join( root, 'share', 'git-core', 'templates' ),
+		GIT_CONFIG_NOSYSTEM: '1',
+		GIT_TERMINAL_PROMPT: '0',
+		GIT_ASKPASS: '',
+		// No interactive credential helper, ever: every fetch the app makes is
+		// anonymous over public HTTPS.
+		GIT_CONFIG_COUNT: '1',
+		GIT_CONFIG_KEY_0: 'credential.helper',
+		GIT_CONFIG_VALUE_0: '',
+		...extra,
+	};
+	const caBundle = path.join( root, 'etc', 'ssl', 'cert.pem' );
+	if ( fs.existsSync( caBundle ) ) env.GIT_SSL_CAINFO = caBundle;
+	return env;
+}
+
+module.exports = { resolveGitRoot, gitBinary, gitEnv };

--- a/scripts/spike-364/probe-fidelity.cjs
+++ b/scripts/spike-364/probe-fidelity.cjs
@@ -1,0 +1,161 @@
+/* eslint-disable -- Spike #364 scaffolding. Thrown away with the branch; not held to the repo's style. */
+/**
+ * Spike #364 / #351 — do the conflicts a real Git reports agree with the ones
+ * the app reports, and with the ones GitHub reports?
+ *
+ * For each pull request it records three verdicts on the same change:
+ *
+ *   app    today's two-way apply (src/patch-apply.js) against today's trunk
+ *   git    a three-way merge from the real merge base, by the bundled binary
+ *   hub    what GitHub says about merging the pull request
+ *
+ * Throwaway. Needs a checkout of wordpress-develop with full commit history:
+ *   git clone --filter=blob:none https://github.com/WordPress/wordpress-develop.git <dir>
+ *
+ * Run with:  node scripts/spike-364/probe-fidelity.cjs <dir> <pr> [<pr> ...]
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { spawnSync } = require( 'node:child_process' );
+
+const { resolveGitRoot, gitBinary, gitEnv } = require( './git-env.cjs' );
+const { applyPatchToDir } = require( '../../src/patch-apply.js' );
+
+const ROOT = resolveGitRoot();
+const BIN = gitBinary( ROOT );
+const ENV = gitEnv( ROOT );
+
+const REPO = 'WordPress/wordpress-develop';
+
+function git( args, cwd ) {
+	const r = spawnSync( BIN, args, { cwd, env: ENV, shell: false, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 } );
+	return { status: r.status, stdout: ( r.stdout || '' ).trim(), stderr: ( r.stderr || '' ).trim() };
+}
+
+function gh( args ) {
+	const r = spawnSync( 'gh', args, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 } );
+	if ( r.status !== 0 ) throw new Error( `gh ${ args.join( ' ' ) }: ${ r.stderr }` );
+	return r.stdout;
+}
+
+/**
+ * `git merge-tree --write-tree` merges in memory, so nothing touches the
+ * working tree. Exit 0 is a clean merge, 1 is conflicts; the conflicted paths
+ * come back in the informational block after the tree oid.
+ */
+function gitVerdict( dir, headRef ) {
+	const r = git( [ 'merge-tree', '--write-tree', '--name-only', '--merge-base=' + mergeBase( dir, headRef ), 'trunk', headRef ], dir );
+	if ( r.status === 0 ) return { clean: true, files: [] };
+	if ( r.status !== 1 ) return { error: r.stderr || r.stdout };
+
+	// <oid>\n<conflicted file>\n...\n\n<messages>
+	const [ block ] = r.stdout.split( '\n\n' );
+	const files = block.split( '\n' ).slice( 1 ).filter( Boolean );
+	return { clean: false, files: [ ...new Set( files ) ].sort() };
+}
+
+function mergeBase( dir, headRef ) {
+	return git( [ 'merge-base', 'trunk', headRef ], dir ).stdout;
+}
+
+async function appVerdict( dir, patchText ) {
+	const before = git( [ 'status', '--porcelain' ], dir ).stdout;
+	if ( before !== '' ) throw new Error( `checkout is dirty before the apply:\n${ before }` );
+
+	const result = await applyPatchToDir( { dir, patchText } );
+
+	const after = git( [ 'status', '--porcelain' ], dir ).stdout;
+	if ( result.ok ) {
+		// An apply that succeeded has to be undone before the next pull request.
+		git( [ 'checkout', '--', '.' ], dir );
+		git( [ 'clean', '-fd' ], dir );
+	}
+
+	return {
+		ok: !! result.ok,
+		// `conflicts` carries the paths; `failures` is prose, one sentence per file.
+		files: [ ...new Set( ( result.conflicts || [] ).map( ( c ) => c.path ) ) ].sort(),
+		failures: ( result.failures || [] ).length,
+		error: result.error || null,
+		wroteOnFailure: ! result.ok && after !== '',
+	};
+}
+
+/**
+ * The app rewrites Trac-style paths into `src/`; a GitHub diff already has them.
+ */
+function normalise( files ) {
+	return files.map( ( f ) => String( f ).replace( /^[ab]\//, '' ) ).sort();
+}
+
+async function main() {
+	const [ dir, ...prs ] = process.argv.slice( 2 );
+	if ( ! dir || ! prs.length ) {
+		throw new Error( 'usage: probe-fidelity.cjs <wordpress-develop dir> <pr> [<pr> ...]' );
+	}
+
+	git( [ 'fetch', '--quiet', 'origin', 'trunk' ], dir );
+	git( [ 'checkout', '--quiet', 'trunk' ], dir );
+	git( [ 'reset', '--hard', '--quiet', 'origin/trunk' ], dir );
+
+	const rows = [];
+
+	for ( const pr of prs ) {
+		const meta = JSON.parse( gh( [ 'api', `repos/${ REPO }/pulls/${ pr }` ] ) );
+		const ref = `refs/pull/${ pr }/head`;
+		const fetched = git( [ 'fetch', '--quiet', 'origin', `${ ref }:${ ref }` ], dir );
+		if ( fetched.status !== 0 ) {
+			rows.push( { pr, skipped: fetched.stderr } );
+			continue;
+		}
+
+		let patchText;
+		try {
+			patchText = gh( [ 'api', `repos/${ REPO }/pulls/${ pr }`, '-H', 'Accept: application/vnd.github.v3.diff' ] );
+		} catch ( error ) {
+			// GitHub refuses a diff over 300 files. The app hits the same wall, so
+			// this is a limit of the route rather than of the comparison.
+			rows.push( { pr: Number( pr ), skipped: String( error.message ).slice( 0, 120 ) } );
+			console.log( `#${ pr } skipped: diff too large for the API\n` );
+			continue;
+		}
+
+		const app = await appVerdict( dir, patchText );
+		const real = gitVerdict( dir, ref );
+		const base = mergeBase( dir, ref );
+
+		rows.push( {
+			pr: Number( pr ),
+			created: meta.created_at.slice( 0, 10 ),
+			title: meta.title.slice( 0, 55 ),
+			mergeBase: base.slice( 0, 8 ),
+			behind: Number( git( [ 'rev-list', '--count', `${ base }..trunk` ], dir ).stdout ),
+			hub: `${ meta.mergeable === null ? 'unknown' : meta.mergeable ? 'mergeable' : 'conflicting' } (${ meta.mergeable_state })`,
+			app: app.ok ? 'applies' : `refuses ${ app.failures } file(s): ${ normalise( app.files ).join( ', ' ) || app.error }`,
+			git: real.error ? `error: ${ real.error }` : real.clean ? 'merges clean' : `conflicts: ${ normalise( real.files ).join( ', ' ) }`,
+			agree: app.ok === ( real.clean === true ),
+			wroteOnFailure: app.wroteOnFailure,
+		} );
+
+		const row = rows[ rows.length - 1 ];
+		console.log(
+			`#${ row.pr } (${ row.created }, ${ row.behind } commits behind)  ${ row.title }\n` +
+			`   hub: ${ row.hub }\n   app: ${ row.app }\n   git: ${ row.git }\n` +
+			`   -> ${ row.agree ? 'AGREE' : 'DISAGREE' }${ row.wroteOnFailure ? '  !! left the tree dirty' : '' }\n`
+		);
+	}
+
+	const compared = rows.filter( ( r ) => ! r.skipped );
+	const agreed = compared.filter( ( r ) => r.agree );
+	console.log( `\n${ agreed.length }/${ compared.length } agree on applies-vs-refuses` );
+	fs.writeFileSync(
+		path.join( require( 'node:os' ).tmpdir(), 'spike364-fidelity.json' ),
+		JSON.stringify( rows, null, 2 )
+	);
+}
+
+main().catch( ( error ) => {
+	console.error( error );
+	process.exit( 1 );
+} );

--- a/scripts/spike-364/probe-fidelity.cjs
+++ b/scripts/spike-364/probe-fidelity.cjs
@@ -23,8 +23,8 @@ const { resolveGitRoot, gitBinary, gitEnv } = require( './git-env.cjs' );
 const { applyPatchToDir } = require( '../../src/patch-apply.js' );
 
 const ROOT = resolveGitRoot();
-const BIN = gitBinary( ROOT );
-const ENV = gitEnv( ROOT );
+const BIN = gitBinary();
+const ENV = gitEnv();
 
 const REPO = 'WordPress/wordpress-develop';
 

--- a/scripts/spike-364/probe-local.cjs
+++ b/scripts/spike-364/probe-local.cjs
@@ -16,8 +16,8 @@ const { resolveGitRoot, gitBinary, gitEnv } = require( './git-env.cjs' );
 const ticketBranches = require( '../../src/ticket-branches.js' );
 
 const ROOT = resolveGitRoot();
-const BIN = gitBinary( ROOT );
-const ENV = gitEnv( ROOT );
+const BIN = gitBinary();
+const ENV = gitEnv();
 const AUTHOR = { name: 'Spike', email: 'spike@example.com' };
 
 const results = [];

--- a/scripts/spike-364/probe-local.cjs
+++ b/scripts/spike-364/probe-local.cjs
@@ -1,0 +1,211 @@
+/**
+ * Spike #364 — the local questions: can we drive the bundled Git, does it agree
+ * with a repository isomorphic-git made, and does it give us reflogs and ref
+ * locks for free.
+ *
+ * Throwaway. Run with:  node scripts/spike-364/probe-local.cjs
+ */
+
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { spawnSync } = require( 'node:child_process' );
+const git = require( 'isomorphic-git' );
+
+const { resolveGitRoot, gitBinary, gitEnv } = require( './git-env.cjs' );
+const ticketBranches = require( '../../src/ticket-branches.js' );
+
+const ROOT = resolveGitRoot();
+const BIN = gitBinary( ROOT );
+const ENV = gitEnv( ROOT );
+const AUTHOR = { name: 'Spike', email: 'spike@example.com' };
+
+const results = [];
+
+function record( id, question, ok, detail ) {
+	results.push( { id, question, ok, detail } );
+	console.log( `${ ok ? 'PASS' : 'FAIL' }  ${ id }  ${ question }\n      ${ String( detail ).replace( /\n/g, '\n      ' ) }\n` );
+}
+
+function run( args, cwd, extraEnv = {} ) {
+	const r = spawnSync( BIN, args, {
+		cwd,
+		env: { ...ENV, ...extraEnv },
+		shell: false,
+		windowsHide: true,
+		encoding: 'utf8',
+	} );
+	return {
+		status: r.status,
+		stdout: ( r.stdout || '' ).trim(),
+		stderr: ( r.stderr || '' ).trim(),
+		error: r.error ? String( r.error.message ) : null,
+	};
+}
+
+function tmp( prefix ) {
+	return fs.mkdtempSync( path.join( os.tmpdir(), prefix ) );
+}
+
+/**
+ * A checkout shaped like one the app made: branch `trunk`, a `src/` tree, a
+ * gitignored substrate, and a ticket branch carrying parked work — the WIP
+ * commit `src/ticket-branches.js` reparents onto the branch point. Built
+ * entirely through isomorphic-git and the app's own module, never through the
+ * binary under test.
+ */
+async function makeAppShapedRepo() {
+	const dir = tmp( 'spike364-iso-' );
+	await git.init( { fs, dir, defaultBranch: 'trunk' } );
+	fs.mkdirSync( path.join( dir, 'src' ), { recursive: true } );
+	fs.writeFileSync( path.join( dir, 'src', 'wp-login.php' ), '<?php\n// login\n' );
+	fs.writeFileSync( path.join( dir, '.gitignore' ), 'node_modules/\n' );
+	await git.add( { fs, dir, filepath: [ 'src/wp-login.php', '.gitignore' ] } );
+	const base = await git.commit( { fs, dir, message: 'trunk', author: AUTHOR } );
+
+	fs.mkdirSync( path.join( dir, 'node_modules', 'react' ), { recursive: true } );
+	fs.writeFileSync( path.join( dir, 'node_modules', 'react', 'index.js' ), 'expensive\n' );
+
+	const started = await ticketBranches.startTicketBranch( dir, '12345' );
+	fs.writeFileSync( path.join( dir, 'src', 'wp-login.php' ), '<?php\n// login\n// ticket work\n' );
+	await ticketBranches.parkCurrentWork( dir, { baseOid: started.baseOid } );
+
+	return { dir, base };
+}
+
+async function main() {
+	// ---------------------------------------------------------------- Q1: runtime
+	const version = run( [ '--version' ], process.cwd() );
+	record(
+		'Q1.version',
+		'the main process can spawn the bundled binary',
+		version.status === 0 && /^git version/.test( version.stdout ),
+		`${ BIN }\n${ version.stdout || version.stderr || version.error }`
+	);
+
+	const bare = spawnSync( BIN, [ '--exec-path' ], { encoding: 'utf8', shell: false } );
+	const withEnv = run( [ '--exec-path' ], process.cwd() );
+	record(
+		'Q1.execpath',
+		'GIT_EXEC_PATH has to be set explicitly',
+		withEnv.stdout.endsWith( path.join( 'libexec', 'git-core' ) ),
+		`without it: ${ ( bare.stdout || '' ).trim() }\nwith it:    ${ withEnv.stdout }`
+	);
+
+	const spaced = path.join( tmp( 'spike364 with space-' ), 'repo dir' );
+	fs.mkdirSync( spaced, { recursive: true } );
+	const inSpaced = run( [ 'init', '-b', 'trunk' ], spaced );
+	record(
+		'Q1.spaces',
+		'a path with a space in it works, no shell involved',
+		inSpaced.status === 0,
+		`${ spaced }\n${ inSpaced.stdout || inSpaced.stderr }`
+	);
+
+	const noSystem = run( [ 'config', '--show-origin', '--get-all', 'include.path' ], spaced );
+	record(
+		'Q1.isolation',
+		'the host\'s system config is not read (GIT_CONFIG_NOSYSTEM)',
+		noSystem.status !== 0 || ! noSystem.stdout.includes( '/etc/gitconfig' ),
+		noSystem.stdout || '(nothing — no system config reached)'
+	);
+
+	// ------------------------------------- Q2: over a repository isomorphic-git made
+	const { dir, base } = await makeAppShapedRepo();
+
+	const status = run( [ 'status', '--porcelain=v2', '--branch' ], dir );
+	record(
+		'Q2.status',
+		'real Git reads the app\'s checkout without complaint',
+		status.status === 0,
+		status.stdout || status.stderr
+	);
+
+	const log = run( [ 'log', '--oneline', '--all' ], dir );
+	const branches = run( [ 'branch', '-a' ], dir );
+	record(
+		'Q2.history',
+		'the parked WIP commit and the ticket branch are visible to Git',
+		log.status === 0 && branches.stdout.includes( '12345' ),
+		`${ branches.stdout }\n--\n${ log.stdout }`
+	);
+
+	const fsck = run( [ 'fsck', '--no-progress' ], dir );
+	record(
+		'Q2.fsck',
+		'the repository passes git fsck',
+		fsck.status === 0,
+		fsck.stdout || fsck.stderr || '(clean)'
+	);
+
+	// The interesting half: does Git see the same dirtiness the app does?
+	const isoStatus = await git.statusMatrix( { fs, dir } );
+	const isoDirty = isoStatus.filter( ( [ , h, w, s ] ) => ! ( h === 1 && w === 1 && s === 1 ) );
+	const gitDirty = run( [ 'status', '--porcelain' ], dir ).stdout;
+	record(
+		'Q2.agreement',
+		'Git and isomorphic-git agree on what is dirty',
+		( gitDirty === '' ) === ( isoDirty.length === 0 ),
+		`isomorphic-git: ${ isoDirty.length } entries\ngit: ${ gitDirty || '(clean)' }`
+	);
+
+	// ------------------------------------------------ Q5: reflog and ref locking
+	const configured = run( [ 'config', '--get', 'core.logallrefupdates' ], dir );
+	record(
+		'Q5.config',
+		'the claim isomorphic-git writes into every repository (#366)',
+		configured.stdout === 'true',
+		`core.logallrefupdates = ${ configured.stdout || '(unset)' }`
+	);
+
+	const before = run( [ 'reflog', '--all' ], dir );
+	// To a *different* oid on purpose: a same-value update writes nothing, which
+	// is how a first pass at this misread the result as "no reflog".
+	const tip = run( [ 'rev-parse', 'ticket/12345' ], dir ).stdout;
+	run( [ 'update-ref', 'refs/heads/trunk', tip ], dir );
+	const after = run( [ 'reflog', '--all' ], dir );
+	record(
+		'Q5.reflog',
+		'a ref update writes a reflog entry (#366 closes by construction)',
+		after.stdout.length > 0 && before.stdout.length === 0,
+		`before: ${ before.stdout || '(empty — nothing isomorphic-git did was logged)' }\nafter:  ${ after.stdout || '(still empty)' }`
+	);
+
+	const logsDir = path.join( dir, '.git', 'logs' );
+	record(
+		'Q5.reflog.files',
+		'.git/logs exists on disk, where a mentor would look',
+		fs.existsSync( logsDir ),
+		fs.existsSync( logsDir ) ? fs.readdirSync( logsDir ).join( ', ' ) : '(no .git/logs)'
+	);
+
+	// A held lock must make a concurrent ref update fail loudly rather than
+	// silently win — the property #355 needs and the in-process mutex cannot give.
+	const lock = path.join( dir, '.git', 'refs', 'heads', 'trunk.lock' );
+	fs.mkdirSync( path.dirname( lock ), { recursive: true } );
+	fs.writeFileSync( lock, '' );
+	const blocked = run( [ 'update-ref', 'refs/heads/trunk', base ], dir );
+	fs.rmSync( lock, { force: true } );
+	record(
+		'Q5.locking',
+		'a held .lock file blocks a second writer',
+		blocked.status !== 0,
+		blocked.stderr || blocked.stdout || '(no error — the lock was ignored)'
+	);
+
+	// ---------------------------------------------------------------- summary
+	const failed = results.filter( ( r ) => ! r.ok );
+	console.log( `\n${ results.length - failed.length }/${ results.length } passed` );
+	if ( failed.length ) {
+		console.log( `failed: ${ failed.map( ( r ) => r.id ).join( ', ' ) }` );
+	}
+	fs.writeFileSync(
+		path.join( os.tmpdir(), 'spike364-local.json' ),
+		JSON.stringify( { platform: process.platform, arch: process.arch, root: ROOT, results }, null, 2 )
+	);
+}
+
+main().catch( ( error ) => {
+	console.error( error );
+	process.exit( 1 );
+} );

--- a/scripts/spike-364/probe-packaged.cjs
+++ b/scripts/spike-364/probe-packaged.cjs
@@ -1,0 +1,130 @@
+/* eslint-disable -- Spike #364 scaffolding. Thrown away with the branch; not held to the repo's style. */
+/**
+ * Spike #364 — the questions only the packaged app can answer: does the main
+ * process find the binary once it is behind app.asar.unpacked, and does a real
+ * shallow clone over HTTPS work from inside the bundle.
+ *
+ * Throwaway. Build first, then run:
+ *   CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack:dir
+ *   node scripts/spike-364/probe-packaged.cjs
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { _electron: electron } = require( 'playwright-core' );
+
+const REPO_ROOT = path.join( __dirname, '..', '..' );
+const DIST = path.join( REPO_ROOT, 'dist' );
+
+function findPackagedBinary() {
+	if ( process.platform === 'darwin' ) {
+		const dir = fs.readdirSync( DIST ).find( ( d ) => d === 'mac' || d.startsWith( 'mac-' ) );
+		const appDir = path.join( DIST, dir );
+		const app = fs.readdirSync( appDir ).find( ( d ) => d.endsWith( '.app' ) );
+		const macOsDir = path.join( appDir, app, 'Contents', 'MacOS' );
+		return path.join( macOsDir, fs.readdirSync( macOsDir )[ 0 ] );
+	}
+	const unpacked = path.join( DIST, 'win-unpacked' );
+	return path.join( unpacked, fs.readdirSync( unpacked ).find( ( f ) => f.endsWith( '.exe' ) ) );
+}
+
+/**
+ * Runs inside the packaged main process. Everything it needs has to be resolved
+ * from the app's own package.json, exactly as src/main.js would.
+ */
+function probeInMain( { app }, cloneUrl ) {
+	const nodeRequire = process.mainModule ? process.mainModule.require : require;
+	const { createRequire } = nodeRequire( 'module' );
+	const nodeFs = nodeRequire( 'fs' );
+	const nodePath = nodeRequire( 'path' );
+	const nodeOs = nodeRequire( 'os' );
+	const { spawnSync } = nodeRequire( 'child_process' );
+
+	const req = createRequire( nodePath.join( app.getAppPath(), 'package.json' ) );
+	const out = { appPath: app.getAppPath(), steps: [] };
+
+	let root;
+	try {
+		const fromDugite = nodePath.join( req.resolve( 'dugite' ), '..', '..', '..', 'git' );
+		const unpacked = fromDugite.replace( `app.asar${ nodePath.sep }`, `app.asar.unpacked${ nodePath.sep }` );
+		root = nodeFs.existsSync( nodePath.join( unpacked, 'bin' ) ) ? unpacked : fromDugite;
+	} catch ( error ) {
+		out.steps.push( { id: 'resolve', ok: false, detail: String( error.message ) } );
+		return out;
+	}
+	out.steps.push( {
+		id: 'resolve',
+		ok: root.includes( 'app.asar.unpacked' ),
+		detail: root,
+	} );
+
+	const bin = nodePath.join( root, 'bin', process.platform === 'win32' ? 'git.exe' : 'git' );
+	const env = {
+		...process.env,
+		GIT_EXEC_PATH: nodePath.join( root, 'libexec', 'git-core' ),
+		GIT_TEMPLATE_DIR: nodePath.join( root, 'share', 'git-core', 'templates' ),
+		GIT_CONFIG_NOSYSTEM: '1',
+		GIT_TERMINAL_PROMPT: '0',
+	};
+	const run = ( args, cwd ) => {
+		const r = spawnSync( bin, args, { cwd, env, shell: false, windowsHide: true, encoding: 'utf8' } );
+		return { status: r.status, stdout: ( r.stdout || '' ).trim(), stderr: ( r.stderr || '' ).trim() };
+	};
+
+	const version = run( [ '--version' ], nodeOs.tmpdir() );
+	out.steps.push( {
+		id: 'spawn',
+		ok: version.status === 0,
+		detail: version.stdout || version.stderr,
+	} );
+
+	// The clone the app actually performs, shape for shape: shallow, one branch.
+	// The point is the certificates — nothing here tells Git where to find any.
+	const target = nodeFs.mkdtempSync( nodePath.join( nodeOs.tmpdir(), 'spike364-clone-' ) );
+	const started = Date.now();
+	const cloned = run( [ 'clone', '--depth', '1', '--single-branch', '--branch', 'trunk', cloneUrl, target ], nodeOs.tmpdir() );
+	const seconds = Math.round( ( Date.now() - started ) / 100 ) / 10;
+	out.steps.push( {
+		id: 'clone',
+		ok: cloned.status === 0,
+		detail: `${ seconds }s — ${ cloned.stderr || cloned.stdout || 'ok' }`,
+	} );
+
+	if ( cloned.status === 0 ) {
+		const head = run( [ 'rev-parse', 'HEAD' ], target );
+		const shallow = nodeFs.existsSync( nodePath.join( target, '.git', 'shallow' ) );
+		out.steps.push( {
+			id: 'clone.shape',
+			ok: head.status === 0 && shallow,
+			detail: `HEAD ${ head.stdout }, .git/shallow present: ${ shallow }`,
+		} );
+
+		const fetched = run( [ 'fetch', '--depth', '1', 'origin', 'trunk' ], target );
+		out.steps.push( {
+			id: 'fetch',
+			ok: fetched.status === 0,
+			detail: fetched.stderr || 'ok',
+		} );
+	}
+
+	out.cloneDir = target;
+	return out;
+}
+
+async function main() {
+	const app = await electron.launch( { executablePath: findPackagedBinary() } );
+	await app.firstWindow();
+	const result = await app.evaluate( probeInMain, 'https://github.com/WordPress/wordpress-develop.git' );
+	await app.close().catch( () => {} );
+	console.log( `appPath: ${ result.appPath }\n` );
+	for ( const step of result.steps ) {
+		console.log( `${ step.ok ? 'PASS' : 'FAIL' }  ${ step.id }\n      ${ step.detail }\n` );
+	}
+	if ( result.cloneDir ) fs.rmSync( result.cloneDir, { recursive: true, force: true } );
+	process.exit( result.steps.every( ( s ) => s.ok ) ? 0 : 1 );
+}
+
+main().catch( ( error ) => {
+	console.error( error );
+	process.exit( 1 );
+} );

--- a/tests/e2e/packaged/spike-364-git.spec.js
+++ b/tests/e2e/packaged/spike-364-git.spec.js
@@ -112,7 +112,19 @@ function probeInMain( { app }, cloneUrl ) {
 		steps.push( { id: 'fetch', ok: fetched.status === 0, detail: fetched.stderr || 'ok' } );
 	}
 
-	nodeFs.rmSync( target, { recursive: true, force: true } );
+	// Deleting what Git wrote is its own question on Windows: Git marks loose
+	// objects read-only, and `rm -rf` with `force` does not clear that attribute.
+	// The app deletes site folders today (`sites:delete`), against repositories
+	// isomorphic-git made — which do not have the attribute set. So this is a
+	// finding, not teardown noise, and it must not mask the steps above.
+	let removal = 'ok';
+	try {
+		nodeFs.rmSync( target, { recursive: true, force: true } );
+	} catch ( error ) {
+		removal = String( error && error.message );
+	}
+	steps.push( { id: 'remove', ok: removal === 'ok', detail: removal } );
+
 	return { appPath: app.getAppPath(), steps };
 }
 

--- a/tests/e2e/packaged/spike-364-git.spec.js
+++ b/tests/e2e/packaged/spike-364-git.spec.js
@@ -1,0 +1,117 @@
+/* eslint-disable -- Spike #364 scaffolding. Thrown away with the branch; not held to the repo's style. */
+/**
+ * SPIKE #364 — NOT A REAL TEST. Delete with the rest of the spike.
+ *
+ * It rides in the packaged smoke project because that is the only harness that
+ * launches the built artifact on macOS and Windows, and the questions here only
+ * have answers there: whether the main process finds the bundled Git once it is
+ * behind `app.asar.unpacked`, and whether a shallow clone over HTTPS works from
+ * inside the bundle with nothing telling Git where the certificates are.
+ *
+ * Unlike everything else in this directory it touches the network, on purpose.
+ */
+
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const { test, expect, _electron: electron } = require( '@playwright/test' );
+
+const REPO_ROOT = path.join( __dirname, '..', '..', '..' );
+const DIST = path.join( REPO_ROOT, 'dist' );
+const CLONE_URL = 'https://github.com/WordPress/wordpress-develop.git';
+
+function findPackagedBinary() {
+	if ( process.platform === 'darwin' ) {
+		const dir = fs.readdirSync( DIST ).find( ( d ) => d === 'mac' || d.startsWith( 'mac-' ) );
+		const appDir = path.join( DIST, dir );
+		const app = fs.readdirSync( appDir ).find( ( d ) => d.endsWith( '.app' ) );
+		const macOsDir = path.join( appDir, app, 'Contents', 'MacOS' );
+		return path.join( macOsDir, fs.readdirSync( macOsDir )[ 0 ] );
+	}
+	const unpacked = path.join( DIST, 'win-unpacked' );
+	return path.join( unpacked, fs.readdirSync( unpacked ).find( ( f ) => f.endsWith( '.exe' ) ) );
+}
+
+/**
+ * Runs inside the packaged main process, resolving as src/main.js would.
+ */
+function probeInMain( { app }, cloneUrl ) {
+	const nodeRequire = process.mainModule ? process.mainModule.require : require;
+	const { createRequire } = nodeRequire( 'module' );
+	const nodeFs = nodeRequire( 'fs' );
+	const nodePath = nodeRequire( 'path' );
+	const nodeOs = nodeRequire( 'os' );
+	const { spawnSync } = nodeRequire( 'child_process' );
+
+	const req = createRequire( nodePath.join( app.getAppPath(), 'package.json' ) );
+	const steps = [];
+
+	const fromDugite = nodePath.join( req.resolve( 'dugite' ), '..', '..', '..', 'git' );
+	const unpacked = fromDugite.replace( `app.asar${ nodePath.sep }`, `app.asar.unpacked${ nodePath.sep }` );
+	const root = nodeFs.existsSync( nodePath.join( unpacked, 'bin' ) ) ? unpacked : fromDugite;
+	steps.push( { id: 'resolve', ok: root.includes( 'app.asar.unpacked' ), detail: root } );
+
+	const bin = nodePath.join( root, 'bin', process.platform === 'win32' ? 'git.exe' : 'git' );
+	const env = {
+		...process.env,
+		GIT_EXEC_PATH: nodePath.join( root, 'libexec', 'git-core' ),
+		GIT_TEMPLATE_DIR: nodePath.join( root, 'share', 'git-core', 'templates' ),
+		GIT_CONFIG_NOSYSTEM: '1',
+		GIT_TERMINAL_PROMPT: '0',
+	};
+	const run = ( args, cwd ) => {
+		const r = spawnSync( bin, args, { cwd, env, shell: false, windowsHide: true, encoding: 'utf8' } );
+		return { status: r.status, stdout: ( r.stdout || '' ).trim(), stderr: ( r.stderr || '' ).trim() };
+	};
+
+	const version = run( [ '--version' ], nodeOs.tmpdir() );
+	steps.push( { id: 'spawn', ok: version.status === 0, detail: version.stdout || version.stderr } );
+
+	// The clone the app performs, shape for shape. Nothing here points Git at a
+	// certificate bundle — if it needs one, this is where that shows.
+	const target = nodeFs.mkdtempSync( nodePath.join( nodeOs.tmpdir(), 'spike364-clone-' ) );
+	const started = Date.now();
+	const cloned = run( [ 'clone', '--depth', '1', '--single-branch', '--branch', 'trunk', cloneUrl, target ], nodeOs.tmpdir() );
+	const seconds = Math.round( ( Date.now() - started ) / 100 ) / 10;
+	steps.push( {
+		id: 'clone',
+		ok: cloned.status === 0,
+		detail: `${ seconds }s — ${ ( cloned.stderr || cloned.stdout || 'ok' ).split( '\n' ).pop() }`,
+	} );
+
+	if ( cloned.status === 0 ) {
+		steps.push( {
+			id: 'clone.shape',
+			ok: nodeFs.existsSync( nodePath.join( target, '.git', 'shallow' ) ),
+			detail: `HEAD ${ run( [ 'rev-parse', 'HEAD' ], target ).stdout }`,
+		} );
+		const fetched = run( [ 'fetch', '--depth', '1', 'origin', 'trunk' ], target );
+		steps.push( { id: 'fetch', ok: fetched.status === 0, detail: fetched.stderr || 'ok' } );
+	}
+
+	nodeFs.rmSync( target, { recursive: true, force: true } );
+	return { appPath: app.getAppPath(), steps };
+}
+
+test( 'spike364: the packaged app drives the bundled Git, network and all', async () => {
+	test.setTimeout( 300_000 );
+
+	const app = await electron.launch( { executablePath: findPackagedBinary() } );
+	let result;
+	try {
+		await app.firstWindow();
+		result = await app.evaluate( probeInMain, CLONE_URL );
+	} finally {
+		const proc = app.process();
+		await Promise.race( [
+			app.close().catch( () => {} ),
+			new Promise( ( resolve ) => setTimeout( resolve, 5_000 ) ),
+		] );
+		if ( proc && proc.exitCode === null ) proc.kill();
+	}
+
+	for ( const step of result.steps ) {
+		console.log( `  ${ step.ok ? 'PASS' : 'FAIL' }  ${ step.id }: ${ step.detail }` );
+	}
+
+	expect( result.steps.filter( ( s ) => ! s.ok ), JSON.stringify( result.steps, null, 2 ) ).toEqual( [] );
+} );

--- a/tests/e2e/packaged/spike-364-git.spec.js
+++ b/tests/e2e/packaged/spike-364-git.spec.js
@@ -149,5 +149,10 @@ test( 'spike364: the packaged app drives the bundled Git, network and all', asyn
 		console.log( `  ${ step.ok ? 'PASS' : 'FAIL' }  ${ step.id }: ${ step.detail }` );
 	}
 
-	expect( result.steps.filter( ( s ) => ! s.ok ), JSON.stringify( result.steps, null, 2 ) ).toEqual( [] );
+	// `remove` is reported, not asserted. It fails on Windows for a real reason
+	// — Git marks loose objects read-only and `force` does not clear that — and
+	// that belongs in the write-up rather than in a red check that hides
+	// whatever breaks next.
+	const asserted = result.steps.filter( ( s ) => s.id !== 'remove' );
+	expect( asserted.filter( ( s ) => ! s.ok ), JSON.stringify( result.steps, null, 2 ) ).toEqual( [] );
 } );

--- a/tests/e2e/packaged/spike-364-git.spec.js
+++ b/tests/e2e/packaged/spike-364-git.spec.js
@@ -45,26 +45,50 @@ function probeInMain( { app }, cloneUrl ) {
 	const req = createRequire( nodePath.join( app.getAppPath(), 'package.json' ) );
 	const steps = [];
 
-	const fromDugite = nodePath.join( req.resolve( 'dugite' ), '..', '..', '..', 'git' );
-	const unpacked = fromDugite.replace( `app.asar${ nodePath.sep }`, `app.asar.unpacked${ nodePath.sep }` );
-	const root = nodeFs.existsSync( nodePath.join( unpacked, 'bin' ) ) ? unpacked : fromDugite;
-	steps.push( { id: 'resolve', ok: root.includes( 'app.asar.unpacked' ), detail: root } );
-
-	const bin = nodePath.join( root, 'bin', process.platform === 'win32' ? 'git.exe' : 'git' );
-	const env = {
-		...process.env,
-		GIT_EXEC_PATH: nodePath.join( root, 'libexec', 'git-core' ),
-		GIT_TEMPLATE_DIR: nodePath.join( root, 'share', 'git-core', 'templates' ),
+	// dugite resolves its own layout, including the app.asar -> app.asar.unpacked
+	// rewrite and the Windows `cmd/git.exe` + `mingw64` exec path. Joining those
+	// by hand is what a first pass did, and it failed on Windows for that reason
+	// alone rather than for anything to do with packaging.
+	const dugite = req( 'dugite' );
+	const { env, gitLocation } = dugite.setupEnvironment( {
 		GIT_CONFIG_NOSYSTEM: '1',
 		GIT_TERMINAL_PROMPT: '0',
-	};
+	} );
+
+	steps.push( {
+		id: 'resolve',
+		ok: gitLocation.includes( 'app.asar.unpacked' ) && nodeFs.existsSync( gitLocation ),
+		detail: `${ gitLocation } (exists: ${ nodeFs.existsSync( gitLocation ) })`,
+	} );
+
 	const run = ( args, cwd ) => {
-		const r = spawnSync( bin, args, { cwd, env, shell: false, windowsHide: true, encoding: 'utf8' } );
-		return { status: r.status, stdout: ( r.stdout || '' ).trim(), stderr: ( r.stderr || '' ).trim() };
+		const r = spawnSync( gitLocation, args, { cwd, env, shell: false, windowsHide: true, encoding: 'utf8' } );
+		return {
+			status: r.status,
+			stdout: ( r.stdout || '' ).trim(),
+			stderr: ( r.stderr || '' ).trim(),
+			error: r.error ? String( r.error.message ) : null,
+		};
 	};
 
 	const version = run( [ '--version' ], nodeOs.tmpdir() );
-	steps.push( { id: 'spawn', ok: version.status === 0, detail: version.stdout || version.stderr } );
+	steps.push( {
+		id: 'spawn',
+		ok: version.status === 0,
+		detail: version.stdout || version.stderr || version.error || '(no output)',
+	} );
+
+	// Every helper Git shells out to has to be present and, on Windows, findable
+	// through the PATH dugite prepends. A trimmed tree that dropped something
+	// load-bearing shows here rather than in the middle of a contributor's clone.
+	const helpers = run( [ '--exec-path' ], nodeOs.tmpdir() );
+	steps.push( {
+		id: 'exec-path',
+		ok: helpers.status === 0 && nodeFs.existsSync( helpers.stdout ),
+		detail: `${ helpers.stdout } (${ nodeFs.existsSync( helpers.stdout ) ? nodeFs.readdirSync( helpers.stdout ).length + ' entries' : 'missing' })`,
+	} );
+
+	if ( version.status !== 0 ) return { appPath: app.getAppPath(), steps };
 
 	// The clone the app performs, shape for shape. Nothing here points Git at a
 	// certificate bundle — if it needs one, this is where that shows.
@@ -75,7 +99,7 @@ function probeInMain( { app }, cloneUrl ) {
 	steps.push( {
 		id: 'clone',
 		ok: cloned.status === 0,
-		detail: `${ seconds }s — ${ ( cloned.stderr || cloned.stdout || 'ok' ).split( '\n' ).pop() }`,
+		detail: `${ seconds }s — ${ ( cloned.stderr || cloned.stdout || cloned.error || 'ok' ).split( '\n' ).pop() }`,
 	} );
 
 	if ( cloned.status === 0 ) {

--- a/tests/unit/spike-364-git.test.cjs
+++ b/tests/unit/spike-364-git.test.cjs
@@ -1,0 +1,139 @@
+/* eslint-disable -- Spike #364 scaffolding. Thrown away with the branch; not held to the repo's style. */
+/**
+ * SPIKE #364 — NOT A REAL TEST. Delete with the rest of the spike.
+ *
+ * It lives here only because `node --test` already runs on macOS and Windows
+ * for every pull request, and the questions it asks — can the main process
+ * drive a bundled Git, does that Git agree with a checkout isomorphic-git
+ * made, does it write reflogs and take ref locks — have different answers on
+ * Windows, where nobody on this spike has a machine.
+ *
+ * Offline. Nothing here reaches the network.
+ */
+
+const test = require( 'node:test' );
+const assert = require( 'node:assert' );
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { spawnSync } = require( 'node:child_process' );
+const git = require( 'isomorphic-git' );
+
+const { resolveGitRoot, gitBinary, gitEnv } = require( '../../scripts/spike-364/git-env.cjs' );
+const ticketBranches = require( '../../src/ticket-branches.js' );
+
+const ROOT = resolveGitRoot();
+const BIN = gitBinary( ROOT );
+const ENV = gitEnv( ROOT );
+const AUTHOR = { name: 'Spike', email: 'spike@example.com' };
+
+function run( args, cwd ) {
+	const r = spawnSync( BIN, args, { cwd, env: ENV, shell: false, windowsHide: true, encoding: 'utf8' } );
+	return { status: r.status, stdout: ( r.stdout || '' ).trim(), stderr: ( r.stderr || '' ).trim() };
+}
+
+function tmp( t, prefix ) {
+	const dir = fs.mkdtempSync( path.join( os.tmpdir(), prefix ) );
+	t.after( () => fs.rmSync( dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } ) );
+	return dir;
+}
+
+/**
+ * A checkout shaped like one the app made, built only through isomorphic-git.
+ */
+async function appShapedRepo( t ) {
+	const dir = tmp( t, 'spike364-iso-' );
+	await git.init( { fs, dir, defaultBranch: 'trunk' } );
+	fs.mkdirSync( path.join( dir, 'src' ), { recursive: true } );
+	fs.writeFileSync( path.join( dir, 'src', 'wp-login.php' ), '<?php\n// login\n' );
+	fs.writeFileSync( path.join( dir, '.gitignore' ), 'node_modules/\n' );
+	await git.add( { fs, dir, filepath: [ 'src/wp-login.php', '.gitignore' ] } );
+	await git.commit( { fs, dir, message: 'trunk', author: AUTHOR } );
+
+	fs.mkdirSync( path.join( dir, 'node_modules', 'react' ), { recursive: true } );
+	fs.writeFileSync( path.join( dir, 'node_modules', 'react', 'index.js' ), 'expensive\n' );
+
+	const started = await ticketBranches.startTicketBranch( dir, '12345' );
+	fs.writeFileSync( path.join( dir, 'src', 'wp-login.php' ), '<?php\n// login\n// ticket work\n' );
+	await ticketBranches.parkCurrentWork( dir, { baseOid: started.baseOid } );
+
+	// Two switches, so the working tree is one isomorphic-git *checked out*
+	// rather than one a test wrote by hand. On Windows that is the difference
+	// that matters: the app synthesises `core.autocrlf = true` on read and never
+	// writes it, so what lands on disk is not what the config describes.
+	await ticketBranches.switchToBranch( dir, 'trunk' );
+	await ticketBranches.switchToBranch( dir, 'ticket/12345' );
+
+	return dir;
+}
+
+test( 'spike364: the bundled binary runs', () => {
+	const r = run( [ '--version' ], os.tmpdir() );
+	assert.strictEqual( r.status, 0, `${ BIN }: ${ r.stderr }` );
+	assert.match( r.stdout, /^git version/ );
+	console.log( `  platform=${ process.platform } arch=${ process.arch } ${ r.stdout }` );
+} );
+
+test( 'spike364: GIT_EXEC_PATH has to be set explicitly', () => {
+	const bare = spawnSync( BIN, [ '--exec-path' ], { encoding: 'utf8', shell: false } );
+	const withEnv = run( [ '--exec-path' ], os.tmpdir() );
+	console.log( `  without: ${ ( bare.stdout || '' ).trim() }\n  with:    ${ withEnv.stdout }` );
+	assert.ok( withEnv.stdout.length > 0 );
+} );
+
+test( 'spike364: a path with a space in it works', ( t ) => {
+	const dir = path.join( tmp( t, 'spike364 with space-' ), 'repo dir' );
+	fs.mkdirSync( dir, { recursive: true } );
+	const r = run( [ 'init', '-b', 'trunk' ], dir );
+	assert.strictEqual( r.status, 0, r.stderr );
+} );
+
+test( 'spike364: real Git reads a checkout isomorphic-git made', async ( t ) => {
+	const dir = await appShapedRepo( t );
+
+	const status = run( [ 'status', '--porcelain' ], dir );
+	assert.strictEqual( status.status, 0, status.stderr );
+
+	const fsck = run( [ 'fsck', '--no-progress' ], dir );
+	assert.strictEqual( fsck.status, 0, fsck.stderr );
+
+	const branches = run( [ 'branch', '-a' ], dir );
+	assert.match( branches.stdout, /12345/ );
+
+	// The one that would bite on Windows: the app fakes `core.autocrlf` on read
+	// and never writes it, so a real Git can see every file as modified.
+	console.log( `  git status --porcelain: ${ status.stdout || '(clean)' }` );
+	assert.strictEqual( status.stdout, '', 'real Git sees the tree as dirty' );
+} );
+
+test( 'spike364: reflogs are written, and #366 closes by construction', async ( t ) => {
+	const dir = await appShapedRepo( t );
+
+	const claim = run( [ 'config', '--get', 'core.logallrefupdates' ], dir );
+	assert.strictEqual( claim.stdout, 'true', 'isomorphic-git no longer writes the claim' );
+
+	const before = run( [ 'reflog', '--all' ], dir );
+	assert.strictEqual( before.stdout, '', 'something was already logged' );
+
+	const tip = run( [ 'rev-parse', 'ticket/12345' ], dir ).stdout;
+	const updated = run( [ 'update-ref', 'refs/heads/trunk', tip ], dir );
+	assert.strictEqual( updated.status, 0, updated.stderr );
+
+	const after = run( [ 'reflog', '--all' ], dir );
+	assert.notStrictEqual( after.stdout, '', 'no reflog entry was written' );
+	assert.ok( fs.existsSync( path.join( dir, '.git', 'logs' ) ) );
+} );
+
+test( 'spike364: a held .lock blocks a second writer', async ( t ) => {
+	const dir = await appShapedRepo( t );
+	const tip = run( [ 'rev-parse', 'ticket/12345' ], dir ).stdout;
+
+	const lock = path.join( dir, '.git', 'refs', 'heads', 'trunk.lock' );
+	fs.mkdirSync( path.dirname( lock ), { recursive: true } );
+	fs.writeFileSync( lock, '' );
+	const blocked = run( [ 'update-ref', 'refs/heads/trunk', tip ], dir );
+	fs.rmSync( lock, { force: true } );
+
+	assert.notStrictEqual( blocked.status, 0, 'the lock was ignored' );
+	assert.match( blocked.stderr, /cannot lock ref/ );
+} );

--- a/tests/unit/spike-364-git.test.cjs
+++ b/tests/unit/spike-364-git.test.cjs
@@ -23,8 +23,8 @@ const { resolveGitRoot, gitBinary, gitEnv } = require( '../../scripts/spike-364/
 const ticketBranches = require( '../../src/ticket-branches.js' );
 
 const ROOT = resolveGitRoot();
-const BIN = gitBinary( ROOT );
-const ENV = gitEnv( ROOT );
+const BIN = gitBinary();
+const ENV = gitEnv();
 const AUTHOR = { name: 'Spike', email: 'spike@example.com' };
 
 function run( args, cwd ) {


### PR DESCRIPTION
**Do not merge.** This branch exists to make CI answer questions a laptop cannot, and will be closed and deleted once it has. Nothing here is meant to land.

## Why

[#364](https://github.com/WordPress/contributor-toolkit/issues/364) proposes that the app carry a real Git binary instead of reimplementing Git's behaviour in JavaScript. [#351](https://github.com/WordPress/contributor-toolkit/issues/351) says two of its three spikes stop being questions if #364 lands, and that #364's spike is cheaper and goes first. So this decides the engine before the pieces of [#350](https://github.com/WordPress/contributor-toolkit/issues/350) are built on the wrong one.

The local questions are already answered on macOS — the findings go on #364, not here. Two are not, and only CI can answer them:

- **Does it sign and notarise?** No signing identity exists on a contributor laptop. Buildkite builds a signed, notarised macOS artifact and an Azure-signed Windows one for every branch with an open pull request, which is the whole reason this pull request is open. Precedent: #312.
- **Does any of it hold on Windows?** Nobody on this spike has a Windows machine. The throwaway suites below ride the existing matrix so the GitHub Actions run answers it for free.

## What changes

- `dugite@3.2.3` as the vehicle — the package GitHub Desktop uses to ship Git inside an Electron app.
- The Git Credential Manager and `git-lfs` that dugite also ships are excluded through `files`. That is 148 MB of payload down to 26 MB, and neither is usable here: every fetch this app makes is anonymous over public HTTPS.
- `asarUnpack` for the Git tree, because a binary cannot execute from inside `app.asar`. There was no `asarUnpack` in the build config before this.
- Probes under `scripts/spike-364/`, and two throwaway suites: a `node --test` file for the local questions, and a packaged spec that clones `wordpress-develop` from inside the built app.

## How to test this

Everything below is what CI is being asked; a reviewer does not need to run any of it.

1. **Signed macOS artifact.** Download the `.dmg` from this branch's Buildkite build, install it, and open it from Finder. Expected: it opens with no Gatekeeper warning — that is the notarisation answer. What must not have happened: a warning that the app is damaged, which is what an unsigned nested binary inside a notarised bundle produces.
2. **The bundled Git is signed too.** `codesign -dv --verbose=2 "/Applications/WordPress Contributor Toolkit.app/Contents/Resources/app.asar.unpacked/node_modules/dugite/git/bin/git"`. Expected: `Authority=Developer ID Application: Automattic, Inc.` What must not have happened: `Signature=adhoc`, which is what the binary carries as shipped and what the notary service rejects.
3. **Windows.** The `Journeys`/`Packaged smoke` jobs on this pull request run the two `spike364` suites on `windows-latest`. Read their output rather than reproducing it: the interesting lines are whether `git status` reports a clean tree over a checkout `isomorphic-git` made (the `core.autocrlf` question) and whether a clone over HTTPS finds its certificates without being told where they are.
4. **Size.** Compare the artifact sizes on this build against the last `trunk` build. Expected: about 26 MB larger per platform.

Platforms: macOS and Windows. Linux is out of scope for the spike and snap confinement is recorded as an open risk.

Cannot be tested by hand here: whether the notary service accepts the bundle. That is a service verdict, and the Buildkite log is the only place it appears.

## Risks and limitations

None to the product — this branch is never merged. The one real risk is leaving it open: it holds a `dugite` dependency and an `asarUnpack` rule that nothing else in the repo wants yet.

## Related

- #364 — the proposition this spike settles, and where the findings are written up
- #351, #352, #366, #355 — the pieces whose shape depends on the answer
- #312 — the precedent for a "do not merge" pull request opened only to get a signed build
