### PR TITLE
[Fix] Detect missing files after a successful patch apply

### DIFF
--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -471,10 +471,25 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	const touched = applicable.flatMap((section) => [section.from, section.path]).filter(Boolean);
 	const snapshot = snapshotFiles(dir, touched);
 	const written = await applyPatch(dir, applyText, { reverse, platform, prefix });
-	if (!written.ok) {
+	let writeError = written.ok ? null : written.stderr.split(/\r?\n/).filter((line) => line.trim()).pop() || `git apply exited ${written.status}`;
+	// Windows Git can exit 0 without creating a file beneath a regular-file
+	// parent (#413). Check the actual destinations before claiming success.
+	// Git still decides the contents; this only detects an omitted write.
+	if (written.ok) {
+		const destinations = new Set(applicable.map((section) => reverse ? section.from : section.to).filter(Boolean));
+		for (const relPath of destinations) {
+			try {
+				// A symlink is itself a written entry, even if its target is absent.
+				await fs.promises.lstat(path.join(dir, relPath));
+			} catch (e) {
+				writeError = `could not verify ${relPath} after git apply: ${e.message}`;
+				break;
+			}
+		}
+	}
+	if (writeError) {
 		const recovery = rollback(dir, snapshot);
-		const reason = written.stderr.split(/\r?\n/).filter((line) => line.trim()).pop() || `git apply exited ${written.status}`;
-		const message = `writing ${reason}`;
+		const message = `writing ${writeError}`;
 		if (recovery.length) {
 			onLog(`\nThe patch could not be written, and the checkout could not be fully put back — it is in an unknown state. Could not undo: ${recovery.join('; ')}\n`);
 			return { ok: false, error: message, applied: [], skipped, rolledBack: false, recovery };

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -363,6 +363,20 @@ function snapshotFiles(dir, relPaths) {
 		if (!relPath || snapshot.has(relPath)) continue;
 		const abs = entryPath(dir, relPath, true);
 		snapshot.set(relPath, abs === null ? null : snapshotEntry(abs));
+		// Remember missing intermediate directories too. Git may create them
+		// without naming them as patch entries; rollback removes only empty ones.
+		for (let parent = path.dirname(relPath); parent !== '.'; parent = path.dirname(parent)) {
+			if (snapshot.has(parent)) continue;
+			const parentAbs = entryPath(dir, parent, true);
+			if (parentAbs === null) snapshot.set(parent, null);
+			else {
+				try { fs.lstatSync(parentAbs); }
+				catch (e) {
+					if (e.code !== 'ENOENT' && e.code !== 'ENOTDIR') throw e;
+					snapshot.set(parent, null);
+				}
+			}
+		}
 	}
 	return snapshot;
 }
@@ -377,10 +391,14 @@ function snapshotFiles(dir, relPaths) {
  */
 function rollback(dir, snapshot) {
 	const errors = [];
-	for (const [relPath, previous] of snapshot) {
+	const restore = new Map();
+	const depth = (relPath) => path.resolve(dir, relPath).split(path.sep).length;
+	const deepestFirst = [...snapshot].sort(([a], [b]) => depth(b) - depth(a));
+	// Remove children before parents, without traversing a replacement link.
+	for (const [relPath, previous] of deepestFirst) {
 		try {
-			const abs = entryPath(dir, relPath);
-			const now = snapshotEntry(abs);
+			const abs = entryPath(dir, relPath, true);
+			const now = abs === null ? null : snapshotEntry(abs);
 			// Leave entries Git never changed alone, including their mtimes.
 			if (previous === null && now === null) continue;
 			if (previous && now && previous.type === now.type) {
@@ -392,7 +410,16 @@ function rollback(dir, snapshot) {
 				if (now.type === 'directory') fs.rmdirSync(abs);
 				else fs.unlinkSync(abs);
 			}
-			if (previous === null) continue;
+			if (previous !== null) restore.set(relPath, previous);
+		} catch (e) {
+			errors.push(`${relPath}: ${String(e && e.message ? e.message : e)}`);
+		}
+	}
+	// Restore parents before children. A remaining symlink parent still blocks
+	// restoration, including when its removal failed in the first phase.
+	for (const [relPath, previous] of [...restore].reverse()) {
+		try {
+			const abs = entryPath(dir, relPath);
 			fs.mkdirSync(path.dirname(abs), { recursive: true });
 			if (previous.type === 'symlink') fs.symlinkSync(previous.target, abs);
 			else if (previous.type === 'directory') fs.mkdirSync(abs);

--- a/src/patch-apply.js
+++ b/src/patch-apply.js
@@ -295,61 +295,111 @@ function explainRefusal(dir, file) {
 }
 
 /**
- * What the files a patch names hold right now, so a write Git left half done
- * can be put back. `null` records an absent file (to be removed again).
+ * Resolve a snapshot path without traversing a symlink below the checkout.
+ * The root itself may use an OS alias (such as macOS /var).
+ *
+ * @param {string}  dir
+ * @param {string}  relPath
+ * @param {boolean} snapshot Whether to treat paths behind links as absent.
+ * @return {?string}
+ */
+function entryPath(dir, relPath, snapshot = false) {
+	const root = fs.realpathSync(dir);
+	const abs = path.resolve(root, relPath);
+	const relative = path.relative(root, abs);
+	if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+		throw new Error('Path is outside the checkout');
+	}
+	let parent = root;
+	for (const part of relative.split(path.sep).slice(0, -1)) {
+		parent = path.join(parent, part);
+		let stat;
+		try { stat = fs.lstatSync(parent); }
+		catch (e) {
+			if (e.code === 'ENOENT' || e.code === 'ENOTDIR') break;
+			throw e;
+		}
+		if (stat.isSymbolicLink()) {
+			// Git may replace this link with a directory. Its future children
+			// have no pre-patch entries here; never snapshot the link's target.
+			if (snapshot) return null;
+			throw new Error(`Parent is a symbolic link: ${parent}`);
+		}
+		if (!stat.isDirectory()) break;
+	}
+	return abs;
+}
+
+/**
+ * Read the entry itself, never a symlink's target. Null means absent.
+ *
+ * @param {string} abs
+ * @return {?Object}
+ */
+function snapshotEntry(abs) {
+	let stat;
+	try { stat = fs.lstatSync(abs); }
+	catch (e) {
+		if (e.code === 'ENOENT' || e.code === 'ENOTDIR') return null;
+		throw e;
+	}
+	if (stat.isSymbolicLink()) return { type: 'symlink', target: fs.readlinkSync(abs) };
+	if (stat.isDirectory()) return { type: 'directory' };
+	if (!stat.isFile()) throw new Error('Unsupported filesystem entry');
+	// eslint-disable-next-line no-bitwise -- Keep only filesystem permission bits.
+	return { type: 'file', bytes: fs.readFileSync(abs), mode: stat.mode & 0o777 };
+}
+
+/**
+ * What the entries a patch names hold, so a partial write can be put back.
  *
  * @param {string}   dir
  * @param {string[]} relPaths
- * @return {Map<string, ?Buffer>}
+ * @return {Map<string, ?Object>}
  */
 function snapshotFiles(dir, relPaths) {
 	const snapshot = new Map();
 	for (const relPath of relPaths) {
 		if (!relPath || snapshot.has(relPath)) continue;
-		let previous = null;
-		try { previous = fs.readFileSync(path.join(dir, relPath)); } catch { previous = null; }
-		snapshot.set(relPath, previous);
+		const abs = entryPath(dir, relPath, true);
+		snapshot.set(relPath, abs === null ? null : snapshotEntry(abs));
 	}
 	return snapshot;
 }
 
 /**
- * Puts back everything a failed run had already written.
- *
- * Returns the paths it could not restore. The same full-disk, lock, or
- * permission condition that broke a write can also break its undo, and the
- * caller must not claim a clean restore when the tree is actually unknown.
+ * Restore entries without following changed links. Nonempty directories and
+ * paths behind a symlink are refused rather than risking unrelated files.
  *
  * @param {string}               dir
- * @param {Map<string, ?Buffer>} snapshot From `snapshotFiles`.
- * @return {Array<string>} paths whose rollback failed (empty when fully restored)
+ * @param {Map<string, ?Object>} snapshot
+ * @return {Array<string>} Paths whose rollback failed.
  */
 function rollback(dir, snapshot) {
 	const errors = [];
-	const unchanged = (abs, previous) => {
-		try {
-			const now = fs.readFileSync(abs);
-			return previous !== null && now.equals(previous);
-		} catch (e) {
-			return previous === null && e && e.code === 'ENOENT';
-		}
-	};
 	for (const [relPath, previous] of snapshot) {
-		const abs = path.join(dir, relPath);
-		// A file Git never reached is left alone: writing the snapshot back
-		// over it would only move its mtime, or, if something else edited it
-		// between the check and the write, lose that edit.
-		if (unchanged(abs, previous)) continue;
 		try {
-			if (previous === null) {
-				// Removing something that was never created is the desired end
-				// state, not a failure.
-				try { fs.rmSync(abs, { force: true }); }
-				catch (e) { if (!e || (e.code !== 'ENOTDIR' && e.code !== 'ENOENT')) throw e; }
-				continue;
+			const abs = entryPath(dir, relPath);
+			const now = snapshotEntry(abs);
+			// Leave entries Git never changed alone, including their mtimes.
+			if (previous === null && now === null) continue;
+			if (previous && now && previous.type === now.type) {
+				if (previous.type === 'directory') continue;
+				if (previous.type === 'symlink' && previous.target === now.target) continue;
+				if (previous.type === 'file' && previous.mode === now.mode && previous.bytes.equals(now.bytes)) continue;
 			}
+			if (now) {
+				if (now.type === 'directory') fs.rmdirSync(abs);
+				else fs.unlinkSync(abs);
+			}
+			if (previous === null) continue;
 			fs.mkdirSync(path.dirname(abs), { recursive: true });
-			fs.writeFileSync(abs, previous);
+			if (previous.type === 'symlink') fs.symlinkSync(previous.target, abs);
+			else if (previous.type === 'directory') fs.mkdirSync(abs);
+			else {
+				fs.writeFileSync(abs, previous.bytes, { flag: 'wx', mode: previous.mode });
+				fs.chmodSync(abs, previous.mode);
+			}
 		} catch (e) {
 			errors.push(`${relPath}: ${String(e && e.message ? e.message : e)}`);
 		}
@@ -469,7 +519,13 @@ async function applyPatchToDir({ dir, patchText, reverse = false, onLog = () => 
 	// for. Both ends of every section: a rename names the file it moves away
 	// from as well as the one it makes.
 	const touched = applicable.flatMap((section) => [section.from, section.path]).filter(Boolean);
-	const snapshot = snapshotFiles(dir, touched);
+	let snapshot;
+	try { snapshot = snapshotFiles(dir, touched); }
+	catch (e) {
+		const error = `Could not snapshot the checkout before applying the patch: ${e.message}`;
+		onLog(`\n${error}\n`);
+		return { ok: false, error, applied: [], skipped };
+	}
 	const written = await applyPatch(dir, applyText, { reverse, platform, prefix });
 	let writeError = written.ok ? null : written.stderr.split(/\r?\n/).filter((line) => line.trim()).pop() || `git apply exited ${written.status}`;
 	// Windows Git can exit 0 without creating a file beneath a regular-file

--- a/src/patch-plan.cjs
+++ b/src/patch-plan.cjs
@@ -98,9 +98,11 @@ function mapToSrcLayout(filePath) {
  *
  * `path` is the file the section ends on; `from` the one it starts from
  * (the same file for a modify, the source of a rename, empty for an add).
+ * `to` is the actual destination, empty for a deletion; `path` keeps the
+ * deleted path for display and snapshots.
  *
  * @param {string} text EOL-normalised patch text.
- * @return {Array<{path: string, from: string, text: string, isBinary: boolean, hasBinaryData: boolean}>}
+ * @return {Array<{path: string, from: string, to: string, text: string, isBinary: boolean, hasBinaryData: boolean}>}
  */
 function splitPatchSections(text) {
 	const lines = text.split('\n');
@@ -122,7 +124,7 @@ function splitPatchSections(text) {
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 		if (startsSection(line, i)) {
-			current = { path: '', from: '', lines: [], isBinary: false, hasBinaryData: false, sawHeader: false };
+			current = { path: '', from: '', lines: [], isBinary: false, hasBinaryData: false, sawHeader: false, isAdd: false, isDelete: false };
 			sections.push(current);
 			const git = /^diff --git (?:"?a\/)?(.+?)"? (?:"?b\/)?(.+?)"?$/.exec(line);
 			const svn = /^Index: (.+)$/.exec(line);
@@ -133,12 +135,14 @@ function splitPatchSections(text) {
 		if (!current) continue;
 		current.lines.push(line);
 		const named = (l) => l.slice(4).replace(/\t.*$/, '');
-		if (line.startsWith('+++ ')) {
+		if (line.startsWith('+++ ') && !current.sawHeader) {
+			current.isDelete = named(line) === '/dev/null';
 			current.sawHeader = true;
 			const to = named(line);
 			current.path = to === '/dev/null' ? current.path : to.replace(/^[ab]\//, '');
 		} else if (line.startsWith('--- ') && !current.sawHeader) {
 			const from = named(line);
+			current.isAdd = from === '/dev/null';
 			current.from = from === '/dev/null' ? '' : from.replace(/^[ab]\//, '');
 			if (!current.path) current.path = current.from;
 		}
@@ -146,13 +150,16 @@ function splitPatchSections(text) {
 		if (renameFrom) current.from = renameFrom[1].trim();
 		const renameTo = /^rename to (.+)$/.exec(line);
 		if (renameTo) current.path = renameTo[1].trim();
+		if (/^new file mode \d+$/.test(line)) current.isAdd = true;
+		if (/^deleted file mode \d+$/.test(line)) current.isDelete = true;
 		if (/^Binary files .* differ$/.test(line)) current.isBinary = true;
 		if (/^GIT binary patch$/.test(line)) { current.isBinary = true; current.hasBinaryData = true; }
 	}
 	const clean = (p) => (p === '/dev/null' ? '' : p);
-	return sections.map(({ path: sectionPath, from, lines: sectionLines, isBinary, hasBinaryData }) => ({
+	return sections.map(({ path: sectionPath, from, lines: sectionLines, isBinary, hasBinaryData, isAdd, isDelete }) => ({
 		path: clean(sectionPath),
-		from: clean(from),
+		from: isAdd ? '' : clean(from),
+		to: isDelete ? '' : clean(sectionPath),
 		text: `${sectionLines.join('\n')}\n`,
 		isBinary,
 		hasBinaryData

--- a/tests/e2e/journeys/patch-apply.spec.js
+++ b/tests/e2e/journeys/patch-apply.spec.js
@@ -15,6 +15,10 @@
  * party in the path of a test that is about the checkout.
  */
 
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+const { gitOk, commitFiles } = require( '../../unit/helpers/git.cjs' );
 const { test, expect } = require( '../helpers/app.cjs' );
 const {
 	makeSite,
@@ -172,4 +176,59 @@ test( 'a patch that does not fit is refused, and writes nothing', async ( { sess
 
 	// INVARIANT — and nothing is offered to undo, because nothing was done.
 	await expect( page.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toHaveCount( 0 );
+} );
+
+
+test( 'a partial patch failure restores the symlink and leaves no applied record (#413)', async ( { session } ) => {
+	const site = await makeSite( session );
+	const outsideDir = session.track( fs.mkdtempSync( path.join( os.tmpdir(), 'wpct-e2e-outside-' ) ) );
+	const outside = path.join( outsideDir, 'untouched.txt' );
+	fs.writeFileSync( outside, 'outside\n' );
+	const link = path.join( site.dir, 'src', 'link' );
+	gitOk( [ 'config', 'core.symlinks', 'true' ], site.dir );
+	fs.symlinkSync( 'wp-login.php', link, 'file' );
+	write( site.dir, 'src/blocker', 'not a directory\n' );
+	commitFiles( site.dir, [ 'src/link', 'src/blocker' ], 'patch failure fixture' );
+
+	// Generate the symlink diff with bundled Git so Windows targets are encoded
+	// correctly. Restore the fixture before the app sees it.
+	fs.unlinkSync( link );
+	fs.symlinkSync( outside, link, 'file' );
+	const patch = path.join( outsideDir, 'blocked.patch' );
+	gitOk( [ 'diff', '--output', patch, '--', 'src/link' ], site.dir );
+	fs.appendFileSync( patch, `diff --git a/src/blocker/new.txt b/src/blocker/new.txt
+new file mode 100644
+--- /dev/null
++++ b/src/blocker/new.txt
+@@ -0,0 +1 @@
++hello
+` );
+	fs.unlinkSync( link );
+	fs.symlinkSync( 'wp-login.php', link, 'file' );
+
+	const { page } = await session.start( site.settings );
+	await linkTicket( page, '60001' );
+	await session.answerFileDialog( [ patch ] );
+	await page.getByRole( 'button', { name: 'or choose a .diff / .patch file…', exact: true } ).click();
+	await expect( page.getByText( 'src/link', { exact: true } ) ).toBeVisible();
+	await page.getByRole( 'button', { name: 'Apply and rebuild', exact: true } ).click();
+
+	// INVARIANT: a partial write is reported as a failure, never as success.
+	const failure = page.getByRole( 'alert' ).filter( { hasText: 'The checkout was not changed' } );
+	await expect( failure ).toBeVisible();
+	await expect( failure ).toContainText( 'src/blocker/new.txt' );
+
+	// INVARIANT: recovery restores link identity without writing outside the site.
+	expect( fs.readFileSync( outside, 'utf8' ) ).toBe( 'outside\n' );
+	expect( fs.lstatSync( link ).isSymbolicLink() ).toBe( true );
+	expect( fs.readlinkSync( link ) ).toBe( 'wp-login.php' );
+	expect( read( site.dir, LOGIN ) ).toBe( `${ TRUNK_LOGIN }\n` );
+	expect( read( site.dir, 'src/blocker' ) ).toBe( 'not a directory\n' );
+	expect( fs.existsSync( path.join( site.dir, 'src/blocker/new.txt' ) ) ).toBe( false );
+	expect( read( site.dir, SUBSTRATE ) ).toBe( SUBSTRATE_CONTENT );
+	await expect( page.getByRole( 'button', { name: 'Revert this patch', exact: true } ) ).toHaveCount( 0 );
+
+	// CHARACTERISATION: the failed patch is absent from the persisted ticket record.
+	const meta = session.readSettings().siteMeta[ site.dir ];
+	expect( meta.branches[ 'ticket/60001' ].appliedPatch ).toBeFalsy();
 } );

--- a/tests/unit/patch-apply.integration.test.cjs
+++ b/tests/unit/patch-apply.integration.test.cjs
@@ -1279,3 +1279,93 @@ test('applyPatchToDir: a neighbouring edit is refused the way git apply refuses 
 	assert.strictEqual(res.conflicts[0].regions[0].status, 'moved');
 	assert.strictEqual(fs.readFileSync(path.join(dir, LONG), 'utf8'), LONG_BODY.replace('line 13\n', 'line 13 on trunk\n'), 'nothing written');
 });
+
+for (const child of ['link/child', 'link/nested/child']) {
+	for (const reverse of [false, true]) {
+		for (const replay of [false, true]) {
+			test(`applyPatchToDir: rollback orders ${child} transition (reverse=${reverse}, replay=${replay}) (#413)`, async (t) => {
+				const dir = makeRepo(t, { target: 'untouched\n', blocker: 'not a directory\n' });
+				gitOk(['config', 'core.symlinks', 'true'], dir);
+				const link = path.join(dir, 'link');
+				if (reverse) {
+					fs.mkdirSync(path.dirname(path.join(dir, child)), { recursive: true });
+					fs.writeFileSync(path.join(dir, child), 'child\n');
+				} else fs.symlinkSync('target', link, 'file');
+				commitFiles(dir, ['link'], 'original entry');
+				const transition = String.raw`diff --git a/link b/link
+deleted file mode 120000
+--- a/link
++++ /dev/null
+@@ -1 +0,0 @@
+-target
+\ No newline at end of file
+diff --git a/${child} b/${child}
+new file mode 100644
+--- /dev/null
++++ b/${child}
+@@ -0,0 +1 @@
++child
+`;
+				const blocked = reverse ? `diff --git a/blocker/new.txt b/blocker/new.txt
+deleted file mode 100644
+--- a/blocker/new.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-hello
+` : `diff --git a/blocker/new.txt b/blocker/new.txt
+new file mode 100644
+--- /dev/null
++++ b/blocker/new.txt
+@@ -0,0 +1 @@
++hello
+`;
+				const apply = replay ? loadWithSuccessfulWrite(() => {
+					if (reverse) assert.strictEqual(fs.existsSync(path.join(dir, child)), false, 'Git removed the child before failing');
+					else assert.strictEqual(fs.lstatSync(link).isDirectory(), true, 'Git replaced the link before failing');
+				}) : applyPatchToDir;
+				const result = await apply({ dir, patchText: transition + blocked, reverse });
+				assert.strictEqual(result.ok, false);
+				assert.strictEqual(result.rolledBack, true, JSON.stringify(result));
+				assert.strictEqual(fs.readFileSync(path.join(dir, 'target'), 'utf8'), 'untouched\n');
+				assert.strictEqual(fs.readFileSync(path.join(dir, 'blocker'), 'utf8'), 'not a directory\n');
+				if (reverse) {
+					assert.strictEqual(fs.lstatSync(link).isDirectory(), true);
+					assert.strictEqual(fs.readFileSync(path.join(dir, child), 'utf8'), 'child\n');
+				} else {
+					assert.strictEqual(fs.lstatSync(link).isSymbolicLink(), true);
+					assert.strictEqual(fs.readlinkSync(link), 'target');
+				}
+			});
+		}
+	}
+}
+
+test('rollback: restores a replaced parent before its child without traversing the link (#413)', (t) => {
+	const dir = tempDir(t, 'patch-413-parent-order-');
+	const outside = tempDir(t, 'patch-413-outside-order-');
+	const parent = path.join(dir, 'parent');
+	fs.mkdirSync(parent);
+	fs.writeFileSync(path.join(parent, 'file'), 'before\n');
+	fs.writeFileSync(path.join(outside, 'file'), 'outside\n');
+	const taken = snapshotFiles(dir, ['parent/file', 'parent']);
+	fs.unlinkSync(path.join(parent, 'file'));
+	fs.rmdirSync(parent);
+	fs.symlinkSync(outside, parent, 'junction');
+	assert.deepStrictEqual(rollback(dir, taken), []);
+	assert.strictEqual(fs.readFileSync(path.join(outside, 'file'), 'utf8'), 'outside\n');
+	assert.strictEqual(fs.lstatSync(parent).isDirectory(), true);
+	assert.strictEqual(fs.readFileSync(path.join(parent, 'file'), 'utf8'), 'before\n');
+});
+
+test('rollback: does not remove unrelated contents of a replacement directory (#413)', (t) => {
+	const dir = tempDir(t, 'patch-413-unrelated-');
+	const link = path.join(dir, 'link');
+	fs.symlinkSync('missing', link, 'file');
+	const taken = snapshotFiles(dir, ['link', 'link/nested/child']);
+	fs.unlinkSync(link);
+	fs.mkdirSync(path.join(link, 'nested'), { recursive: true });
+	fs.writeFileSync(path.join(link, 'nested/child'), 'patch\n');
+	fs.writeFileSync(path.join(link, 'nested/unrelated'), 'keep\n');
+	assert.notStrictEqual(rollback(dir, taken).length, 0);
+	assert.strictEqual(fs.readFileSync(path.join(link, 'nested/unrelated'), 'utf8'), 'keep\n');
+});

--- a/tests/unit/patch-apply.integration.test.cjs
+++ b/tests/unit/patch-apply.integration.test.cjs
@@ -680,7 +680,7 @@ test('rollback: reports the paths it could not restore instead of swallowing the
 
 	// Restoring this entry means writing under `afile`, which is a file, not a
 	// directory — mkdirSync/writeFileSync throw ENOTDIR.
-	const recovery = rollback(dir, new Map([['afile/child', Buffer.from('x')]]));
+	const recovery = rollback(dir, new Map([['afile/child', { type: 'file', bytes: Buffer.from('x'), mode: 0o644 }]]));
 
 	assert.ok(Array.isArray(recovery) && recovery.length === 1);
 	assert.match(recovery[0], /afile\/child/);
@@ -1101,4 +1101,103 @@ test('applyPatchToDir: added content resembling a path header is not a destinati
 	const reverse = await applyPatchToDir({ dir, patchText, reverse: true });
 	assert.strictEqual(reverse.ok, true, reverse.error);
 	assert.strictEqual(fs.readFileSync(path.join(dir, 'x.php'), 'utf8'), 'old\n');
+});
+
+for (const variant of ['different bytes', 'equal bytes', 'dangling original']) {
+	test(`applyPatchToDir: rollback restores the symlink itself with ${variant} (#413)`, async (t) => {
+		const dir = makeRepo(t, { 'inside.txt': 'inside\n', 'blocker': 'not a directory\n' });
+		gitOk(['config', 'core.symlinks', 'true'], dir);
+		const outsideDir = tempDir(t, 'patch-413-outside-');
+		const outside = path.join(outsideDir, 'untouched.txt');
+		const outsideBytes = variant === 'equal bytes' ? 'inside\n' : 'outside\n';
+		fs.writeFileSync(outside, outsideBytes);
+		const original = variant === 'dangling original' ? 'missing.txt' : 'inside.txt';
+		const link = path.join(dir, 'link');
+		fs.symlinkSync(original, link, 'file');
+		commitFiles(dir, ['link'], 'original link');
+		fs.unlinkSync(link);
+		fs.symlinkSync(outside, link, 'file');
+		const out = path.join(outsideDir, 'link.patch');
+		gitOk(['diff', '--output', out, '--', 'link'], dir);
+		const patchText = fs.readFileSync(out, 'utf8') + `diff --git a/blocker/new.txt b/blocker/new.txt
+new file mode 100644
+--- /dev/null
++++ b/blocker/new.txt
+@@ -0,0 +1 @@
++hello
+`;
+		fs.unlinkSync(link);
+		fs.symlinkSync(original, link, 'file');
+		const apply = loadWithSuccessfulWrite(() => {
+			assert.strictEqual(fs.readlinkSync(link), outside, 'Git changed the symlink before failing');
+		});
+		const result = await apply({ dir, patchText });
+		assert.strictEqual(result.ok, false);
+		assert.strictEqual(fs.readFileSync(outside, 'utf8'), outsideBytes, 'rollback must not write through the new link');
+		assert.strictEqual(fs.lstatSync(link).isSymbolicLink(), true);
+		assert.strictEqual(fs.readlinkSync(link), original);
+		assert.strictEqual(result.rolledBack, true);
+		assert.strictEqual(fs.readFileSync(path.join(dir, 'inside.txt'), 'utf8'), 'inside\n');
+	});
+}
+
+test('rollback: a file replaced by a symlink does not overwrite its target (#413)', (t) => {
+	const dir = tempDir(t, 'patch-413-file-link-');
+	const file = path.join(dir, 'file');
+	const outside = path.join(tempDir(t, 'patch-413-target-'), 'outside');
+	fs.writeFileSync(file, 'before\n');
+	fs.writeFileSync(outside, 'outside\n');
+	const taken = snapshotFiles(dir, ['file']);
+	fs.unlinkSync(file);
+	fs.symlinkSync(outside, file, 'file');
+	assert.deepStrictEqual(rollback(dir, taken), []);
+	assert.strictEqual(fs.readFileSync(outside, 'utf8'), 'outside\n');
+	assert.strictEqual(fs.lstatSync(file).isFile(), true);
+	assert.strictEqual(fs.readFileSync(file, 'utf8'), 'before\n');
+});
+
+test('rollback: refuses to restore through a changed parent symlink (#413)', (t) => {
+	const dir = tempDir(t, 'patch-413-parent-');
+	const parent = path.join(dir, 'parent');
+	const outside = tempDir(t, 'patch-413-parent-target-');
+	fs.mkdirSync(parent);
+	fs.writeFileSync(path.join(parent, 'file'), 'before\n');
+	fs.writeFileSync(path.join(outside, 'file'), 'outside\n');
+	const taken = snapshotFiles(dir, ['parent/file']);
+	fs.unlinkSync(path.join(parent, 'file'));
+	fs.rmdirSync(parent);
+	fs.symlinkSync(outside, parent, 'junction');
+	const errors = rollback(dir, taken);
+	assert.strictEqual(fs.readFileSync(path.join(outside, 'file'), 'utf8'), 'outside\n');
+	assert.strictEqual(errors.length, 1);
+	assert.match(errors[0], /parent\/file/);
+});
+
+test('applyPatchToDir: a symlink can become a directory and return to a symlink (#413)', async (t) => {
+	const dir = makeRepo(t, { target: 'untouched\n' });
+	gitOk(['config', 'core.symlinks', 'true'], dir);
+	const link = path.join(dir, 'link');
+	fs.symlinkSync('target', link, 'file');
+	commitFiles(dir, ['link'], 'original link');
+	const patchText = `diff --git a/link b/link
+deleted file mode 120000
+--- a/link
++++ /dev/null
+@@ -1 +0,0 @@
+-target
+\\ No newline at end of file
+diff --git a/link/child b/link/child
+new file mode 100644
+--- /dev/null
++++ b/link/child
+@@ -0,0 +1 @@
++child
+`;
+	const applied = await applyPatchToDir({ dir, patchText });
+	assert.strictEqual(applied.ok, true, applied.error);
+	assert.strictEqual(fs.readFileSync(path.join(link, 'child'), 'utf8'), 'child\n');
+	const reverted = await applyPatchToDir({ dir, patchText, reverse: true });
+	assert.strictEqual(reverted.ok, true, reverted.error);
+	assert.strictEqual(fs.readlinkSync(link), 'target');
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'target'), 'utf8'), 'untouched\n');
 });

--- a/tests/unit/patch-apply.integration.test.cjs
+++ b/tests/unit/patch-apply.integration.test.cjs
@@ -6,6 +6,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const JsDiff = require('diff');
+const Module = require('node:module');
 const { applyPatchToDir, rollback, snapshotFiles, diagnoseHunks } = require('../../src/patch-apply');
 const { parsePatchFiles } = require('../../src/patch-plan.cjs');
 const { gitOk, initRepo, commitFiles, tempDir } = require('./helpers/git.cjs');
@@ -374,13 +375,11 @@ test('applyPatchToDir: an unreadable patch reports why and changes nothing (issu
 // cannot write by construction. This is the one that can — a write that throws
 // partway through, after earlier files are already on disk.
 //
-// POSIX only for now (#413): on Windows the bundled Git exits 0 on the same
-// patch, so the injection does not inject and the rollback path goes
-// unexercised there until the cause is known.
-test('applyPatchToDir: a write failing partway through is rolled back (issue #11)', { skip: process.platform === 'win32' && '#413' }, async (t) => {
+// Windows Git reports success despite the missing child (#413); POSIX fails.
+// Both must restore the earlier writes.
+test('applyPatchToDir: a write failing partway through is rolled back (issue #11)', async (t) => {
 	// src/blocker is a regular file, so creating src/blocker/new.php fails with
-	// ENOTDIR — deterministically, on every platform — after foo.php has
-	// already been written.
+	// a blocked path after foo.php has already been written.
 	const dir = makeRepo(t, { [FOO]: FOO_BODY, 'src/blocker': 'not a directory\n' });
 	const before = snapshot(dir);
 
@@ -649,8 +648,7 @@ index 0000000..e69de29
 // A rename that completes and is then undone by a later failure must restore the
 // source and remove the destination — registering each action before its
 // mutations is what lets rollback see a half-done one. (Copilot #3.)
-// Same injection as above, so the same Windows skip (#413).
-test('applyPatchToDir: a later failure rolls a completed rename fully back (issue #11)', { skip: process.platform === 'win32' && '#413' }, async (t) => {
+test('applyPatchToDir: a later failure rolls a completed rename fully back (issue #11)', async (t) => {
 	const dir = makeRepo(t, { 'src/old.php': 'one\ntwo\n', 'src/blocker': 'not a directory\n' });
 	const before = snapshot(dir);
 	const renameThenBlocked = `diff --git a/src/old.php b/src/new.php
@@ -972,4 +970,135 @@ test('applyPatchToDir: a failing reverse reports which regions were edited over 
 	assert.strictEqual(res.conflicts[0].path, FOO);
 	assert.strictEqual(res.conflicts[0].total, 1);
 	assert.strictEqual(res.conflicts[0].regions.length, 1);
+});
+
+// Replay the Windows 2.53.0.windows.4 result on every OS. The real binary
+// still checks and writes the fixture; only its final result is replaced.
+// No applier or rollback logic is mocked, and the native cases above remain.
+function loadWithSuccessfulWrite(onWrite) {
+	const primitives = require('../../src/git-write.cjs');
+	const filename = require.resolve('../../src/patch-apply');
+	const cached = require.cache[filename];
+	const originalLoad = Module._load;
+	Module._load = function (request, parent, isMain) {
+		if (parent && parent.filename === filename && request === './git-write.cjs') {
+			return { ...primitives, applyPatch: async (...args) => {
+				const result = await primitives.applyPatch(...args);
+				if (args[2].check) return result;
+				onWrite();
+				return { ok: true, status: 0, stderr: '' };
+			} };
+		}
+		return originalLoad.call(this, request, parent, isMain);
+	};
+	try {
+		delete require.cache[filename];
+		return require(filename).applyPatchToDir;
+	} finally {
+		Module._load = originalLoad;
+		if (cached) require.cache[filename] = cached;
+		else delete require.cache[filename];
+	}
+}
+
+test('applyPatchToDir: a successful exit with a missing addition restores earlier writes (#413)', async (t) => {
+	const dir = makeRepo(t, { [FOO]: FOO_BODY, 'src/blocker': 'not a directory\n' });
+	const before = snapshot(dir);
+	let wrote = false;
+	const apply = loadWithSuccessfulWrite(() => {
+		wrote = true;
+		assert.strictEqual(fs.readFileSync(path.join(dir, FOO), 'utf8'), 'one\nTWO\nthree\n');
+		assert.strictEqual(fs.existsSync(path.join(dir, 'src/blocker/new.php')), false);
+	});
+	const patchText = FOO_PATCH + `diff --git a/src/blocker/new.php b/src/blocker/new.php
+new file mode 100644
+--- /dev/null
++++ b/src/blocker/new.php
+@@ -0,0 +1 @@
++hello
+`;
+	const result = await apply({ dir, patchText });
+	assert.strictEqual(wrote, true, 'the write, not just preflight, was exercised');
+	assert.strictEqual(result.ok, false);
+	assert.strictEqual(result.rolledBack, true);
+	assert.match(result.error, /src\/blocker\/new\.php/);
+	assert.deepStrictEqual(result.applied, []);
+	assert.deepStrictEqual(snapshot(dir), before);
+});
+
+for (const reverse of [false, true]) {
+	for (const kind of ['text', 'empty', 'binary', 'rename']) {
+		test(`applyPatchToDir: ${reverse ? 'reverse' : 'forward'} ${kind} creation cannot silently disappear (#413)`, async (t) => {
+			const child = 'src/blocker/new.php';
+			const source = 'src/source.php';
+			let bytes = 'hello\n';
+			if (kind === 'binary') bytes = Buffer.from([0, 255, 1, 128]);
+			if (kind === 'empty') bytes = '';
+			// Generate the patch with Git, including header-only and binary shapes.
+			const initial = { 'kept.txt': 'kept\n' };
+			if (reverse) initial[child] = bytes;
+			else if (kind === 'rename') initial[source] = bytes;
+			const scratch = makeRepo(t, initial);
+			if (reverse) fs.unlinkSync(path.join(scratch, child));
+			else if (kind === 'rename') fs.unlinkSync(path.join(scratch, source));
+			if (!reverse || kind === 'rename') {
+				const destination = path.join(scratch, reverse ? source : child);
+				fs.mkdirSync(path.dirname(destination), { recursive: true });
+				fs.writeFileSync(destination, bytes);
+			}
+			gitOk(['add', '-A'], scratch);
+			const out = path.join(tempDir(t, 'patch-413-diff-'), 'change.diff');
+			gitOk(['diff', '--cached', '--binary', '--find-renames', '--output', out], scratch);
+			const generated = fs.readFileSync(out, 'utf8');
+			const patchText = reverse ? generated + FOO_PATCH : FOO_PATCH + generated;
+			const files = { [FOO]: reverse ? 'one\nTWO\nthree\n' : FOO_BODY, 'src/blocker': 'not a directory\n' };
+			if (kind === 'rename') files[source] = bytes;
+			const dir = makeRepo(t, files);
+			const before = snapshot(dir);
+			let wrote = false;
+			const apply = loadWithSuccessfulWrite(() => {
+				wrote = true;
+				assert.notDeepStrictEqual(snapshot(dir), before, 'Git left a partial write');
+				assert.strictEqual(fs.existsSync(path.join(dir, child)), false);
+			});
+			const result = await apply({ dir, patchText, reverse });
+			assert.strictEqual(wrote, true);
+			assert.strictEqual(result.ok, false);
+			assert.strictEqual(result.rolledBack, true);
+			assert.match(result.error, /src\/blocker\/new\.php/);
+			assert.deepStrictEqual(snapshot(dir), before);
+		});
+	}
+}
+
+test('applyPatchToDir: a file can become a directory and return to a file (#413)', async (t) => {
+	const dir = makeRepo(t, { 'src/blocker': 'hello\n' });
+	const patchText = `diff --git a/src/blocker b/src/blocker/new.php
+similarity index 100%
+rename from src/blocker
+rename to src/blocker/new.php
+`;
+	const applied = await applyPatchToDir({ dir, patchText });
+	assert.strictEqual(applied.ok, true, applied.error);
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'src/blocker/new.php'), 'utf8'), 'hello\n');
+	const reverted = await applyPatchToDir({ dir, patchText, reverse: true });
+	assert.strictEqual(reverted.ok, true, reverted.error);
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'src/blocker'), 'utf8'), 'hello\n');
+});
+
+test('applyPatchToDir: added content resembling a path header is not a destination (#413)', async (t) => {
+	const dir = makeRepo(t, { 'x.php': 'old\n' });
+	const patchText = `diff --git a/x.php b/x.php
+--- a/x.php
++++ b/x.php
+@@ -1 +1 @@
+-old
++++ hello
+`;
+	const result = await applyPatchToDir({ dir, patchText });
+	assert.strictEqual(result.ok, true, result.error);
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'x.php'), 'utf8'), '++ hello\n');
+	const reverse = await applyPatchToDir({ dir, patchText, reverse: true });
+	assert.strictEqual(reverse.ok, true, reverse.error);
+	assert.strictEqual(fs.readFileSync(path.join(dir, 'x.php'), 'utf8'), 'old\n');
 });

--- a/tests/unit/patch-plan.test.cjs
+++ b/tests/unit/patch-plan.test.cjs
@@ -478,7 +478,7 @@ test('splitPatchSections: one section per file, binary data told apart from a da
 	assert.deepStrictEqual(sections.map((s) => [s.path, s.from, s.isBinary, s.hasBinaryData]), [
 		['src/wp-includes/foo.php', 'src/wp-includes/foo.php', false, false],
 		['src/x.png', 'src/x.png', true, false],
-		['src/x.png', 'src/x.png', true, true],
+		['src/x.png', '', true, true],
 		['src/new.php', '', false, false]
 	]);
 	assert.strictEqual(sections.map((s) => s.text).join(''), text.slice(text.indexOf('diff --git')), 'the sections are the text, minus the prose');
@@ -499,4 +499,21 @@ test('parsePatchFiles: a binary or a pure rename ahead of a text file is not swa
 		['binary', 'src/x.png'], ['rename', 'src/new.php'], ['modify', 'src/wp-includes/foo.php'], ['binary', 'src/x.png']
 	]);
 	assert.strictEqual(files[1].oldPath, 'src/old.php');
+});
+
+test('splitPatchSections: records actual destinations for forward and reverse writes (#413)', () => {
+	const cases = [
+		['diff --git a/a.php b/a.php\n--- a/a.php\n+++ b/a.php\n@@ -1 +1 @@\n-old\n+new\n', 'a.php', 'a.php'],
+		['diff --git a/a.php b/a.php\n--- /dev/null\n+++ b/a.php\n@@ -0,0 +1 @@\n+new\n', '', 'a.php'],
+		['diff --git a/a.php b/a.php\n--- a/a.php\n+++ /dev/null\n@@ -1 +0,0 @@\n-old\n', 'a.php', ''],
+		['diff --git a/a.php b/a.php\nnew file mode 100644\nindex 0000000..e69de29\n', '', 'a.php'],
+		['diff --git a/a.php b/a.php\ndeleted file mode 100644\nindex e69de29..0000000\n', 'a.php', ''],
+		['diff --git a/a.bin b/a.bin\nnew file mode 100644\nGIT binary patch\nliteral 0\nHcmV?d00001\n', '', 'a.bin'],
+		['diff --git a/a.bin b/a.bin\ndeleted file mode 100644\nGIT binary patch\nliteral 0\nHcmV?d00001\n', 'a.bin', ''],
+		['diff --git a/a.php b/b.php\nsimilarity index 100%\nrename from a.php\nrename to b.php\n', 'a.php', 'b.php']
+	];
+	for (const [text, from, to] of cases) {
+		const [section] = splitPatchSections(text);
+		assert.deepStrictEqual([section.from, section.to], [from, to], text);
+	}
 });


### PR DESCRIPTION
## Why

Bundled Git on Windows can return success while omitting a file whose parent is a regular file. The app trusted that result, leaving earlier changes applied and reporting success. Both `--check` and `apply` returned 0 in the Windows reproduction on Git 2.53.0.windows.4.

## What changes

Verify destination entries after Git reports success and restore the existing snapshot if any cannot be verified. The parser records actual forward/reverse destinations, including empty and binary files. Both Windows rollback tests are enabled again. Snapshots preserve symlink targets as links; rollback removes changed entries deepest-first and restores snapshots shallowest-first without writing through symlinks. Missing intermediate directories are removed only when empty.

## How to test this

**Platforms:** Windows for the reported bug; macOS for comparison. Install this PR's Buildkite artifact matching the current head commit.

**Starting state:** A fresh app-created site with setup complete and no patch applied. No linked ticket or running server is required. Prepare the two files and patch using the collapsed instructions below.

1. Select the site and find **Apply a patch or PR**.
2. Click **or choose a .diff / .patch file…** and select `413-blocked.patch` from the Desktop. The preview should name the two affected paths.
3. Click **Apply and rebuild**. Expect a failure naming the missing destination; the terminal should report that the checkout was restored.
4. Inspect `src/413-before.txt`: it must still contain `before`. `src/413-blocker` must remain a file containing `not a directory`, and `src/413-blocker/new.txt` must not exist.

**What must not have happened:** No partial modification left behind, no applied-patch record or **Revert this patch** button for this patch, and no rebuild triggered by the failed operation.

The regression `a successful exit with a missing addition restores earlier writes (#413)` and eight forward/reverse variants all fail against the old applier. Both existing native rollback tests now run on Windows. For symlink recovery, run `node --test tests/unit/patch-apply.integration.test.cjs` from the repository root after installing dependencies. Five regressions failed before the symlink fix and now verify unchanged external files, original links (including dangling links), and refusal to restore through a changed parent. A permanent UI journey covers the partial-write symlink case without mocking Git: `npm run test:e2e -- -g "a partial patch failure"`. It checks failure feedback, unchanged external bytes, restored link identity and no applied-patch record. It fails against the old rollback. The existing workflow runs it on macOS and Windows for every non-draft PR.

## Risks and limitations

The core failure and restored file content were verified manually in Windows on 2026-09-10. The screenshots do not independently verify persisted metadata or absence of an additional rebuild; a build watch was already running. The new check verifies existence, not every output byte. Git's internal Windows failure mechanism remains unverified. The original PowerShell probe exercises raw Git and will still show its bug. The symlink fix passed integration tests in Windows CI. Its installed-app manual acceptance remains pending; the added UI journey automates the same failure and recovery checks from source. Earlier app acceptance used commit `367ff4e` and does not validate this follow-up.

## Related

Fixes #413

---

<details>
<summary>Design decisions and alternatives considered</summary>

Git still validates and writes the patch. Checking destinations afterward preserves valid file-to-directory transitions that a blanket parent-file preflight would reject. Filesystem checks are asynchronous; recovery keeps entry types, symlink text, and regular-file bytes and permissions. It never recursively removes directories during rollback.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 open [fix here] · 0 [follow-up] · 4 resolved.

Fresh-context review found a false rollback when added content beginning `++ ` was parsed as a path header. A failing integration test reproduced it, header parsing was restricted, and the independent reviewer confirmed the fix. CodeRabbit then identified rollback writing through changed symlinks. This was independently reproduced with bundled Git; five failing regressions preceded the fix. The follow-up self-review caught rejection of valid symlink-to-directory patches; a sixth failing test covers applying and reversing that transition. A later CodeRabbit finding exposed rollback restoring a parent before removing its children. Five regressions failed before the dependency-order fix; the matrix also covers reverse recovery and preservation of unrelated directory contents.

GitHub checks passed on macOS and Windows at `6e5c4e9`, including the symlink integration regressions on both Node runtimes. At `7913c45`, all 20 journeys, including the new partial-write case, and packaged smoke pass on both macOS and Windows in run [34486904179](https://github.com/WordPress/contributor-toolkit/actions/runs/34486904179). Local validation: lint and diff check pass; Node and Electron Node each pass 1,229 tests with no skips. All 20 E2E journeys pass locally on macOS, including the new partial-write case. The merge from trunk preserves both sets of patch regressions. The four patch journeys also pass locally after the dependency-order fix. The new journey fails against the old applier when rollback corrupts the external file.

</details>

<details>
<summary>Implementation notes and manual fixture setup</summary>

In Windows PowerShell, from any directory, replace the first path with the new site's checkout. The app must already have finished creating it. These names should not already exist in that fresh site.

```powershell
$Site = 'C:\path\to\your\test-site'
$Utf8 = New-Object Text.UTF8Encoding($false)
[IO.File]::WriteAllText((Join-Path $Site 'src\413-before.txt'), "before`n", $Utf8)
[IO.File]::WriteAllText((Join-Path $Site 'src\413-blocker'), "not a directory`n", $Utf8)
$Patch = @'
diff --git a/src/413-before.txt b/src/413-before.txt
--- a/src/413-before.txt
+++ b/src/413-before.txt
@@ -1 +1 @@
-before
+after
diff --git a/src/413-blocker/new.txt b/src/413-blocker/new.txt
new file mode 100644
--- /dev/null
+++ b/src/413-blocker/new.txt
@@ -0,0 +1 @@
+hello
'@
$PatchPath = Join-Path ([Environment]::GetFolderPath('Desktop')) '413-blocked.patch'
[IO.File]::WriteAllText($PatchPath, ($Patch.Replace("`r`n", "`n").TrimEnd() + "`n"), $Utf8)
```

The test matrix also covers empty and binary creations, renames, reversal, and a valid file-to-directory transition in both directions.

</details>

<details>
<summary>Screenshots or recording</summary>

JuanMa tested the corrected Windows app on 2026-09-10 after installing the artifact for this branch. Three screenshots were reviewed:

- Preview lists `src/413-before.txt` and `src/413-blocker/new.txt`.
- After applying, the app reports `could not verify src/413-blocker/new.txt after git apply: ENOENT` and keeps the preview instead of showing patch success.
- The subsequent editor view shows `413-before.txt` containing `before` and `413-blocker` still as a regular file.

This confirms native Windows failure detection and the expected restored content. The screenshots themselves do not display a build ID. The fix uses the existing failure surface; no controls or layout change.

</details>

<details>
<summary>Dependency-order rollback validation</summary>

The added integration matrix combines a symlink-to-directory transition with a later blocked destination, at one and two directory levels, for apply and reverse. It runs both native Git results and replayed successful results. Separate tests check parent-before-child restoration behind a replaced junction and preservation of unrelated directory contents. Local Node and Electron suites pass 1,229 tests without skips. At `aa75fed`, all checks pass on macOS and Windows. The dependency-order regressions pass natively with both Node and Electron Node in [run 34489416534](https://github.com/WordPress/contributor-toolkit/actions/runs/34489416534); journeys and packaged smoke pass in [run 34489416370](https://github.com/WordPress/contributor-toolkit/actions/runs/34489416370). CodeRabbit marks both rollback findings addressed, and independent self-review has no open findings.

</details>
