### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Desktop app that sets up a WordPress core development environment with no prerequisites, applies the work already on a Trac ticket, and submits a contribution back",


### PR DESCRIPTION
## Why

`v1.0.0` shipped on 14 August. Two of the thirteen commits since then reach the packaged app:

- [#382](https://github.com/WordPress/contributor-toolkit/pull/382) — a site can be deleted when Git marked it read-only, and the app says so when it cannot.
- [#390](https://github.com/WordPress/contributor-toolkit/pull/390) — the macOS signing step no longer writes the App Store Connect key into the project, so it stops being packaged.

The other eleven are tests and documentation.

`electron-builder` derives artifact names from `package.json`, so the version has to move before the tag and the artifacts exist.

There is a second reason this release is needed rather than optional. Every macOS artifact published so far carries the notarization key inside `app.asar` — the incident behind #390. The key is already revoked, so it is inert, but the download still hands it out, and the docs site's download button resolves against `releases/latest`. Publishing v1.0.1 is what stops that button serving the compromised build; v1.0.0's macOS asset is then deleted.

## What changes

Only the version. All three package-version fields in `package.json` and `package-lock.json` move together from `1.0.0` to `1.0.1`. No dependency versions change, and there is no application behaviour change in this PR.

## How to test this

Platforms: any for the suite; macOS for the artifact check that follows the merge.

1. `npm run lint` is clean and `npm test` passes.
2. `node -e "console.log(require('./package.json').version)"` prints `1.0.1`.
3. `python3 -c "import json;d=json.load(open('package-lock.json'));print(d['version'], d['packages']['']['version'])"` prints `1.0.1 1.0.1` — both root entries move together, and no dependency pinned at 1.0.0 was touched.

**What must not have happened:** no dependency version may change. `git diff` must show exactly three lines, all of them the root package version.

After merge, the release build must produce artifacts named `wordpress-contributor-toolkit-1.0.1-*`, and the macOS one must contain no `.codesigning` directory and no `apple_api_key`.

## Risks and limitations

No UI change. The risk is a mis-scoped edit in `package-lock.json`, where several dependencies also sit at version `1.0.0`; the replacement was confined to the first 2000 bytes of the file, which covers the two root entries and nothing else, and both files were re-parsed as JSON afterwards.

Verified locally on this branch: lint clean, `npm test` 1046 pass / 0 fail.

---

Review outcome (required — see AGENTS.md)

0 `[fix here]` · 0 `[follow-up]`. Deterministic layer only: lint clean, 1046 tests pass, both files valid JSON, diff confined to the three root version fields. No judgement pass was run — this change has no logic to review.
