### PR TITLE
[Fix] Stop site processes before deleting their folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ Line breaks still mean something everywhere else, and none of this touches them:
 
 See `package.json` scripts. To run a single test file (not exposed as a script): `node --test tests/unit/azure-sign.test.cjs`.
 
+Do not run Electron or E2E tests from a worktree without its own `node_modules`. Install dependencies in that worktree first, and do not rely on `NODE_PATH` from another worktree for Electron tests.
+
+Prefer the simplest fix for reproducible user-facing failures. Do not add defensive state or branches for hypothetical edge cases unless a test demonstrates a realistic path.
+
 **[TESTING.md](TESTING.md) is the canonical description of the suite** — the five layers it is made of, which one a new test belongs in, what each layer is blind to, and how to read a failure. Read it before adding or moving a test; do not restate it elsewhere.
 
 When writing manual test instructions, inspect the current renderer flow first and distinguish actions that happen automatically after linking a ticket from controls used only to retry or refresh them. Do not tell a tester to click a control when the app already starts that operation.

--- a/src/kill-tree.js
+++ b/src/kill-tree.js
@@ -69,4 +69,48 @@ function killChildTree(child, {
 	return true;
 }
 
-module.exports = { killTreePlan, killChildTree };
+/**
+ * Stops a process tree and waits until the ChildProcess has fully closed.
+ * `close`, rather than the successful signal attempt, is the boundary callers
+ * need before removing a working directory the process may still hold open.
+ *
+ * Returns false when the child cannot be signalled or does not close within the
+ * timeout. The caller decides whether that means retry, refusal, or best effort.
+ *
+ * @param {?Object} child
+ * @param {Object}  [deps]           killChildTree options plus the wait limit.
+ * @param {number}  [deps.timeoutMs]
+ * @return {Promise<boolean>}
+ */
+function killChildTreeAndWait(child, { timeoutMs = 5000, ...killDeps } = {}) {
+	if (!child || typeof child.once !== 'function' || typeof child.removeListener !== 'function') {
+		return Promise.resolve(false);
+	}
+	const exited = (child.exitCode !== null && child.exitCode !== undefined) || child.signalCode;
+
+	return new Promise((resolve) => {
+		let timer = null;
+		let settled = false;
+		const finish = (stopped) => {
+			if (settled) return;
+			settled = true;
+			child.removeListener('close', onClose);
+			if (timer !== null) clearTimeout(timer);
+			resolve(stopped);
+		};
+		const onClose = () => finish(true);
+
+		// Listen first: taskkill is synchronous on Windows, and a very short-lived
+		// child can close before killChildTree returns.
+		child.once('close', onClose);
+		if (!exited && !killChildTree(child, killDeps)) {
+			finish(false);
+			return;
+		}
+		if (settled) return;
+		const waitMs = Number.isFinite(timeoutMs) ? Math.max(0, timeoutMs) : 5000;
+		timer = setTimeout(() => finish(false), waitMs);
+	});
+}
+
+module.exports = { killTreePlan, killChildTree, killChildTreeAndWait };

--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ const {
 	logError
 } = require('./logging');
 const { buildMenuTemplate } = require('./menu');
-const { killChildTree } = require('./kill-tree');
+const { killChildTree, killChildTreeAndWait } = require('./kill-tree');
 const { normalizeEol } = require('./git-update.cjs');
 const { readTrunkInfo, collectDirtyFiles, discardChanges, discardToBase, updateToLatestTrunk } = require('./trunk-update');
 const { applyPatchToDir } = require('./patch-apply');
@@ -287,6 +287,8 @@ const runIdByDirectory = {};
 const installIdByDirectory = {};
 /** @type {Record<string, { child: import('child_process').ChildProcess, url?: string }>} */
 const playgroundServers = {};
+/** @type {Map<string, Set<import('child_process').ChildProcess>>} */
+const runningChildrenByDirectory = new Map();
 // The sites being created right now — liveness, not truth, which is why it is
 // here beside the other per-site maps and not in the store. See
 // setup-tracker.js: a directory exists minutes before its clone finishes, and
@@ -298,6 +300,44 @@ const wpDebugWatchers = {};
 const smtpServers = {};
 /** @type {{ child: import('child_process').ChildProcess, url?: string } | null} */
 let playgroundWebServer = null;
+
+function runningChildrenForSite(sitePath) {
+	return [...new Set([
+		...(runningChildrenByDirectory.get(sitePath) || []),
+		runningGit.get(sitePath),
+		playgroundServers[sitePath]?.child
+	].filter(Boolean))];
+}
+
+function trackDirectoryChild(directoryPath, child) {
+	let children = runningChildrenByDirectory.get(directoryPath);
+	if (!children) {
+		children = new Set();
+		runningChildrenByDirectory.set(directoryPath, children);
+	}
+	children.add(child);
+	child.once('close', () => untrackDirectoryChild(directoryPath, child));
+}
+
+function untrackDirectoryChild(directoryPath, child) {
+	const children = runningChildrenByDirectory.get(directoryPath);
+	if (!children || !child) return;
+	children.delete(child);
+	if (children.size === 0) runningChildrenByDirectory.delete(directoryPath);
+}
+
+async function stopSiteChildren(sitePath) {
+	const children = runningChildrenForSite(sitePath);
+	// Deletion is an explicit stop too. In particular, a cancelled install must
+	// not interpret its non-zero exit as an engine mismatch and restart itself.
+	for (const child of children) cancelledChildren.add(child);
+	const stopped = await Promise.all(children.map((child) => killChildTreeAndWait(child)));
+	if (stopped.some((result) => !result)) {
+		const error = new Error(`A running process for ${sitePath} did not stop within the timeout`);
+		error.code = 'ETIMEDOUT';
+		throw error;
+	}
+}
 
 function smtpStoreKey(sitePath) {
     return `siteMail:${sitePath}`;
@@ -2064,47 +2104,35 @@ ipcMain.handle('sites:mark-initialized', async (_e, sitePath) => {
 // for why. A refusal is logged rather than dropped so a future caller that trips
 // the guard shows up in the log file instead of just doing nothing.
 ipcMain.handle('sites:delete', async (_e, sitePath) => {
-	const s = await getStore();
-	// Filled in by `remove` when the deletion itself fails. Kept outside the
-	// guard call because deleteRegisteredSite's boolean only answers "was this
-	// allowed", and the renderer needs the other half of the story too (#381).
-	let removalError = null;
-	const allowed = await deleteRegisteredSite(sitePath, {
-		sites: s.get('sites'),
-		// A site whose clone is still running is refused outright, registered or
-		// not: `remove` would be deleting a tree the clone is still writing into.
-		pending: setupTracker.paths(),
-		forget: () => {
-			s.set('sites', s.get('sites').filter((p) => p !== sitePath));
-			const meta = s.get('siteMeta');
-			delete meta[sitePath];
-			s.set('siteMeta', meta);
-		},
-		// removeTree handles what plain removal leaves unanswered on the
-		// protected object files a real Git writes: on POSIX, a directory whose
-		// write bit is missing, which nothing else clears; on Windows, an entry
-		// something still holds open, which only a retry budget survives (#381).
-		// A failure is recorded rather than swallowed: `forget` has already
-		// run — deliberately, so a locked directory cannot leave a site stuck
-		// undeletable — which means the one honest thing left to do when the
-		// disk half fails is to say so, in the log and to the caller.
-		remove: async (p) => {
-			try {
+	try {
+		const s = await getStore();
+		const allowed = await deleteRegisteredSite(sitePath, {
+			sites: s.get('sites'),
+			// A site whose clone is still running is refused outright, registered or
+			// not: `remove` would be deleting a tree the clone is still writing into.
+			pending: setupTracker.paths(),
+			forget: () => {
+				s.set('sites', s.get('sites').filter((p) => p !== sitePath));
+				const meta = s.get('siteMeta');
+				delete meta[sitePath];
+				s.set('siteMeta', meta);
+			},
+			// Stop and fully close every child associated with this directory before
+			// removeTree reaches it. Windows keeps a process's cwd locked until then.
+			// removeTree still owns protected Git objects and transient filesystem
+			// failures; only after it succeeds does site-registry forget the site.
+			remove: async (p) => {
+				await stopSiteChildren(p);
 				await removeTree(p);
-			} catch (e) {
-				removalError = e;
-				logError('sites', `deleted ${sitePath} from the registry, but its folder could not be removed and is still on disk: ${String(e && e.stack ? e.stack : e)}`);
-			}
-		},
-		onRefused: (description) => logEvent('sites', `refused to delete ${description} — not a registered site, or still being created`)
-	});
-	if (!allowed) return { ok: false, refused: true };
-	if (removalError) {
-		// Machine-readable on purpose: the sentence the contributor reads is
-		// composed in the renderer (confirmations.cjs), where it is testable.
-		return { ok: false, reason: 'remove-failed', path: sitePath, code: removalError.code };
+			},
+			onRefused: (description) => logEvent('sites', `refused to delete ${description}: not a registered site, or still being created`)
+		});
+		if (!allowed) return { ok: false, refused: true };
+		return { ok: true };
+	} catch (e) {
+		logError('sites', `kept ${sitePath} in the registry because deletion could not safely finish and its folder may still be on disk: ${String(e && e.stack ? e.stack : e)}`);
+		return { ok: false, reason: 'remove-failed', path: sitePath, code: e?.code };
 	}
-	return { ok: true };
 });
 
 ipcMain.handle('sites:set-label', async (_e, sitePath, label) => {
@@ -2675,6 +2703,7 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 		register: (child) => {
 			runningInstalls[installId] = child;
 			installIdByDirectory[directoryPath] = installId;
+			trackDirectoryChild(directoryPath, child);
 		},
 		onLog: (type, data) => {
 			event.sender.send('npm:install:log', { installId, type, data });
@@ -2693,6 +2722,7 @@ ipcMain.handle('npm:install', async (event, directoryPath) => {
 				s.set('siteMeta', meta);
 			} catch {}
 			event.sender.send('npm:install:done', { installId, code });
+			untrackDirectoryChild(directoryPath, runningInstalls[installId]);
 			delete runningInstalls[installId];
 			// Guarded on identity: a second install for the same directory has
 			// already claimed the slot, and clearing it blind would leave that
@@ -2724,12 +2754,14 @@ ipcMain.handle('npm:run-script', async (event, directoryPath, scriptName, script
 		register: (child) => {
 			runningScripts[runId] = child;
 			runIdByDirectory[directoryPath] = runId;
+			trackDirectoryChild(directoryPath, child);
 		},
 		onLog: (type, data) => {
 			event.sender.send('npm:run-script:log', { runId, type, data });
 		},
 		onDone: (code) => {
 			event.sender.send('npm:run-script:done', { runId, code });
+			untrackDirectoryChild(directoryPath, runningScripts[runId]);
 			delete runningScripts[runId];
 			if (runIdByDirectory[directoryPath] === runId) {
 				delete runIdByDirectory[directoryPath];

--- a/src/renderer/confirmations.cjs
+++ b/src/renderer/confirmations.cjs
@@ -93,19 +93,18 @@ function prConfirmationMessage(res = {}) {
 /**
  * The notice for a site deletion, or null when there is nothing to say (#381).
  *
- * Only the half-failure speaks: the registry entry is gone either way — that
- * ordering is main's recorded decision — but the folder can survive, a file
- * held open or the read-only attribute a real Git leaves on its object files.
- * The message names the path because that folder is what the contributor now
- * has to deal with by hand, and carries the error code because "could not be
- * deleted" without one is the kind of report a mentor cannot act on.
+ * Only a failure speaks. The registry entry now stays in place until the folder
+ * is gone, so the message says the deletion can be retried after the contributor
+ * releases whatever still holds the directory. It names the path and carries
+ * the error code because "could not be deleted" without either is the kind of
+ * report a mentor cannot act on.
  *
  * @param {{ ok?: boolean, reason?: string, path?: string, code?: string }} res The main process's result.
  */
 function deleteFailureMessage(res = {}) {
 	if (res.ok !== false || res.reason !== 'remove-failed') return null;
 	const code = res.code ? ` (${res.code})` : '';
-	return `The site was removed from the list, but its folder could not be deleted${code} and is still at ${res.path}`;
+	return `The site is still listed because its folder could not be deleted${code}. Close anything using it, then try again. Folder: ${res.path}`;
 }
 
 module.exports = { initialConfirmations, confirmationReducer, prConfirmationMessage, deleteFailureMessage, MAX_NOTICES };

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -349,6 +349,10 @@ function App() {
   useEffect(() => { (async () => { try { setWebAvailable(Boolean(await window.api.playgroundWebAvailable())); } catch {} })(); }, []);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeSite, setActiveSite] = useState(null);
+  const [deletingSites, setDeletingSites] = useState([]);
+  // State paints the progress, while the ref closes the same-tick gap before
+  // React renders it and prevents two delete requests for one site.
+  const deletingSitesRef = useRef(new Set());
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [createSiteName, setCreateSiteName] = useState('');
   const [createSiteDir, setCreateSiteDir] = useState('');
@@ -681,15 +685,25 @@ function App() {
   }, [setSiteMeta]);
 
   const onDelete = useCallback(async (sitePath) => {
-    const result = await window.api.deleteSite(sitePath);
-    await refresh();
-    removeSetupLog(sitePath);
-    // A deletion that half-happened must not look like one that worked (#381).
-    // The sentence and the decision to show it live in confirmations.cjs,
-    // where the suite can reach them; the error tone stays until dismissed.
-    const failure = deleteFailureMessage(result);
-    if (failure) {
-      confirm(failure, { tone: 'error' });
+    if (deletingSitesRef.current.has(sitePath)) return;
+    deletingSitesRef.current.add(sitePath);
+    setDeletingSites((current) => (current.includes(sitePath) ? current : [...current, sitePath]));
+    let result;
+    try {
+      try {
+        result = await window.api.deleteSite(sitePath);
+      } catch {
+        result = { ok: false, reason: 'remove-failed', path: sitePath };
+      }
+      try { await refresh(); } catch {}
+      if (result?.ok) removeSetupLog(sitePath);
+      // A failed deletion stays visible and retryable. The error tone keeps its
+      // notice on screen until dismissed rather than expiring on a timer.
+      const failure = deleteFailureMessage(result);
+      if (failure) confirm(failure, { tone: 'error' });
+    } finally {
+      deletingSitesRef.current.delete(sitePath);
+      setDeletingSites((current) => current.filter((path) => path !== sitePath));
     }
   }, [refresh, removeSetupLog, confirm]);
 
@@ -804,6 +818,7 @@ function App() {
             const meta = siteMeta?.[sitePath] || {};
             const siteName = (meta.label && meta.label.trim()) || pathBasename(sitePath);
             const isActive = activeSite === sitePath;
+            const isDeleting = deletingSites.includes(sitePath);
             // Staleness surfaces in the sidebar before the site is even
             // opened (#94): amber = old trunk snapshot, red = an update that
             // moved trunk but never finished install/build.
@@ -824,6 +839,8 @@ function App() {
               <Button
                 key={sitePath}
                 onClick={() => handleSelectSite(sitePath)}
+                aria-busy={isDeleting}
+                aria-label={isDeleting ? `${siteName}, Deleting` : undefined}
                 variant="tertiary"
                 isSmall
                 isPressed={isActive}
@@ -842,6 +859,7 @@ function App() {
                 ) : (
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
                     <span style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 6 }}>{siteName}{staleDot}</span>
+                    {isDeleting ? <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.72)' }}>Deleting…</span> : null}
                   </div>
                 )}
               </Button>
@@ -938,6 +956,7 @@ function App() {
                       editor={detectedApplications}
                       wporg={wporg}
                       isPending={pendingSites.includes(s)}
+                      isDeleting={deletingSites.includes(s)}
                       setupLogs={setupLogsBySite[s] || ''}
                       switchProgress={switchProgressBySite[s] || null}
                       onClearSwitchNotices={clearSwitchNotices}
@@ -1195,7 +1214,7 @@ function TerminalCommandLink({ command, onPrefill, disabled }) {
   );
 }
 
-function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onDelete, onRename, onCreateSite, editor, wporg, isPending = false, setupLogs = '', isActive = false, switchProgress = null, carriedWork = null, onClearSwitchNotices = null }) {
+function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSiteMetaPatch, onDelete, onRename, onCreateSite, editor, wporg, isPending = false, isDeleting = false, setupLogs = '', isActive = false, switchProgress = null, carriedWork = null, onClearSwitchNotices = null }) {
   // The window's confirmation queue (#253): confirm(message) after an action
   // completes, so the outcome is announced rather than left silent or buried in
   // the terminal.
@@ -4321,7 +4340,9 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
               // the backstop, and not offering a control that cannot work is
               // the actual answer.
               ...(isPending ? [] : [
-                { title:'Delete this site', onClick:()=>confirmAnd('Delete this site from disk? This cannot be undone.', ()=>onDelete(sitePath)) }
+                isDeleting
+                  ? { title: 'Deleting…', isDisabled: true }
+                  : { title:'Delete this site', onClick:()=>confirmAnd('Delete this site from disk? This cannot be undone.', ()=>onDelete(sitePath)) }
               ])
             ]}
           />

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -819,6 +819,9 @@ function App() {
             const siteName = (meta.label && meta.label.trim()) || pathBasename(sitePath);
             const isActive = activeSite === sitePath;
             const isDeleting = deletingSites.includes(sitePath);
+            let siteButtonMinHeight = 40;
+            if (sidebarCollapsed) siteButtonMinHeight = 36;
+            else if (isDeleting) siteButtonMinHeight = 58;
             // Staleness surfaces in the sidebar before the site is even
             // opened (#94): amber = old trunk snapshot, red = an update that
             // moved trunk but never finished install/build.
@@ -841,6 +844,8 @@ function App() {
                 onClick={() => handleSelectSite(sitePath)}
                 aria-busy={isDeleting}
                 aria-label={isDeleting ? `${siteName}, Deleting` : undefined}
+                disabled={isDeleting}
+                accessibleWhenDisabled={isDeleting}
                 variant="tertiary"
                 isSmall
                 isPressed={isActive}
@@ -852,16 +857,24 @@ function App() {
                   color: '#f7f7f7',
                   padding: sidebarCollapsed ? '8px 0' : '10px 12px',
                   borderRadius: 6,
+                  height: 'auto',
+                  minHeight: siteButtonMinHeight,
+                  opacity: 1,
                 }}
               >
-                {sidebarCollapsed ? (
+                {sidebarCollapsed && !isDeleting ? (
                   <span style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 4 }}>{siteName.slice(0, 1).toUpperCase()}{staleDot}</span>
-                ) : (
-                  <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
-                    <span style={{ fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 6 }}>{siteName}{staleDot}</span>
-                    {isDeleting ? <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.72)' }}>Deleting…</span> : null}
+                ) : null}
+                {sidebarCollapsed && isDeleting ? <Spinner style={{ width: 16, height: 16, margin: 0 }} /> : null}
+                {!sidebarCollapsed ? (
+                  <div style={{ width: '100%', minWidth: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                    <div style={{ minWidth: 0, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 3 }}>
+                      <span style={{ maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 6 }}>{siteName}{staleDot}</span>
+                      {isDeleting ? <span style={{ fontSize: 11, lineHeight: 1.3, color: 'rgba(255,255,255,0.72)' }}>Deleting site…</span> : null}
+                    </div>
+                    {isDeleting ? <Spinner style={{ width: 16, height: 16, margin: 0, flexShrink: 0 }} /> : null}
                   </div>
-                )}
+                ) : null}
               </Button>
             );
           })}

--- a/src/site-registry.js
+++ b/src/site-registry.js
@@ -66,10 +66,11 @@ function describeRefusedSite(sitePath) {
 }
 
 // The `sites:delete` handler's body, kept out of main.js so both sides of the
-// guard can be tested without an Electron process. `forget` drops the path from
-// the store, `remove` is the real tree removal in the app, and both are recording
-// stubs in the tests. A path that is not registered performs neither: no store
-// mutation and no removal, just a logged refusal.
+// guard can be tested without an Electron process. `remove` is the real tree
+// removal in the app, and only after it succeeds does `forget` drop the path
+// from the store. This order keeps a failed deletion visible and retryable. A
+// path that is not registered performs neither: no store mutation and no
+// removal, just a logged refusal.
 async function deleteRegisteredSite(sitePath, { sites, pending, forget, remove, onRefused } = {}) {
 	// Checked before the registry, and separately from it. A site whose clone is
 	// still running is the one case where `remove` would delete a tree another
@@ -87,8 +88,8 @@ async function deleteRegisteredSite(sitePath, { sites, pending, forget, remove, 
 		return false;
 	}
 
-	forget();
 	await remove(sitePath);
+	forget();
 	return true;
 }
 

--- a/tests/e2e/journeys/engine.spec.js
+++ b/tests/e2e/journeys/engine.spec.js
@@ -135,3 +135,44 @@ test( 'a native file dialog can be answered from the test', async ( { session } 
 	expect( chosen.name ).toBe( 'engine.patch' );
 	expect( chosen.text ).toContain( 'wp-login.php' );
 } );
+
+test( 'a failed site deletion stays visible, reports the failure, and can be retried (#414)', async ( { session } ) => {
+	const site = makeListedSite( session, 'delete-retry' );
+	const { app, page } = await session.start( site.settings );
+	const confirmsAnswered = await session.acceptConfirms();
+
+	// Hold the IPC reply in the main process. This keeps the UI operation pending
+	// without shipping a test-only delay or relying on filesystem timing.
+	await app.evaluate( ( { ipcMain } ) => {
+		ipcMain.removeHandler( 'sites:delete' );
+		ipcMain.handle( 'sites:delete', ( _event, sitePath ) => new Promise( ( resolve ) => {
+			globalThis.__toolkitDeleteRequest = { resolve, sitePath };
+		} ) );
+	} );
+
+	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
+	await page.getByRole( 'menuitem', { name: 'Delete this site', exact: true } ).click();
+
+	// The row speaks while the call is outstanding, and the only delete action is
+	// disabled so a second request cannot race the first one.
+	await expect( page.getByText( 'Deleting…', { exact: true } ) ).toBeVisible();
+	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
+	await expect( page.getByRole( 'menuitem', { name: 'Deleting…', exact: true } ) ).toBeDisabled();
+	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
+
+	await app.evaluate( () => {
+		const request = globalThis.__toolkitDeleteRequest;
+		if ( ! request ) throw new Error( 'The renderer never reached sites:delete' );
+		request.resolve( { ok: false, reason: 'remove-failed', path: request.sitePath, code: 'EBUSY' } );
+	} );
+
+	const failure = `The site is still listed because its folder could not be deleted (EBUSY). Close anything using it, then try again. Folder: ${ site.dir }`;
+	await expect( page.getByText( failure, { exact: true } ) ).toBeVisible();
+	await expect( sidebarEntry( page, 'delete-retry' ) ).toBeVisible();
+	await expect( page.getByText( 'Deleting…', { exact: true } ) ).toHaveCount( 0 );
+
+	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
+	await expect( page.getByRole( 'menuitem', { name: 'Delete this site', exact: true } ) ).toBeEnabled();
+	expect( await confirmsAnswered() ).toBe( 1 );
+	expect( session.readSettings().sites ).toEqual( [ site.dir ] );
+} );

--- a/tests/e2e/journeys/engine.spec.js
+++ b/tests/e2e/journeys/engine.spec.js
@@ -155,7 +155,12 @@ test( 'a failed site deletion stays visible, reports the failure, and can be ret
 
 	// The row speaks while the call is outstanding, and the only delete action is
 	// disabled so a second request cannot race the first one.
-	await expect( page.getByText( 'Deleting…', { exact: true } ) ).toBeVisible();
+	const deletingEntry = page.getByRole( 'button', { name: 'delete-retry, Deleting', exact: true } );
+	await expect( deletingEntry ).toBeDisabled();
+	await expect( deletingEntry.getByText( 'Deleting site…', { exact: true } ) ).toBeVisible();
+	await page.getByRole( 'button', { name: 'Collapse site list', exact: true } ).click();
+	await expect( deletingEntry.locator( '.components-spinner' ) ).toBeVisible();
+	await page.getByRole( 'button', { name: 'Expand site list', exact: true } ).click();
 	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
 	await expect( page.getByRole( 'menuitem', { name: 'Deleting…', exact: true } ) ).toBeDisabled();
 	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
@@ -169,7 +174,7 @@ test( 'a failed site deletion stays visible, reports the failure, and can be ret
 	const failure = `The site is still listed because its folder could not be deleted (EBUSY). Close anything using it, then try again. Folder: ${ site.dir }`;
 	await expect( page.getByText( failure, { exact: true } ) ).toBeVisible();
 	await expect( sidebarEntry( page, 'delete-retry' ) ).toBeVisible();
-	await expect( page.getByText( 'Deleting…', { exact: true } ) ).toHaveCount( 0 );
+	await expect( page.getByText( 'Deleting site…', { exact: true } ) ).toHaveCount( 0 );
 
 	await page.getByRole( 'button', { name: 'More', exact: true } ).click();
 	await expect( page.getByRole( 'menuitem', { name: 'Delete this site', exact: true } ) ).toBeEnabled();

--- a/tests/unit/confirmations.test.cjs
+++ b/tests/unit/confirmations.test.cjs
@@ -104,17 +104,17 @@ test('a dry run says no pull request was opened rather than "#undefined" (issue 
 	);
 });
 
-test('a deletion that half-failed names the surviving path and the code (issue #381)', () => {
+test('a failed deletion says the listed site can be retried and names the code (#414)', () => {
 	assert.strictEqual(
 		deleteFailureMessage({ ok: false, reason: 'remove-failed', path: '/sites/demo', code: 'EPERM' }),
-		'The site was removed from the list, but its folder could not be deleted (EPERM) and is still at /sites/demo'
+		'The site is still listed because its folder could not be deleted (EPERM). Close anything using it, then try again. Folder: /sites/demo'
 	);
 });
 
-test('a deletion failure without a code still reads as a sentence (issue #381)', () => {
+test('a deletion failure without a code still reads as a sentence (#414)', () => {
 	assert.strictEqual(
 		deleteFailureMessage({ ok: false, reason: 'remove-failed', path: '/sites/demo' }),
-		'The site was removed from the list, but its folder could not be deleted and is still at /sites/demo'
+		'The site is still listed because its folder could not be deleted. Close anything using it, then try again. Folder: /sites/demo'
 	);
 });
 

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -451,6 +451,135 @@ test('sites:delete removes a registered directory and refuses an unregistered on
 	assert.deepEqual(Object.keys(settings.values.siteMeta), [unregistered]);
 });
 
+// A build watch and dev server keep their working directory open. On Windows
+// that makes the site's root undeletable until both process trees have fully
+// closed, so sending a kill and immediately calling removeTree is still a race.
+// The delete must wait for close, and the registry entry must remain retryable
+// throughout that wait.
+test('sites:delete stops and waits for the site processes before removing it (#414)', async () => {
+	const registered = '/sites/wp';
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const cp = stubbedSpawn();
+	const killChildTreeAndWait = spy((child) => new Promise((resolve) => child.once('close', () => resolve(true))));
+	const removeTree = spy(async () => {});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			...noSmtpServer(),
+			'child_process': { spawn: cp.spawn },
+			'./kill-tree': { killChildTreeAndWait },
+			'./remove-tree': { removeTree }
+		}
+	});
+
+	await main.invoke('npm:run-script', registered, 'dev');
+	await main.invoke('npm:run-script', registered, 'build');
+	const pendingServer = main.invoke('playground:start', registered);
+	await waitForSpawnCount(cp, 3);
+	const deletion = main.invoke('sites:delete', registered);
+	await new Promise(setImmediate);
+
+	const beforeClose = {
+		killCalls: killChildTreeAndWait.calls.slice(),
+		removeCalls: removeTree.calls.slice(),
+		sites: settings.values.sites.slice()
+	};
+	for (const child of cp.children) child.emit('close', 0, null);
+	const [result] = await Promise.all([deletion, pendingServer]);
+
+	assert.deepEqual(beforeClose.killCalls, cp.children.map((child) => [child]), 'every site process tree must be stopped');
+	assert.deepEqual(beforeClose.removeCalls, [], 'removal must wait until every child has closed');
+	assert.deepEqual(beforeClose.sites, [registered], 'the site must stay visible and retryable while deletion waits');
+	assert.deepEqual(removeTree.calls, [[registered]]);
+	assert.deepEqual(result, { ok: true });
+	assert.deepEqual(settings.values.sites, []);
+});
+
+test('sites:delete keeps the site when one of its processes does not stop (#414)', async () => {
+	const registered = '/sites/wp';
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const cp = stubbedSpawn();
+	const killChildTreeAndWait = spy(async () => false);
+	const removeTree = spy(async () => {});
+	const logError = spy();
+	const main = loadMain({
+		stubs: {
+			'./logging': { ...silentLogging()['./logging'], logError },
+			...settings.stubs,
+			'child_process': { spawn: cp.spawn },
+			'./kill-tree': { killChildTreeAndWait },
+			'./remove-tree': { removeTree }
+		}
+	});
+
+	await main.invoke('npm:run-script', registered, 'dev');
+	const result = await main.invoke('sites:delete', registered);
+	cp.children[0].emit('close', 1, null);
+
+	assert.deepEqual(killChildTreeAndWait.calls, [[cp.children[0]]]);
+	assert.deepEqual(removeTree.calls, [], 'a process that may still hold the folder must prevent removal');
+	assert.deepEqual(result, { ok: false, reason: 'remove-failed', path: registered, code: 'ETIMEDOUT' });
+	assert.deepEqual(settings.values.sites, [registered]);
+	assert.deepEqual(Object.keys(settings.values.siteMeta), [registered]);
+	assert.equal(logError.calls.length, 1);
+	assert.match(logError.calls[0][1], /kept .* in the registry/);
+});
+
+test('sites:delete does not let a stopped install retry while removing the site (#414)', async () => {
+	const registered = '/sites/wp';
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const cp = stubbedSpawn();
+	const shouldRetryWithRelaxedEngines = spy(({ cancelled }) => !cancelled);
+	const killChildTreeAndWait = spy(async (child) => {
+		child.emit('close', 1, null);
+		return true;
+	});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'child_process': { spawn: cp.spawn },
+			'./kill-tree': { killChildTreeAndWait },
+			'./npm-runner': { shouldRetryWithRelaxedEngines },
+			'./remove-tree': { removeTree: async () => {} }
+		}
+	});
+
+	await main.invoke('npm:install', registered);
+	assert.equal(cp.spawned.length, 1);
+	assert.deepEqual(await main.invoke('sites:delete', registered), { ok: true });
+
+	assert.equal(shouldRetryWithRelaxedEngines.calls.length, 1);
+	assert.equal(shouldRetryWithRelaxedEngines.calls[0][0].cancelled, true);
+	assert.equal(cp.spawned.length, 1, 'deletion must not restart the install it stopped');
+});
+
+test('sites:delete ignores a runner that failed to spawn without closing (#414)', async () => {
+	const registered = '/sites/wp';
+	const settings = fakeSettingsStore({ sites: [registered], siteMeta: { [registered]: {} } });
+	const cp = stubbedSpawn();
+	const killChildTreeAndWait = spy(async () => false);
+	const removeTree = spy(async () => {});
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...settings.stubs,
+			'child_process': { spawn: cp.spawn },
+			'./kill-tree': { killChildTreeAndWait },
+			'./remove-tree': { removeTree }
+		}
+	});
+
+	await main.invoke('npm:install', registered);
+	cp.children[0].emit('error', Object.assign(new Error('spawn EPERM'), { code: 'EPERM' }));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.deepEqual(await main.invoke('sites:delete', registered), { ok: true });
+	assert.deepEqual(killChildTreeAndWait.calls, [], 'a runner that never started cannot hold the folder open');
+	assert.deepEqual(removeTree.calls, [[registered]]);
+});
+
 // The tree a real Git leaves behind: a read-only loose object inside a
 // directory without its write bit. On POSIX plain removal fails on it — the
 // state that used to strand a site's folder on disk while the registry forgot
@@ -478,10 +607,10 @@ test('sites:delete clears the read-only attributes a real Git leaves behind (#38
 });
 
 // When the disk genuinely refuses, the handler must say so instead of
-// pretending: the registry half has already happened (deliberately — a locked
-// folder must not leave a site stuck undeletable), so the renderer gets a
-// machine-readable failure naming the surviving path, and the log gets the
-// stack. The refusal is staged by stubbing remove-tree rather than by locking
+// pretending: the registry entry must stay intact, so the contributor can retry
+// after releasing the folder. The renderer gets a machine-readable failure
+// naming the surviving path, and the log gets the stack. The refusal is staged
+// by stubbing remove-tree rather than by locking
 // a real directory: the real ways a removal fails differ by platform (an open
 // handle on Windows does not even refuse the unlink — libuv opens with
 // FILE_SHARE_DELETE), and the real propagation is remove-tree.test.cjs's job.
@@ -509,11 +638,10 @@ test('sites:delete reports a folder it could not remove instead of pretending (#
 	const result = await main.invoke('sites:delete', registered);
 	assert.deepEqual(result, { ok: false, reason: 'remove-failed', path: registered, code: 'EPERM' });
 	assert.equal(fs.existsSync(registered), true, 'the folder really did survive');
-	// The forget half happened first, on purpose; the contract is honesty, not rollback.
-	assert.deepEqual(settings.values.sites, []);
+	assert.deepEqual(settings.values.sites, [registered], 'the failed delete must remain retryable');
 	assert.equal(logError.calls.length, 1);
 	assert.equal(logError.calls[0][0], 'sites');
-	assert.match(logError.calls[0][1], /still on disk/);
+	assert.match(logError.calls[0][1], /kept .* in the registry/);
 });
 
 // --- site:status -> src/trunk-update.js ----------------------------------

--- a/tests/unit/kill-tree.test.cjs
+++ b/tests/unit/kill-tree.test.cjs
@@ -1,7 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
 
-const { killTreePlan, killChildTree } = require('../../src/kill-tree.js');
+const { killTreePlan, killChildTree, killChildTreeAndWait } = require('../../src/kill-tree.js');
 
 test('killTreePlan on win32 builds a taskkill for the whole tree', () => {
 	const plan = killTreePlan('win32', 1234);
@@ -76,4 +77,71 @@ test('killChildTree never throws when every mechanism fails', () => {
 		kill: () => { throw new Error('boom'); }
 	});
 	assert.equal(attempted, true);
+});
+
+function waitingChild() {
+	return Object.assign(new EventEmitter(), {
+		pid: 42,
+		exitCode: null,
+		signalCode: null
+	});
+}
+
+test('killChildTreeAndWait resolves only after the child closes', async () => {
+	const child = waitingChild();
+	let settled = false;
+	const stopped = killChildTreeAndWait(child, {
+		platform: 'darwin',
+		kill: () => {},
+		timeoutMs: 1000
+	}).then((result) => {
+		settled = true;
+		return result;
+	});
+
+	await new Promise(setImmediate);
+	assert.equal(settled, false, 'sending the signal is not the same as closing');
+	child.emit('close', 0, 'SIGTERM');
+	assert.equal(await stopped, true);
+});
+
+test('killChildTreeAndWait listens before it sends the kill', async () => {
+	const child = waitingChild();
+	const stopped = await killChildTreeAndWait(child, {
+		platform: 'darwin',
+		kill: () => child.emit('close', 0, 'SIGTERM'),
+		timeoutMs: 1000
+	});
+
+	assert.equal(stopped, true, 'a synchronous close must not be missed');
+});
+
+test('killChildTreeAndWait reports a child that does not close', async () => {
+	const child = waitingChild();
+	const stopped = await killChildTreeAndWait(child, {
+		platform: 'darwin',
+		kill: () => {},
+		timeoutMs: 0
+	});
+
+	assert.equal(stopped, false);
+	assert.equal(child.listenerCount('close'), 0, 'a timed-out wait must remove its listener');
+});
+
+test('killChildTreeAndWait still waits for close after exit', async () => {
+	const child = Object.assign(waitingChild(), { exitCode: 0 });
+	let settled = false;
+	const stopped = killChildTreeAndWait(child, {
+		platform: 'darwin',
+		kill: () => { throw new Error('an exited child must not be signalled'); },
+		timeoutMs: 1000
+	}).then((result) => {
+		settled = true;
+		return result;
+	});
+
+	await new Promise(setImmediate);
+	assert.equal(settled, false, 'exit can happen before stdio closes');
+	child.emit('close', 0, null);
+	assert.equal(await stopped, true);
 });


### PR DESCRIPTION
## Why

Deleting a site while its development server or build watch is running can fail with `EBUSY` on Windows because those process trees still hold the working directory open. The app previously forgot the site before removing its folder and gave no useful progress or recovery state.

## What changes

Site deletion now stops every tracked install, script, Git operation, and Playground server for that directory and waits for each child to emit `close` before removing the tree. The registry is updated only after removal succeeds, so failures leave the site visible and retryable. The renderer shows a contained `Deleting site…` status and spinner in expanded and collapsed sidebars, prevents duplicate deletion requests, and keeps an actionable failure notice visible.

The test instructions also record two worktree guardrails learned while validating this fix: Electron tests require local dependencies, and defensive code needs a realistic failing path.

## How to test this

Platforms: Windows is required because the reported failure depends on Windows directory locking. macOS or Linux can verify the visible flow but cannot prove the original `EBUSY` behavior.

**Starting state:** A fully set up site created by the app, with the signed Buildkite artifact for this PR's current head commit.

1. Open the site and click **Start dev server**. Wait until the server is running, which also leaves its build watch active.
2. Open **More**, choose **Delete this site**, and confirm the destructive action. Expected: the sidebar immediately shows **Deleting…** and the delete action is disabled.
3. Wait for deletion to finish. Expected: the development processes stop, the site disappears from the sidebar, and its directory no longer exists on disk.
4. Repeat with a process that keeps a handle in the site directory and cannot be stopped by the app. Expected: the site stays listed, a persistent notice names the directory and error code, and **Delete this site** becomes available to retry after releasing the handle.

**What must not have happened:** No development child may survive a successful deletion. A failed deletion must not remove the site or its metadata from the registry, start a relaxed-engine installation retry, or leave the delete action permanently disabled.

The failure response and retry UI are covered by an Electron journey because reliably staging an unshareable Windows file handle from the packaged app is not portable. The backend IPC test fails on the old implementation and proves removal waits for all `close` events.

## Risks and limitations

Self-review: 0 fix-here, 1 follow-up (see the review outcome below). The five-second shutdown timeout favors a visible retry over deleting a directory that a process may still use. Verified by hand on Windows on the signed artifact for 861d9a3: deleting a site with its dev server running works, and the progress state renders correctly in both sidebar widths.

## Related

Fixes #414

---

<details>
<summary>Design decisions and alternatives considered</summary>

The app tracks every npm runner for a directory because a replacement can start before the earlier child emits `close`; keeping only the latest runner can miss the process that still locks Windows. The final design does not add a global deletion state or new IPC rejection contracts. It waits for processes already owned by the site and relies on the renderer's immediate lock to prevent duplicate deletions.

The registry update follows disk removal. This keeps the failed operation recoverable without inventing rollback state for `electron-store`.

</details>

<details>
<summary>Review outcome (required, see AGENTS.md)</summary>

0 [fix here] · 1 [follow-up]

Fresh-context review initially found lifecycle races around `exit` versus `close`, installation retry, superseded runners, and failed spawns. Each reproducible case received a failing test and a focused fix. A proposed main-process deletion gate was removed because its new rejection contracts added more complexity than the narrow race justified. The UI follow-up review found that collapsed mode lacked a visible progress indicator; the shared spinner and journey now cover it. The final independent review found no remaining architecture, security, performance, cross-platform, or coverage findings. CodeRabbit raised two Major findings, both declined on the PR with reasons (short-lived `runGit` children are not tracked; `forget` is not transactional), and one nitpick kept as the follow-up: move the renderer's deletion flow (duplicate guard, IPC failure mapping, refresh, notices) out of `index.jsx` into a tested `src/renderer/*.cjs` module.

</details>

<details>
<summary>Implementation notes</summary>

Node documents `close` as the event emitted after the process has ended and its stdio streams have closed. `killChildTreeAndWait` therefore treats `close`, not signal delivery or `exitCode`, as the safe deletion boundary.

Validation: `npm test` 1,190 passed; `npm run test:electron` 1,190 passed; `npm run lint` passed; `git diff --check` passed. The #414 journey passed on every run. Two full E2E runs passed 19/19; a later repetition had one unrelated ticket-link timeout in the patch-apply journey, and that exact scenario passed alone immediately afterward in 1.4 seconds.

</details>

<details>
<summary>Screenshots or recording</summary>

A local recording was captured and visually reviewed after the WordPress Design System pass. It verifies the contained **Deleting site…** status and spinner in both sidebar widths. The same state was checked by hand on Windows on the signed artifact for 861d9a3.

</details>

