### PR TITLE
Fix macOS signing key leakage in packaged apps

### DIFF
--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -11,8 +11,17 @@ bundle exec fastlane setup_code_signing
 echo "Expose signing config to electron-builder..."
 # Export necessary env vars for `electron-builder` to find those for its `notarize` option
 # See https://www.electron.build/mac#notarize
-mkdir -p .codesigning/
-echo "$APP_STORE_CONNECT_API_KEY_KEY" >.codesigning/apple_api_key
-export APPLE_API_KEY=".codesigning/apple_api_key"
+MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")"
+export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
+
+cleanup_macos_notarization_key() {
+	rm -f "$APPLE_API_KEY"
+	rmdir "$MACOS_NOTARIZATION_TEMP_DIR"
+}
+trap cleanup_macos_notarization_key EXIT
+
+# `printenv` keeps the key itself out of shell traces, while the private temporary directory and
+# restrictive file mode keep it unavailable to other users on the build agent.
+( umask 077; printenv APP_STORE_CONNECT_API_KEY_KEY >"$APPLE_API_KEY" )
 export APPLE_API_KEY_ID="$APP_STORE_CONNECT_API_KEY_KEY_ID"
 export APPLE_API_ISSUER="$APP_STORE_CONNECT_API_KEY_ISSUER_ID"

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -11,17 +11,23 @@ bundle exec fastlane setup_code_signing
 echo "Expose signing config to electron-builder..."
 # Export necessary env vars for `electron-builder` to find those for its `notarize` option
 # See https://www.electron.build/mac#notarize
-MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")"
+#
+# The Buildkite step sources this script, so the shebang's `-eu` never applies. Return explicitly
+# so callers without `errexit` still receive materialization failures instead of continuing.
+MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")" || return 1
 export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
 
 cleanup_macos_notarization_key() {
-	rm -f "$APPLE_API_KEY"
-	rmdir "$MACOS_NOTARIZATION_TEMP_DIR"
+	rm -rf "$MACOS_NOTARIZATION_TEMP_DIR"
 }
 trap cleanup_macos_notarization_key EXIT
 
 # `printenv` keeps the key itself out of shell traces, while the private temporary directory and
-# restrictive file mode keep it unavailable to other users on the build agent.
-( umask 077; printenv APP_STORE_CONNECT_API_KEY_KEY >"$APPLE_API_KEY" )
+# restrictive file mode keep it unavailable to other users on the build agent. Unlike `echo` under
+# `set -u`, `printenv` exits quietly when the variable is missing — hence the explicit guard.
+( umask 077; printenv APP_STORE_CONNECT_API_KEY_KEY >"$APPLE_API_KEY" ) || {
+	echo "APP_STORE_CONNECT_API_KEY_KEY is unset or could not be written to $APPLE_API_KEY" >&2
+	return 1
+}
 export APPLE_API_KEY_ID="$APP_STORE_CONNECT_API_KEY_KEY_ID"
 export APPLE_API_ISSUER="$APP_STORE_CONNECT_API_KEY_ISSUER_ID"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,10 @@ jobs:
       # Buildkite creates this directory during signed macOS builds. A canary makes the
       # packaged test prove that build-only signing material stays out of every payload.
       - name: Stage a build-only signing canary
-        run: node -e "const fs = require('node:fs'); fs.mkdirSync('.codesigning', { recursive:true }); fs.writeFileSync('.codesigning/apple_api_key', 'must not ship');"
+        shell: bash
+        run: |
+          mkdir -p .codesigning
+          printf 'must not ship' > .codesigning/apple_api_key
 
       - name: Package (unsigned, --dir)
         # Mandatory on macOS: electron-builder signs during `--dir` otherwise.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,11 @@ jobs:
       - name: Build the renderer bundle
         run: npm run build:once
 
+      # Buildkite creates this directory during signed macOS builds. A canary makes the
+      # packaged test prove that build-only signing material stays out of every payload.
+      - name: Stage a build-only signing canary
+        run: node -e "const fs = require('node:fs'); fs.mkdirSync('.codesigning', { recursive:true }); fs.writeFileSync('.codesigning/apple_api_key', 'must not ship\\n');"
+
       - name: Package (unsigned, --dir)
         # Mandatory on macOS: electron-builder signs during `--dir` otherwise.
         # Harmless elsewhere. Windows signing already no-ops without the Azure

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,7 @@ jobs:
       # Buildkite creates this directory during signed macOS builds. A canary makes the
       # packaged test prove that build-only signing material stays out of every payload.
       - name: Stage a build-only signing canary
-        run: node -e "const fs = require('node:fs'); fs.mkdirSync('.codesigning', { recursive:true }); fs.writeFileSync('.codesigning/apple_api_key', 'must not ship\\n');"
+        run: node -e "const fs = require('node:fs'); fs.mkdirSync('.codesigning', { recursive:true }); fs.writeFileSync('.codesigning/apple_api_key', 'must not ship');"
 
       - name: Package (unsigned, --dir)
         # Mandatory on macOS: electron-builder signs during `--dir` otherwise.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "buildResources": "build"
     },
     "files": [
-      "!vendor{,/**/*}"
+      "!vendor{,/**/*}",
+      "!.codesigning{,/**/*}"
     ],
     "icon": "build/icon.png",
     "linux": {

--- a/tests/e2e/packaged/smoke.spec.js
+++ b/tests/e2e/packaged/smoke.spec.js
@@ -202,6 +202,19 @@ test( 'the preload bridge exposes every expected key', async () => {
 	expect( exposed ).toEqual( EXPECTED_API_KEYS );
 } );
 
+test( 'the packaged app excludes build-only signing material', async () => {
+	const signingFiles = await electronApp.evaluate( ( { app } ) => {
+		const nodeRequire = process.mainModule.require;
+		const appFs = nodeRequire( 'node:fs' );
+		const appPath = nodeRequire( 'node:path' );
+		const signingDirectory = appPath.join( app.getAppPath(), '.codesigning' );
+
+		return appFs.existsSync( signingDirectory ) ? appFs.readdirSync( signingDirectory ) : [];
+	} );
+
+	expect( signingFiles ).toEqual( [] );
+} );
+
 for ( const moduleName of REQUIRED_MODULES ) {
 	test( `the packaged app can resolve ${ moduleName }`, async () => {
 		const resolved = await electronApp.evaluate( ( { app }, name ) => {

--- a/tests/e2e/packaged/smoke.spec.js
+++ b/tests/e2e/packaged/smoke.spec.js
@@ -215,6 +215,31 @@ test( 'the packaged app excludes build-only signing material', async () => {
 	expect( signingFiles ).toEqual( [] );
 } );
 
+test( 'the packaged payload has no .codesigning directory outside app.asar', () => {
+	// The sibling test above reads through Electron's asar-aware fs, so it sees
+	// inside app.asar — and only there. This walk runs on plain Node fs, which is
+	// not asar-aware, so it checks the rest of the payload for the same directory:
+	// the unpacked asar directory, extra resources or files, and framework helpers.
+	const binary = findPackagedBinary();
+	const packagedRoot = process.platform === 'darwin'
+		? path.join( binary, '..', '..', '..' ) // Contents/MacOS/<binary> -> the .app bundle
+		: path.dirname( binary ); // win-unpacked/<exe> -> win-unpacked
+
+	const offenders = [];
+	const walk = ( dir ) => {
+		for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+			if ( entry.name === '.codesigning' ) {
+				offenders.push( path.join( dir, entry.name ) );
+			} else if ( entry.isDirectory() ) {
+				walk( path.join( dir, entry.name ) );
+			}
+		}
+	};
+	walk( packagedRoot );
+
+	expect( offenders ).toEqual( [] );
+} );
+
 for ( const moduleName of REQUIRED_MODULES ) {
 	test( `the packaged app can resolve ${ moduleName }`, async () => {
 		const resolved = await electronApp.evaluate( ( { app }, name ) => {

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -3,32 +3,81 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawnSync } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 
 const SETUP_SCRIPT = path.join(__dirname, '..', '..', '.buildkite', 'commands', 'setup_macos_code_signing.sh');
 const DUMMY_KEY = '-----BEGIN PRIVATE KEY-----\na dummy key with spaces and $shell syntax\n-----END PRIVATE KEY-----';
 
 // The real Buildkite command sources this script, so exercise it in the same shape. Fastlane is
-// stubbed because this test is only responsible for where the notarization key is materialized,
-// its permissions, and whether the sourced shell cleans it up.
+// stubbed because these tests are responsible only for materializing and cleaning up the key.
 const SOURCE_HARNESS = String.raw`
 set -eu
 install_gems() { :; }
 bundle() { :; }
 source "$SETUP_SCRIPT"
 
-case "$APPLE_API_KEY" in
-	"$PROJECT_ROOT"/*)
+# Compare real paths: the regression this guards against exported a *relative* in-project path,
+# and macOS temp directories reach here both as /var/... and its /private/var/... target.
+key_dir="$(cd "$(dirname "$APPLE_API_KEY")" && pwd -P)"
+project_dir="$(cd "$PROJECT_ROOT" && pwd -P)"
+case "$key_dir" in
+	"$project_dir"|"$project_dir"/*)
 		echo "notarization key was written inside the project: $APPLE_API_KEY" >&2
 		exit 1
 		;;
 esac
+
+# Independent of what APPLE_API_KEY claims: no signing material may exist in the project itself.
+test ! -e "$PROJECT_ROOT/.codesigning"
 
 test -f "$APPLE_API_KEY"
 test "$(cat "$APPLE_API_KEY")" = "$APP_STORE_CONNECT_API_KEY_KEY"
 test "$(stat -f '%Lp' "$APPLE_API_KEY")" = "600"
 printf '%s\n' "$APPLE_API_KEY"
 `;
+
+const FAILED_MKTEMP_HARNESS = String.raw`
+install_gems() { :; }
+bundle() { :; }
+mktemp() {
+	printf '%s\n' "$MKTEMP_FALLBACK"
+	return 1
+}
+source "$SETUP_SCRIPT"
+status=$?
+exit "$status"
+`;
+
+const FAILED_KEY_WRITE_HARNESS = String.raw`
+install_gems() { :; }
+bundle() { :; }
+printenv() { return 1; }
+source "$SETUP_SCRIPT"
+status=$?
+exit "$status"
+`;
+
+const TERM_HARNESS = String.raw`
+set -e
+install_gems() { :; }
+bundle() { :; }
+source "$SETUP_SCRIPT"
+printf 'READY:%s\n' "$APPLE_API_KEY"
+read -r _
+echo "signing shell survived TERM" >&2
+exit 1
+`;
+
+function signingEnv(overrides = {}) {
+	return {
+		...process.env,
+		APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
+		APP_STORE_CONNECT_API_KEY_KEY_ID: 'dummy-key-id',
+		APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'dummy-issuer-id',
+		SETUP_SCRIPT,
+		...overrides,
+	};
+}
 
 test('macOS signing keeps its temporary notarization key outside the project and removes it on exit', { skip: process.platform !== 'darwin' }, (t) => {
 	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-project-'));
@@ -37,14 +86,9 @@ test('macOS signing keeps its temporary notarization key outside the project and
 	const result = spawnSync('/bin/bash', ['-c', SOURCE_HARNESS], {
 		cwd: projectRoot,
 		encoding: 'utf8',
-		env: {
-			...process.env,
-			APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
-			APP_STORE_CONNECT_API_KEY_KEY_ID: 'dummy-key-id',
-			APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'dummy-issuer-id',
+		env: signingEnv({
 			PROJECT_ROOT: projectRoot,
-			SETUP_SCRIPT,
-		},
+		}),
 	});
 
 	assert.equal(result.status, 0, `signing setup failed:\n${result.stdout}${result.stderr}`);
@@ -52,4 +96,92 @@ test('macOS signing keeps its temporary notarization key outside the project and
 	assert.ok(path.isAbsolute(keyPath), `expected an absolute key path, received ${keyPath}`);
 	assert.equal(fs.existsSync(keyPath), false, 'the key file survived the Buildkite shell');
 	assert.equal(fs.existsSync(path.dirname(keyPath)), false, 'the key temporary directory survived the Buildkite shell');
+});
+
+test('sourced macOS signing returns failure when its temporary directory cannot be created', { skip: process.platform !== 'darwin' }, (t) => {
+	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-mktemp-'));
+	const fallbackDirectory = path.join(projectRoot, 'mktemp-fallback');
+	fs.mkdirSync(fallbackDirectory);
+	t.after(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+
+	const result = spawnSync('/bin/bash', ['-c', FAILED_MKTEMP_HARNESS], {
+		cwd: projectRoot,
+		encoding: 'utf8',
+		env: signingEnv({ MKTEMP_FALLBACK: fallbackDirectory }),
+	});
+
+	assert.equal(result.status, 1, `signing setup did not return the mktemp failure:\n${result.stdout}${result.stderr}`);
+	assert.equal(fs.existsSync(fallbackDirectory), true, 'signing claimed and removed a directory that mktemp did not create');
+	assert.equal(fs.existsSync(path.join(fallbackDirectory, 'apple_api_key')), false, 'signing continued after mktemp failed');
+});
+
+test('sourced macOS signing returns failure and cleans up when writing the key fails', { skip: process.platform !== 'darwin' }, (t) => {
+	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-key-write-project-'));
+	const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-key-write-temp-'));
+	t.after(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+	t.after(() => fs.rmSync(temporaryRoot, { recursive: true, force: true }));
+
+	const result = spawnSync('/bin/bash', ['-c', FAILED_KEY_WRITE_HARNESS], {
+		cwd: projectRoot,
+		encoding: 'utf8',
+		env: signingEnv({ TMPDIR: temporaryRoot }),
+	});
+
+	assert.equal(result.status, 1, `signing setup did not return the key-write failure:\n${result.stdout}${result.stderr}`);
+	assert.deepEqual(fs.readdirSync(temporaryRoot), [], 'temporary signing material survived the failed shell');
+});
+
+test('macOS signing removes its temporary key when Buildkite terminates the shell', { skip: process.platform !== 'darwin' }, async (t) => {
+	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-term-'));
+	const child = spawn('/bin/bash', ['-c', TERM_HARNESS], {
+		cwd: projectRoot,
+		env: signingEnv(),
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+	t.after(() => {
+		if (child.exitCode === null && child.signalCode === null) {
+			child.kill('SIGKILL');
+		}
+		fs.rmSync(projectRoot, { recursive: true, force: true });
+	});
+
+	let stdout = '';
+	let stderr = '';
+	let keyPath;
+	let keyExistedBeforeTermination = false;
+	let terminationSent = false;
+	child.stdout.on('data', (chunk) => {
+		stdout += chunk;
+		const match = stdout.match(/READY:(.+)/);
+		if (!terminationSent && match) {
+			terminationSent = true;
+			keyPath = match[1].trim();
+			keyExistedBeforeTermination = fs.existsSync(keyPath);
+			child.kill('SIGTERM');
+		}
+	});
+	child.stderr.on('data', (chunk) => {
+		stderr += chunk;
+	});
+
+	const outcome = await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			child.kill('SIGKILL');
+			reject(new Error(`signing shell did not terminate after SIGTERM:\n${stdout}${stderr}`));
+		}, 5_000);
+		child.once('error', (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.once('close', (code, signal) => {
+			clearTimeout(timeout);
+			resolve({ code, signal });
+		});
+	});
+
+	assert.equal(terminationSent, true, `signing shell never materialized the key:\n${stdout}${stderr}`);
+	assert.equal(keyExistedBeforeTermination, true, `temporary key did not exist before SIGTERM: ${keyPath}`);
+	assert.deepEqual(outcome, { code: null, signal: 'SIGTERM' }, `signing shell did not preserve the TERM result:\n${stdout}${stderr}`);
+	assert.equal(fs.existsSync(keyPath), false, 'the key file survived SIGTERM');
+	assert.equal(fs.existsSync(path.dirname(keyPath)), false, 'the key temporary directory survived SIGTERM');
 });

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const SETUP_SCRIPT = path.join(__dirname, '..', '..', '.buildkite', 'commands', 'setup_macos_code_signing.sh');
+const DUMMY_KEY = '-----BEGIN PRIVATE KEY-----\na dummy key with spaces and $shell syntax\n-----END PRIVATE KEY-----';
+
+// The real Buildkite command sources this script, so exercise it in the same shape. Fastlane is
+// stubbed because this test is only responsible for where the notarization key is materialized,
+// its permissions, and whether the sourced shell cleans it up.
+const SOURCE_HARNESS = String.raw`
+set -eu
+install_gems() { :; }
+bundle() { :; }
+source "$SETUP_SCRIPT"
+
+case "$APPLE_API_KEY" in
+	"$PROJECT_ROOT"/*)
+		echo "notarization key was written inside the project: $APPLE_API_KEY" >&2
+		exit 1
+		;;
+esac
+
+test -f "$APPLE_API_KEY"
+test "$(cat "$APPLE_API_KEY")" = "$APP_STORE_CONNECT_API_KEY_KEY"
+test "$(stat -f '%Lp' "$APPLE_API_KEY")" = "600"
+printf '%s\n' "$APPLE_API_KEY"
+`;
+
+test('macOS signing keeps its temporary notarization key outside the project and removes it on exit', { skip: process.platform !== 'darwin' }, (t) => {
+	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-project-'));
+	t.after(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+
+	const result = spawnSync('/bin/bash', ['-c', SOURCE_HARNESS], {
+		cwd: projectRoot,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
+			APP_STORE_CONNECT_API_KEY_KEY_ID: 'dummy-key-id',
+			APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'dummy-issuer-id',
+			PROJECT_ROOT: projectRoot,
+			SETUP_SCRIPT,
+		},
+	});
+
+	assert.equal(result.status, 0, `signing setup failed:\n${result.stdout}${result.stderr}`);
+	const keyPath = result.stdout.trim().split('\n').at(-1);
+	assert.ok(path.isAbsolute(keyPath), `expected an absolute key path, received ${keyPath}`);
+	assert.equal(fs.existsSync(keyPath), false, 'the key file survived the Buildkite shell');
+	assert.equal(fs.existsSync(path.dirname(keyPath)), false, 'the key temporary directory survived the Buildkite shell');
+});


### PR DESCRIPTION
Fixes AINFRA-2941

## Why

macOS signing wrote the App Store Connect API key to `.codesigning/` in the project root. Because `electron-builder` included that directory in `app.asar`, packaged builds contained the key.

## What changes

- Write the notarization key to a private temporary directory outside the project and clean it up when the build exits or is cancelled.
- Fail immediately if the temporary directory or key cannot be created.
- Exclude `.codesigning` from packages and use a CI canary to verify the full packaged payload.

## How to test this

**Starting state:** This PR's GitHub Actions and Buildkite builds correspond to the current head commit.

1. Confirm the packaged smoke jobs pass on macOS and Windows; the staged `.codesigning/apple_api_key` canary must be absent from each package.
2. Confirm the Buildkite macOS signing, packaging, notarization, and `verify_code_signing` steps pass.
3. Mount the signed DMG and launch the app; it must open normally with a valid signature.

**What must not have happened:** No `.codesigning` directory or `apple_api_key` may be present in a packaged app, and the temporary key must not survive normal exit, setup failure, or `SIGTERM` cancellation.

Platforms: macOS for signing; macOS and Windows for packaged-payload coverage.

## Risks and limitations

There is no visible UI change. `SIGTERM` cleanup is covered by a process-level test; `SIGKILL` cannot run shell cleanup traps.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 `[fix here]` · 0 `[follow-up]`. No findings across the five review dimensions.

</details>
