### PR TITLE
Simplify macOS signing failure handling

### DIFF
--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -2,17 +2,14 @@
 
 echo "~~~ :apple: Configure macOS code signing"
 
-# The Buildkite step sources this script, so the shebang's `-eu` never applies. Validate before
-# installing gems, and avoid expanding the private-key value into a command that xtrace would log.
-for required_var in \
-	WPCT_MACOS_SIGNING_KEY_ID \
-	WPCT_MACOS_SIGNING_ISSUER_ID \
-	WPCT_MACOS_SIGNING_PRIVATE_KEY; do
-	if ! printenv "$required_var" | grep -q .; then
-		echo "$required_var is required. Configure the macOS signing credentials in Buildkite." >&2
-		return 1
-	fi
-done
+# The Buildkite command enables `set -eu` before sourcing this script. Validate the non-secret values
+# while exporting them, but keep the private key out of commands that xtrace would log.
+export APPLE_API_KEY_ID="${WPCT_MACOS_SIGNING_KEY_ID:?WPCT_MACOS_SIGNING_KEY_ID is required. Configure the macOS signing credentials in Buildkite.}"
+export APPLE_API_ISSUER="${WPCT_MACOS_SIGNING_ISSUER_ID:?WPCT_MACOS_SIGNING_ISSUER_ID is required. Configure the macOS signing credentials in Buildkite.}"
+if ! printenv WPCT_MACOS_SIGNING_PRIVATE_KEY | grep -q .; then
+	echo "WPCT_MACOS_SIGNING_PRIVATE_KEY is required. Configure the macOS signing credentials in Buildkite." >&2
+	return 1
+fi
 
 echo "--- :ruby: Install gems"
 install_gems
@@ -21,10 +18,8 @@ install_gems
 # Fastlane reads it explicitly in Fastfile, and electron-builder inherits it during the later `npm run dist`.
 # APPLE_API_KEY must contain a filepath, not the private-key contents.
 # See https://www.electron.build/mac#notarize
-MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")" || return 1
+MACOS_NOTARIZATION_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wordpress-contributor-toolkit-signing.XXXXXX")"
 export APPLE_API_KEY="$MACOS_NOTARIZATION_TEMP_DIR/apple_api_key"
-export APPLE_API_KEY_ID="$WPCT_MACOS_SIGNING_KEY_ID"
-export APPLE_API_ISSUER="$WPCT_MACOS_SIGNING_ISSUER_ID"
 
 cleanup_macos_notarization_key() {
 	rm -rf "$MACOS_NOTARIZATION_TEMP_DIR"
@@ -39,6 +34,6 @@ trap cleanup_macos_notarization_key EXIT
 }
 
 echo "--- :key: Set up signing"
-bundle exec fastlane setup_code_signing || return $?
+bundle exec fastlane setup_code_signing
 
 echo "Signing config is ready for electron-builder."

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -4,8 +4,8 @@ echo "~~~ :apple: Configure macOS code signing"
 
 # The Buildkite command enables `set -eu` before sourcing this script. Validate the non-secret values
 # while exporting them, but keep the private key out of commands that xtrace would log.
-export APPLE_API_KEY_ID="${WPCT_MACOS_SIGNING_KEY_ID:?WPCT_MACOS_SIGNING_KEY_ID is required. Configure the macOS signing credentials in Buildkite.}"
-export APPLE_API_ISSUER="${WPCT_MACOS_SIGNING_ISSUER_ID:?WPCT_MACOS_SIGNING_ISSUER_ID is required. Configure the macOS signing credentials in Buildkite.}"
+export APPLE_API_KEY_ID="${WPCT_MACOS_SIGNING_KEY_ID:?is required. Configure the macOS signing credentials in Buildkite.}"
+export APPLE_API_ISSUER="${WPCT_MACOS_SIGNING_ISSUER_ID:?is required. Configure the macOS signing credentials in Buildkite.}"
 if ! printenv WPCT_MACOS_SIGNING_PRIVATE_KEY | grep -q .; then
 	echo "WPCT_MACOS_SIGNING_PRIVATE_KEY is required. Configure the macOS signing credentials in Buildkite." >&2
 	return 1

--- a/.buildkite/commands/setup_macos_code_signing.sh
+++ b/.buildkite/commands/setup_macos_code_signing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-echo "~~~ :apple: Configure macOS code signing"
+echo "~~~ :apple: Validate macOS signing credentials"
 
 # The Buildkite command enables `set -eu` before sourcing this script. Validate the non-secret values
 # while exporting them, but keep the private key out of commands that xtrace would log.
@@ -13,6 +13,8 @@ fi
 
 echo "--- :ruby: Install gems"
 install_gems
+
+echo "--- :key: Configure macOS code signing"
 
 # Materialize the Buildkite credential once, then expose the APPLE_API_* interface used by both consumers:
 # Fastlane reads it explicitly in Fastfile, and electron-builder inherits it during the later `npm run dist`.
@@ -33,7 +35,6 @@ trap cleanup_macos_notarization_key EXIT
 	return 1
 }
 
-echo "--- :key: Set up signing"
 bundle exec fastlane setup_code_signing
 
 echo "Signing config is ready for electron-builder."

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,6 @@ steps:
     command: |
       set -eu
 
-      echo "~~~ Setup code signing"
       source .buildkite/commands/setup_macos_code_signing.sh
 
       echo "~~~ Install dependencies"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,8 @@ steps:
       IMAGE_ID: $IMAGE_ID
     plugins: [$CI_TOOLKIT, $NVM_PLUGIN]
     command: |
+      set -eu
+
       echo "~~~ Setup code signing"
       source .buildkite/commands/setup_macos_code_signing.sh
 

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -75,15 +75,6 @@ bundle() { :; }
 source "$SETUP_SCRIPT"
 `;
 
-const SHELL_OPTIONS_HARNESS = String.raw`
-set -eu
-install_gems() { :; }
-bundle() { :; }
-options_before="$-"
-source "$SETUP_SCRIPT"
-test "$-" = "$options_before"
-`;
-
 const FAILED_MKTEMP_HARNESS = String.raw`
 set -eu
 install_gems() { :; }
@@ -186,24 +177,11 @@ test('macOS signing does not expose the private key in shell traces', { skip: pr
 	assert.doesNotMatch(`${result.stdout}${result.stderr}`, /a dummy key with spaces and \$shell syntax/);
 });
 
-test('sourced macOS signing does not change its caller shell options', { skip: process.platform !== 'darwin' }, () => {
-	const result = spawnSync('/bin/bash', ['-c', SHELL_OPTIONS_HARNESS], {
-		encoding: 'utf8',
-		env: signingEnv(),
-	});
-
-	assert.equal(result.status, 0, `signing setup changed its caller shell options:\n${result.stdout}${result.stderr}`);
-});
-
 test('macOS Buildkite command enables strict shell options before sourcing signing setup', () => {
-	const normalizedPipeline = fs.readFileSync(PIPELINE, 'utf8').replace(/\r\n/g, '\n');
+	const pipeline = fs.readFileSync(PIPELINE, 'utf8').replace(/\r\n/g, '\n');
+	const macStep = pipeline.slice(pipeline.indexOf('# macOS build'), pipeline.indexOf('# Linux build'));
 
-	for (const lineEnding of ['\n', '\r\n']) {
-		const pipeline = normalizedPipeline.replace(/\n/g, lineEnding);
-		const macStep = pipeline.slice(pipeline.indexOf('# macOS build'), pipeline.indexOf('# Linux build'));
-
-		assert.match(macStep, /command: \|\r?\n      set -eu\r?\n[\s\S]*source \.buildkite\/commands\/setup_macos_code_signing\.sh/);
-	}
+	assert.match(macStep, /command: \|\n      set -eu\n[\s\S]*source \.buildkite\/commands\/setup_macos_code_signing\.sh/);
 });
 
 test('sourced macOS signing returns failure when its temporary directory cannot be created', { skip: process.platform !== 'darwin' }, (t) => {

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -143,7 +143,8 @@ for (const missingVariable of [
 		});
 
 		assert.notEqual(result.status, 0, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
-		assert.match(result.stderr, new RegExp(`${missingVariable} is required\\. Configure the macOS signing credentials in Buildkite\\.`));
+		assert.match(result.stderr, new RegExp(missingVariable));
+		assert.match(result.stderr, /is required\. Configure the macOS signing credentials in Buildkite\./);
 		assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
 	});
 }

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -196,10 +196,14 @@ test('sourced macOS signing does not change its caller shell options', { skip: p
 });
 
 test('macOS Buildkite command enables strict shell options before sourcing signing setup', () => {
-	const pipeline = fs.readFileSync(PIPELINE, 'utf8');
-	const macStep = pipeline.slice(pipeline.indexOf('# macOS build'), pipeline.indexOf('# Linux build'));
+	const normalizedPipeline = fs.readFileSync(PIPELINE, 'utf8').replace(/\r\n/g, '\n');
 
-	assert.match(macStep, /command: \|\n      set -eu\n[\s\S]*source \.buildkite\/commands\/setup_macos_code_signing\.sh/);
+	for (const lineEnding of ['\n', '\r\n']) {
+		const pipeline = normalizedPipeline.replace(/\n/g, lineEnding);
+		const macStep = pipeline.slice(pipeline.indexOf('# macOS build'), pipeline.indexOf('# Linux build'));
+
+		assert.match(macStep, /command: \|\r?\n      set -eu\r?\n[\s\S]*source \.buildkite\/commands\/setup_macos_code_signing\.sh/);
+	}
 });
 
 test('sourced macOS signing returns failure when its temporary directory cannot be created', { skip: process.platform !== 'darwin' }, (t) => {

--- a/tests/unit/macos-signing.test.cjs
+++ b/tests/unit/macos-signing.test.cjs
@@ -6,6 +6,7 @@ const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
 const SETUP_SCRIPT = path.join(__dirname, '..', '..', '.buildkite', 'commands', 'setup_macos_code_signing.sh');
+const PIPELINE = path.join(__dirname, '..', '..', '.buildkite', 'pipeline.yml');
 const DUMMY_KEY = '-----BEGIN PRIVATE KEY-----\na dummy key with spaces and $shell syntax\n-----END PRIVATE KEY-----';
 
 // The real Buildkite command sources this script, so exercise it in the same shape. Fastlane is
@@ -42,32 +43,49 @@ printf '%s\n' "$APPLE_API_KEY"
 `;
 
 const LEGACY_ENV_HARNESS = String.raw`
+set -eu
 install_gems() { :; }
 bundle() {
 	echo "Fastlane ran with legacy credentials" >&2
 	return 0
 }
 source "$SETUP_SCRIPT"
-status=$?
-exit "$status"
 `;
 
 const FAILED_FASTLANE_HARNESS = String.raw`
+set -eu
 install_gems() { :; }
 bundle() { return 7; }
 source "$SETUP_SCRIPT"
-status=$?
-exit "$status"
+`;
+
+const FAILED_GEM_INSTALL_HARNESS = String.raw`
+set -eu
+install_gems() { return 6; }
+bundle() {
+	echo "Fastlane ran after gem installation failed" >&2
+}
+source "$SETUP_SCRIPT"
 `;
 
 const TRACE_HARNESS = String.raw`
-set -x
+set -eux
 install_gems() { :; }
 bundle() { :; }
 source "$SETUP_SCRIPT"
 `;
 
+const SHELL_OPTIONS_HARNESS = String.raw`
+set -eu
+install_gems() { :; }
+bundle() { :; }
+options_before="$-"
+source "$SETUP_SCRIPT"
+test "$-" = "$options_before"
+`;
+
 const FAILED_MKTEMP_HARNESS = String.raw`
+set -eu
 install_gems() { :; }
 bundle() { :; }
 mktemp() {
@@ -75,11 +93,10 @@ mktemp() {
 	return 1
 }
 source "$SETUP_SCRIPT"
-status=$?
-exit "$status"
 `;
 
 const FAILED_KEY_WRITE_HARNESS = String.raw`
+set -eu
 install_gems() { :; }
 bundle() { :; }
 printenv() {
@@ -89,12 +106,10 @@ printenv() {
 	command printenv "$@"
 }
 source "$SETUP_SCRIPT"
-status=$?
-exit "$status"
 `;
 
 const TERM_HARNESS = String.raw`
-set -e
+set -eu
 install_gems() { :; }
 bundle() { :; }
 source "$SETUP_SCRIPT"
@@ -136,7 +151,7 @@ for (const missingVariable of [
 			env: signingEnvMissing(missingVariable),
 		});
 
-		assert.equal(result.status, 1, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
+		assert.notEqual(result.status, 0, `legacy signing credentials unexpectedly worked:\n${result.stdout}${result.stderr}`);
 		assert.match(result.stderr, new RegExp(`${missingVariable} is required\\. Configure the macOS signing credentials in Buildkite\\.`));
 		assert.doesNotMatch(result.stderr, /Fastlane ran with legacy credentials/);
 	});
@@ -171,6 +186,22 @@ test('macOS signing does not expose the private key in shell traces', { skip: pr
 	assert.doesNotMatch(`${result.stdout}${result.stderr}`, /a dummy key with spaces and \$shell syntax/);
 });
 
+test('sourced macOS signing does not change its caller shell options', { skip: process.platform !== 'darwin' }, () => {
+	const result = spawnSync('/bin/bash', ['-c', SHELL_OPTIONS_HARNESS], {
+		encoding: 'utf8',
+		env: signingEnv(),
+	});
+
+	assert.equal(result.status, 0, `signing setup changed its caller shell options:\n${result.stdout}${result.stderr}`);
+});
+
+test('macOS Buildkite command enables strict shell options before sourcing signing setup', () => {
+	const pipeline = fs.readFileSync(PIPELINE, 'utf8');
+	const macStep = pipeline.slice(pipeline.indexOf('# macOS build'), pipeline.indexOf('# Linux build'));
+
+	assert.match(macStep, /command: \|\n      set -eu\n[\s\S]*source \.buildkite\/commands\/setup_macos_code_signing\.sh/);
+});
+
 test('sourced macOS signing returns failure when its temporary directory cannot be created', { skip: process.platform !== 'darwin' }, (t) => {
 	const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-mktemp-'));
 	const fallbackDirectory = path.join(projectRoot, 'mktemp-fallback');
@@ -202,6 +233,20 @@ test('sourced macOS signing returns failure and cleans up when writing the key f
 
 	assert.equal(result.status, 1, `signing setup did not return the key-write failure:\n${result.stdout}${result.stderr}`);
 	assert.deepEqual(fs.readdirSync(temporaryRoot), [], 'temporary signing material survived the failed shell');
+});
+
+test('sourced macOS signing preserves a gem installation failure', { skip: process.platform !== 'darwin' }, (t) => {
+	const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wpct-signing-gem-install-failure-'));
+	t.after(() => fs.rmSync(temporaryRoot, { recursive: true, force: true }));
+
+	const result = spawnSync('/bin/bash', ['-c', FAILED_GEM_INSTALL_HARNESS], {
+		encoding: 'utf8',
+		env: signingEnv({ TMPDIR: temporaryRoot }),
+	});
+
+	assert.equal(result.status, 6, `signing setup swallowed the gem installation failure:\n${result.stdout}${result.stderr}`);
+	assert.doesNotMatch(result.stderr, /Fastlane ran after gem installation failed/);
+	assert.deepEqual(fs.readdirSync(temporaryRoot), [], 'signing material was created after gem installation failed');
 });
 
 test('sourced macOS signing preserves a Fastlane failure and cleans up', { skip: process.platform !== 'darwin' }, (t) => {


### PR DESCRIPTION
## Why

Following up to the [discussion on #396](https://github.com/WordPress/contributor-toolkit/pull/396#discussion_r3830285893), this PR updates the the macOS signing setup script, which is `source`d, so its shebang's `-eu` flags are ignored. We then enable strict mode in the pipeline itself to cover the whole macOS build step.

## What changes

- The macOS Buildkite command in the .yml pipeline now enables `set -eu`.
- The signing script uses direct assertions for the key ID and issuer and keeps the private-key check safe under shell tracing and lets strict mode propagate command failures.

Tests mirror the caller behavior and cover gem installation failures.

## How to test this

- Run `npm run lint` + `npm test`.

## Risks and limitations

This affects only macOS CI. Real signing can only be exercised in Buildkite; local tests stub the external signing operations. Strict mode intentionally stops the macOS step on any command failure or unset variable.

## Related

Follow-up to #396.

---

<details>
<summary>Design decisions and alternatives considered</summary>

Strict mode belongs to the caller because it governs the full command sequence. The private key still uses `printenv` because `${VAR:?…}` could expose the secret when shell tracing is enabled.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 `[fix here]` · 0 `[follow-up]`. No findings.

</details>
