### PR TITLE
Delete a site even when Git marked it read-only, and say when it could not

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1961,8 +1961,10 @@ ipcMain.handle('sites:delete', async (_e, sitePath) => {
 			delete meta[sitePath];
 			s.set('siteMeta', meta);
 		},
-		// removeTree clears the read-only attribute a real Git leaves on its
-		// object files, which plain removal cannot delete on Windows (#381).
+		// removeTree handles what plain removal leaves unanswered on the
+		// protected object files a real Git writes: on POSIX, a directory whose
+		// write bit is missing, which nothing else clears; on Windows, an entry
+		// something still holds open, which only a retry budget survives (#381).
 		// A failure is recorded rather than swallowed: `forget` has already
 		// run — deliberately, so a locked directory cannot leave a site stuck
 		// undeletable — which means the one honest thing left to do when the

--- a/src/main.js
+++ b/src/main.js
@@ -38,6 +38,7 @@ const { buildPullRequestEntries } = require('./pr-files.cjs');
 const { openAndScrape, fetchAttachment } = require('./trac-view');
 const { openExternalUrl, ALLOWED_URL_SCHEMES } = require('./external-url');
 const { deleteRegisteredSite, revealRegisteredSite, clearRegisteredSiteLog } = require('./site-registry');
+const { removeTree } = require('./remove-tree');
 const { createSetupTracker } = require('./setup-tracker');
 const { planInitialRead, planTailRead } = require('./log-tail');
 const {
@@ -1945,7 +1946,11 @@ ipcMain.handle('sites:mark-initialized', async (_e, sitePath) => {
 // the guard shows up in the log file instead of just doing nothing.
 ipcMain.handle('sites:delete', async (_e, sitePath) => {
 	const s = await getStore();
-	return deleteRegisteredSite(sitePath, {
+	// Filled in by `remove` when the deletion itself fails. Kept outside the
+	// guard call because deleteRegisteredSite's boolean only answers "was this
+	// allowed", and the renderer needs the other half of the story too (#381).
+	let removalError = null;
+	const allowed = await deleteRegisteredSite(sitePath, {
 		sites: s.get('sites'),
 		// A site whose clone is still running is refused outright, registered or
 		// not: `remove` would be deleting a tree isomorphic-git is writing into.
@@ -1956,11 +1961,31 @@ ipcMain.handle('sites:delete', async (_e, sitePath) => {
 			delete meta[sitePath];
 			s.set('siteMeta', meta);
 		},
-		// Best-effort, as before: a site whose registry entry is gone should not be
-		// stuck undeletable because its directory is missing or locked.
-		remove: async (p) => { try { await fse.remove(p); } catch {} },
+		// removeTree clears the read-only attribute a real Git leaves on its
+		// object files, which plain removal cannot delete on Windows (#381).
+		// A failure is recorded rather than swallowed: `forget` has already
+		// run — deliberately, so a locked directory cannot leave a site stuck
+		// undeletable — which means the one honest thing left to do when the
+		// disk half fails is to say so, in the log and to the caller.
+		remove: async (p) => {
+			try {
+				await removeTree(p);
+			} catch (e) {
+				removalError = e;
+				logError('sites', `deleted ${sitePath} from the registry, but its folder could not be removed and is still on disk: ${String(e && e.stack ? e.stack : e)}`);
+			}
+		},
 		onRefused: (description) => logEvent('sites', `refused to delete ${description} — not a registered site, or still being created`)
 	});
+	if (!allowed) return { ok: false, refused: true };
+	if (removalError) {
+		return {
+			ok: false,
+			error: `The site was removed from the list, but its folder could not be deleted and is still at ${sitePath}`,
+			code: removalError.code
+		};
+	}
+	return { ok: true };
 });
 
 ipcMain.handle('sites:set-label', async (_e, sitePath, label) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1979,11 +1979,9 @@ ipcMain.handle('sites:delete', async (_e, sitePath) => {
 	});
 	if (!allowed) return { ok: false, refused: true };
 	if (removalError) {
-		return {
-			ok: false,
-			error: `The site was removed from the list, but its folder could not be deleted and is still at ${sitePath}`,
-			code: removalError.code
-		};
+		// Machine-readable on purpose: the sentence the contributor reads is
+		// composed in the renderer (confirmations.cjs), where it is testable.
+		return { ok: false, reason: 'remove-failed', path: sitePath, code: removalError.code };
 	}
 	return { ok: true };
 });

--- a/src/remove-tree.js
+++ b/src/remove-tree.js
@@ -37,28 +37,38 @@ function shouldClearAttributes(error) {
 }
 
 /**
- * Restores the write bit on everything under `dir`, directories first so the
- * walk can enter them. Errors on individual entries are ignored: a path that
- * cannot be chmodded will fail the removal that follows, which is the honest
- * place for the failure to surface.
+ * Restores the owner write bit on everything under `dir`, directories first so
+ * the walk can enter them. Owner-only on purpose: `0o700`/`0o600` clears the
+ * read-only attribute on Windows and unblocks POSIX unlinking just as well as
+ * wider modes, without leaving a world-writable tree behind if the removal
+ * still fails. Errors on individual entries are ignored: a path that cannot be
+ * chmodded will fail the removal that follows, which is the honest place for
+ * the failure to surface.
  *
  * @param {string} dir
  * @param {Object} fs
  */
 async function makeWritable(dir, fs) {
+	// The chmod and the readdir fail independently: a directory whose mode
+	// cannot be changed may still be readable, and its children deserve the
+	// pass either way.
+	try { await fs.promises.chmod(dir, 0o700); } catch {}
 	let entries;
 	try {
-		await fs.promises.chmod(dir, 0o777);
 		entries = await fs.promises.readdir(dir, { withFileTypes: true });
 	} catch {
 		return;
 	}
 	for (const entry of entries) {
+		// chmod follows symlinks — there is no portable lchmod — so touching one
+		// would change its target's mode, possibly outside this tree. `rm` does
+		// not follow them when deleting, so they need no help anyway.
+		if (entry.isSymbolicLink()) continue;
 		const child = path.join(dir, entry.name);
 		if (entry.isDirectory()) {
 			await makeWritable(child, fs);
 		} else {
-			try { await fs.promises.chmod(child, 0o666); } catch {}
+			try { await fs.promises.chmod(child, 0o600); } catch {}
 		}
 	}
 }
@@ -74,7 +84,12 @@ async function makeWritable(dir, fs) {
  * @param {Object} [deps.fs]
  */
 async function removeTree(dir, { fs = fsDefault } = {}) {
-	const options = { recursive: true, force: true, maxRetries: 3, retryDelay: 100 };
+	// maxRetries 10 is inherited from the e2e teardown this replaces: an
+	// ENOTEMPTY that only ever appeared on a macOS CI runner — a just-closed
+	// app's last flush — needed that budget, and ENOTEMPTY is not a permission
+	// code, so the attribute pass below does nothing for it. Retries are still
+	// its only mitigation.
+	const options = { recursive: true, force: true, maxRetries: 10, retryDelay: 100 };
 	try {
 		await fs.promises.rm(dir, options);
 	} catch (error) {

--- a/src/remove-tree.js
+++ b/src/remove-tree.js
@@ -1,0 +1,87 @@
+// Removes a directory tree, including the parts Git protects.
+//
+// A real Git marks its loose object files read-only, and Windows refuses to
+// unlink a read-only file. `fs.rm` with `force: true` never clears the
+// attribute — `force` only forgives a path that is already gone — and its
+// `maxRetries` cannot help either, because a retry does not change the file.
+// fs-extra 11 is a bare `fs.rm(recursive, force)`, so it inherits the same
+// blind spot. On POSIX the analogue is a directory without the write bit,
+// which blocks unlinking its entries the same way.
+//
+// Today the app gets away with plain removal because isomorphic-git does not
+// set the attribute. Any real Git writing into a checkout plants it — a mentor
+// making a commit with their own tools does — and from then on `sites:delete`
+// leaves the tree behind on Windows (#381).
+//
+// The shape: try the cheap removal first, and only when it fails with a
+// permission error walk whatever survived, restore the write bit, and remove
+// once more. The walk is the recovery path, so the common case pays nothing.
+// Anything that still fails after that propagates: the caller decides what a
+// failed deletion means, this module only refuses to hide one.
+
+'use strict';
+
+const fsDefault = require('fs');
+const path = require('path');
+
+/**
+ * Pure decision: does this removal error call for clearing attributes and
+ * retrying? Only a permission error does — anything else (a path that is a
+ * file, a disk error) would fail the same way twice.
+ *
+ * @param {?Object} error
+ * @return {boolean}
+ */
+function shouldClearAttributes(error) {
+	return !!error && (error.code === 'EPERM' || error.code === 'EACCES');
+}
+
+/**
+ * Restores the write bit on everything under `dir`, directories first so the
+ * walk can enter them. Errors on individual entries are ignored: a path that
+ * cannot be chmodded will fail the removal that follows, which is the honest
+ * place for the failure to surface.
+ *
+ * @param {string} dir
+ * @param {Object} fs
+ */
+async function makeWritable(dir, fs) {
+	let entries;
+	try {
+		await fs.promises.chmod(dir, 0o777);
+		entries = await fs.promises.readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const child = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await makeWritable(child, fs);
+		} else {
+			try { await fs.promises.chmod(child, 0o666); } catch {}
+		}
+	}
+}
+
+/**
+ * Removes `dir` recursively, clearing read-only attributes if they are what
+ * stands in the way. Resolves when the tree is gone (or never existed);
+ * rejects with the underlying error when it could not be removed.
+ *
+ * @param {string} dir
+ * @param {Object} [deps]    Injection point, so the tests can assert the
+ *                           retry decision without staging a real EPERM.
+ * @param {Object} [deps.fs]
+ */
+async function removeTree(dir, { fs = fsDefault } = {}) {
+	const options = { recursive: true, force: true, maxRetries: 3, retryDelay: 100 };
+	try {
+		await fs.promises.rm(dir, options);
+	} catch (error) {
+		if (!shouldClearAttributes(error)) throw error;
+		await makeWritable(dir, fs);
+		await fs.promises.rm(dir, options);
+	}
+}
+
+module.exports = { shouldClearAttributes, removeTree };

--- a/src/remove-tree.js
+++ b/src/remove-tree.js
@@ -1,17 +1,20 @@
 // Removes a directory tree, including the parts Git protects.
 //
-// A real Git marks its loose object files read-only, and Windows refuses to
-// unlink a read-only file. `fs.rm` with `force: true` never clears the
-// attribute — `force` only forgives a path that is already gone — and its
-// `maxRetries` cannot help either, because a retry does not change the file.
-// fs-extra 11 is a bare `fs.rm(recursive, force)`, so it inherits the same
-// blind spot. On POSIX the analogue is a directory without the write bit,
-// which blocks unlinking its entries the same way.
+// A real Git marks its loose object files read-only, and what that does to a
+// removal differs by platform — with a different hole in each default. On
+// Windows, Node's own `fs.rm` chmods an entry it failed to delete and tries
+// again (inherited from rimraf when core absorbed it), so the read-only file
+// itself is survivable there; what has no answer is an entry something still
+// holds open, because `fse.remove` passes no retry budget at all. On POSIX
+// nothing clears a directory whose write bit is missing, so the same
+// protected checkout fails with EACCES and no recovery of any kind. The #364
+// spike hit EPERM on every packaged Windows run; the CI suite proves the
+// POSIX half.
 //
-// Today the app gets away with plain removal because isomorphic-git does not
-// set the attribute. Any real Git writing into a checkout plants it — a mentor
-// making a commit with their own tools does — and from then on `sites:delete`
-// leaves the tree behind on Windows (#381).
+// Today the app mostly gets away with plain removal because isomorphic-git
+// sets no attribute. Any real Git writing into a checkout changes that — a
+// mentor making a commit with their own tools does — and `sites:delete`
+// swallowed whatever went wrong besides (#381).
 //
 // The shape: try the cheap removal first, and only when it fails with a
 // permission error walk whatever survived, restore the write bit, and remove

--- a/src/remove-tree.js
+++ b/src/remove-tree.js
@@ -40,39 +40,53 @@ function shouldClearAttributes(error) {
 }
 
 /**
- * Restores the owner write bit on everything under `dir`, directories first so
- * the walk can enter them. Owner-only on purpose: `0o700`/`0o600` clears the
- * read-only attribute on Windows and unblocks POSIX unlinking just as well as
- * wider modes, without leaving a world-writable tree behind if the removal
- * still fails. Errors on individual entries are ignored: a path that cannot be
- * chmodded will fail the removal that follows, which is the honest place for
- * the failure to surface.
+ * Adds the owner write bit to `target` and, if it is a directory, to
+ * everything under it — the directory first, so the walk can enter it.
+ * Additive on purpose: this runs when a removal has already failed once, and
+ * it may fail again, so whatever survives has to keep the mode it came with.
+ * Assigning a fixed mode instead would strip an executable's exec bit and
+ * every group and other permission from a tree the caller is about to be told
+ * still exists. Errors on individual entries are ignored: a path that cannot
+ * be chmodded will fail the removal that follows, which is the honest place
+ * for the failure to surface.
  *
- * @param {string} dir
+ * @param {string} target
  * @param {Object} fs
  */
-async function makeWritable(dir, fs) {
-	// The chmod and the readdir fail independently: a directory whose mode
-	// cannot be changed may still be readable, and its children deserve the
-	// pass either way.
-	try { await fs.promises.chmod(dir, 0o700); } catch {}
-	let entries;
+async function makeWritable(target, fs) {
+	// One lstat answers all three questions: link or not, directory or not,
+	// and what mode to add to. `lstat`, not `stat`, so a link is recognised
+	// rather than resolved.
+	let stats;
 	try {
-		entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		stats = await fs.promises.lstat(target);
 	} catch {
 		return;
 	}
-	for (const entry of entries) {
-		// chmod follows symlinks — there is no portable lchmod — so touching one
-		// would change its target's mode, possibly outside this tree. `rm` does
-		// not follow them when deleting, so they need no help anyway.
-		if (entry.isSymbolicLink()) continue;
-		const child = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
-			await makeWritable(child, fs);
-		} else {
-			try { await fs.promises.chmod(child, 0o600); } catch {}
-		}
+	// chmod follows symlinks — there is no portable lchmod — so touching one
+	// would change its target's mode, possibly outside this tree. `rm` does not
+	// follow them when deleting, so they need no help anyway. The check sits at
+	// the top of the recursion, which is also the root: a registered site path
+	// can itself be a link, and the first `rm` can fail without unlinking it.
+	if (stats.isSymbolicLink()) return;
+	const isDirectory = stats.isDirectory();
+	// A directory needs owner rwx for the walk to enter it and for the removal
+	// to unlink inside it; a file only needs to stop being read-only.
+	// eslint-disable-next-line no-bitwise -- adding a permission to a POSIX mode is what `|` is for; the same idiom as pr-files.cjs.
+	const restored = stats.mode | (isDirectory ? 0o700 : 0o200);
+	// The chmod and the readdir fail independently: a directory whose mode
+	// cannot be changed may still be readable, and its children deserve the
+	// pass either way.
+	try { await fs.promises.chmod(target, restored); } catch {}
+	if (!isDirectory) return;
+	let entries;
+	try {
+		entries = await fs.promises.readdir(target);
+	} catch {
+		return;
+	}
+	for (const name of entries) {
+		await makeWritable(path.join(target, name), fs);
 	}
 }
 

--- a/src/renderer/confirmations.cjs
+++ b/src/renderer/confirmations.cjs
@@ -19,7 +19,8 @@
  *     the contributor does not have to act on.
  *   - `error` speaks assertively and stays until dismissed, so it is not gone
  *     before it has been read. Supported here so successes and errors can share
- *     one mechanism (#253); this pass only emits successes.
+ *     one mechanism (#253). The first error emitter is the site deletion
+ *     that half-happened (#381).
  */
 
 // At most this many confirmations are kept on screen at once. A burst — a
@@ -89,4 +90,22 @@ function prConfirmationMessage(res = {}) {
 	return `Opened pull request #${res.number}`;
 }
 
-module.exports = { initialConfirmations, confirmationReducer, prConfirmationMessage, MAX_NOTICES };
+/**
+ * The notice for a site deletion, or null when there is nothing to say (#381).
+ *
+ * Only the half-failure speaks: the registry entry is gone either way — that
+ * ordering is main's recorded decision — but the folder can survive, a file
+ * held open or the read-only attribute a real Git leaves on its object files.
+ * The message names the path because that folder is what the contributor now
+ * has to deal with by hand, and carries the error code because "could not be
+ * deleted" without one is the kind of report a mentor cannot act on.
+ *
+ * @param {{ ok?: boolean, reason?: string, path?: string, code?: string }} res The main process's result.
+ */
+function deleteFailureMessage(res = {}) {
+	if (res.ok !== false || res.reason !== 'remove-failed') return null;
+	const code = res.code ? ` (${res.code})` : '';
+	return `The site was removed from the list, but its folder could not be deleted${code} and is still at ${res.path}`;
+}
+
+module.exports = { initialConfirmations, confirmationReducer, prConfirmationMessage, deleteFailureMessage, MAX_NOTICES };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -48,7 +48,7 @@ import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 import { changesNoteParts, discardOutcome, applyFeedbackAfterDiscard, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
-import { initialConfirmations, confirmationReducer, prConfirmationMessage } from './confirmations.cjs';
+import { initialConfirmations, confirmationReducer, prConfirmationMessage, deleteFailureMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
 // One face for everything that is process output: the terminal below and every
@@ -683,13 +683,12 @@ function App() {
     const result = await window.api.deleteSite(sitePath);
     await refresh();
     removeSetupLog(sitePath);
-    // A deletion that half-happened must not look like one that worked: the
-    // registry entry is gone either way, but the folder can survive — a file
-    // held open, or the read-only attribute a real Git leaves on its object
-    // files (#381). The error tone stays until dismissed, and the message
-    // names the path so the contributor knows what is still on disk.
-    if (result && result.ok === false && result.error) {
-      confirm(result.error, { tone: 'error' });
+    // A deletion that half-happened must not look like one that worked (#381).
+    // The sentence and the decision to show it live in confirmations.cjs,
+    // where the suite can reach them; the error tone stays until dismissed.
+    const failure = deleteFailureMessage(result);
+    if (failure) {
+      confirm(failure, { tone: 'error' });
     }
   }, [refresh, removeSetupLog, confirm]);
 

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -680,10 +680,18 @@ function App() {
   }, [setSiteMeta]);
 
   const onDelete = useCallback(async (sitePath) => {
-    await window.api.deleteSite(sitePath);
+    const result = await window.api.deleteSite(sitePath);
     await refresh();
     removeSetupLog(sitePath);
-  }, [refresh, removeSetupLog]);
+    // A deletion that half-happened must not look like one that worked: the
+    // registry entry is gone either way, but the folder can survive — a file
+    // held open, or the read-only attribute a real Git leaves on its object
+    // files (#381). The error tone stays until dismissed, and the message
+    // names the path so the contributor knows what is still on disk.
+    if (result && result.ok === false && result.error) {
+      confirm(result.error, { tone: 'error' });
+    }
+  }, [refresh, removeSetupLog, confirm]);
 
   const onRename = useCallback(async (sitePath, newLabel) => {
     try {

--- a/src/site-registry.js
+++ b/src/site-registry.js
@@ -1,6 +1,6 @@
 // The gate in front of the recursive directory removal in `sites:delete`.
 //
-// `sites:delete` is handed a path and calls `fse.remove` on it — the least
+// `sites:delete` is handed a path and removes the tree at it — the least
 // recoverable action reachable from the window. The renderer is the only caller
 // and every call site passes a path the app itself registered, so nothing today
 // misuses it. But the renderer also displays content the app does not author:
@@ -67,7 +67,7 @@ function describeRefusedSite(sitePath) {
 
 // The `sites:delete` handler's body, kept out of main.js so both sides of the
 // guard can be tested without an Electron process. `forget` drops the path from
-// the store, `remove` is the real `fse.remove` in the app, and both are recording
+// the store, `remove` is the real tree removal in the app, and both are recording
 // stubs in the tests. A path that is not registered performs neither: no store
 // mutation and no removal, just a logged refusal.
 async function deleteRegisteredSite(sitePath, { sites, pending, forget, remove, onRefused } = {}) {
@@ -113,7 +113,7 @@ async function revealRegisteredSite(sitePath, { sites, pending, reveal, onRefuse
 }
 
 // The `wp-debug:clear` handler's body. Emptying a file is nowhere near as
-// severe as `fse.remove`, but the shape is the same one this module exists for:
+// severe as a tree removal, but the shape is the same one this module exists for:
 // the renderer names a path and the app then writes to a location derived from
 // it. A path outside the registry would have the app truncating a file in a
 // directory it never created.

--- a/tests/e2e/helpers/app.cjs
+++ b/tests/e2e/helpers/app.cjs
@@ -23,6 +23,7 @@ const fs = require( 'node:fs' );
 const os = require( 'node:os' );
 const path = require( 'node:path' );
 const { test: base, _electron: electron } = require( '@playwright/test' );
+const { removeTree } = require( '../../../src/remove-tree.js' );
 
 const REPO_ROOT = path.join( __dirname, '..', '..', '..' );
 
@@ -306,34 +307,32 @@ class Session {
 		return written;
 	}
 
-	dispose() {
+	async dispose() {
 		for ( const dir of this.scratch.splice( 0 ) ) {
-			discard( dir );
+			await discard( dir );
 		}
-		discard( this.userDataDir );
+		await discard( this.userDataDir );
 	}
 }
 
 /**
  * Removes a directory the app was using, without ever failing a passing test.
  *
- * `force: true` covers a directory that is already gone; it does nothing for one
- * that is still being written to, which is what a just-closed app does to its
- * profile — the process is gone, its last flush is not. That surfaces as
- * `ENOTEMPTY` from `rmSync`, in teardown, on a test that passed. It appeared on
- * a macOS CI runner and never once locally, which is the worst way to find out.
+ * removeTree retries the transient failures — a just-closed app's last flush
+ * surfaces as `ENOTEMPTY` on a macOS runner, an open handle as `EBUSY` on a
+ * Windows one — and clears the read-only attribute a real Git leaves on its
+ * object files, which no amount of retrying fixes (#381).
  *
- * `maxRetries` is the documented answer: Node retries `ENOTEMPTY`, `EBUSY` and
- * `EPERM` on a backoff. The `catch` behind it is deliberate all the same. These
- * live under the system temp directory, the operating system reaps them, and a
- * suite that goes red because it could not tidy up is reporting on itself rather
- * than on the app.
+ * The `catch` behind it is deliberate all the same. These live under the
+ * system temp directory, the operating system reaps them, and a suite that
+ * goes red because it could not tidy up is reporting on itself rather than on
+ * the app.
  *
  * @param {string} dir
  */
-function discard( dir ) {
+async function discard( dir ) {
 	try {
-		fs.rmSync( dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } );
+		await removeTree( dir );
 	} catch {
 		// Left for the operating system.
 	}
@@ -362,7 +361,7 @@ const test = base.extend( {
 
 		await session.close();
 		await session.saveVideos( testInfo.title.replace( /[^a-z0-9]+/gi, '-' ).toLowerCase() );
-		session.dispose();
+		await session.dispose();
 	},
 } );
 

--- a/tests/unit/confirmations.test.cjs
+++ b/tests/unit/confirmations.test.cjs
@@ -7,6 +7,7 @@ const {
 	initialConfirmations,
 	confirmationReducer,
 	prConfirmationMessage,
+	deleteFailureMessage,
 	MAX_NOTICES
 } = require('../../src/renderer/confirmations.cjs');
 
@@ -101,4 +102,25 @@ test('a dry run says no pull request was opened rather than "#undefined" (issue 
 		prConfirmationMessage({ ok: true, dryRun: true, branch: 'fix/thing' }),
 		'Dry run — branch created, no pull request opened'
 	);
+});
+
+test('a deletion that half-failed names the surviving path and the code (issue #381)', () => {
+	assert.strictEqual(
+		deleteFailureMessage({ ok: false, reason: 'remove-failed', path: '/sites/demo', code: 'EPERM' }),
+		'The site was removed from the list, but its folder could not be deleted (EPERM) and is still at /sites/demo'
+	);
+});
+
+test('a deletion failure without a code still reads as a sentence (issue #381)', () => {
+	assert.strictEqual(
+		deleteFailureMessage({ ok: false, reason: 'remove-failed', path: '/sites/demo' }),
+		'The site was removed from the list, but its folder could not be deleted and is still at /sites/demo'
+	);
+});
+
+test('a clean deletion, a refusal, and a malformed result all stay silent (issue #381)', () => {
+	assert.strictEqual(deleteFailureMessage({ ok: true }), null);
+	assert.strictEqual(deleteFailureMessage({ ok: false, refused: true }), null);
+	assert.strictEqual(deleteFailureMessage({}), null);
+	assert.strictEqual(deleteFailureMessage(), null);
 });

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -420,9 +420,10 @@ test('sites:delete removes a registered directory and refuses an unregistered on
 });
 
 // The tree a real Git leaves behind: a read-only loose object inside a
-// directory without its write bit. Plain removal fails on it — read-only file
-// on Windows, unwritable directory on POSIX — which is exactly the state that
-// used to strand a site's folder on disk while the registry forgot it (#381).
+// directory without its write bit. On POSIX plain removal fails on it — the
+// state that used to strand a site's folder on disk while the registry forgot
+// it (#381); on Windows Node's own rm clears the read-only entry, so this
+// runs the handler end to end rather than proving the old code wrong.
 test('sites:delete clears the read-only attributes a real Git leaves behind (#381)', async (t) => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-delete-ro-'));
 	t.after(() => {

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -378,10 +378,10 @@ test('sites:delete asks site-registry whether the path may be removed', async ()
 	assert.equal(typeof options.onRefused, 'function');
 });
 
-// The end of the wire, with the real module and the real `fse.remove` in place,
+// The end of the wire, with the real module and the real removeTree in place,
 // on real directories: this is the assertion #145 is about. It fails if the
 // handler stops consulting site-registry, however it stops — deleted call,
-// renamed export, or a bare `fse.remove(sitePath)` added beside it.
+// renamed export, or a bare `removeTree(sitePath)` added beside it.
 test('sites:delete removes a registered directory and refuses an unregistered one', async (t) => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-delete-'));
 	t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -446,41 +446,35 @@ test('sites:delete clears the read-only attributes a real Git leaves behind (#38
 
 // When the disk genuinely refuses, the handler must say so instead of
 // pretending: the registry half has already happened (deliberately — a locked
-// folder must not leave a site stuck undeletable), so the renderer gets
-// `{ ok: false, error }` naming the surviving path, and the log gets the
-// stack. The stage differs by platform because the ways a removal can still
-// fail differ: Windows refuses while a handle is open, POSIX refuses inside a
-// directory whose parent it cannot write.
+// folder must not leave a site stuck undeletable), so the renderer gets a
+// machine-readable failure naming the surviving path, and the log gets the
+// stack. The refusal is staged by stubbing remove-tree rather than by locking
+// a real directory: the real ways a removal fails differ by platform (an open
+// handle on Windows does not even refuse the unlink — libuv opens with
+// FILE_SHARE_DELETE), and the real propagation is remove-tree.test.cjs's job.
+// This test pins the wire.
 test('sites:delete reports a folder it could not remove instead of pretending (#381)', async (t) => {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-delete-fail-'));
+	t.after(() => fs.rmSync(root, { recursive: true, force: true }));
 	const registered = path.join(root, 'held');
 	fs.mkdirSync(registered, { recursive: true });
-	fs.writeFileSync(path.join(registered, 'pinned.txt'), 'x');
-
-	let release = () => {};
-	if (process.platform === 'win32') {
-		const fd = fs.openSync(path.join(registered, 'pinned.txt'), 'r');
-		release = () => fs.closeSync(fd);
-	} else {
-		fs.chmodSync(root, 0o555);
-		release = () => fs.chmodSync(root, 0o777);
-	}
-	t.after(() => {
-		release();
-		fs.rmSync(root, { recursive: true, force: true });
-	});
 
 	const logError = spy();
 	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
 	const main = loadMain({
-		stubs: { './logging': { ...silentLogging()['./logging'], logError }, ...settings.stubs }
+		stubs: {
+			'./logging': { ...silentLogging()['./logging'], logError },
+			'./remove-tree': {
+				removeTree: async () => {
+					throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+				}
+			},
+			...settings.stubs
+		}
 	});
 
 	const result = await main.invoke('sites:delete', registered);
-	assert.equal(result.ok, false);
-	assert.equal(result.refused, undefined, 'a disk failure is not a guard refusal');
-	assert.match(result.error, /could not be deleted/);
-	assert.ok(result.error.includes(registered), 'the message names the surviving path');
+	assert.deepEqual(result, { ok: false, reason: 'remove-failed', path: registered, code: 'EPERM' });
 	assert.equal(fs.existsSync(registered), true, 'the folder really did survive');
 	// The forget half happened first, on purpose; the contract is honesty, not rollback.
 	assert.deepEqual(settings.values.sites, []);

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -404,7 +404,7 @@ test('sites:delete removes a registered directory and refuses an unregistered on
 	// A path the app never registered: neither the directory nor the store may
 	// be touched, and the refusal is logged rather than dropped so a caller that
 	// trips the guard is visible in the file contributors attach to bug reports.
-	assert.equal(await main.invoke('sites:delete', unregistered), false);
+	assert.deepEqual(await main.invoke('sites:delete', unregistered), { ok: false, refused: true });
 	assert.equal(fs.existsSync(unregistered), true);
 	assert.deepEqual(settings.values.sites, [registered]);
 	assert.deepEqual(Object.keys(settings.values.siteMeta).sort(), [registered, unregistered].sort());
@@ -413,10 +413,80 @@ test('sites:delete removes a registered directory and refuses an unregistered on
 	assert.match(logEvent.calls[0][1], /refused to delete .*unregistered/);
 
 	// And the other branch, so the guard cannot be passed by refusing everything.
-	assert.equal(await main.invoke('sites:delete', registered), true);
+	assert.deepEqual(await main.invoke('sites:delete', registered), { ok: true });
 	assert.equal(fs.existsSync(registered), false);
 	assert.deepEqual(settings.values.sites, []);
 	assert.deepEqual(Object.keys(settings.values.siteMeta), [unregistered]);
+});
+
+// The tree a real Git leaves behind: a read-only loose object inside a
+// directory without its write bit. Plain removal fails on it — read-only file
+// on Windows, unwritable directory on POSIX — which is exactly the state that
+// used to strand a site's folder on disk while the registry forgot it (#381).
+test('sites:delete clears the read-only attributes a real Git leaves behind (#381)', async (t) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-delete-ro-'));
+	t.after(() => {
+		try { fs.chmodSync(path.join(root, 'registered', '.git', 'objects', 'ab'), 0o777); } catch {}
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+	const registered = path.join(root, 'registered');
+	const loose = path.join(registered, '.git', 'objects', 'ab');
+	fs.mkdirSync(loose, { recursive: true });
+	fs.writeFileSync(path.join(loose, 'cdef0123'), 'blob');
+	fs.chmodSync(path.join(loose, 'cdef0123'), 0o444);
+	fs.chmodSync(loose, 0o555);
+
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const main = loadMain({ stubs: { ...silentLogging(), ...settings.stubs } });
+
+	assert.deepEqual(await main.invoke('sites:delete', registered), { ok: true });
+	assert.equal(fs.existsSync(registered), false, 'the protected tree must actually be gone');
+	assert.deepEqual(settings.values.sites, []);
+});
+
+// When the disk genuinely refuses, the handler must say so instead of
+// pretending: the registry half has already happened (deliberately — a locked
+// folder must not leave a site stuck undeletable), so the renderer gets
+// `{ ok: false, error }` naming the surviving path, and the log gets the
+// stack. The stage differs by platform because the ways a removal can still
+// fail differ: Windows refuses while a handle is open, POSIX refuses inside a
+// directory whose parent it cannot write.
+test('sites:delete reports a folder it could not remove instead of pretending (#381)', async (t) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ipc-wiring-delete-fail-'));
+	const registered = path.join(root, 'held');
+	fs.mkdirSync(registered, { recursive: true });
+	fs.writeFileSync(path.join(registered, 'pinned.txt'), 'x');
+
+	let release = () => {};
+	if (process.platform === 'win32') {
+		const fd = fs.openSync(path.join(registered, 'pinned.txt'), 'r');
+		release = () => fs.closeSync(fd);
+	} else {
+		fs.chmodSync(root, 0o555);
+		release = () => fs.chmodSync(root, 0o777);
+	}
+	t.after(() => {
+		release();
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	const logError = spy();
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const main = loadMain({
+		stubs: { './logging': { ...silentLogging()['./logging'], logError }, ...settings.stubs }
+	});
+
+	const result = await main.invoke('sites:delete', registered);
+	assert.equal(result.ok, false);
+	assert.equal(result.refused, undefined, 'a disk failure is not a guard refusal');
+	assert.match(result.error, /could not be deleted/);
+	assert.ok(result.error.includes(registered), 'the message names the surviving path');
+	assert.equal(fs.existsSync(registered), true, 'the folder really did survive');
+	// The forget half happened first, on purpose; the contract is honesty, not rollback.
+	assert.deepEqual(settings.values.sites, []);
+	assert.equal(logError.calls.length, 1);
+	assert.equal(logError.calls[0][0], 'sites');
+	assert.match(logError.calls[0][1], /still on disk/);
 });
 
 // --- site:status -> src/trunk-update.js ----------------------------------
@@ -3541,7 +3611,7 @@ test('deleting a site is refused while its clone is running, and the directory s
 		})
 	});
 
-	assert.equal(inside.deleted, false);
+	assert.deepEqual(inside.deleted, { ok: false, refused: true });
 	assert.equal(inside.stillThere, true);
 	assert.equal(fs.existsSync(path.join(root, 'demo')), true, 'the finished clone is still on disk');
 });

--- a/tests/unit/remove-tree.test.cjs
+++ b/tests/unit/remove-tree.test.cjs
@@ -1,0 +1,114 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { shouldClearAttributes, removeTree } = require('../../src/remove-tree.js');
+
+test('shouldClearAttributes: a permission error calls for the attribute pass', () => {
+	assert.equal(shouldClearAttributes({ code: 'EPERM' }), true);
+	assert.equal(shouldClearAttributes({ code: 'EACCES' }), true);
+});
+
+test('shouldClearAttributes: anything else would fail the same way twice', () => {
+	assert.equal(shouldClearAttributes({ code: 'ENOTDIR' }), false);
+	assert.equal(shouldClearAttributes({ code: 'EIO' }), false);
+	assert.equal(shouldClearAttributes(null), false);
+	assert.equal(shouldClearAttributes(undefined), false);
+});
+
+/**
+ * A tree shaped like the case #381 is about: a checkout whose `.git/objects`
+ * a real Git protected. On Windows the read-only file is what blocks the
+ * unlink; on POSIX it is the directory without its write bit. Both are staged
+ * so the same test is the red one on either CI runner.
+ *
+ * @param {Object} t The node:test context, for cleanup.
+ * @return {string} The root of the staged tree.
+ */
+function makeProtectedTree(t) {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-'));
+	t.after(() => {
+		// Belt and braces for a failing run: restore what the test locked so
+		// the tmpdir does not outlive the suite.
+		try { fs.chmodSync(path.join(root, 'objects'), 0o777); } catch {}
+		try { fs.rmSync(root, { recursive: true, force: true }); } catch {}
+	});
+	const objects = path.join(root, 'objects');
+	fs.mkdirSync(path.join(objects, 'ab'), { recursive: true });
+	const loose = path.join(objects, 'ab', 'cdef0123');
+	fs.writeFileSync(loose, 'blob');
+	fs.writeFileSync(path.join(root, 'ordinary.txt'), 'fine');
+	fs.chmodSync(loose, 0o444);
+	fs.chmodSync(path.join(objects, 'ab'), 0o555);
+	return root;
+}
+
+test('removeTree: deletes a tree a real Git protected', async (t) => {
+	const root = makeProtectedTree(t);
+
+	// The staging is real: the cheap removal this module wraps must fail on
+	// this tree, or the test proves nothing. (Windows refuses the read-only
+	// file; POSIX refuses to unlink inside the 0o555 directory.)
+	await assert.rejects(fs.promises.rm(root, { recursive: true, force: true }));
+
+	await removeTree(root);
+	assert.equal(fs.existsSync(root), false);
+});
+
+test('removeTree: a tree with nothing wrong costs one rm call', async (t) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-plain-'));
+	t.after(() => { try { fs.rmSync(root, { recursive: true, force: true }); } catch {} });
+	fs.writeFileSync(path.join(root, 'file.txt'), 'x');
+
+	const calls = [];
+	const counting = {
+		promises: {
+			rm: (p, o) => { calls.push(p); return fs.promises.rm(p, o); },
+			chmod: fs.promises.chmod.bind(fs.promises),
+			readdir: fs.promises.readdir.bind(fs.promises)
+		}
+	};
+	await removeTree(root, { fs: counting });
+	assert.equal(calls.length, 1);
+	assert.equal(fs.existsSync(root), false);
+});
+
+test('removeTree: a missing directory is not an error', async () => {
+	await removeTree(path.join(os.tmpdir(), 'remove-tree-never-existed-xyz'));
+});
+
+test('removeTree: a failure that survives the attribute pass propagates', async () => {
+	const stubborn = Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+	const failing = {
+		promises: {
+			rm: async () => { throw stubborn; },
+			chmod: async () => {},
+			readdir: async () => []
+		}
+	};
+	await assert.rejects(
+		removeTree(path.join(os.tmpdir(), 'remove-tree-stubborn'), { fs: failing }),
+		(e) => e === stubborn
+	);
+});
+
+test('removeTree: a non-permission failure is not retried', async () => {
+	const io = Object.assign(new Error('EIO: i/o error'), { code: 'EIO' });
+	let attempts = 0;
+	const failing = {
+		promises: {
+			rm: async () => { attempts += 1; throw io; },
+			chmod: async () => { throw new Error('the attribute pass must not run'); },
+			readdir: async () => { throw new Error('the attribute pass must not run'); }
+		}
+	};
+	await assert.rejects(
+		removeTree(path.join(os.tmpdir(), 'remove-tree-io'), { fs: failing }),
+		(e) => e === io
+	);
+	assert.equal(attempts, 1);
+});

--- a/tests/unit/remove-tree.test.cjs
+++ b/tests/unit/remove-tree.test.cjs
@@ -77,6 +77,31 @@ test('removeTree: a tree with nothing wrong costs one rm call', async (t) => {
 	assert.equal(fs.existsSync(root), false);
 });
 
+test('removeTree: the attribute pass does not follow a symlink out of the tree', { skip: process.platform === 'win32' && 'symlink creation needs privileges on Windows' }, async (t) => {
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-outside-'));
+	t.after(() => { try { fs.rmSync(outside, { recursive: true, force: true }); } catch {} });
+	const script = path.join(outside, 'bin.sh');
+	fs.writeFileSync(script, '#!/bin/sh\n');
+	fs.chmodSync(script, 0o755);
+
+	// A protected tree, so the attribute pass actually runs — and a symlink
+	// pointing at the executable outside, placed *inside* the unwritable
+	// directory so the first (failing) rm cannot unlink it before the walk
+	// runs. chmod follows symlinks, so a walk that touches the link would
+	// strip the target's exec bit (a populated node_modules/.bin is exactly
+	// this shape).
+	const root = makeProtectedTree(t);
+	const locked = path.join(root, 'objects', 'ab');
+	fs.chmodSync(locked, 0o755);
+	fs.symlinkSync(script, path.join(locked, 'linked-bin'));
+	fs.chmodSync(locked, 0o555);
+
+	await removeTree(root);
+	assert.equal(fs.existsSync(root), false);
+	// eslint-disable-next-line no-bitwise -- masking is how a POSIX mode is read; the same idiom as pr-files.cjs.
+	assert.equal(fs.statSync(script).mode & 0o777, 0o755, 'the symlink target must keep its mode');
+});
+
 test('removeTree: a missing directory is not an error', async () => {
 	await removeTree(path.join(os.tmpdir(), 'remove-tree-never-existed-xyz'));
 });

--- a/tests/unit/remove-tree.test.cjs
+++ b/tests/unit/remove-tree.test.cjs
@@ -107,6 +107,78 @@ test('removeTree: the attribute pass does not follow a symlink out of the tree',
 	assert.equal(fs.statSync(script).mode & 0o777, 0o755, 'the symlink target must keep its mode');
 });
 
+/**
+ * An `fs` whose `rm` always refuses with EPERM, over the real `chmod`,
+ * `readdir` and `lstat`. The attribute pass then runs for real against a real
+ * tree while nothing is ever deleted — which is exactly the state a caller is
+ * told about when a removal half-fails, and the only state in which the modes
+ * the pass leaves behind are observable.
+ *
+ * @return {Object} The injectable fs.
+ */
+function refusingFs() {
+	return {
+		promises: {
+			rm: async () => { throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' }); },
+			chmod: fs.promises.chmod.bind(fs.promises),
+			readdir: fs.promises.readdir.bind(fs.promises),
+			lstat: fs.promises.lstat.bind(fs.promises)
+		}
+	};
+}
+
+// eslint-disable-next-line no-bitwise -- masking is how a POSIX mode is read; the same idiom as pr-files.cjs.
+const modeOf = (p) => fs.statSync(p).mode & 0o777;
+
+test('removeTree: the attribute pass adds the write bit without replacing the mode', { skip: process.platform === 'win32' && 'POSIX modes are not what Windows stores' }, async (t) => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-modes-'));
+	const locked = path.join(root, 'objects');
+	fs.mkdirSync(locked);
+	const script = path.join(locked, 'bin.sh');
+	const loose = path.join(locked, 'cdef0123');
+	fs.writeFileSync(script, '#!/bin/sh\n');
+	fs.writeFileSync(loose, 'blob');
+	fs.chmodSync(script, 0o755);
+	fs.chmodSync(loose, 0o444);
+	fs.chmodSync(locked, 0o555);
+	t.after(() => {
+		try { fs.chmodSync(locked, 0o777); } catch {}
+		try { fs.rmSync(root, { recursive: true, force: true }); } catch {}
+	});
+
+	// The removal never succeeds, so the tree survives the pass — the half
+	// deletion this module reports rather than hides.
+	await assert.rejects(removeTree(root, { fs: refusingFs() }));
+
+	assert.equal(modeOf(script), 0o755, 'an executable survivor must keep its exec bit');
+	assert.equal(modeOf(loose), 0o644, 'the read-only file gains owner write and keeps the rest');
+	assert.equal(modeOf(locked), 0o755, 'the directory gains owner rwx and keeps the rest');
+});
+
+test('removeTree: the attribute pass does not follow a symlink given as the root', { skip: process.platform === 'win32' && 'symlink creation needs privileges on Windows' }, async (t) => {
+	const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-root-target-'));
+	const inside = path.join(outside, 'private.txt');
+	fs.writeFileSync(inside, 'not yours');
+	fs.chmodSync(inside, 0o444);
+	fs.chmodSync(outside, 0o555);
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), 'remove-tree-root-link-'));
+	t.after(() => {
+		try { fs.chmodSync(outside, 0o777); } catch {}
+		try { fs.rmSync(outside, { recursive: true, force: true }); } catch {}
+		try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+	});
+
+	// A registered site path that is itself a link. The removal refuses, so the
+	// attribute pass runs on the root — and the root is the one entry no
+	// per-child check ever sees.
+	const link = path.join(home, 'site');
+	fs.symlinkSync(outside, link);
+	await assert.rejects(removeTree(link, { fs: refusingFs() }));
+
+	assert.equal(modeOf(outside), 0o555, 'the link target must keep its mode');
+	assert.equal(modeOf(inside), 0o444, 'and so must everything inside it');
+});
+
 test('removeTree: a missing directory is not an error', async () => {
 	await removeTree(path.join(os.tmpdir(), 'remove-tree-never-existed-xyz'));
 });
@@ -117,7 +189,8 @@ test('removeTree: a failure that survives the attribute pass propagates', async 
 		promises: {
 			rm: async () => { throw stubborn; },
 			chmod: async () => {},
-			readdir: async () => []
+			readdir: async () => [],
+			lstat: async () => ({ isSymbolicLink: () => false, isDirectory: () => true, mode: 0o700 })
 		}
 	};
 	await assert.rejects(
@@ -133,7 +206,8 @@ test('removeTree: a non-permission failure is not retried', async () => {
 		promises: {
 			rm: async () => { attempts += 1; throw io; },
 			chmod: async () => { throw new Error('the attribute pass must not run'); },
-			readdir: async () => { throw new Error('the attribute pass must not run'); }
+			readdir: async () => { throw new Error('the attribute pass must not run'); },
+			lstat: async () => { throw new Error('the attribute pass must not run'); }
 		}
 	};
 	await assert.rejects(

--- a/tests/unit/remove-tree.test.cjs
+++ b/tests/unit/remove-tree.test.cjs
@@ -22,9 +22,9 @@ test('shouldClearAttributes: anything else would fail the same way twice', () =>
 
 /**
  * A tree shaped like the case #381 is about: a checkout whose `.git/objects`
- * a real Git protected. On Windows the read-only file is what blocks the
- * unlink; on POSIX it is the directory without its write bit. Both are staged
- * so the same test is the red one on either CI runner.
+ * a real Git protected. Both protections are staged — the read-only file that
+ * matters on Windows and the write-bit-less directory that matters on POSIX —
+ * so the module is exercised end to end on either CI runner.
  *
  * @param {Object} t The node:test context, for cleanup.
  * @return {string} The root of the staged tree.
@@ -50,10 +50,15 @@ function makeProtectedTree(t) {
 test('removeTree: deletes a tree a real Git protected', async (t) => {
 	const root = makeProtectedTree(t);
 
-	// The staging is real: the cheap removal this module wraps must fail on
-	// this tree, or the test proves nothing. (Windows refuses the read-only
-	// file; POSIX refuses to unlink inside the 0o555 directory.)
-	await assert.rejects(fs.promises.rm(root, { recursive: true, force: true }));
+	// The staging is real on POSIX: plain rm refuses to unlink inside the
+	// 0o555 directory, so this test is red without the attribute pass. Not on
+	// Windows — Node's rm chmods a read-only entry and retries by itself (CI
+	// proved it: this guard held a rejection that never came) — so there the
+	// tree only exercises the module end to end, and the failure this module
+	// answers on Windows is the held handle the retry budget covers.
+	if (process.platform !== 'win32') {
+		await assert.rejects(fs.promises.rm(root, { recursive: true, force: true }));
+	}
 
 	await removeTree(root);
 	assert.equal(fs.existsSync(root), false);


### PR DESCRIPTION
## Why

A real Git marks its loose object files read-only, and Windows refuses to unlink a read-only file — `fs.rm` with `force: true` never clears the attribute, and fs-extra 11 is a bare `fs.rm` underneath. Today the app survives because isomorphic-git sets no attribute; the moment a real Git writes into a checkout — the mentor sitting next to a newcomer (#355), or the #364 engine — deleting that site on Windows leaves the whole tree on disk. And silently: the handler swallowed the error after the registry entry was already gone, and the renderer discarded the result, so the site vanished from the sidebar while its folder quietly survived (#381). Measured for real on the #364 spike, where every packaged Windows run hit it.

## What changes

The root cause is two stacked assumptions: that `force: true` means "delete no matter what" (it only forgives a missing path), and that a failed removal is not worth mentioning.

- **`src/remove-tree.js`** — try the cheap removal first; only on `EPERM`/`EACCES` walk whatever survived, restore the owner write bit (`0o700`/`0o600` — clearing the attribute does not require leaving a world-writable tree behind), and remove once more. Symlinks are skipped: `chmod` follows them, and a link's target — possibly outside the tree — must not have its mode touched. Anything that still fails propagates. Shape mirrors `kill-tree.js`.
- **`sites:delete`** routes through it and stops pretending: a disk failure is logged with the path, and the handler returns machine-readable `{ ok: false, reason: 'remove-failed', path, code }` — the contract moves from a bare boolean to the `{ ok }` shape the other handlers use. `forget()` still runs first; that ordering is a recorded decision (a locked folder must not leave a site stuck undeletable), so the honest thing left is to say what survived.
- **The renderer** turns that result into the confirmations queue's first error-tone notice, via a tested `deleteFailureMessage` in `confirmations.cjs` beside `prConfirmationMessage` — the sentence a contributor reads does not live untested in `index.jsx`.
- **The e2e teardown** discards through the same helper, keeping its final swallow (teardown must never red a passing test) and its `ENOTEMPTY` retry budget.

Deliberately not in it: bounding the recovery walk (see Risks), and the swallowed single-file `unlink`s in `src/trunk-update.js` discard flows, which share the blind spot and are left for a follow-up.

## How to test this

Platforms: the interesting one is **Windows** (the read-only attribute blocks unlinking there); the POSIX analogue below reproduces the same failure on macOS/Linux.

**Starting state:** a site already created, app open.

1. In a terminal, protect part of the checkout the way a real Git would: `chmod -R a-w "<site>/.git/objects"` on macOS/Linux, or on Windows `attrib +r "<site>\.git\objects\*" /s`.
2. In the app: **Delete this site** → confirm.
3. Expected: the site leaves the sidebar **and the folder is gone from disk**.
4. To see the other half — the honesty path — make the folder genuinely undeletable instead (Windows: keep a file inside it open in another program, e.g. a shell with `cd` into it; macOS: `chmod a-w` the site's *parent* directory), then delete. Expected: an error notice appears and stays until dismissed, reading "The site was removed from the list, but its folder could not be deleted (EPERM) and is still at `<path>`" — and the same line, with stack, in the log file.

**What must not have happened:** a site that vanishes from the list while its folder quietly survives — which is exactly what steps 1–2 produced before this change on Windows, with nothing shown and nothing logged.

The bugfix tests fail on the old code, checked by reverting the fix and watching them: `removeTree: deletes a tree a real Git protected` (on POSIX — see the platform note in Risks) and `the attribute pass does not follow a symlink out of the tree` (its staged link survives the first failing `rm` on purpose).

## Risks and limitations

- **A finding from this PR's own Windows CI run corrected the mechanism**: Node's `fs.rm` already chmods a read-only entry and retries on Windows (rimraf's dance came into core with it), so the read-only *file* was never the unanswered half there — the first CI run failed on the test's own "plain rm must fail" guard and proved it. What Windows actually lacks is a retry budget against held handles (`fse.remove` passes none; the #364 spike's EPERM fits that), and what POSIX lacks is anything at all for a directory without its write bit. The module provides both; the prose and the red-on-old-code claim are now scoped to the platform where each is true.
- **The recovery walk is unbounded**: on a checkout with `node_modules` it chmods a large tree sequentially while the renderer waits on `deleteSite()` with no progress channel. It only runs when plain removal already failed, and only `.git/objects` normally needs it — bounding or targeting the walk is deferred until anyone sees the delete button hang. (Review finding 7, deferred.)
- The Windows read-only case runs in CI (`unit (windows-latest)` stages a real protected tree) but the by-hand pass on a real Windows machine has not been done for this branch — the Buildkite artifact makes that possible without building.
- Review outcome headline, two rounds: 5 [fix here] · 2 [follow-up] from the self-review (all 5 applied, plus one follow-up pulled in), and 3 [fix here] from Copilot's review of the branch (all 3 applied). Details below.

## Related

Fixes #381. Part of the ground the #350/#364 track stands on: real Git makes this path hot, so it lands ahead of the engine swap. Follow-up candidates: the `trunk-update.js` discard `unlink`s, and bounding the walk.

---

<details>
<summary>Design decisions and alternatives considered</summary>

- **Fix-and-retry per failing path** (what old rimraf did per entry) was rejected: `fs.rm` reports one offender per call, so a checkout with thousands of read-only objects would mean thousands of restarted traversals. One full attribute pass over the survivors, then one more `rm`, is bounded at two traversals.
- **Remove first, forget after** would let a failed deletion keep the site listed for retry — but "forget first" is the module's recorded decision (a locked folder must not make a site permanently undeletable), and with the failure now visible the original rationale holds. The message says what is left and where.
- **`maxRetries: 10`** is inherited from the e2e teardown this replaces: an `ENOTEMPTY` that only ever appeared on a macOS CI runner needed that budget, and `ENOTEMPTY` is not a permission code — retries are still its only mitigation.
- The wiring failure case stubs `remove-tree` rather than staging a real refusal per platform: an open handle on Windows does not even refuse the unlink (libuv opens with `FILE_SHARE_DELETE`), so the "real" staging would have tested a mechanism nobody watched run. Real propagation is `remove-tree.test.cjs`'s job, on real trees.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**Round 1 — the self-review AGENTS.md asks for.** 5 [fix here] · 2 [follow-up] — all 5 applied, plus follow-up 6; follow-up 7 deferred.

1. 🟡 Failure sentence composed in main, decided by an untested `if` in `index.jsx` → moved to `deleteFailureMessage` in `confirmations.cjs`, main returns `reason`/`path`/`code`. **Fixed.**
2. 🟡 `makeWritable` followed symlinks, chmodding targets possibly outside the tree → skipped, with a regression test staged so the link survives the first `rm`. **Fixed.**
3. 🟡 Teardown retry budget silently dropped 10 → 3, losing the recorded `ENOTEMPTY` mitigation → module default raised to 10, with the why in a comment. **Fixed.**
4. 🔵 `0o777`/`0o666` left a world-writable tree when removal still failed → owner-only `0o700`/`0o600`. **Fixed.**
5. 🔵 `chmod` and `readdir` shared a `try`, an unchmoddable directory aborted its subtree's walk → split. **Fixed.**
6. 🔵 [follow-up] Platform-split failure staging in the wiring test, with a shaky Windows branch → replaced with a stubbed `remove-tree`, deterministic on both runners. **Applied anyway.**
7. 🔵 [follow-up] Unbounded sequential recovery walk → **deferred**, named in Risks; the trigger is the recovery path only.

**Round 2 — Copilot, on the pushed branch.** 3 [fix here] · 0 [follow-up] — all 3 applied.

1. 🟡 The attribute pass assigned fixed `0o700`/`0o600`, so a tree that survived the retry — the half deletion this PR exists to report — came back with its executables at `0o600` and every group and other bit erased. Round 1's finding 4 tightened the mode but kept it an assignment; the answer to both is to add rather than assign: `mode | 0o700` for a directory, `mode | 0o200` for a file. **Fixed**, with a test that a refused removal leaves a `0o755` executable at `0o755`.
2. 🟡 The symlink skip from round 1's finding 2 covered children but not the root: `chmod` and `readdir` ran before anything `lstat`ted the directory, so a site path that is itself a link had its target chmodded — the same blind spot, one level up. The check now sits at the top of the recursion, and one `lstat` answers all three questions the walk asks. **Fixed**, with a test that hands a link in as the root.
3. 🔵 The wiring comment in `main.js` still carried the superseded Windows diagnosis this branch's own CI run disproved, contradicting the corrected module header. **Fixed** — it now names the failure each platform actually has.

Deterministic layer: lint clean, 1042/1042 unit tests, 14/14 journeys.

</details>

<details>
<summary>Implementation notes</summary>

- `deleteRegisteredSite` in `site-registry.js` keeps its boolean guard contract; the `{ ok }` IPC shape lives in the handler. The pure module stays IPC-free, per its own header.
- The read-only wiring test (`sites:delete clears the read-only attributes a real Git leaves behind`) runs the real handler against a really-protected tree on both CI platforms — the Windows runner is the authoritative one for the attribute semantics.
- `git-lfs`-style `attrib +r` and POSIX `0o444`/`0o555` are both staged in `remove-tree.test.cjs` so the same test is the red one on either runner.
- Nothing on screen changed except the (new) error notice, which only appears when a deletion half-fails; no screenshot for the happy path, where the change is invisible by design.

</details>


