### PR TITLE
Require the safe setup for rotated macOS signing credentials

### DIFF
--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -2,20 +2,20 @@
 
 echo "~~~ :apple: Configure macOS code signing"
 
-echo "--- :ruby: Install gems"
-install_gems
-
-# The Buildkite step sources this script, so the shebang's `-eu` never applies. Return explicitly
-# so callers without `errexit` still receive materialization failures instead of continuing.
+# The Buildkite step sources this script, so the shebang's `-eu` never applies. Validate before
+# installing gems, and avoid expanding the private-key value into a command that xtrace would log.
 for required_var in \
-	WPCT_MACOS_SIGNING_KEY_ID_V2 \
-	WPCT_MACOS_SIGNING_ISSUER_ID_V2 \
-	WPCT_MACOS_SIGNING_PRIVATE_KEY_V2; do
-	if [ -z "${!required_var:-}" ]; then
-		echo "$required_var is required. Configure the V2 macOS signing credentials in Buildkite." >&2
+	WPCT_MACOS_SIGNING_KEY_ID \
+	WPCT_MACOS_SIGNING_ISSUER_ID \
+	WPCT_MACOS_SIGNING_PRIVATE_KEY; do
+	if ! printenv "$required_var" | grep -q .; then
+		echo "$required_var is required. Configure the macOS signing credentials in Buildkite." >&2
 		return 1
 	fi
 done
+
+echo "--- :ruby: Install gems"
+install_gems
 
 # Materialize the Buildkite credential once, then expose the APPLE_API_* interface used by both consumers:
 # Fastlane reads it explicitly in Fastfile, and electron-builder inherits it during the later `npm run dist`.
@@ -23,8 +23,8 @@ done
 # See https://www.electron.build/mac#notarize
 MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")" || return 1
 export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
-export APPLE_API_KEY_ID="$WPCT_MACOS_SIGNING_KEY_ID_V2"
-export APPLE_API_ISSUER="$WPCT_MACOS_SIGNING_ISSUER_ID_V2"
+export APPLE_API_KEY_ID="$WPCT_MACOS_SIGNING_KEY_ID"
+export APPLE_API_ISSUER="$WPCT_MACOS_SIGNING_ISSUER_ID"
 
 cleanup_macos_notarization_key() {
 	rm -rf "$MACOS_NOTARIZATION_TEMP_DIR"
@@ -32,14 +32,13 @@ cleanup_macos_notarization_key() {
 trap cleanup_macos_notarization_key EXIT
 
 # `printenv` keeps the key itself out of shell traces, while the private temporary directory and
-# restrictive file mode keep it unavailable to other users on the build agent. Unlike `echo` under
-# `set -u`, `printenv` exits quietly when the variable is missing — hence the explicit guard.
-( umask 077; printenv WPCT_MACOS_SIGNING_PRIVATE_KEY_V2 >"$APPLE_API_KEY" ) || {
-	echo "WPCT_MACOS_SIGNING_PRIVATE_KEY_V2 could not be written to $APPLE_API_KEY" >&2
+# restrictive file mode keep it unavailable to other users on the build agent.
+( umask 077; printenv WPCT_MACOS_SIGNING_PRIVATE_KEY >"$APPLE_API_KEY" ) || {
+	echo "WPCT_MACOS_SIGNING_PRIVATE_KEY could not be written to $APPLE_API_KEY" >&2
 	return 1
 }
 
 echo "--- :key: Set up signing"
-bundle exec fastlane setup_code_signing
+bundle exec fastlane setup_code_signing || return $?
 
 echo "Signing config is ready for electron-builder."

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -5,17 +5,22 @@ echo "~~~ :apple: Configure macOS code signing"
 echo "--- :ruby: Install gems"
 install_gems
 
-echo "--- :key: Set up signing"
-bundle exec fastlane setup_code_signing
-
-echo "Expose signing config to electron-builder..."
-# Export necessary env vars for `electron-builder` to find those for its `notarize` option
-# See https://www.electron.build/mac#notarize
-#
 # The Buildkite step sources this script, so the shebang's `-eu` never applies. Return explicitly
 # so callers without `errexit` still receive materialization failures instead of continuing.
+for required_var in \
+	WPCT_MACOS_SIGNING_KEY_ID_V2 \
+	WPCT_MACOS_SIGNING_ISSUER_ID_V2 \
+	WPCT_MACOS_SIGNING_PRIVATE_KEY_V2; do
+	if [ -z "${!required_var:-}" ]; then
+		echo "$required_var is required. This branch predates the secure macOS signing credentials; merge the latest trunk." >&2
+		return 1
+	fi
+done
+
 MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")" || return 1
 export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
+export APPLE_API_KEY_ID="$WPCT_MACOS_SIGNING_KEY_ID_V2"
+export APPLE_API_ISSUER="$WPCT_MACOS_SIGNING_ISSUER_ID_V2"
 
 cleanup_macos_notarization_key() {
 	rm -rf "$MACOS_NOTARIZATION_TEMP_DIR"
@@ -25,9 +30,12 @@ trap cleanup_macos_notarization_key EXIT
 # `printenv` keeps the key itself out of shell traces, while the private temporary directory and
 # restrictive file mode keep it unavailable to other users on the build agent. Unlike `echo` under
 # `set -u`, `printenv` exits quietly when the variable is missing — hence the explicit guard.
-( umask 077; printenv APP_STORE_CONNECT_API_KEY_KEY >"$APPLE_API_KEY" ) || {
-	echo "APP_STORE_CONNECT_API_KEY_KEY is unset or could not be written to $APPLE_API_KEY" >&2
+( umask 077; printenv WPCT_MACOS_SIGNING_PRIVATE_KEY_V2 >"$APPLE_API_KEY" ) || {
+	echo "WPCT_MACOS_SIGNING_PRIVATE_KEY_V2 could not be written to $APPLE_API_KEY" >&2
 	return 1
 }
-export APPLE_API_KEY_ID="$APP_STORE_CONNECT_API_KEY_KEY_ID"
-export APPLE_API_ISSUER="$APP_STORE_CONNECT_API_KEY_ISSUER_ID"
+
+echo "--- :key: Set up signing"
+bundle exec fastlane setup_code_signing
+
+echo "Signing config is ready for electron-builder."

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -12,7 +12,7 @@ for required_var in \
 	WPCT_MACOS_SIGNING_ISSUER_ID_V2 \
 	WPCT_MACOS_SIGNING_PRIVATE_KEY_V2; do
 	if [ -z "${!required_var:-}" ]; then
-		echo "$required_var is required. This branch predates the secure macOS signing credentials; merge the latest trunk." >&2
+		echo "$required_var is required. Configure the V2 macOS signing credentials in Buildkite." >&2
 		return 1
 	fi
 done

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -17,6 +17,10 @@ for required_var in \
 	fi
 done
 
+# Materialize the Buildkite credential once, then expose the APPLE_API_* interface used by both consumers:
+# Fastlane reads it explicitly in Fastfile, and electron-builder inherits it during the later `npm run dist`.
+# APPLE_API_KEY must contain a filepath, not the private-key contents.
+# See https://www.electron.build/mac#notarize
 MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")" || return 1
 export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
 export APPLE_API_KEY_ID="$WPCT_MACOS_SIGNING_KEY_ID_V2"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,11 @@ end
 desc 'Download the development signing certificates to this machine'
 lane :setup_code_signing do |readonly: true|
   check_env_vars!
-  app_store_connect_api_key
+  app_store_connect_api_key(
+    key_id: ENV.fetch('APPLE_API_KEY_ID'),
+    issuer_id: ENV.fetch('APPLE_API_ISSUER'),
+    key_filepath: ENV.fetch('APPLE_API_KEY')
+  )
 
   sync_code_signing(
     platform: 'macos',
@@ -76,7 +80,7 @@ end
 ############
 
 def check_env_vars!
-  required_vars = %w[APP_STORE_CONNECT_API_KEY_KEY_ID APP_STORE_CONNECT_API_KEY_ISSUER_ID APP_STORE_CONNECT_API_KEY_KEY]
+  required_vars = %w[APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_API_KEY]
   required_vars.each do |var|
     UI.user_error!("The environment variable `#{var}` is required but not set") unless ENV.key?(var)
   end

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -92,30 +92,32 @@ function signingEnv(overrides = {}) {
 	};
 }
 
-function legacySigningEnv() {
-	const env = {
-		...process.env,
+function signingEnvMissing(missingVariable) {
+	const env = signingEnv({
 		APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
 		APP_STORE_CONNECT_API_KEY_KEY_ID: 'legacy-key-id',
 		APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'legacy-issuer-id',
-		SETUP_SCRIPT,
-	};
-	delete env.WPCT_MACOS_SIGNING_PRIVATE_KEY_V2;
-	delete env.WPCT_MACOS_SIGNING_KEY_ID_V2;
-	delete env.WPCT_MACOS_SIGNING_ISSUER_ID_V2;
+	});
+	delete env[missingVariable];
 	return env;
 }
 
-test('legacy macOS signing variables cannot activate the rotated credentials', { skip: process.platform !== 'darwin' }, () => {
-	const result = spawnSync('/bin/bash', ['-c', LEGACY_ENV_HARNESS], {
-		encoding: 'utf8',
-		env: legacySigningEnv(),
-	});
+for (const missingVariable of [
+	'WPCT_MACOS_SIGNING_KEY_ID_V2',
+	'WPCT_MACOS_SIGNING_ISSUER_ID_V2',
+	'WPCT_MACOS_SIGNING_PRIVATE_KEY_V2',
+]) {
+	test(`legacy macOS signing variables cannot replace a missing ${missingVariable}`, { skip: process.platform !== 'darwin' }, () => {
+		const result = spawnSync('/bin/bash', ['-c', LEGACY_ENV_HARNESS], {
+			encoding: 'utf8',
+			env: signingEnvMissing(missingVariable),
+		});
 
-	assert.equal(result.status, 1, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
-	assert.match(result.stderr, /WPCT_MACOS_SIGNING_KEY_ID_V2 is required/);
-	assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
-});
+		assert.equal(result.status, 1, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
+		assert.match(result.stderr, new RegExp(`${missingVariable} is required\\. Configure the V2 macOS signing credentials in Buildkite\\.`));
+		assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
+	});
+}
 
 test('macOS signing keeps its temporary notarization key outside the project and removes it on exit', { skip: process.platform !== 'darwin' }, (t) => {
 	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-project-'));

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -31,9 +31,22 @@ esac
 test ! -e "$PROJECT_ROOT/.codesigning"
 
 test -f "$APPLE_API_KEY"
-test "$(cat "$APPLE_API_KEY")" = "$APP_STORE_CONNECT_API_KEY_KEY"
+test "$(cat "$APPLE_API_KEY")" = "$WPCT_MACOS_SIGNING_PRIVATE_KEY_V2"
+test "$APPLE_API_KEY_ID" = "$WPCT_MACOS_SIGNING_KEY_ID_V2"
+test "$APPLE_API_ISSUER" = "$WPCT_MACOS_SIGNING_ISSUER_ID_V2"
 test "$(stat -f '%Lp' "$APPLE_API_KEY")" = "600"
 printf '%s\n' "$APPLE_API_KEY"
+`;
+
+const LEGACY_ENV_HARNESS = String.raw`
+install_gems() { :; }
+bundle() {
+	echo "Fastlane ran with legacy credentials" >&2
+	return 0
+}
+source "$SETUP_SCRIPT"
+status=$?
+exit "$status"
 `;
 
 const FAILED_MKTEMP_HARNESS = String.raw`
@@ -71,13 +84,38 @@ exit 1
 function signingEnv(overrides = {}) {
 	return {
 		...process.env,
-		APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
-		APP_STORE_CONNECT_API_KEY_KEY_ID: 'dummy-key-id',
-		APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'dummy-issuer-id',
+		WPCT_MACOS_SIGNING_PRIVATE_KEY_V2: DUMMY_KEY,
+		WPCT_MACOS_SIGNING_KEY_ID_V2: 'dummy-key-id',
+		WPCT_MACOS_SIGNING_ISSUER_ID_V2: 'dummy-issuer-id',
 		SETUP_SCRIPT,
 		...overrides,
 	};
 }
+
+function legacySigningEnv() {
+	const env = {
+		...process.env,
+		APP_STORE_CONNECT_API_KEY_KEY: DUMMY_KEY,
+		APP_STORE_CONNECT_API_KEY_KEY_ID: 'legacy-key-id',
+		APP_STORE_CONNECT_API_KEY_ISSUER_ID: 'legacy-issuer-id',
+		SETUP_SCRIPT,
+	};
+	delete env.WPCT_MACOS_SIGNING_PRIVATE_KEY_V2;
+	delete env.WPCT_MACOS_SIGNING_KEY_ID_V2;
+	delete env.WPCT_MACOS_SIGNING_ISSUER_ID_V2;
+	return env;
+}
+
+test('legacy macOS signing variables cannot activate the rotated credentials', { skip: process.platform !== 'darwin' }, () => {
+	const result = spawnSync('/bin/bash', ['-c', LEGACY_ENV_HARNESS], {
+		encoding: 'utf8',
+		env: legacySigningEnv(),
+	});
+
+	assert.equal(result.status, 1, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
+	assert.match(result.stderr, /WPCT_MACOS_SIGNING_KEY_ID_V2 is required/);
+	assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
+});
 
 test('macOS signing keeps its temporary notarization key outside the project and removes it on exit', { skip: process.platform !== 'darwin' }, (t) => {
 	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-project-'));

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -13,7 +13,10 @@ const DUMMY_KEY = '-----BEGIN PRIVATE KEY-----\na dummy key with spaces and $she
 const SOURCE_HARNESS = String.raw`
 set -eu
 install_gems() { :; }
-bundle() { :; }
+bundle() {
+	test -s "$APPLE_API_KEY"
+	test "$(cat "$APPLE_API_KEY")" = "$WPCT_MACOS_SIGNING_PRIVATE_KEY"
+}
 source "$SETUP_SCRIPT"
 
 # Compare real paths: the regression this guards against exported a *relative* in-project path,
@@ -31,9 +34,9 @@ esac
 test ! -e "$PROJECT_ROOT/.codesigning"
 
 test -f "$APPLE_API_KEY"
-test "$(cat "$APPLE_API_KEY")" = "$WPCT_MACOS_SIGNING_PRIVATE_KEY_V2"
-test "$APPLE_API_KEY_ID" = "$WPCT_MACOS_SIGNING_KEY_ID_V2"
-test "$APPLE_API_ISSUER" = "$WPCT_MACOS_SIGNING_ISSUER_ID_V2"
+test "$(cat "$APPLE_API_KEY")" = "$WPCT_MACOS_SIGNING_PRIVATE_KEY"
+test "$APPLE_API_KEY_ID" = "$WPCT_MACOS_SIGNING_KEY_ID"
+test "$APPLE_API_ISSUER" = "$WPCT_MACOS_SIGNING_ISSUER_ID"
 test "$(stat -f '%Lp' "$APPLE_API_KEY")" = "600"
 printf '%s\n' "$APPLE_API_KEY"
 `;
@@ -47,6 +50,21 @@ bundle() {
 source "$SETUP_SCRIPT"
 status=$?
 exit "$status"
+`;
+
+const FAILED_FASTLANE_HARNESS = String.raw`
+install_gems() { :; }
+bundle() { return 7; }
+source "$SETUP_SCRIPT"
+status=$?
+exit "$status"
+`;
+
+const TRACE_HARNESS = String.raw`
+set -x
+install_gems() { :; }
+bundle() { :; }
+source "$SETUP_SCRIPT"
 `;
 
 const FAILED_MKTEMP_HARNESS = String.raw`
@@ -64,7 +82,12 @@ exit "$status"
 const FAILED_KEY_WRITE_HARNESS = String.raw`
 install_gems() { :; }
 bundle() { :; }
-printenv() { return 1; }
+printenv() {
+	if [ "$1" = WPCT_MACOS_SIGNING_PRIVATE_KEY ] && command printenv APPLE_API_KEY >/dev/null; then
+		return 1
+	fi
+	command printenv "$@"
+}
 source "$SETUP_SCRIPT"
 status=$?
 exit "$status"
@@ -84,9 +107,9 @@ exit 1
 function signingEnv(overrides = {}) {
 	return {
 		...process.env,
-		WPCT_MACOS_SIGNING_PRIVATE_KEY_V2: DUMMY_KEY,
-		WPCT_MACOS_SIGNING_KEY_ID_V2: 'dummy-key-id',
-		WPCT_MACOS_SIGNING_ISSUER_ID_V2: 'dummy-issuer-id',
+		WPCT_MACOS_SIGNING_PRIVATE_KEY: DUMMY_KEY,
+		WPCT_MACOS_SIGNING_KEY_ID: 'dummy-key-id',
+		WPCT_MACOS_SIGNING_ISSUER_ID: 'dummy-issuer-id',
 		SETUP_SCRIPT,
 		...overrides,
 	};
@@ -103,9 +126,9 @@ function signingEnvMissing(missingVariable) {
 }
 
 for (const missingVariable of [
-	'WPCT_MACOS_SIGNING_KEY_ID_V2',
-	'WPCT_MACOS_SIGNING_ISSUER_ID_V2',
-	'WPCT_MACOS_SIGNING_PRIVATE_KEY_V2',
+	'WPCT_MACOS_SIGNING_KEY_ID',
+	'WPCT_MACOS_SIGNING_ISSUER_ID',
+	'WPCT_MACOS_SIGNING_PRIVATE_KEY',
 ]) {
 	test(`legacy macOS signing variables cannot replace a missing ${missingVariable}`, { skip: process.platform !== 'darwin' }, () => {
 		const result = spawnSync('/bin/bash', ['-c', LEGACY_ENV_HARNESS], {
@@ -114,7 +137,7 @@ for (const missingVariable of [
 		});
 
 		assert.equal(result.status, 1, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
-		assert.match(result.stderr, new RegExp(`${missingVariable} is required\\. Configure the V2 macOS signing credentials in Buildkite\\.`));
+		assert.match(result.stderr, new RegExp(`${missingVariable} is required\\. Configure the macOS signing credentials in Buildkite\\.`));
 		assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
 	});
 }
@@ -136,6 +159,16 @@ test('macOS signing keeps its temporary notarization key outside the project and
 	assert.ok(path.isAbsolute(keyPath), `expected an absolute key path, received ${keyPath}`);
 	assert.equal(fs.existsSync(keyPath), false, 'the key file survived the Buildkite shell');
 	assert.equal(fs.existsSync(path.dirname(keyPath)), false, 'the key temporary directory survived the Buildkite shell');
+});
+
+test('macOS signing does not expose the private key in shell traces', { skip: process.platform !== 'darwin' }, () => {
+	const result = spawnSync('/bin/bash', ['-c', TRACE_HARNESS], {
+		encoding: 'utf8',
+		env: signingEnv(),
+	});
+
+	assert.equal(result.status, 0, `signing setup failed under xtrace:\n${result.stdout}${result.stderr}`);
+	assert.doesNotMatch(`${result.stdout}${result.stderr}`, /a dummy key with spaces and \$shell syntax/);
 });
 
 test('sourced macOS signing returns failure when its temporary directory cannot be created', { skip: process.platform !== 'darwin' }, (t) => {
@@ -169,6 +202,20 @@ test('sourced macOS signing returns failure and cleans up when writing the key f
 
 	assert.equal(result.status, 1, `signing setup did not return the key-write failure:\n${result.stdout}${result.stderr}`);
 	assert.deepEqual(fs.readdirSync(temporaryRoot), [], 'temporary signing material survived the failed shell');
+});
+
+test('sourced macOS signing preserves a Fastlane failure and cleans up', { skip: process.platform !== 'darwin' }, (t) => {
+	const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-fastlane-failure-'));
+	t.after(() => fs.rmSync(temporaryRoot, { recursive: true, force: true }));
+
+	const result = spawnSync('/bin/bash', ['-c', FAILED_FASTLANE_HARNESS], {
+		encoding: 'utf8',
+		env: signingEnv({ TMPDIR: temporaryRoot }),
+	});
+
+	assert.equal(result.status, 7, `signing setup swallowed the Fastlane failure:\n${result.stdout}${result.stderr}`);
+	assert.doesNotMatch(result.stdout, /Signing config is ready/);
+	assert.deepEqual(fs.readdirSync(temporaryRoot), [], 'temporary signing material survived the Fastlane failure');
 });
 
 test('macOS signing removes its temporary key when Buildkite terminates the shell', { skip: process.platform !== 'darwin' }, async (t) => {


### PR DESCRIPTION
## Why

We've rotated the macOS signing credentials, but branches that predate the secure signing setup (or any new branch accidentally created from an old revision) could consume them accidentally. This PR creates a new "credential epoch" by renaming the CI variables so only code with the safer setup can use the rotated credentials.

## What changes

Buildkite must supply three repository-specific `WPCT_MACOS_SIGNING_*` inputs, and setup fails with an actionable error if any is missing.

The setup script materializes the private key in a protected temporary file and exports the `APPLE_API_*` interface required by Electron Builder. Fastlane explicitly reuses that same interface. CI no longer injects the legacy names, and repository code no longer references them, so older code cannot use the rotated credentials.

## How to test this

**Starting state:** Check out this branch on macOS. The protected signing credentials are not needed for the focused unit tests.

1. Run `node --test tests/unit/macos-signing.test.cjs`. All nine tests pass, including one rejection case for each missing repository-specific variable, trace-safety and Fastlane-failure checks, and temporary-key cleanup coverage.
2. After the new variables are enabled in Buildkite, open the macOS build for the current head. `npm run dist` and `bundle exec fastlane verify_code_signing` both pass.

**What must not have happened:** Legacy variables alone must not reach Fastlane, signing material must not appear in the checkout or packaged payload, the private key must not appear in shell traces, and the temporary key must not survive the Buildkite shell.

## Risks and limitations

The new variables live outside this repository and must be configured in Buildkite before the macOS build can pass. Real signing and notarization can only be verified through Buildkite.

## Related

Follow-up to #390.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The repository-specific `WPCT_MACOS_SIGNING_*` names create the credential epoch without needing a version suffix, and routine future rotations can replace their values without another code change. `WPCT_MACOS_SIGNING_PRIVATE_KEY` also matches Buildkite's default `*_PRIVATE_KEY` redaction pattern. Electron Builder requires `APPLE_API_KEY` to be a filepath, so the key is materialized once and Fastlane explicitly reuses the same temporary-file-backed interface.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Final self-review: 0 `[fix here]` · 1 `[follow-up]`. Direct Fastlane invocation still accepts empty environment entries and remains a pre-existing follow-up; the normal Buildkite path rejects them. Lint, all 1,051 tests, all nine focused signing tests, and shell and Ruby syntax checks pass.

</details>
