### PR TITLE
Say how to get an installed tree in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,14 @@ The reasons are editing, not rendering. A long line reflows to whatever width th
 
 Line breaks still mean something everywhere else, and none of this touches them: list items, table rows, headings, fenced code, VitePress `:::` containers, YAML frontmatter and the body of an HTML comment all keep the shape they have.
 
+## Bootstrap
+
+`npm ci` at the repository root, on the Node pinned in [`.nvmrc`](.nvmrc).
+
+Do not add `--ignore-scripts`. `postinstall` is where a usable tree comes from: `electron-builder install-app-deps` fetches the Electron binary and rebuilds the native file-locking module against its ABI, and `npm run build:once` generates `src/renderer/index.js` and `index.css`, which are not committed. Skip it and there is no renderer to load and no Electron to load it. The lint workflow installs that way deliberately, so that it never executes the pull request's code — it is the exception, not the pattern to copy.
+
+The user guide under `docs/` is a separate npm package with its own lockfile. A root `npm ci` does not reach it, and `npm run docs:*` fails with `vitepress: not found` until `npm ci --prefix docs` has been run once; [CONTRIBUTING.md](CONTRIBUTING.md) covers the rest of that workflow.
+
 ## Commands
 
 See `package.json` scripts. To run a single test file (not exposed as a script): `node --test tests/unit/azure-sign.test.cjs`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,11 @@ Line breaks still mean something everywhere else, and none of this touches them:
 
 `npm ci` at the repository root, on the Node pinned in [`.nvmrc`](.nvmrc).
 
-Do not add `--ignore-scripts`. `postinstall` is where a usable tree comes from: `electron-builder install-app-deps` fetches the Electron binary and rebuilds the native file-locking module against its ABI, and `npm run build:once` generates `src/renderer/index.js` and `index.css`, which are not committed. Skip it and there is no renderer to load and no Electron to load it. The lint workflow installs that way deliberately, so that it never executes the pull request's code — it is the exception, not the pattern to copy.
+Do not add `--ignore-scripts`. The root `postinstall` is what makes the tree usable: `electron-builder install-app-deps` rebuilds the native file-locking module against Electron's ABI, and `npm run build:once` generates `src/renderer/index.js` and `index.css`, which are not committed. Skip it and there is no renderer to load. The lint workflow installs that way deliberately, so that it never executes the pull request's code — it is the exception, not the pattern to copy.
+
+The Electron binary is not part of that. `electron` ships no install script of its own; `require('electron')` downloads it into `node_modules/electron/dist/` the first time something asks for it. So a finished `npm ci` still has that download in front of the first `npm start`, `npm run test:electron` or end-to-end run.
+
+The `allowScripts` map in `package.json` is npm's install-script approval list, and a fresh install warns about the few packages it does not cover. That warning is expected; approving more is a change to make deliberately, not a step in getting set up.
 
 The user guide under `docs/` is a separate npm package with its own lockfile. A root `npm ci` does not reach it, and `npm run docs:*` fails with `vitepress: not found` until `npm ci --prefix docs` has been run once; [CONTRIBUTING.md](CONTRIBUTING.md) covers the rest of that workflow.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,11 +78,11 @@ Line breaks still mean something everywhere else, and none of this touches them:
 
 `npm ci` at the repository root, on the Node pinned in [`.nvmrc`](.nvmrc).
 
-Do not add `--ignore-scripts`. The root `postinstall` is what makes the tree usable: `electron-builder install-app-deps` rebuilds the native file-locking module against Electron's ABI, and `npm run build:once` generates `src/renderer/index.js` and `index.css`, which are not committed. Skip it and there is no renderer to load. The lint workflow installs that way deliberately, so that it never executes the pull request's code — it is the exception, not the pattern to copy.
+Do not add `--ignore-scripts`. The root `postinstall` is what makes the tree usable.
 
-The Electron binary is not part of that. `electron` ships no install script of its own; `require('electron')` downloads it into `node_modules/electron/dist/` the first time something asks for it. So a finished `npm ci` still has that download in front of the first `npm start`, `npm run test:electron` or end-to-end run.
+Notice that a finished `npm ci` still has to download the Electron binary. `electron` ships no install script of its own; `require('electron')` downloads it into `node_modules/electron/dist/` the first time something asks for it.
 
-The `allowScripts` map in `package.json` is npm's install-script approval list, and a fresh install warns about the few packages it does not cover. That warning is expected; approving more is a change to make deliberately, not a step in getting set up.
+The `allowScripts` map in `package.json` is npm's install-script approval list, and a fresh install warns about the few packages it does not cover. That warning is expected.
 
 The user guide under `docs/` is a separate npm package with its own lockfile. A root `npm ci` does not reach it, and `npm run docs:*` fails with `vitepress: not found` until `npm ci --prefix docs` has been run once; [CONTRIBUTING.md](CONTRIBUTING.md) covers the rest of that workflow.
 


### PR DESCRIPTION
Adds a "Bootstrap" section to `AGENTS.md` with instruction on how to set up a new checkout.

<details>
<summary>AI-generated details</summary>

## Why

`AGENTS.md` tells an agent how to review, how to write Markdown here and how to run one test file, but never how to get an installed tree to run any of it in. Those steps existed only in `README.md`, written for a human building from source, and in `CONTRIBUTING.md`, written to explain what CI does — neither is where an agent looks first, and neither says which parts are traps.

This came up while working on another branch: an agent following `AGENTS.md` had no documented install step and had to infer one from the workflow files.

## What changes

A `Bootstrap` section above `Commands`, holding only what a reader cannot deduce from `package.json`: what the root `postinstall` actually produces, why `--ignore-scripts` is the wrong shortcut even though the lint workflow uses it, when the Electron binary is really downloaded, and that `docs/` is a separate package with its own lockfile. It points at `CONTRIBUTING.md` for the docs workflow rather than restating it.

One thing the second commit corrects rather than adds. The workflow comments say `postinstall` pulls the Electron binary. Running a clean `npm ci` and looking shows it does not: `electron` ships no install script, `node_modules/electron/dist/` is absent when the install finishes, and it appears the first time something requires `electron`. So a finished install still has a download in front of the first `npm start` or E2E run, which is worth knowing when a first run seems to hang.

## How to test this

Platforms: any — this is documentation, and the claims in it were checked on macOS.

**Starting state:** a clean checkout of this branch with no `node_modules`.

1. `npm ci` at the root. It should exit 0, warn about the packages `allowScripts` does not cover, and leave `src/renderer/index.js` and `src/renderer/index.css` on disk.
2. `ls node_modules/electron/dist` — should not exist yet.
3. `node -e "console.log(require('electron'))"` — prints `Downloading Electron binary...`, then a path under `node_modules/electron/dist/`.

**What must not have happened:** none of the section's claims should hold only on one machine. If step 2 finds a `dist/` directory already there, the paragraph about the lazy download is wrong for that setup and should be fixed rather than left to mislead.

## Risks and limitations

Documentation only; no code path changes. The three steps above were run on macOS with Node 24.19.0 against `.nvmrc`'s 24.18.0 — close but not identical, so a Windows or exact-version run confirming the same behaviour would be worth having before treating it as settled.

## Related

Follow-up to work on #391.


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance covering dependency installation, Node.js version requirements, install scripts, Electron downloads, expected warnings, and documentation-package setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->