### PR TITLE
[Fix] Stop a build from spawning processes without bound (#275)

### DIFF
--- a/src/electron-node-compat.js
+++ b/src/electron-node-compat.js
@@ -1,0 +1,64 @@
+// Preloaded (via NODE_OPTIONS=--require) into every descendant Node process, so
+// that the tools this app spawns see the plain Node they are actually running
+// on.
+//
+// Why this is needed: the only `node` on PATH is the shim written by
+// ensureNodeShimDir() in main.js, and that shim is Electron under
+// ELECTRON_RUN_AS_NODE. Electron keeps `process.versions.electron` set in that
+// mode, and a command-line tool built on yargs reads exactly that to decide
+// where its arguments begin — `yargs/helpers.hideBin` reads "electron set,
+// defaultApp unset" as a packaged Electron app and slices argv one element
+// short. Every such tool then sees its own executable path as the first
+// argument it was passed.
+//
+// For a task runner that extra argument is a command to run, so it runs itself
+// with no arguments, and the copy it starts does the same, without end: a
+// Gutenberg build reached ~1300 processes before the machine gave out (#275).
+// The runaway processes are only the loudest form of the failure — the general
+// one is that every yargs-based tool reached through the shim misreads its
+// arguments, quietly.
+//
+// Deliberately self-contained (no requires at all): this file is copied into the
+// temp shim dir and required from there, because --require into a path inside
+// app.asar is not reliable under ELECTRON_RUN_AS_NODE.
+
+// Only `versions.electron` is hidden, and the narrowness is load-bearing.
+//
+// `versions.chrome` was hidden alongside it at first — it is the other half of
+// how the runtime describes itself — and that broke Gutenberg's bundling step
+// outright, while the recursion it was meant to help with was already gone.
+// Build tooling reads `chrome` to decide what it is compiling for, which is a
+// question about the output, not about who is running the compiler. `versions.v8`
+// carries an `-electron` suffix and is left alone for the same reason, plus a
+// blunter one: tools parse it as a version number.
+//
+// So this hides the runtime from code asking "am I inside Electron?", and hides
+// nothing from code asking "what can I emit?".
+const ELECTRON_VERSION_KEYS = ['electron'];
+
+// Returns the keys actually removed, so a caller (and the tests) can tell the
+// difference between "nothing to hide" and "could not hide it". A frozen
+// `versions` object would make the delete a silent no-op in sloppy mode, hence
+// re-reading the key rather than trusting `delete`'s return value.
+// A default parameter, not `proc || process`: falling back on a null argument
+// would quietly strip the *current* process, which under the Electron test pass
+// is the suite itself.
+function hideElectronRuntime(proc = process) {
+	const versions = proc && proc.versions;
+	if (!versions) return [];
+	const hidden = [];
+	for (const key of ELECTRON_VERSION_KEYS) {
+		if (versions[key] === undefined) continue;
+		delete versions[key];
+		if (versions[key] === undefined) hidden.push(key);
+	}
+	return hidden;
+}
+
+// Only self-applies when the app explicitly asked for it, so requiring this
+// module from a test never mutates the test process.
+if (process.env.WPTK_NODE_COMPAT === '1') {
+	hideElectronRuntime(process);
+}
+
+module.exports = { hideElectronRuntime, ELECTRON_VERSION_KEYS };

--- a/src/main.js
+++ b/src/main.js
@@ -250,6 +250,7 @@ function spawnRunner(runnerPath, args, { cwd, extraEnv = {} }) {
 			spawnPatchPath,
 			npmCliPath,
 			npxCliPath,
+			nodeCompatPath,
 			extraEnv
 		}),
 		shell: false,

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const {
 	buildChildEnv,
 	RELAXED_ENGINES_ENV
 } = require('./npm-runner');
+const { nodeShim, cliShim } = require('./node-shims.cjs');
 const {
 	initLogging,
 	getLogFilePath,
@@ -155,15 +156,32 @@ let nodeShimDir = null;
 // shims, preloaded into descendant Node processes via NODE_OPTIONS so that a
 // bare spawn('node') hitting node.cmd does not fail with EINVAL.
 let spawnPatchPath = null;
+// All platforms: absolute path of the runtime-identity patch copied next to the
+// shims, and `--require`d by each of them so that a tool started through the
+// shim sees plain Node instead of Electron (#275). See node-shims.cjs.
+let nodeCompatPath = null;
 let npmCliPath = null;
 let npxCliPath = null;
 function ensureNodeShimDir() {
     if (nodeShimDir) return nodeShimDir;
     nodeShimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
     fse.ensureDirSync(nodeShimDir);
+    // Copied out of the app bundle for the same reason as win-spawn-patch below:
+    // a --require path inside app.asar is not reliably resolvable under
+    // ELECTRON_RUN_AS_NODE. Must happen before the shims are written, since each
+    // of them names this path. A failure here is non-fatal on its own terms — the
+    // shims are still written, just without the preload — but it is what keeps a
+    // build from running away, so it is worth a log line.
+    try {
+        const dest = path.join(nodeShimDir, 'electron-node-compat.js');
+        fs.copyFileSync(path.join(__dirname, 'electron-node-compat.js'), dest);
+        nodeCompatPath = dest;
+    } catch (e) {
+        process.stderr.write(`Could not install the Node compatibility preload: ${String(e && e.message ? e.message : e)}\n`);
+    }
     try {
         if (process.platform === 'win32') {
-            const content = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" %*\r\n`;
+            const content = nodeShim({ execPath: process.execPath, compatPath: nodeCompatPath });
             fs.writeFileSync(path.join(nodeShimDir, 'node.cmd'), content);
             fs.writeFileSync(path.join(nodeShimDir, 'node.bat'), content);
             // Provide npm/npx shims that invoke npm's CLI through Electron's Node
@@ -174,8 +192,8 @@ function ensureNodeShimDir() {
                 const npxCliAbsPath = path.join(npmRootDir, 'bin', 'npx-cli.js');
                 npmCliPath = npmCliAbsPath;
                 npxCliPath = npxCliAbsPath;
-                const npmCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npmCliAbsPath}" %*\r\n`;
-                const npxCmd = `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n"${process.execPath}" "${npxCliAbsPath}" %*\r\n`;
+                const npmCmd = cliShim({ execPath: process.execPath, compatPath: nodeCompatPath, cliPath: npmCliAbsPath });
+                const npxCmd = cliShim({ execPath: process.execPath, compatPath: nodeCompatPath, cliPath: npxCliAbsPath });
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.cmd'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npm.bat'), npmCmd);
                 fs.writeFileSync(path.join(nodeShimDir, 'npx.cmd'), npxCmd);
@@ -193,7 +211,7 @@ function ensureNodeShimDir() {
             // Intentionally do NOT create node.exe here, as Electron's exe depends on adjacent DLLs.
             // Using node.exe from a temp dir causes STATUS_DLL_NOT_FOUND (0xC0000135) when spawned by npm.
         } else {
-            const content = `#!/usr/bin/env bash\nELECTRON_RUN_AS_NODE=1 "${process.execPath}" "$@"\n`;
+            const content = nodeShim({ execPath: process.execPath, compatPath: nodeCompatPath });
             fs.writeFileSync(path.join(nodeShimDir, 'node'), content, { mode: 0o755 });
             // Provide npm/npx shims that invoke npm's CLI through Electron's Node
             try {
@@ -201,8 +219,8 @@ function ensureNodeShimDir() {
                 const npmRootDir = path.dirname(npmPkgJsonPath);
                 const npmCliAbsPath = path.join(npmRootDir, 'bin', 'npm-cli.js');
                 const npxCliAbsPath = path.join(npmRootDir, 'bin', 'npx-cli.js');
-                const npmSh = `#!/usr/bin/env bash\nELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${npmCliAbsPath}" "$@"\n`;
-                const npxSh = `#!/usr/bin/env bash\nELECTRON_RUN_AS_NODE=1 "${process.execPath}" "${npxCliAbsPath}" "$@"\n`;
+                const npmSh = cliShim({ execPath: process.execPath, compatPath: nodeCompatPath, cliPath: npmCliAbsPath });
+                const npxSh = cliShim({ execPath: process.execPath, compatPath: nodeCompatPath, cliPath: npxCliAbsPath });
                 fs.writeFileSync(path.join(nodeShimDir, 'npm'), npmSh, { mode: 0o755 });
                 fs.writeFileSync(path.join(nodeShimDir, 'npx'), npxSh, { mode: 0o755 });
             } catch {}
@@ -227,6 +245,7 @@ function spawnRunner(runnerPath, args, { cwd, extraEnv = {} }) {
 		env: buildChildEnv({
 			shimDir: ensureNodeShimDir(),
 			spawnPatchPath,
+			nodeCompatPath,
 			npmCliPath,
 			npxCliPath,
 			extraEnv

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,10 @@ function ensureNodeShimDir() {
         fs.copyFileSync(path.join(__dirname, 'electron-node-compat.js'), dest);
         nodeCompatPath = dest;
     } catch (e) {
-        process.stderr.write(`Could not install the Node compatibility preload: ${String(e && e.message ? e.message : e)}\n`);
+        // The app's own log, not stderr: a packaged app has no terminal
+        // attached, so a stream write would go nowhere on the one path that
+        // decides whether a build can run away.
+        logError('app', `Could not install the Node compatibility preload: ${String(e && e.message ? e.message : e)}`);
     }
     try {
         if (process.platform === 'win32') {
@@ -245,7 +248,6 @@ function spawnRunner(runnerPath, args, { cwd, extraEnv = {} }) {
 		env: buildChildEnv({
 			shimDir: ensureNodeShimDir(),
 			spawnPatchPath,
-			nodeCompatPath,
 			npmCliPath,
 			npxCliPath,
 			extraEnv

--- a/src/main.js
+++ b/src/main.js
@@ -169,18 +169,19 @@ function ensureNodeShimDir() {
     // Copied out of the app bundle for the same reason as win-spawn-patch below:
     // a --require path inside app.asar is not reliably resolvable under
     // ELECTRON_RUN_AS_NODE. Must happen before the shims are written, since each
-    // of them names this path. A failure here is non-fatal on its own terms — the
-    // shims are still written, just without the preload — but it is what keeps a
-    // build from running away, so it is worth a log line.
+    // of them names this path. A failure here is fatal, not a degraded mode:
+    // shims without the preload are the state #275 describes, and a build
+    // launched into them hangs the machine rather than failing. The directory
+    // is forgotten so the next call tries again instead of handing out a
+    // remembered path with nothing in it; the caller reports a run that never
+    // started, which is the surface the person who clicked the button can see.
     try {
         const dest = path.join(nodeShimDir, 'electron-node-compat.js');
         fs.copyFileSync(path.join(__dirname, 'electron-node-compat.js'), dest);
         nodeCompatPath = dest;
     } catch (e) {
-        // The app's own log, not stderr: a packaged app has no terminal
-        // attached, so a stream write would go nowhere on the one path that
-        // decides whether a build can run away.
-        logError('app', `Could not install the Node compatibility preload: ${String(e && e.message ? e.message : e)}`);
+        nodeShimDir = null;
+        throw new Error(`Could not install the Node compatibility preload: ${String(e && e.message ? e.message : e)}`);
     }
     try {
         if (process.platform === 'win32') {
@@ -2686,10 +2687,25 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 		// Windows) produces no output, so without this the log would show nothing
 		// where the failure was.
 		logEvent(logScope, `spawn ${path.basename(runnerPath)} ${args.join(' ')} in ${cwd}${relaxEngines ? ' (relaxed engines)' : ''}`);
-		const child = spawnRunner(runnerPath, args, {
-			cwd,
-			extraEnv: relaxEngines ? RELAXED_ENGINES_ENV : {}
-		});
+		let child;
+		try {
+			child = spawnRunner(runnerPath, args, {
+				cwd,
+				extraEnv: relaxEngines ? RELAXED_ENGINES_ENV : {}
+			});
+		} catch (err) {
+			// Synchronous, unlike a spawn failure: the shim directory refused to
+			// hand out shims without the compat preload (#275). Same surface as
+			// the 'error' path below, and settled a turn later for the same
+			// reason: the handler has not stored the run yet.
+			logError(logScope, `could not start: ${String(err)}`);
+			onLog('stderr', `\nFailed to start: ${err && err.message ? err.message : String(err)}\n`);
+			setTimeout(() => {
+				logEvent(logScope, 'never started; shims not written');
+				onDone(null);
+			}, 0);
+			return;
+		}
 		register(child);
 
 		const detector = createEngineMismatchDetector();

--- a/src/node-shims.cjs
+++ b/src/node-shims.cjs
@@ -1,0 +1,60 @@
+'use strict';
+
+// The contents of the `node`, `npm` and `npx` shims the app writes onto PATH for
+// every child process it starts (see ensureNodeShimDir in main.js). Pure string
+// building, no fs and no electron, so the one property these shims must hold can
+// be unit-tested without spawning anything.
+//
+// That property is the preload. The shims point at Electron running under
+// ELECTRON_RUN_AS_NODE, and Electron keeps `process.versions.electron` set in
+// that mode — which makes every yargs-based tool misread its own arguments and,
+// for a task runner, spawn itself without end (#275, and see
+// electron-node-compat.js for the mechanism).
+//
+// The preload is passed as an explicit `--require` argument rather than through
+// NODE_OPTIONS. NODE_OPTIONS is how win-spawn-patch.js reaches descendants, and
+// it is the right tool there — it has to reach a process several levels down that
+// we never invoke ourselves. Here we are the one invoking the process, and
+// measurement showed NODE_OPTIONS did not survive every chain reliably: an
+// argument does, always, because it is not inherited at all. It also confines the
+// patch to processes that actually go through the shim, instead of leaking into
+// every unrelated Node process a build happens to start.
+
+// Set alongside the flag so the preload only acts when the app asked for it —
+// requiring the module in a test must not mutate the test's own process.
+const COMPAT_FLAG = 'WPTK_NODE_COMPAT';
+
+// `--require` is separated from the arguments the caller passed, so a shim
+// invoked as `node -e …` still ends up as `node --require … -e …`.
+function requireArgs(compatPath) {
+	return compatPath ? `--require "${compatPath}" ` : '';
+}
+
+// POSIX shims are bash scripts. The compat path is interpolated into a quoted
+// argument, so spaces are safe; unlike NODE_OPTIONS, nothing re-tokenises it.
+function posixShim({ execPath, compatPath, cliPath = null }) {
+	const flag = compatPath ? `${COMPAT_FLAG}=1 ` : '';
+	const cli = cliPath ? `"${cliPath}" ` : '';
+	return `#!/usr/bin/env bash\n${flag}ELECTRON_RUN_AS_NODE=1 "${execPath}" ${requireArgs(compatPath)}${cli}"$@"\n`;
+}
+
+// Windows shims are .cmd/.bat. Backslashes inside a quoted command-line argument
+// are literal — the escaping problem that forces forward slashes in NODE_OPTIONS
+// does not exist here, so the path goes in as the OS spells it.
+function windowsShim({ execPath, compatPath, cliPath = null }) {
+	const flag = compatPath ? `set ${COMPAT_FLAG}=1\r\n` : '';
+	const cli = cliPath ? `"${cliPath}" ` : '';
+	return `@echo off\r\nset ELECTRON_RUN_AS_NODE=1\r\n${flag}"${execPath}" ${requireArgs(compatPath)}${cli}%*\r\n`;
+}
+
+function nodeShim({ execPath, compatPath, platform = process.platform }) {
+	const build = platform === 'win32' ? windowsShim : posixShim;
+	return build({ execPath, compatPath });
+}
+
+function cliShim({ execPath, compatPath, cliPath, platform = process.platform }) {
+	const build = platform === 'win32' ? windowsShim : posixShim;
+	return build({ execPath, compatPath, cliPath });
+}
+
+module.exports = { nodeShim, cliShim, COMPAT_FLAG };

--- a/src/node-shims.cjs
+++ b/src/node-shims.cjs
@@ -18,7 +18,10 @@
 // measurement showed NODE_OPTIONS did not survive every chain reliably: an
 // argument does, always, because it is not inherited at all. It also confines the
 // patch to processes that actually go through the shim, instead of leaking into
-// every unrelated Node process a build happens to start.
+// every unrelated Node process a build happens to start. The one other route to
+// Electron-as-Node is the Windows spawn patch, which redirects `spawn('node')`
+// straight to the binary; it re-attaches the same `--require` from
+// WPTK_NODE_COMPAT_PATH so both routes present the same runtime.
 
 // Set alongside the flag so the preload only acts when the app asked for it —
 // requiring the module in a test must not mutate the test's own process.

--- a/src/npm-runner.js
+++ b/src/npm-runner.js
@@ -75,7 +75,8 @@ function buildChildEnv({
 	execPath = process.execPath,
 	spawnPatchPath = null,
 	npmCliPath = null,
-	npxCliPath = null
+	npxCliPath = null,
+	nodeCompatPath = null
 } = {}) {
 	const isWindows = platform === 'win32';
 	const separator = isWindows ? ';' : ':';
@@ -114,6 +115,10 @@ function buildChildEnv({
 		env.WPTK_SPAWN_PATCH = '1';
 		if (npmCliPath) env.WPTK_NPM_CLI = npmCliPath;
 		if (npxCliPath) env.WPTK_NPX_CLI = npxCliPath;
+		// The spawns the patch redirects skip the node.cmd shim, so the patch
+		// re-attaches the compat preload itself (#275); this is where it is.
+		// A native path: it goes in as an argument, never through NODE_OPTIONS.
+		if (nodeCompatPath) env.WPTK_NODE_COMPAT_PATH = nodeCompatPath;
 	}
 	return { ...env, ...extraEnv };
 }

--- a/src/win-spawn-patch.js
+++ b/src/win-spawn-patch.js
@@ -76,10 +76,23 @@ function quoteForCmd(value) {
 }
 
 // Clones the caller's env (or inherits process.env) and forces Electron into
-// Node mode, since the command we redirect to is electron.exe.
-function withNodeMode(options) {
+// Node mode, since the command we redirect to is electron.exe. When the app
+// installed the runtime-identity preload, the flag it acts on travels too.
+function withNodeMode(options, nodeCompatPath) {
 	const baseEnv = options && options.env ? options.env : process.env;
-	return { ...options, env: { ...baseEnv, ELECTRON_RUN_AS_NODE: '1' } };
+	const env = { ...baseEnv, ELECTRON_RUN_AS_NODE: '1' };
+	if (nodeCompatPath) env.WPTK_NODE_COMPAT = '1';
+	return { ...options, env };
+}
+
+// The redirect below skips the node.cmd shim, and with it the `--require` of
+// electron-node-compat.js the shim carries (#275, see node-shims.cjs). Without
+// re-attaching it here a tool reached through `spawn('node', …)` sees
+// `versions.electron` again and misreads its own arguments. An argument, not
+// NODE_OPTIONS, for the reason given in node-shims.cjs; a native path, because
+// a quoted argument is literal and nothing re-tokenises it.
+function preloadArgs(nodeCompatPath) {
+	return nodeCompatPath ? ['--require', nodeCompatPath] : [];
 }
 
 // Decides how a child_process call must be rewritten. Returns null when the call
@@ -92,6 +105,7 @@ function resolveSpawnTarget({
 	execPath = process.execPath,
 	npmCliPath = null,
 	npxCliPath = null,
+	nodeCompatPath = null,
 	env = process.env,
 	lookup = defaultLookup
 } = {}) {
@@ -103,13 +117,13 @@ function resolveSpawnTarget({
 	// Preferred path: call Electron's binary directly. No shell, so no quoting
 	// hazard, and it works even when the .cmd shim is missing entirely.
 	if (name === 'node') {
-		return { file: execPath, args: [...args], options: withNodeMode(options) };
+		return { file: execPath, args: [...preloadArgs(nodeCompatPath), ...args], options: withNodeMode(options, nodeCompatPath) };
 	}
 	if (name === 'npm' && npmCliPath) {
-		return { file: execPath, args: [npmCliPath, ...args], options: withNodeMode(options) };
+		return { file: execPath, args: [...preloadArgs(nodeCompatPath), npmCliPath, ...args], options: withNodeMode(options, nodeCompatPath) };
 	}
 	if (name === 'npx' && npxCliPath) {
-		return { file: execPath, args: [npxCliPath, ...args], options: withNodeMode(options) };
+		return { file: execPath, args: [...preloadArgs(nodeCompatPath), npxCliPath, ...args], options: withNodeMode(options, nodeCompatPath) };
 	}
 
 	// A bare `tar` goes to Windows's bsdtar, which understands drive letters. An
@@ -183,7 +197,8 @@ function applyPatch(childProcess = require('child_process'), config = {}) {
 if (process.env.WPTK_SPAWN_PATCH === '1') {
 	applyPatch(require('child_process'), {
 		npmCliPath: process.env.WPTK_NPM_CLI || null,
-		npxCliPath: process.env.WPTK_NPX_CLI || null
+		npxCliPath: process.env.WPTK_NPX_CLI || null,
+		nodeCompatPath: process.env.WPTK_NODE_COMPAT_PATH || null
 	});
 }
 

--- a/tests/unit/electron-node-compat.test.cjs
+++ b/tests/unit/electron-node-compat.test.cjs
@@ -1,0 +1,154 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { hideElectronRuntime, ELECTRON_VERSION_KEYS } = require('../src/electron-node-compat.js');
+const { COMPAT_FLAG } = require('../src/node-shims.cjs');
+
+const COMPAT_PATH = path.join(__dirname, '..', 'src', 'electron-node-compat.js');
+
+// The detection this patch exists to defeat, spelled out rather than described:
+// `yargs/helpers.hideBin` slices process.argv from here, and reads "electron set,
+// defaultApp unset" as a packaged Electron app whose argv carries no script path.
+// Under ELECTRON_RUN_AS_NODE both halves hold while a script path *is* present,
+// so every yargs-based tool starts reading one argument too early (#275).
+function yargsArgvStart(proc) {
+	const isElectronApp = Boolean(proc.versions && proc.versions.electron);
+	const isBundledElectronApp = isElectronApp && !proc.defaultApp;
+	return isBundledElectronApp ? 1 : 2;
+}
+
+function fakeElectronProcess() {
+	return {
+		versions: {
+			node: '24.18.0',
+			electron: '43.2.0',
+			chrome: '150.0.7871.129',
+			v8: '15.0.1240245-electron.0'
+		}
+	};
+}
+
+test('hideElectronRuntime makes an Electron runtime describe itself as Node', () => {
+	const proc = fakeElectronProcess();
+
+	assert.deepEqual(hideElectronRuntime(proc), ELECTRON_VERSION_KEYS);
+	assert.equal(proc.versions.electron, undefined);
+	// Node's own identity has to survive: this hides a runtime, it does not fake one.
+	assert.equal(proc.versions.node, '24.18.0');
+	// Left alone on purpose — tools parse it as a version number.
+	assert.equal(proc.versions.v8, '15.0.1240245-electron.0');
+});
+
+// The bug itself, at the only layer where it can be pinned deterministically on
+// both runtimes: not "a key is gone" but "argument parsing lands where it should".
+test('hiding the runtime moves a yargs-style tool back onto its real arguments', () => {
+	const proc = fakeElectronProcess();
+	// What the shim actually produces: the Electron binary, the tool, its args.
+	const argv = ['/path/to/Electron', '/site/node_modules/.bin/runner', 'npm run build:js'];
+
+	assert.equal(yargsArgvStart(proc), 1);
+	// One argument too few is sliced off, so the tool's own path arrives as the
+	// first thing the user supposedly asked for. For a task runner that is a
+	// command to run — itself, with no arguments — and the copy it starts does
+	// the same, without end.
+	assert.deepEqual(argv.slice(yargsArgvStart(proc)), [
+		'/site/node_modules/.bin/runner',
+		'npm run build:js'
+	]);
+
+	hideElectronRuntime(proc);
+
+	assert.equal(yargsArgvStart(proc), 2);
+	assert.deepEqual(argv.slice(yargsArgvStart(proc)), ['npm run build:js']);
+});
+
+// Widening this set is the tempting change — the runtime still describes itself
+// as Chrome-flavoured — and it is the one that must not be made silently.
+// Hiding `versions.chrome` as well fails Gutenberg's bundling step outright,
+// because build tooling reads it to decide what to compile for. That question is
+// about the output, not about who is running the compiler.
+test('the Chrome version is deliberately left in place', () => {
+	const proc = fakeElectronProcess();
+
+	hideElectronRuntime(proc);
+
+	assert.equal(proc.versions.chrome, '150.0.7871.129');
+	assert.deepEqual(ELECTRON_VERSION_KEYS, ['electron']);
+});
+
+test('hideElectronRuntime reports honestly when there is nothing to hide', () => {
+	const plainNode = { versions: { node: '24.18.0', v8: '13.6.233.10' } };
+
+	assert.deepEqual(hideElectronRuntime(plainNode), []);
+	assert.equal(plainNode.versions.node, '24.18.0');
+
+	assert.deepEqual(hideElectronRuntime({}), []);
+	assert.deepEqual(hideElectronRuntime(null), []);
+});
+
+// A frozen `versions` makes `delete` a silent no-op in sloppy mode. Claiming
+// success there would be worse than failing: the caller would stop looking.
+test('hideElectronRuntime does not claim a removal it could not make', () => {
+	const frozen = { versions: Object.freeze({ node: '24.18.0', electron: '43.2.0' }) };
+
+	assert.deepEqual(hideElectronRuntime(frozen), []);
+	assert.equal(frozen.versions.electron, '43.2.0');
+});
+
+// Everything above works on a fake process. These two spawn a real child, so
+// they also cover the wiring — and under `npm run test:electron` the child is
+// Electron, which is the only place the bug can actually occur.
+const REPORT_RUNTIME = 'process.stdout.write(JSON.stringify({'
+	+ 'electron: process.versions.electron || null,'
+	+ 'chrome: process.versions.chrome || null,'
+	+ 'node: process.versions.node || null'
+	+ '}))';
+
+// Mirrors what the shim does: --require as an argument, plus the flag that lets
+// the preload act. See node-shims.cjs.
+function runtimeOfChild({ preload = true, flag = true } = {}) {
+	const env = { ...process.env, ELECTRON_RUN_AS_NODE: '1' };
+	delete env[COMPAT_FLAG];
+	if (flag) env[COMPAT_FLAG] = '1';
+
+	const args = preload ? ['--require', COMPAT_PATH, '-e', REPORT_RUNTIME] : ['-e', REPORT_RUNTIME];
+	const result = spawnSync(process.execPath, args, {
+		env,
+		encoding: 'utf8',
+		shell: false,
+		windowsHide: true
+	});
+	assert.equal(result.status, 0, `child failed: ${result.stderr}`);
+	return JSON.parse(result.stdout);
+}
+
+test('a child started the way the shim starts one sees plain Node', () => {
+	const runtime = runtimeOfChild();
+
+	assert.equal(runtime.electron, null);
+	assert.ok(runtime.node, 'the child still reports a Node version');
+});
+
+// Under `npm run test:electron` this is the assertion that would have caught the
+// bug: without the preload the child really is an Electron pretending to be Node.
+// On the system Node it is vacuous, and CI runs the suite on both.
+test('without the preload the child still looks like Electron', () => {
+	if (!process.versions.electron) return;
+
+	const runtime = runtimeOfChild({ preload: false });
+
+	assert.equal(runtime.electron, process.versions.electron);
+});
+
+// The preload is loaded by anything that requires the module — including this
+// suite. It must stay inert unless the app asked for it, or the Electron test
+// pass would strip its own runtime out from under the other tests.
+test('the preload stays inert without the flag the shim sets', () => {
+	if (!process.versions.electron) return;
+
+	const runtime = runtimeOfChild({ flag: false });
+
+	assert.equal(runtime.electron, process.versions.electron);
+});

--- a/tests/unit/electron-node-compat.test.cjs
+++ b/tests/unit/electron-node-compat.test.cjs
@@ -3,10 +3,10 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const { hideElectronRuntime, ELECTRON_VERSION_KEYS } = require('../src/electron-node-compat.js');
-const { COMPAT_FLAG } = require('../src/node-shims.cjs');
+const { hideElectronRuntime, ELECTRON_VERSION_KEYS } = require('../../src/electron-node-compat.js');
+const { COMPAT_FLAG } = require('../../src/node-shims.cjs');
 
-const COMPAT_PATH = path.join(__dirname, '..', 'src', 'electron-node-compat.js');
+const COMPAT_PATH = path.join(__dirname, '..', '..', 'src', 'electron-node-compat.js');
 
 // The detection this patch exists to defeat, spelled out rather than described:
 // `yargs/helpers.hideBin` slices process.argv from here, and reads "electron set,

--- a/tests/unit/electron-node-compat.test.cjs
+++ b/tests/unit/electron-node-compat.test.cjs
@@ -134,8 +134,10 @@ test('a child started the way the shim starts one sees plain Node', () => {
 // Under `npm run test:electron` this is the assertion that would have caught the
 // bug: without the preload the child really is an Electron pretending to be Node.
 // On the system Node it is vacuous, and CI runs the suite on both.
-test('without the preload the child still looks like Electron', () => {
-	if (!process.versions.electron) return;
+test('without the preload the child still looks like Electron', (t) => {
+	// Reported as skipped rather than passed: on the system Node this asserts
+	// nothing, and a silent pass is how a one-runtime test goes unnoticed.
+	if (!process.versions.electron) return t.skip('needs the Electron runtime');
 
 	const runtime = runtimeOfChild({ preload: false });
 
@@ -145,8 +147,8 @@ test('without the preload the child still looks like Electron', () => {
 // The preload is loaded by anything that requires the module — including this
 // suite. It must stay inert unless the app asked for it, or the Electron test
 // pass would strip its own runtime out from under the other tests.
-test('the preload stays inert without the flag the shim sets', () => {
-	if (!process.versions.electron) return;
+test('the preload stays inert without the flag the shim sets', (t) => {
+	if (!process.versions.electron) return t.skip('needs the Electron runtime');
 
 	const runtime = runtimeOfChild({ flag: false });
 

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -1825,6 +1825,25 @@ function assertChildEnvRequest(buildChildEnv, label) {
 	}
 }
 
+// The shims on disk, not the module that formats them. node-shims.cjs is unit
+// tested, but it is main.js that decides whether to hand it the preload path at
+// all — and blanking that argument reintroduces #275 (a build that spawns
+// processes without bound) while every other test in the repo stays green.
+// ensureNodeShimDir cannot be stubbed, so the shims it really wrote are the
+// evidence; the `after` hook above sweeps them.
+function assertShimsPreloadCompat(label) {
+	const shimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
+	const compat = path.join(shimDir, 'electron-node-compat.js');
+	assert.ok(fs.existsSync(compat), `${label}: the compat preload was not copied next to the shims`);
+
+	const shimName = process.platform === 'win32' ? 'node.cmd' : 'node';
+	const shim = fs.readFileSync(path.join(shimDir, shimName), 'utf8');
+	assert.ok(
+		shim.includes(`--require "${compat}"`),
+		`${label}: the node shim starts a child without the preload, so any yargs-based tool it runs misreads its arguments`
+	);
+}
+
 // The three cross-platform decisions every spawn in main.js makes. No module
 // owns them — they are options handed to child_process, not behaviour someone
 // else can test — so this is the only thing that fails when one is deleted
@@ -1909,6 +1928,8 @@ test('npm:run-script spawns the script runner through npm-runner too', async () 
 	assert.deepEqual(cp.spawned[0].args.slice(1), ['/sites/wp', 'build', '--quiet']);
 	assert.equal(cp.spawned[0].options.env, env);
 	assertChildEnvRequest(buildChildEnv, 'npm:run-script');
+	// The build path: the one a runaway would actually be launched from (#275).
+	assertShimsPreloadCompat('npm:run-script');
 	assertCrossPlatformSpawnOptions(cp.spawned[0].options, 'npm:run-script');
 });
 

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -1933,6 +1933,53 @@ test('npm:run-script spawns the script runner through npm-runner too', async () 
 	assertCrossPlatformSpawnOptions(cp.spawned[0].options, 'npm:run-script');
 });
 
+// The other half of the same wire: a preload that cannot be installed must not
+// degrade into shims without it. That state is #275 exactly, and it is reached
+// silently, the build hangs the machine instead of failing. The way it happens
+// in practice is the source file missing from the packaged bundle (a packaging
+// allow-list that forgot it), so it is the copy that fails here, not the temp
+// directory, which is why the shim writes would otherwise have gone ahead.
+test('npm:run-script refuses to start when the compat preload cannot be installed (#275)', async () => {
+	const shimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
+	// A previous test in this file may have written a good set; the assertion
+	// below is about what this load writes.
+	fs.rmSync(shimDir, { recursive: true, force: true });
+	const cp = stubbedSpawn();
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			'child_process': { spawn: cp.spawn },
+			'fs': {
+				copyFileSync(src, dest, ...rest) {
+					if (path.basename(src) === 'electron-node-compat.js') {
+						throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+					}
+					return fs.copyFileSync(src, dest, ...rest);
+				}
+			}
+		}
+	});
+	const event = createIpcEvent();
+
+	await main.invokeWith('npm:run-script', event, '/sites/wp', 'build');
+	// The refusal is reported a turn later, like a spawn failure, so the handler
+	// has finished its bookkeeping before it is told the run is over.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(cp.spawned.length, 0, 'the runner was started into shims that carry no preload');
+	const shimName = process.platform === 'win32' ? 'node.cmd' : 'node';
+	assert.ok(!fs.existsSync(path.join(shimDir, shimName)), 'a node shim without the preload was written anyway');
+	const stderr = event.sent
+		.filter((m) => m.channel === 'npm:run-script:log' && m.payload.type === 'stderr')
+		.map((m) => m.payload.data)
+		.join('');
+	assert.match(stderr, /Failed to start/, 'the person who clicked the button was not told the run never started');
+	assert.match(stderr, /preload/, 'the reason does not name the preload');
+	const done = event.sent.find((m) => m.channel === 'npm:run-script:done');
+	assert.ok(done, 'the run was never settled, so the renderer waits forever');
+	assert.equal(done.payload.code, null);
+});
+
 test('npm:kill ends the script tree rather than signalling the runner alone', async (t) => {
 	const cp = stubbedSpawn();
 	const killChildTree = spy();

--- a/tests/unit/node-shims.test.cjs
+++ b/tests/unit/node-shims.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { nodeShim, cliShim, COMPAT_FLAG } = require('../src/node-shims.cjs');
+const { nodeShim, cliShim, COMPAT_FLAG } = require('../../src/node-shims.cjs');
 
 const EXEC = {
 	darwin: '/Applications/App.app/Contents/MacOS/App',

--- a/tests/unit/node-shims.test.cjs
+++ b/tests/unit/node-shims.test.cjs
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { nodeShim, cliShim, COMPAT_FLAG } = require('../src/node-shims.cjs');
+
+const EXEC = {
+	darwin: '/Applications/App.app/Contents/MacOS/App',
+	win32: 'C:\\Program Files\\App\\App.exe'
+};
+const COMPAT = {
+	darwin: '/tmp/electron-node-shims-42/electron-node-compat.js',
+	win32: 'C:\\Users\\JuanMa\\AppData\\Local\\Temp\\electron-node-shims-42\\electron-node-compat.js'
+};
+
+// Every shim, on every platform, has to carry the preload. Missing it on one of
+// them is exactly the shape of this bug: a build that runs away only through
+// whichever entry point was forgotten.
+test('every shim preloads the compat patch, on every platform', () => {
+	for (const platform of ['darwin', 'win32']) {
+		const shims = {
+			node: nodeShim({ execPath: EXEC[platform], compatPath: COMPAT[platform], platform }),
+			npm: cliShim({
+				execPath: EXEC[platform],
+				compatPath: COMPAT[platform],
+				cliPath: 'npm-cli.js',
+				platform
+			})
+		};
+
+		for (const [name, script] of Object.entries(shims)) {
+			assert.ok(
+				script.includes(`--require "${COMPAT[platform]}"`),
+				`${platform} ${name} shim does not preload the patch`
+			);
+			assert.ok(script.includes(COMPAT_FLAG), `${platform} ${name} shim does not set the flag`);
+			assert.ok(script.includes('ELECTRON_RUN_AS_NODE=1'), `${platform} ${name} shim`);
+		}
+	}
+});
+
+// The caller's own arguments must arrive untouched and *after* ours — a shim
+// invoked as `node -e …` has to end up as `node --require … -e …`, not the other
+// way round, or the script never runs.
+test('the preload precedes the arguments the caller passed', () => {
+	const posix = nodeShim({ execPath: EXEC.darwin, compatPath: COMPAT.darwin, platform: 'darwin' });
+	assert.ok(posix.endsWith('"$@"\n'));
+	assert.ok(posix.indexOf('--require') < posix.indexOf('"$@"'));
+
+	const win = nodeShim({ execPath: EXEC.win32, compatPath: COMPAT.win32, platform: 'win32' });
+	assert.ok(win.trimEnd().endsWith('%*'));
+	assert.ok(win.indexOf('--require') < win.indexOf('%*'));
+});
+
+// The npm/npx shims run a CLI script; it has to sit between the preload and the
+// caller's arguments, or npm would read `--require` as one of its own.
+test('a CLI shim keeps the preload, the CLI and the arguments in order', () => {
+	const npm = cliShim({
+		execPath: EXEC.darwin,
+		compatPath: COMPAT.darwin,
+		cliPath: '/app/node_modules/npm/bin/npm-cli.js',
+		platform: 'darwin'
+	});
+
+	assert.ok(npm.indexOf('--require') < npm.indexOf('npm-cli.js'));
+	assert.ok(npm.indexOf('npm-cli.js') < npm.indexOf('"$@"'));
+});
+
+// Paths are interpolated into quoted arguments, so a space must not split them.
+// This is the failure mode that would only ever appear on someone else's machine.
+test('a path with spaces stays one argument', () => {
+	const spaced = '/Users/Juan Ma/Library/Application Support/electron-node-compat.js';
+	const shim = nodeShim({ execPath: '/Apps/My App/App', compatPath: spaced, platform: 'darwin' });
+
+	assert.ok(shim.includes(`--require "${spaced}"`));
+	assert.ok(shim.includes('"/Apps/My App/App"'));
+});
+
+// Windows keeps its native separators here. Unlike NODE_OPTIONS — which Node
+// re-tokenises, eating backslashes as escapes — a quoted command-line argument
+// is taken literally, so there is nothing to work around.
+test('the Windows shim keeps backslashes in the preload path', () => {
+	const shim = nodeShim({ execPath: EXEC.win32, compatPath: COMPAT.win32, platform: 'win32' });
+
+	assert.ok(shim.includes(`--require "${COMPAT.win32}"`));
+	assert.ok(shim.includes('\\'));
+	assert.ok(shim.startsWith('@echo off\r\n'));
+});
+
+// Copying the patch out of the bundle is best-effort. Without it the shim must
+// still be a working shim — a build that cannot be patched has to keep running.
+test('a shim without a patch to preload is still a valid shim', () => {
+	const posix = nodeShim({ execPath: EXEC.darwin, compatPath: null, platform: 'darwin' });
+	assert.equal(posix, `#!/usr/bin/env bash\nELECTRON_RUN_AS_NODE=1 "${EXEC.darwin}" "$@"\n`);
+	assert.ok(!posix.includes(COMPAT_FLAG));
+
+	const win = nodeShim({ execPath: EXEC.win32, compatPath: null, platform: 'win32' });
+	assert.ok(!win.includes('--require'));
+	assert.ok(!win.includes(COMPAT_FLAG));
+	assert.ok(win.includes('%*'));
+});

--- a/tests/unit/npm-runner.test.cjs
+++ b/tests/unit/npm-runner.test.cjs
@@ -214,6 +214,40 @@ test('buildChildEnv leaves NODE_OPTIONS alone off Windows or without a patch', (
 	assert.equal(noPatch.WPTK_SPAWN_PATCH, undefined);
 });
 
+// The spawn patch re-attaches the compat preload to the spawns it redirects
+// (see win-spawn-patch.js), and this is how it learns where the file is. A
+// native path: it travels as an argument, never through NODE_OPTIONS, so the
+// backslash problem above does not apply.
+test('buildChildEnv hands the spawn patch the compat preload path on Windows only', () => {
+	const win = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js',
+		nodeCompatPath: 'C:\\shims\\electron-node-compat.js'
+	});
+	assert.equal(win.WPTK_NODE_COMPAT_PATH, 'C:\\shims\\electron-node-compat.js');
+
+	const noCompat = buildChildEnv({
+		shimDir: 'C:\\shims',
+		baseEnv: { PATH: 'C:\\Windows' },
+		platform: 'win32',
+		execPath: 'C:\\App\\App.exe',
+		spawnPatchPath: 'C:\\shims\\win-spawn-patch.js'
+	});
+	assert.equal(noCompat.WPTK_NODE_COMPAT_PATH, undefined);
+
+	const posix = buildChildEnv({
+		shimDir: '/tmp/shims',
+		baseEnv: { PATH: '/usr/bin' },
+		platform: 'darwin',
+		execPath: '/App/Electron',
+		nodeCompatPath: '/tmp/shims/electron-node-compat.js'
+	});
+	assert.equal(posix.WPTK_NODE_COMPAT_PATH, undefined);
+});
+
 test('buildChildEnv applies extraEnv last so the retry can relax engines', () => {
 	const env = buildChildEnv({
 		shimDir: '/shims',

--- a/tests/unit/win-spawn-patch.test.cjs
+++ b/tests/unit/win-spawn-patch.test.cjs
@@ -61,6 +61,28 @@ test('npm and npx are redirected to their JS CLIs', () => {
 	assert.deepEqual(npx.args, [WIN.npxCliPath, 'wp-scripts', 'build']);
 });
 
+// The redirect bypasses the node.cmd shim, so the runtime-identity preload the
+// shim carries (#275) has to be re-attached here or a tool started this way sees
+// `versions.electron` again and misreads its arguments.
+test('the node, npm and npx redirects carry the compat preload when the app installed one', () => {
+	const compat = 'C:\\shims\\electron-node-compat.js';
+	const node = resolveSpawnTarget({ ...WIN, nodeCompatPath: compat, file: 'node', args: ['-e', '1'] });
+	assert.deepEqual(node.args, ['--require', compat, '-e', '1']);
+	assert.equal(node.options.env.WPTK_NODE_COMPAT, '1');
+
+	const npm = resolveSpawnTarget({ ...WIN, nodeCompatPath: compat, file: 'npm', args: ['ci'] });
+	assert.deepEqual(npm.args, ['--require', compat, WIN.npmCliPath, 'ci']);
+
+	const npx = resolveSpawnTarget({ ...WIN, nodeCompatPath: compat, file: 'npx', args: ['x'] });
+	assert.deepEqual(npx.args, ['--require', compat, WIN.npxCliPath, 'x']);
+});
+
+test('without a compat preload the redirects add no --require and no flag', () => {
+	const node = resolveSpawnTarget({ ...WIN, file: 'node', args: ['x.js'] });
+	assert.deepEqual(node.args, ['x.js']);
+	assert.equal(node.options.env.WPTK_NODE_COMPAT, undefined);
+});
+
 test('npm falls through to the shell branch when no npm CLI path is known', () => {
 	const target = resolveSpawnTarget({
 		...WIN,


### PR DESCRIPTION
> Rebased out of the Gutenberg stack (#251) and retargeted at trunk. The rest of that stack — #255, #261, #264, #269 — is closed; this change never depended on it, it only sat on top of it. Continues #283, which could not be retargeted because GitHub locks the base of a stacked PR.

## Why

Building a Gutenberg site never finished. The wizard sat on "Run build" forever while the app spawned processes without bound — over 1,300 in a few minutes, until the machine was unusable and the app had to be killed. Nothing was ever written to `build/`.

The same checkout builds fine outside the app, so this was never a Gutenberg problem. Core sites never hit it either: their build is Grunt, which does not reach the code path below.

Fixes #275.

## What changes

Root cause: the `node`/`npm`/`npx` shims this app puts on `PATH` are Electron running under `ELECTRON_RUN_AS_NODE`, and Electron keeps `process.versions.electron` set in that mode. `yargs` reads exactly that to decide where a command's arguments begin — "electron set, `defaultApp` unset" reads as a packaged Electron app whose argv carries no script path — so **every yargs-based tool started through a shim treats its own executable path as the first argument it was given**.

For a task runner that extra argument is a command to run: itself, with no arguments. The copy it starts does the same, forever. Each link spawns exactly one child, which is why the process tree is an unbounded chain rather than a fan-out.

Argument shifting is the general failure here; the runaway processes are only its loudest form. Other tools reached through the shim have been misreading their arguments quietly.

The fix: each shim now `--require`s a small module that hides the Electron version from the process it starts. Two decisions worth naming, because both were arrived at by measurement rather than by reasoning:

- **An argument, not `NODE_OPTIONS`.** `win-spawn-patch.js` uses `NODE_OPTIONS` and is untouched — it is right there, because it must reach a process several levels down that we never invoke ourselves. Here we *are* the one invoking the process, and `NODE_OPTIONS` did not survive every chain reliably in testing. An argument cannot fail to be inherited, and it confines the patch to processes that actually go through the shim.
- **Only `versions.electron` is hidden, not `versions.chrome`.** Hiding both was the plan; it broke Gutenberg's bundling step outright. Build tooling reads `chrome` to decide what it is compiling *for*, which is a question about the output, not about who is running the compiler.

Deliberately not in this PR: `versions.v8` still carries its `-electron` suffix (tools parse it as a version number), and the shim directory is still a predictable path under `os.tmpdir()`.

## How to test this

Platforms: **any** for the suite. The manual path below was driven on macOS; Windows is covered by unit tests only — see Risks.

**Starting state:** a throwaway package whose only script is `concurrently "npm run a" "npm run b"`, with `concurrently@9`, in a site the app can run a script in. The original Gutenberg path is no longer reachable from trunk — that support lived in the closed stack — and it was never needed to see this: the trigger is the task runner, not Gutenberg.

1. Run the script through the app.
2. While it runs, watch the process count: `ps -A | grep -c concurrently` on macOS/Linux.
3. It finishes in about a second.

**What must not have happened:** the process count must stay flat — on the broken code the same package reached ~50 processes in three seconds and never recovered. The run must also *finish*: a run that merely stops spawning but hangs is the earlier, subtler half of this bug.

Which test covers it, and yes, I checked it fails on the old code: `tests/unit/ipc-wiring.test.cjs` → *"npm:run-script"* now asserts the shims `ensureNodeShimDir` really wrote carry the preload. Blanking the preload path at all six `main.js` call sites — the exact way this regresses — left the entire suite green before that assertion existed, and now fails it. Under `npm run test:electron`, `tests/unit/electron-node-compat.test.cjs` → *"without the preload the child still looks like Electron"* pins the runtime condition itself.

## Risks and limitations

Review outcome: **4 `[fix here]` · 3 `[follow-up]` — all 4 fixed.**

- **Windows is unit-tested, not hand-tested.** The generated `.cmd`/`.bat` content is asserted directly (quoting, `set` ordering, `%*` last, backslashes kept), and the review checked it line by line, but no one ran a Gutenberg build on a real Windows machine. Buildkite has a signed artifact for this branch if someone wants to.
- **Two preload delivery mechanisms now exist** (`NODE_OPTIONS` in `buildChildEnv` for `win-spawn-patch.js`, `--require` in the shims and in the patch's redirects for `electron-node-compat.js`), with different reach and different quoting rules. Nothing ties them together beyond the comments in `node-shims.cjs` and `win-spawn-patch.js`. Consolidating the choice into one documented place is a follow-up.
- **The preload reaches forks and the Windows redirects, not every descendant.** `child_process.fork` inherits `execArgv`, so worker pools are covered, and since the 2026-09-10 rebase the Windows spawn patch re-attaches the `--require` to the `node`/`npm`/`npx` spawns it redirects past the shim. A descendant started with an explicit `spawn(process.execPath, …)`, or a `worker_threads` worker, inherits `ELECTRON_RUN_AS_NODE` and sees `versions.electron` again. No such case is known to be reachable today; `NODE_OPTIONS` would cover them, at the cost of the reliability problem that ruled it out.
- The shim directory remains world-readable and predictably named under `os.tmpdir()`. This PR adds one more file to a directory that already holds executable shims, so it extends an existing exposure rather than introducing one — but it is worth closing with `mkdtempSync` for all of them.

## Related

Fixes #275. Part of #251, whose remaining PRs are closed pending a redo against current trunk.

---

<details>
<summary>Design decisions and alternatives considered</summary>

**Preferring a real system Node over the shim.** Verified to work — the same Gutenberg build completes in 30s through the app's own spawn path once `node` on `PATH` is a real Node. Rejected because it does nothing for a contributor with no Node installed, which is precisely the case the shims exist for: the app's promise is zero prerequisites.

**Neutralising only yargs' branch** (setting `process.defaultApp`, the other half of its condition). Narrower, and it would have fixed the runaway. Rejected because it leaves every other library that asks "am I inside Electron?" answering wrongly, which is the general bug.

**`NODE_OPTIONS` for the compat preload.** Implemented first, then abandoned: measured, it did not survive every chain from the app down to a task runner's children, while the same preload passed as an argument did. `win-spawn-patch.js` keeps using it because it has no alternative.

**Where the shim content lives.** Moved out of `main.js` into `src/node-shims.cjs` as pure string building, so the property that matters — every shim, on every platform, carries the preload — is a unit test rather than something only a real Windows machine could show.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**4 `[fix here]` · 3 `[follow-up]` — all 4 `[fix here]` fixed.** Run per `.github/instructions/code-review.instructions.md`, with the judgement pass given to a subagent with fresh context. Deterministic layer: lint clean, 889 tests pass on both Node runtimes.

Fixed:

1. **Nothing tested the wiring that ships the fix.** The reviewer mutated all six `main.js` call sites to pass no preload path and the suite stayed green on both runtimes — the bug could be fully reintroduced without a single red test. The unit tests covered `node-shims.cjs`'s parameters, not the decision to hand it the path. Now `ipc-wiring` reads the shims from disk.
2. **`nodeCompatPath` was passed to `buildChildEnv`, which does not accept it.** Silently dropped, and it read as though descendants were covered through the environment — the exact misreading that would justify removing a `--require` from a shim later. Argument removed.
3. **Two Electron-only tests returned early instead of skipping**, so on the system Node they reported as passing while asserting nothing. Now `t.skip()`, and the two passes no longer report identical counts.
4. **A failed preload copy was reported with `process.stderr.write`**, which `electron-log` does not hook, so a packaged app recorded nothing on the one path that decides whether builds run away — and the write itself sat outside a `try`. Now goes through the app's logger.

Deferred, with reasons:

- **The test reimplements yargs' `hideBin` heuristic** rather than importing it, so it pins our model of the dependency rather than the dependency. Verified faithful against `yargs` as vendored today. Importing from a transitive dependency in a test is its own trap; left as is, and the comment says what it models.
- **The preload does not reach `worker_threads` or an explicit `spawn(process.execPath, …)`.** No reachable case today; noted under Risks so the next reader does not take "an argument always survives" as covering more than it does.
- **The shim directory is a predictable path in `os.tmpdir()`.** Pre-existing for the shims and `win-spawn-patch.js`; fixing it properly means `mkdtempSync` for all of them, which is a change to code this PR does not otherwise touch.

</details>

<details>
<summary>Implementation notes</summary>

How the root cause was isolated, since the trail is not obvious from the diff:

1. The process tree was a chain of `bash → Electron → bash → Electron`, every one of them running `concurrently` — 25 copies **with no arguments** alongside a single correct invocation.
2. Instrumenting the task runner's `spawn` showed the original process launching *three* children for two commands: its own path, then the two real ones.
3. That pointed at argument parsing rather than at process management, and from there to `hideBin`'s Electron branch.
4. A throwaway package reproduced it in three seconds with no Gutenberg involved — and only with `concurrently@9`, which still uses that yargs path; `@10` does not, which is why a first attempt to reproduce failed and briefly looked like the trigger was elsewhere.

`versions.chrome` is the interesting negative result: hiding it removed no recursion (already gone) and broke the bundling step, and there is now a test whose only job is to stop someone widening the set back.

</details>



---

**Rebase and re-review, 2026-09-10.** Replayed onto trunk at `74e700a` (past the bundled-Git engine, #420 and #422) with no conflicts. The self-review was re-run against the current standard with a fresh-context subagent: **1 `[fix here]` · 1 `[follow-up]`**.

- Fixed, in `65c1f7e`: cross-platform 🔴. The compat preload travelled only inside the shims, but on Windows `win-spawn-patch.js` rewrites `spawn('node', …)` straight to Electron's binary, skipping the shim and its `--require`. A tool reached that way saw `versions.electron` again. The route #275 itself takes (`npm run` → `cmd.exe` → `concurrently.cmd` → `node` on PATH) does go through the shim, so the reported failure was covered; the redirect route was not. `buildChildEnv` now exports `WPTK_NODE_COMPAT_PATH` and the patch prepends the same `--require` to its three redirects. Tests by injection in `win-spawn-patch.test.cjs` and `npm-runner.test.cjs`, both red before the change.
- Follow-up: the two preload mechanisms, listed under Risks.

Re-verified on that head: lint clean, `npm test` 1273 pass / 2 skipped, `npm run test:electron` 1275 pass / 0 skipped.

**Manual pass, macOS, 2026-09-10.** The throwaway package from "How to test this" (`concurrently@9.2.4`, `build` = `concurrently "npm run a" "npm run b"`), run through shims generated by this branch's `node-shims.cjs` against the repo's Electron binary. Old-style shims (no preload): 86 `concurrently` processes after six seconds, still climbing, never finished. This branch's shims: both scripts printed, exit 0, no leftover process.

**Earlier rebase note.** Replayed onto trunk (`a0fcbc9`) from the closed stack; `src/main.js` and `ipc-wiring` merged without conflict. One extra commit points the two new tests at the `tests/unit/` layout, since they were written before #377 moved unit tests a directory deeper — nothing they assert changed. Re-verified on trunk: lint clean, `npm test` 1058 pass / 0 fail / 2 skipped (the two Electron-runtime tests).



---

**Rebase and validation decision, 2026-09-11.** Replayed onto trunk `dd8bc22` with no conflicts. Lint clean, `npm test` 1260 pass / 2 skipped, `npm run test:electron` 1262 pass / 0 skipped.

**The Windows manual pass was dropped on purpose, not forgotten.** Recording the reasoning, because the earlier Risks section says someone should run it.

There is no reachable trigger from the current product surface. The app's terminal runs only `build`, `build:dev`, `dev`, `test`, `watch` and `grunt`, and in `wordpress-develop` every one of those is Grunt, which parses arguments with nopt rather than yargs. The Gutenberg build that produced the original report is not reachable from trunk: that support lived in a stack that is now closed. An attempt to stage the failure by hand on Windows, with a throwaway `concurrently@9` script installed into a site, ran into the same wall from the other side: the terminal will not run a script outside that list.

So what this PR fixes is real but currently latent, and the evidence available matches that status:

- macOS, by hand, on the branch's own shims: old shims reached 86 `concurrently` processes in six seconds and never finished; these shims exit 0 and stay flat.
- Windows, by unit test: the generated `.cmd`/`.bat` content is asserted directly (quoting, `set` ordering, `%*` last, backslashes kept), `win-spawn-patch` and `npm-runner` cover the redirect route that re-attaches the preload, and `ipc-wiring` reads the shims `ensureNodeShimDir` actually wrote so the fix cannot be removed from the call sites without a red test.

What stays open, plainly: nobody has watched a yargs-based task runner start, misparse and recover under these shims on a real Windows machine. If that path becomes reachable again, returning Gutenberg support being the obvious case, run the pass before trusting this on Windows.

This is also why the change is not treated as a release blocker: it removes a hazard rather than repairing a failure a contributor can hit today.


**CodeRabbit round, 2026-09-11: 1 `[fix here]` fixed · 1 `[follow-up]` filed · 1 declined.**

- Fixed in `50a1216`: a failed copy of the compat preload logged a line and wrote the shims without `--require`, which is the runaway state reached silently. Now `ensureNodeShimDir` forgets the directory and throws, and `runNpmWithEngineRetry` reports it through the same "Failed to start" surface as a spawn failure. The realistic trigger is the file missing from the packaged bundle. Wiring test by injection, red before the change. Note for the two Playground handlers that also call `spawnRunner`: they now reject instead of starting without the preload, which is the right outcome for a broken package.
- Follow-up #445: the POSIX shims interpolate paths into bash between double quotes, so `$` and backticks in a path expand. Pre-existing in `main.js` before this branch moved the strings; not a security boundary, since whoever controls the app's environment already has `NODE_OPTIONS`.
- Declined: running the two Electron-only tests on the system Node by planting a fake `process.versions.electron`. That would assert the fixture, not the runtime; the skips are explicit by design (fix 3 of the first review) and CI runs both passes, so both branches execute.
