### PR TITLE
[Add] Pin the ticket move's conflicts to Git's, and word them by kind (#351)

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -133,6 +133,7 @@ macOS and Windows are the primary targets; Linux artifacts are published too. CI
 
 - Mocking the very thing the test claims to verify.
 - Asserting implementation details — exact log strings, call order of internals — instead of observable behaviour. These break on harmless refactors and survive real bugs.
+- Cleanup that is green while doing nothing. `t.after` hooks run in the order they were registered, so a fixture that reaches outside its own temporary directory (a worktree beside it, a patch file next to it) cannot clean up through a repository an earlier hook already removed; remove it as a directory with `removeRepo`, and use the throwing helper (`gitOk`) for any cleanup that goes through Git, or the only symptom is disk filling up.
 - Passing on only one of the two Node runtimes. CI runs the suite on `.nvmrc`'s Node *and* on Electron's bundled Node because the two are set independently and have drifted; a test (or the code under it) that assumes the newer of the two is broken on the other.
 
 **Platform-conditional code needs both branches tested — from one machine.** The house pattern is dependency injection, not skipping: `tests/unit/win-spawn-patch.test.cjs` exercises the Windows paths from macOS by injecting `platform`, lookup and env rather than reading `process.platform`. A new platform split tested with `it.skip` on the other OS is a coverage hole CI will never close, since the suite runs on both platforms but each skips the other's branch.

--- a/docs/guide/ticket-branches.md
+++ b/docs/guide/ticket-branches.md
@@ -93,7 +93,7 @@ Updating the site moves its copy of trunk, but deliberately does not move existi
 
 > **Trunk has moved since this ticket started.** Newer patches may not apply cleanly. Move your work onto the current trunk here, or save a copy of it and start the ticket again.
 
-Nothing moves on its own. The notice carries a button, **Update this ticket to the current trunk**, that replays the ticket's work onto the trunk the site now has: the same lines you changed, on top of the new code, in one step. Edits you have not parked yet come along. It is all or nothing: if trunk changed the same lines as your work, the app refuses, names the files, and moves nothing. The button waits while an update, an install, a build or the dev server is running, for the same reason the discard link does.
+Nothing moves on its own. The notice carries a button, **Update this ticket to the current trunk**, that replays the ticket's work onto the trunk the site now has: the same lines you changed, on top of the new code, in one step. Edits you have not parked yet come along. It is all or nothing: if trunk and your work disagree, for instance because trunk changed the same lines, one side deleted a file the other edited, or both added the same file, the app refuses, names the files and the reason, and moves nothing. These are the same conflicts Git itself would report for that merge. The button waits while an update, an install, a build or the dev server is running, for the same reason the discard link does.
 
 When the move is refused, or when you would rather see the work land on fresh code yourself, the manual path is still there:
 

--- a/src/git-read.cjs
+++ b/src/git-read.cjs
@@ -234,25 +234,61 @@ function parseLsTreeZ(buf) {
 }
 
 /**
- * `git merge-tree --write-tree -z --name-only` output → the merged tree and
- * the paths that conflicted. The first field is the tree oid (written even
- * when there are conflicts, with conflict markers inside); then, only on a
- * conflict, one path per field until an empty field closes that section;
- * the informational messages after it are for a human and dropped. A path
- * appears once per conflicting stage, so it is listed once here.
+ * `git merge-tree --write-tree -z --name-only` output → the merged tree, the
+ * paths that conflicted, and what kind of conflict each is. The first field
+ * is the tree oid (written even when there are conflicts, with conflict
+ * markers inside); then, only on a conflict, one path per field until an
+ * empty field closes that section. A path appears once per conflicting
+ * stage, so it is listed once here.
+ *
+ * After that come the informational records, `<count>`, that many paths,
+ * a type, and a message, each its own field. Most are `Auto-merging` and
+ * dropped; the `CONFLICT (…)` ones say what Git would print, and the word
+ * in the message's parentheses is the precise kind (`content`, `add/add`,
+ * `modify/delete`, `rename/delete`…; the record's own type says only
+ * `contents` for the first two). The kind is what lets the refusal say
+ * "deleted on one side" instead of "trunk changed the same lines" when
+ * that is what happened (#351). A conflicted path with no record keeps no
+ * kind, and the caller words it generically.
+ *
+ * That parenthesis is read from Git's human-facing message on purpose, the
+ * one place this module does so: the machine-readable type cannot tell
+ * `content` from `add/add`, and the message is the only field that can.
+ * The `-z` framing around it is stable; a reworded message degrades to no
+ * kind (a generic sentence), never to a wrong one; and the acceptance test
+ * in git-read.integration.test.cjs compares the kinds with what `git merge`
+ * prints on the pinned binary, so a Git upgrade that changes the wording
+ * fails there rather than in a contributor's card.
  *
  * @param {Buffer} buf
- * @return {{tree: string, conflicts: string[]}}
+ * @return {{tree: string, conflicts: string[], kinds: Object<string, string>}}
  */
 function parseMergeTreeZ(buf) {
 	const fields = splitNul(buf).map((field) => field.toString('utf8'));
 	const tree = (fields[0] || '').trim();
 	const conflicts = [];
-	for (let i = 1; i < fields.length; i++) {
+	// No prototype: a conflicted path named `__proto__` is a path, not a
+	// property, and `kinds[p]` must not read Object.prototype for it.
+	const kinds = Object.create(null);
+	let i = 1;
+	for (; i < fields.length; i++) {
 		if (fields[i].length === 0) break;
 		if (!conflicts.includes(fields[i])) conflicts.push(fields[i]);
 	}
-	return { tree, conflicts };
+	for (i += 1; i < fields.length;) {
+		const count = Number(fields[i]);
+		if (!Number.isInteger(count) || count < 0) break;
+		const paths = fields.slice(i + 1, i + 1 + count);
+		const type = fields[i + 1 + count] || '';
+		const message = fields[i + 2 + count] || '';
+		i += 3 + count;
+		if (!type.startsWith('CONFLICT')) continue;
+		const kind = (message.match(/^CONFLICT \(([^)]+)\)/) || type.match(/^CONFLICT \(([^)]+)\)/) || [])[1];
+		for (const p of paths) {
+			if (kind && conflicts.includes(p) && !kinds[p]) kinds[p] = kind;
+		}
+	}
+	return { tree, conflicts, kinds: { ...kinds } };
 }
 
 /**
@@ -388,7 +424,7 @@ async function isAncestor(dir, ancestor, descendant, { run = runGit } = {}) {
  * @param {string}   root0.theirs
  * @param {Object}   [options]
  * @param {Function} [options.run]
- * @return {Promise<{tree: string, conflicted: boolean, conflicts: string[]}>}
+ * @return {Promise<{tree: string, conflicted: boolean, conflicts: string[], kinds: Object<string, string>}>}
  */
 async function mergeTree(dir, { base, ours, theirs }, { run = runGit } = {}) {
 	// No lazy fetch: on a partial clone a blob none of the three sides has
@@ -399,7 +435,7 @@ async function mergeTree(dir, { base, ours, theirs }, { run = runGit } = {}) {
 	const parsed = parseMergeTreeZ(stdout);
 	// The exit code is the answer; the paths are the detail. A conflict Git
 	// reports in a shape the parser does not read is still a conflict.
-	return { tree: parsed.tree, conflicted: status === 1, conflicts: status === 1 ? parsed.conflicts : [] };
+	return { tree: parsed.tree, conflicted: status === 1, conflicts: status === 1 ? parsed.conflicts : [], kinds: status === 1 ? parsed.kinds : {} };
 }
 
 /**

--- a/src/git-read.cjs
+++ b/src/git-read.cjs
@@ -234,31 +234,22 @@ function parseLsTreeZ(buf) {
 }
 
 /**
- * `git merge-tree --write-tree -z --name-only` output → the merged tree, the
- * paths that conflicted, and what kind of conflict each is. The first field
- * is the tree oid (written even when there are conflicts, with conflict
- * markers inside); then, only on a conflict, one path per field until an
- * empty field closes that section. A path appears once per conflicting
- * stage, so it is listed once here.
+ * `git merge-tree --write-tree -z` output → the merged tree, the paths that
+ * conflicted, and what kind of conflict each is. The first field is the
+ * tree oid (written even when there are conflicts, with conflict markers
+ * inside); then, only on a conflict, one field per conflicting index entry,
+ * `<mode> <oid> <stage>\t<path>`, until an empty field closes that section.
+ * The informational messages after it are for a human and never read.
  *
- * After that come the informational records, `<count>`, that many paths,
- * a type, and a message, each its own field. Most are `Auto-merging` and
- * dropped; the `CONFLICT (…)` ones say what Git would print, and the word
- * in the message's parentheses is the precise kind (`content`, `add/add`,
- * `modify/delete`, `rename/delete`…; the record's own type says only
- * `contents` for the first two). The kind is what lets the refusal say
- * "deleted on one side" instead of "trunk changed the same lines" when
- * that is what happened (#351). A conflicted path with no record keeps no
- * kind, and the caller words it generically.
- *
- * That parenthesis is read from Git's human-facing message on purpose, the
- * one place this module does so: the machine-readable type cannot tell
- * `content` from `add/add`, and the message is the only field that can.
- * The `-z` framing around it is stable; a reworded message degrades to no
- * kind (a generic sentence), never to a wrong one; and the acceptance test
- * in git-read.integration.test.cjs compares the kinds with what `git merge`
- * prints on the pinned binary, so a Git upgrade that changes the wording
- * fails there rather than in a contributor's card.
+ * The stages are the kind (#351), the same way `git status` and every merge
+ * tool read them: stage 1 is the base, 2 ours, 3 theirs. All three present
+ * is a `content` clash; 2 and 3 with no base is `add/add`, both sides
+ * created the path; a base with only one side left is `modify/delete`,
+ * whichever side deleted. Those three are what a ticket and a moving trunk
+ * produce, and what the refusal has words for; any other combination (a
+ * rename tangle, a type change) keeps no kind and reads generically. Nothing
+ * here depends on Git's wording: the record layout is the porcelain, and a
+ * `--name-only` listing would have thrown the stages away.
  *
  * @param {Buffer} buf
  * @return {{tree: string, conflicts: string[], kinds: Object<string, string>}}
@@ -268,25 +259,26 @@ function parseMergeTreeZ(buf) {
 	const tree = (fields[0] || '').trim();
 	const conflicts = [];
 	// No prototype: a conflicted path named `__proto__` is a path, not a
-	// property, and `kinds[p]` must not read Object.prototype for it.
-	const kinds = Object.create(null);
-	let i = 1;
-	for (; i < fields.length; i++) {
+	// property, and `stages[p]` must not read Object.prototype for it.
+	const stages = Object.create(null);
+	for (let i = 1; i < fields.length; i++) {
 		if (fields[i].length === 0) break;
-		if (!conflicts.includes(fields[i])) conflicts.push(fields[i]);
+		const tab = fields[i].indexOf('\t');
+		if (tab === -1) continue;
+		const stage = Number(fields[i].slice(0, tab).split(' ')[2]);
+		const entryPath = fields[i].slice(tab + 1);
+		if (!conflicts.includes(entryPath)) conflicts.push(entryPath);
+		if (!stages[entryPath]) stages[entryPath] = new Set();
+		stages[entryPath].add(stage);
 	}
-	for (i += 1; i < fields.length;) {
-		const count = Number(fields[i]);
-		if (!Number.isInteger(count) || count < 0) break;
-		const paths = fields.slice(i + 1, i + 1 + count);
-		const type = fields[i + 1 + count] || '';
-		const message = fields[i + 2 + count] || '';
-		i += 3 + count;
-		if (!type.startsWith('CONFLICT')) continue;
-		const kind = (message.match(/^CONFLICT \(([^)]+)\)/) || type.match(/^CONFLICT \(([^)]+)\)/) || [])[1];
-		for (const p of paths) {
-			if (kind && conflicts.includes(p) && !kinds[p]) kinds[p] = kind;
-		}
+	// Built without a prototype for the same reason, then spread into a
+	// plain object (the spread defines own properties, `__proto__` included).
+	const kinds = Object.create(null);
+	for (const p of conflicts) {
+		const has = (...want) => want.every((stage) => stages[p].has(stage)) && stages[p].size === want.length;
+		if (has(1, 2, 3)) kinds[p] = 'content';
+		else if (has(2, 3)) kinds[p] = 'add/add';
+		else if (has(1, 2) || has(1, 3)) kinds[p] = 'modify/delete';
 	}
 	return { tree, conflicts, kinds: { ...kinds } };
 }
@@ -431,7 +423,7 @@ async function mergeTree(dir, { base, ours, theirs }, { run = runGit } = {}) {
 	// checked out would be pulled from the promisor mid-merge, with no
 	// timeout to bound it. Refusing with Git's reason beats waiting on a
 	// network the contributor may not have.
-	const { status, stdout } = await run(['merge-tree', '--write-tree', '-z', '--name-only', `--merge-base=${base}`, ours, theirs], { cwd: dir, okCodes: [0, 1], extraEnv: { GIT_NO_LAZY_FETCH: '1' } });
+	const { status, stdout } = await run(['merge-tree', '--write-tree', '-z', `--merge-base=${base}`, ours, theirs], { cwd: dir, okCodes: [0, 1], extraEnv: { GIT_NO_LAZY_FETCH: '1' } });
 	const parsed = parseMergeTreeZ(stdout);
 	// The exit code is the answer; the paths are the detail. A conflict Git
 	// reports in a shape the parser does not read is still a conflict.

--- a/src/main.js
+++ b/src/main.js
@@ -2162,7 +2162,15 @@ async function withRegisteredSite(sitePath, run) {
 		// file a contributor attaches to a bug report — and two of the three
 		// channels have no UI to show that string yet.
 		logError('branches', `${describeRefused(sitePath)}: ${String(e && e.stack ? e.stack : e)}`);
-		return { ok: false, error: String(e && e.message ? e.message : e), code: e && e.code, ...(e && Array.isArray(e.conflicts) ? { conflicts: e.conflicts } : {}) };
+		return {
+			ok: false,
+			error: String(e && e.message ? e.message : e),
+			code: e && e.code,
+			...(e && Array.isArray(e.conflicts) ? { conflicts: e.conflicts } : {}),
+			// The kind of each conflict (`content`, `modify/delete`, `add/add`),
+			// so the refusal can say which (#351).
+			...(e && e.kinds && typeof e.kinds === 'object' ? { kinds: e.kinds } : {})
+		};
 	}
 }
 

--- a/src/renderer/ticket-trunk-notice.cjs
+++ b/src/renderer/ticket-trunk-notice.cjs
@@ -24,21 +24,52 @@ function ticketTrunkNotice({ ticketId = null, behind = false } = {}) {
 
 const MANUAL_PATH = (ticketId) => `Save a copy of your work, unlink the ticket, delete its work from the site, then link #${ticketId} again and apply the copy.`;
 
+// One clause per kind of conflict Git reports, in the contributor's terms
+// (#351). `content` is the classic clash; the other two are what a mentor
+// looking at the same merge would call them, and "changed the same lines"
+// would be false for both. `modify/delete` is the same word whichever side
+// deleted (trunk removing a file the ticket edits, or the ticket removing
+// one trunk edits), so its clause names no side. Anything Git names that is
+// not listed here (`rename/delete`, `rename/rename`, `distinct types`)
+// reads generically.
+const KIND_CLAUSES = {
+	content: (paths) => `Trunk changed the same lines as your work in: ${paths.join(', ')}`,
+	'modify/delete': (paths) => `Deleted on one side and changed on the other: ${paths.join(', ')}`,
+	'add/add': (paths) => `Trunk added ${paths.length === 1 ? 'a file' : 'files'} your work also adds, with different content: ${paths.join(', ')}`
+};
+const OTHER_CLAUSE = (paths) => `Trunk and your work disagree in: ${paths.join(', ')}`;
+
 /**
  * What the panel says when the move is refused.
  *
  * @param {Object}             root0
  * @param {string}             [root0.code]      `rebase-conflict`, `no-base`, `on-trunk`, or anything main returns.
  * @param {string[]}           [root0.conflicts] Paths, for `rebase-conflict`.
+ * @param {Object}             [root0.kinds]     Path → kind of conflict, for `rebase-conflict`; a path with no kind reads generically.
  * @param {string}             [root0.error]     Main's sentence, used for codes this module has no words for.
  * @param {string|number|null} [root0.ticketId]
  * @return {string}
  */
-function rebaseRefusal({ code = '', conflicts = [], error = '', ticketId = null } = {}) {
+function rebaseRefusal({ code = '', conflicts = [], kinds = {}, error = '', ticketId = null } = {}) {
 	const ticket = ticketId || 'the ticket';
 	if (code === 'rebase-conflict') {
-		const list = conflicts.length ? ` in: ${conflicts.join(', ')}` : '';
-		return `Trunk changed the same lines as your work${list}. Nothing was moved. ${MANUAL_PATH(ticket)}`;
+		// No paths means Git reported the conflict in a shape the parser did
+		// not read: the one case where the app knows least, so it claims least.
+		if (!conflicts.length) return `Trunk and your work disagree. Nothing was moved. ${MANUAL_PATH(ticket)}`;
+		const grouped = new Map();
+		for (const p of conflicts) {
+			// Own property only: a kind that names something inherited
+			// (`constructor`) must not slip into a group nothing renders.
+			const kind = kinds && Object.hasOwn(KIND_CLAUSES, kinds[p]) ? kinds[p] : 'other';
+			if (!grouped.has(kind)) grouped.set(kind, []);
+			grouped.get(kind).push(p);
+		}
+		// Known kinds first, in the order they are declared, so the classic
+		// clash leads when the list is mixed.
+		const clauses = [...Object.keys(KIND_CLAUSES), 'other']
+			.filter((kind) => grouped.has(kind))
+			.map((kind) => (KIND_CLAUSES[kind] || OTHER_CLAUSE)(grouped.get(kind)));
+		return `${clauses.join('. ')}. Nothing was moved. ${MANUAL_PATH(ticket)}`;
 	}
 	if (code === 'no-base') {
 		return `The app does not know which trunk #${ticket} started from, so it cannot move the work safely. ${MANUAL_PATH(ticket)}`;

--- a/src/ticket-branches.js
+++ b/src/ticket-branches.js
@@ -445,13 +445,16 @@ async function rebaseOntoTrunk(dir, ref, { baseOid, author = WIP_AUTHOR, onProgr
 		// from the new trunk.
 		oid = trunkTip;
 	} else {
-		const { tree, conflicted, conflicts } = await mergeTree(dir, { base: baseOid, ours: trunkTip, theirs: wip });
+		const { tree, conflicted, conflicts, kinds } = await mergeTree(dir, { base: baseOid, ours: trunkTip, theirs: wip });
 		if (conflicted) {
 			const error = new Error(conflicts.length
-				? `Trunk changed the same lines as this ticket's work in ${conflicts.length} ${conflicts.length === 1 ? 'file' : 'files'}`
-				: 'Trunk changed the same lines as this ticket\'s work');
+				? `Trunk and this ticket's work disagree in ${conflicts.length} ${conflicts.length === 1 ? 'file' : 'files'}`
+				: 'Trunk and this ticket\'s work disagree');
 			error.code = 'rebase-conflict';
 			error.conflicts = conflicts;
+			// Which way each file disagrees (`content`, `modify/delete`,
+			// `add/add`), so the refusal can say so (#351).
+			error.kinds = kinds;
 			throw error;
 		}
 		oid = await commitTree(dir, { tree, parent: trunkTip, message: WIP_MESSAGE, author });

--- a/tests/unit/git-read.integration.test.cjs
+++ b/tests/unit/git-read.integration.test.cjs
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const read = require('../../src/git-read.cjs');
-const { git, tempDir } = require('./helpers/git.cjs');
+const { git, tempDir, removeRepo } = require('./helpers/git.cjs');
 
 // The read functions against a repository the bundled Git built, so the flag
 // set each command uses is proven on this platform too, including the states
@@ -186,3 +186,88 @@ test('mergeTree merges two sides from a base without touching the index or the w
 	assert.match(conflicted.tree, /^[0-9a-f]{40}$/, 'a tree is still written, with markers, for whoever wants it');
 	await assert.rejects(read.mergeTree(dir, { base, ours: '0000000000000000000000000000000000000001', theirs }), (e) => e.code === 128);
 });
+
+// #351's acceptance bar for the one three-way merge the app performs: the
+// files `mergeTree` names are the files `git merge` leaves unmerged, and the
+// markers in the tree it writes sit on the same lines as the markers `git
+// merge` leaves in a worktree. One fixture per conflict shape a ticket and a
+// moving trunk actually produce; the clean shapes prove the app refuses
+// nothing Git would accept.
+const MERGE_BASE = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+const withLine = (text, n, replacement) => text.split('\n').map((l, i) => (i === n - 1 ? replacement : l)).join('\n');
+const markerRegions = (text) => {
+	const regions = [];
+	let start = -1;
+	text.split('\n').forEach((line, i) => {
+		if (line.startsWith('<<<<<<<')) start = i + 1;
+		if (line.startsWith('>>>>>>>') && start !== -1) { regions.push(`${start}-${i + 1}`); start = -1; }
+	});
+	return regions;
+};
+
+const MERGE_SHAPES = [
+	{ name: 'same lines', ours: { 'a.php': withLine(MERGE_BASE, 10, 'line 10 OURS') }, theirs: { 'a.php': withLine(MERGE_BASE, 10, 'line 10 THEIRS') }, conflicts: ['src/a.php'] },
+	{ name: 'same file, far apart', ours: { 'a.php': withLine(MERGE_BASE, 3, 'line 3 OURS') }, theirs: { 'a.php': withLine(MERGE_BASE, 25, 'line 25 THEIRS') }, conflicts: [] },
+	{ name: 'same file, adjacent lines', ours: { 'a.php': withLine(MERGE_BASE, 10, 'line 10 OURS') }, theirs: { 'a.php': withLine(MERGE_BASE, 12, 'line 12 THEIRS') }, conflicts: [] },
+	{ name: 'rename on trunk, modify on the ticket', ours: { 'a.php': null, 'b.php': MERGE_BASE }, theirs: { 'a.php': withLine(MERGE_BASE, 15, 'line 15 THEIRS') }, conflicts: [] },
+	{ name: 'delete on trunk, modify on the ticket', ours: { 'a.php': null }, theirs: { 'a.php': withLine(MERGE_BASE, 15, 'line 15 THEIRS') }, conflicts: ['src/a.php'] },
+	{ name: 'modify on trunk, delete on the ticket', ours: { 'a.php': withLine(MERGE_BASE, 15, 'line 15 OURS') }, theirs: { 'a.php': null }, conflicts: ['src/a.php'] },
+	{ name: 'same new path on both sides', ours: { 'new.php': '<?php // ours\n' }, theirs: { 'new.php': '<?php // theirs\n' }, conflicts: ['src/new.php'] },
+	{ name: 'three regions, one clashing', ours: { 'a.php': withLine(MERGE_BASE, 15, 'line 15 OURS') }, theirs: { 'a.php': withLine(withLine(withLine(MERGE_BASE, 3, 'line 3 THEIRS'), 15, 'line 15 THEIRS'), 27, 'line 27 THEIRS') }, conflicts: ['src/a.php'] }
+];
+
+for (const shape of MERGE_SHAPES) {
+	test(`mergeTree names the files and regions git merge would, ${shape.name} (#351)`, async (t) => {
+		const dir = makeRepo(t);
+		const author = ['-c', 'user.name=T', '-c', 'user.email=t@example.com'];
+		const writeSide = (files) => {
+			for (const [name, content] of Object.entries(files)) {
+				const abs = path.join(dir, 'src', name);
+				if (content === null) fs.rmSync(abs);
+				else fs.writeFileSync(abs, content);
+			}
+			assert.equal(git(['add', '-A'], dir).status, 0);
+			assert.equal(git([...author, 'commit', '-q', '-m', 'side'], dir).status, 0);
+			return git(['rev-parse', 'HEAD'], dir).stdout;
+		};
+		fs.writeFileSync(path.join(dir, 'src', 'a.php'), MERGE_BASE);
+		assert.equal(git(['add', '-A'], dir).status, 0);
+		assert.equal(git([...author, 'commit', '-q', '-m', 'base'], dir).status, 0);
+		const base = git(['rev-parse', 'HEAD'], dir).stdout;
+		const theirs = writeSide(shape.theirs);
+		assert.equal(git(['reset', '-q', '--hard', base], dir).status, 0);
+		const ours = writeSide(shape.ours);
+
+		// What Git itself would show: a real merge in a throwaway worktree,
+		// the unmerged paths from the index and the markers from disk.
+		const worktree = path.join(dir, '..', `${path.basename(dir)}-merge`);
+		assert.equal(git(['worktree', 'add', '-q', '--detach', worktree, ours], dir).status, 0);
+		// The fixture's own cleanup registered first and runs first, taking
+		// the repository with it, so the worktree is removed as a directory
+		// (with #381's read-only objects in mind) rather than through Git.
+		t.after(() => removeRepo(worktree));
+		const merge = git([...author, 'merge', '--no-ff', '--no-commit', theirs], worktree);
+		const unmerged = git(['diff', '--name-only', '--diff-filter=U'], worktree).stdout.split('\n').filter(Boolean);
+		assert.equal(merge.status, unmerged.length ? 1 : 0, merge.stderr);
+
+		const result = await read.mergeTree(dir, { base, ours, theirs });
+		assert.deepEqual(unmerged, shape.conflicts, 'the fixture produces the shape it claims');
+		assert.equal(result.conflicted, unmerged.length > 0);
+		assert.deepEqual(result.conflicts, unmerged, 'same files');
+		// Same kind, too: the word `git merge` prints in `CONFLICT (…)` for
+		// each path is the one the app hands the refusal (#351).
+		const printed = {};
+		for (const line of merge.stdout.split('\n')) {
+			const m = line.match(/^CONFLICT \(([^)]+)\): (?:Merge conflict in (.+)|(\S+) deleted in)/);
+			if (m) printed[m[2] || m[3]] = m[1];
+		}
+		assert.deepEqual(result.kinds, printed, 'same kinds');
+		for (const relPath of unmerged) {
+			const onDisk = fs.existsSync(path.join(worktree, relPath)) ? fs.readFileSync(path.join(worktree, relPath), 'utf8') : null;
+			const inTree = git(['show', `${result.tree}:${relPath}`], dir);
+			// Git's merge leaves the modified side in place when the other side
+			// deleted it: no markers on either side, and that is the agreement.
+			assert.deepEqual(inTree.status === 0 ? markerRegions(inTree.stdout) : [], onDisk === null ? [] : markerRegions(onDisk), `same regions in ${relPath}`);
+		}
+	});
+}

--- a/tests/unit/git-read.test.cjs
+++ b/tests/unit/git-read.test.cjs
@@ -158,51 +158,45 @@ test('isLegacySite reads no config when the repository is not shallow (#385)', a
 	assert.deepEqual(seen, []);
 });
 
-test('merge-tree -z --name-only: the tree, then the conflicted paths once each, then the kind of each conflict (#385, #351)', () => {
+test('merge-tree -z: the tree, then each conflicted path once with its kind read from the stages (#385, #351)', () => {
 	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\0')), { tree: 'abc123', conflicts: [], kinds: {} });
 	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\n')), { tree: 'abc123', conflicts: [], kinds: {} });
-	const conflicted = z('abc123', 'src/wp-login.php', 'src/wp-login.php', 'with space.txt', '', '1', 'src/wp-login.php', 'Auto-merging', 'Auto-merging src/wp-login.php\n', '2', 'src/wp-login.php', 'with space.txt', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict\n');
-	assert.deepEqual(read.parseMergeTreeZ(conflicted), { tree: 'abc123', conflicts: ['src/wp-login.php', 'with space.txt'], kinds: { 'src/wp-login.php': 'content', 'with space.txt': 'content' } });
 	assert.deepEqual(read.parseMergeTreeZ(Buffer.alloc(0)), { tree: '', conflicts: [], kinds: {} });
 
-	// The shapes Git 2.53 actually writes, captured from the bundled binary:
-	// an add/add is typed `contents` and only the message says `add/add`; a
-	// modify/delete has the same word in both; a path can carry an
-	// `Auto-merging` record before its CONFLICT one; the first CONFLICT wins.
-	const kinds = z('t', 'n', 'n', 'x', 'x', 'x', 'y', 'y', '',
-		'1', 'n', 'Auto-merging', 'Auto-merging n\n',
-		'1', 'n', 'CONFLICT (contents)', 'CONFLICT (add/add): Merge conflict in n\n',
-		'1', 'x', 'Auto-merging', 'Auto-merging x\n',
-		'1', 'x', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in x\n',
-		'1', 'y', 'CONFLICT (modify/delete)', 'CONFLICT (modify/delete): y deleted in abc and modified in def.  Version def of y left in tree.\n');
-	assert.deepEqual(read.parseMergeTreeZ(kinds), { tree: 't', conflicts: ['n', 'x', 'y'], kinds: { n: 'add/add', x: 'content', y: 'modify/delete' } });
-	// A record about a path that is not in the conflicted section (Git lists
-	// informational paths for clean auto-merges too) adds no kind.
-	const stray = z('t', 'x', '', '1', 'z', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in z\n');
-	assert.deepEqual(read.parseMergeTreeZ(stray), { tree: 't', conflicts: ['x'], kinds: {} });
-	// A CONFLICT message with no parenthesis (a reworded Git) falls back to
-	// the record's coarse type, which the refusal has no clause for and so
-	// words generically: degraded, never wrong.
-	const reworded = z('t', 'q', '', '1', 'q', 'CONFLICT (contents)', 'Merge conflict in q\n');
-	assert.deepEqual(read.parseMergeTreeZ(reworded), { tree: 't', conflicts: ['q'], kinds: { q: 'contents' } });
-	// A record whose count is not a number ends the parse: the kinds read
-	// before it survive, the ones after it are dropped rather than guessed.
-	const malformed = z('t', 'a', 'b', '', '1', 'a', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in a\n', 'x', 'b', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in b\n');
-	assert.deepEqual(read.parseMergeTreeZ(malformed), { tree: 't', conflicts: ['a', 'b'], kinds: { a: 'content' } });
+	// The bytes the bundled Git 2.53.0 wrote for one merge with all three
+	// kinds at once, captured as they came: a content clash in `src/x.php`,
+	// both sides adding `src/n.php`, and `src/gone with space.php` deleted on
+	// one side and edited on the other. The informational records after the
+	// empty field are in the capture too, and are never read.
+	const captured = Buffer.from('NDk3M2Q4MmMzZDZjMGUzZWI4NDdjMzU4ZDQ0YmQ3YmE4NWY2ZTFiYgAxMDA2NDQgNzg5ODE5MjI2MTNiMmFmYjYwMjUwNDJmZjZiZDg3OGFjMTk5NGU4NSAxCXNyYy9nb25lIHdpdGggc3BhY2UucGhwADEwMDY0NCBhYjdkYjhlNDc1ZTAwZmViYTVhMTI0NjI3MDI4NzZjMzM5ZDBjMDc4IDMJc3JjL2dvbmUgd2l0aCBzcGFjZS5waHAAMTAwNjQ0IDgxOWQ5OTM3OGVlMzVjMTE0MzlhMGJmNWMyMmI2MjNhOTkyOGQyZGQgMglzcmMvbi5waHAAMTAwNjQ0IDNlYWM2MmVjNDg0YTBjNzUwNTE2NDdhOWI0NmU3NGNjMzBlMjkyYmMgMwlzcmMvbi5waHAAMTAwNjQ0IGRlOTgwNDQxYzNhYjAzYThjMDdkZGExYWQyN2I4YTExZjM5ZGViMWUgMQlzcmMveC5waHAAMTAwNjQ0IGY0ZWE3MDJkNDc5ZWYxMzg4ZGRlNjBlMzQzMDc5MWE5YzZlYjhkNGYgMglzcmMveC5waHAAMTAwNjQ0IDNiNmY0MGFmMTMxMTA0Y2NhM2E4NGU3YTc2MGMzYzM0NzUzNzcxMDYgMwlzcmMveC5waHAAADEAc3JjL2dvbmUgd2l0aCBzcGFjZS5waHAAQ09ORkxJQ1QgKG1vZGlmeS9kZWxldGUpAENPTkZMSUNUIChtb2RpZnkvZGVsZXRlKTogc3JjL2dvbmUgd2l0aCBzcGFjZS5waHAgZGVsZXRlZCBpbiAyN2RjM2ExNjA0ZjVmN2Y3M2I3M2I5YzM3NjE4NmI5Y2QzNTExZmI3IGFuZCBtb2RpZmllZCBpbiBlMWNlNTdhYmE3NmI0MmYzM2VjMWE2M2FmY2E1ZjQ2ZTVkMTg2ZWJiLiAgVmVyc2lvbiBlMWNlNTdhYmE3NmI0MmYzM2VjMWE2M2FmY2E1ZjQ2ZTVkMTg2ZWJiIG9mIHNyYy9nb25lIHdpdGggc3BhY2UucGhwIGxlZnQgaW4gdHJlZS4KADEAc3JjL24ucGhwAEF1dG8tbWVyZ2luZwBBdXRvLW1lcmdpbmcgc3JjL24ucGhwCgAxAHNyYy9uLnBocABDT05GTElDVCAoY29udGVudHMpAENPTkZMSUNUIChhZGQvYWRkKTogTWVyZ2UgY29uZmxpY3QgaW4gc3JjL24ucGhwCgAxAHNyYy94LnBocABBdXRvLW1lcmdpbmcAQXV0by1tZXJnaW5nIHNyYy94LnBocAoAMQBzcmMveC5waHAAQ09ORkxJQ1QgKGNvbnRlbnRzKQBDT05GTElDVCAoY29udGVudCk6IE1lcmdlIGNvbmZsaWN0IGluIHNyYy94LnBocAoA', 'base64');
+	assert.deepEqual(read.parseMergeTreeZ(captured), {
+		tree: '4973d82c3d6c0e3eb847c358d44bd7ba85f6e1bb',
+		conflicts: ['src/gone with space.php', 'src/n.php', 'src/x.php'],
+		kinds: { 'src/gone with space.php': 'modify/delete', 'src/n.php': 'add/add', 'src/x.php': 'content' }
+	});
+	// The same binary, a clean merge: the tree and nothing else.
+	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('YzRkNzZjOGFiMjM4NDA5NDI0Yzk0ZDliYTlhOGQ2ZmI3MzcyNTViMwA=', 'base64')), { tree: 'c4d76c8ab238409424c94d9ba9a8d6fb737255b3', conflicts: [], kinds: {} });
+
+	// Shapes the app has no words for keep no kind: a lone stage (one side
+	// of a rename/rename), and a stage Git does not use.
+	const entry = (stage, p) => `100644 0000000000000000000000000000000000000000 ${stage}\t${p}`;
+	assert.deepEqual(read.parseMergeTreeZ(z('t', entry(2, 'moved.php'), entry(1, 'weird.php'), entry(4, 'weird.php'), '')), { tree: 't', conflicts: ['moved.php', 'weird.php'], kinds: {} });
 	// A path named like a prototype property is a path.
-	const proto = z('t', '__proto__', '', '1', '__proto__', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in __proto__\n');
+	const proto = z('t', entry(1, '__proto__'), entry(2, '__proto__'), entry(3, '__proto__'), '');
 	assert.deepEqual(Object.entries(read.parseMergeTreeZ(proto).kinds), [['__proto__', 'content']]);
+	// A field with no tab is not an entry and is skipped, the rest still read.
+	assert.deepEqual(read.parseMergeTreeZ(z('t', 'garbage', entry(2, 'a'), entry(3, 'a'), '')), { tree: 't', conflicts: ['a'], kinds: { a: 'add/add' } });
 });
 
 test('mergeTree is one merge-tree call whose exit code says whether the tree is usable (#385)', async () => {
 	const calls = [];
 	const run = async (args, options) => {
 		calls.push({ args, options });
-		return args.includes('bad') ? { status: 1, stdout: z('t2', 'a.php', ''), stderr: '' } : { status: 0, stdout: Buffer.from('t1\0'), stderr: '' };
+		return args.includes('bad') ? { status: 1, stdout: z('t2', '100644 0000000000000000000000000000000000000000 2\ta.php', ''), stderr: '' } : { status: 0, stdout: Buffer.from('t1\0'), stderr: '' };
 	};
 	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'good' }, { run }), { tree: 't1', conflicted: false, conflicts: [], kinds: {} });
 	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'bad' }, { run }), { tree: 't2', conflicted: true, conflicts: ['a.php'], kinds: {} });
-	assert.deepEqual(calls[0].args, ['merge-tree', '--write-tree', '-z', '--name-only', '--merge-base=b', 'o', 'good']);
+	assert.deepEqual(calls[0].args, ['merge-tree', '--write-tree', '-z', '--merge-base=b', 'o', 'good']);
 	assert.deepEqual(calls[0].options, { cwd: '/sites/wp', okCodes: [0, 1], extraEnv: { GIT_NO_LAZY_FETCH: '1' } });
 	// Exit 1 with a path list the parser cannot read is still a conflict.
 	const mute = async () => ({ status: 1, stdout: Buffer.from('t3\0'), stderr: '' });

--- a/tests/unit/git-read.test.cjs
+++ b/tests/unit/git-read.test.cjs
@@ -158,12 +158,40 @@ test('isLegacySite reads no config when the repository is not shallow (#385)', a
 	assert.deepEqual(seen, []);
 });
 
-test('merge-tree -z --name-only: the tree, then the conflicted paths once each, the messages dropped (#385)', () => {
-	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\0')), { tree: 'abc123', conflicts: [] });
-	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\n')), { tree: 'abc123', conflicts: [] });
+test('merge-tree -z --name-only: the tree, then the conflicted paths once each, then the kind of each conflict (#385, #351)', () => {
+	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\0')), { tree: 'abc123', conflicts: [], kinds: {} });
+	assert.deepEqual(read.parseMergeTreeZ(Buffer.from('abc123\n')), { tree: 'abc123', conflicts: [], kinds: {} });
 	const conflicted = z('abc123', 'src/wp-login.php', 'src/wp-login.php', 'with space.txt', '', '1', 'src/wp-login.php', 'Auto-merging', 'Auto-merging src/wp-login.php\n', '2', 'src/wp-login.php', 'with space.txt', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict\n');
-	assert.deepEqual(read.parseMergeTreeZ(conflicted), { tree: 'abc123', conflicts: ['src/wp-login.php', 'with space.txt'] });
-	assert.deepEqual(read.parseMergeTreeZ(Buffer.alloc(0)), { tree: '', conflicts: [] });
+	assert.deepEqual(read.parseMergeTreeZ(conflicted), { tree: 'abc123', conflicts: ['src/wp-login.php', 'with space.txt'], kinds: { 'src/wp-login.php': 'content', 'with space.txt': 'content' } });
+	assert.deepEqual(read.parseMergeTreeZ(Buffer.alloc(0)), { tree: '', conflicts: [], kinds: {} });
+
+	// The shapes Git 2.53 actually writes, captured from the bundled binary:
+	// an add/add is typed `contents` and only the message says `add/add`; a
+	// modify/delete has the same word in both; a path can carry an
+	// `Auto-merging` record before its CONFLICT one; the first CONFLICT wins.
+	const kinds = z('t', 'n', 'n', 'x', 'x', 'x', 'y', 'y', '',
+		'1', 'n', 'Auto-merging', 'Auto-merging n\n',
+		'1', 'n', 'CONFLICT (contents)', 'CONFLICT (add/add): Merge conflict in n\n',
+		'1', 'x', 'Auto-merging', 'Auto-merging x\n',
+		'1', 'x', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in x\n',
+		'1', 'y', 'CONFLICT (modify/delete)', 'CONFLICT (modify/delete): y deleted in abc and modified in def.  Version def of y left in tree.\n');
+	assert.deepEqual(read.parseMergeTreeZ(kinds), { tree: 't', conflicts: ['n', 'x', 'y'], kinds: { n: 'add/add', x: 'content', y: 'modify/delete' } });
+	// A record about a path that is not in the conflicted section (Git lists
+	// informational paths for clean auto-merges too) adds no kind.
+	const stray = z('t', 'x', '', '1', 'z', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in z\n');
+	assert.deepEqual(read.parseMergeTreeZ(stray), { tree: 't', conflicts: ['x'], kinds: {} });
+	// A CONFLICT message with no parenthesis (a reworded Git) falls back to
+	// the record's coarse type, which the refusal has no clause for and so
+	// words generically: degraded, never wrong.
+	const reworded = z('t', 'q', '', '1', 'q', 'CONFLICT (contents)', 'Merge conflict in q\n');
+	assert.deepEqual(read.parseMergeTreeZ(reworded), { tree: 't', conflicts: ['q'], kinds: { q: 'contents' } });
+	// A record whose count is not a number ends the parse: the kinds read
+	// before it survive, the ones after it are dropped rather than guessed.
+	const malformed = z('t', 'a', 'b', '', '1', 'a', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in a\n', 'x', 'b', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in b\n');
+	assert.deepEqual(read.parseMergeTreeZ(malformed), { tree: 't', conflicts: ['a', 'b'], kinds: { a: 'content' } });
+	// A path named like a prototype property is a path.
+	const proto = z('t', '__proto__', '', '1', '__proto__', 'CONFLICT (contents)', 'CONFLICT (content): Merge conflict in __proto__\n');
+	assert.deepEqual(Object.entries(read.parseMergeTreeZ(proto).kinds), [['__proto__', 'content']]);
 });
 
 test('mergeTree is one merge-tree call whose exit code says whether the tree is usable (#385)', async () => {
@@ -172,13 +200,13 @@ test('mergeTree is one merge-tree call whose exit code says whether the tree is 
 		calls.push({ args, options });
 		return args.includes('bad') ? { status: 1, stdout: z('t2', 'a.php', ''), stderr: '' } : { status: 0, stdout: Buffer.from('t1\0'), stderr: '' };
 	};
-	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'good' }, { run }), { tree: 't1', conflicted: false, conflicts: [] });
-	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'bad' }, { run }), { tree: 't2', conflicted: true, conflicts: ['a.php'] });
+	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'good' }, { run }), { tree: 't1', conflicted: false, conflicts: [], kinds: {} });
+	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'bad' }, { run }), { tree: 't2', conflicted: true, conflicts: ['a.php'], kinds: {} });
 	assert.deepEqual(calls[0].args, ['merge-tree', '--write-tree', '-z', '--name-only', '--merge-base=b', 'o', 'good']);
 	assert.deepEqual(calls[0].options, { cwd: '/sites/wp', okCodes: [0, 1], extraEnv: { GIT_NO_LAZY_FETCH: '1' } });
 	// Exit 1 with a path list the parser cannot read is still a conflict.
 	const mute = async () => ({ status: 1, stdout: Buffer.from('t3\0'), stderr: '' });
-	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'x' }, { run: mute }), { tree: 't3', conflicted: true, conflicts: [] });
+	assert.deepEqual(await read.mergeTree('/sites/wp', { base: 'b', ours: 'o', theirs: 'x' }, { run: mute }), { tree: 't3', conflicted: true, conflicts: [], kinds: {} });
 });
 
 test('remoteUrl is one config read, null when the remote is not there (#385)', async () => {

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -3512,9 +3512,10 @@ test('branches:rebase refuses on trunk, without a recorded base, on a legacy sit
 
 test('branches:rebase hands a conflict back with the paths, and the base stays where it was (#385)', async () => {
 	const rebaseOntoTrunk = spy(async () => {
-		const error = new Error('Trunk changed the same lines');
+		const error = new Error('Trunk and this ticket\'s work disagree');
 		error.code = 'rebase-conflict';
 		error.conflicts = ['src/wp-login.php'];
+		error.kinds = { 'src/wp-login.php': 'modify/delete' };
 		throw error;
 	});
 	const settings = rebaseFixture();
@@ -3527,6 +3528,7 @@ test('branches:rebase hands a conflict back with the paths, and the base stays w
 	assert.equal(result.ok, false);
 	assert.equal(result.code, 'rebase-conflict');
 	assert.deepEqual(result.conflicts, ['src/wp-login.php']);
+	assert.deepEqual(result.kinds, { 'src/wp-login.php': 'modify/delete' }, 'the kind reaches the renderer (#351)');
 	const branch = settings.values.siteMeta['/sites/wp'].branches['ticket/61002'];
 	assert.equal(branch.baseOid, 'old');
 	assert.equal(branch.appliedPatch.label, 'A.diff', 'nothing moved, so nothing is forgotten');

--- a/tests/unit/patch-apply.integration.test.cjs
+++ b/tests/unit/patch-apply.integration.test.cjs
@@ -8,7 +8,7 @@ const path = require('path');
 const JsDiff = require('diff');
 const { applyPatchToDir, rollback, snapshotFiles, diagnoseHunks } = require('../../src/patch-apply');
 const { parsePatchFiles } = require('../../src/patch-plan.cjs');
-const { gitOk, initRepo, commitFiles, tempDir } = require('./helpers/git.cjs');
+const { git, gitOk, initRepo, commitFiles, tempDir, removeRepo } = require('./helpers/git.cjs');
 
 // A real on-disk repo, shaped the way the app's clone shapes one: the applier
 // hands the patch to the bundled Git, which wants a repository to apply into
@@ -972,4 +972,77 @@ test('applyPatchToDir: a failing reverse reports which regions were edited over 
 	assert.strictEqual(res.conflicts[0].path, FOO);
 	assert.strictEqual(res.conflicts[0].total, 1);
 	assert.strictEqual(res.conflicts[0].regions.length, 1);
+});
+
+// #351's acceptance bar for the patch flow. `git apply` decides, so the
+// files and the hunks the app names have to be the ones Git names: the
+// region breakdown is derived by jsdiff, which is a second opinion on Git's
+// verdict and could in principle disagree with it. `--reject` is the one
+// form of `git apply` that reports per hunk, so it is the reference.
+test('applyPatchToDir: the regions it names are the hunks git apply --reject rejects (#351)', async (t) => {
+	const dir = makeRepo(t, { [LONG]: LONG_BODY });
+	// Trunk moved under the middle region only; the fixture commits it so a
+	// worktree can be added at the same tree for Git's own run.
+	fs.writeFileSync(path.join(dir, LONG), LONG_BODY.replace('line 15\n', 'line 15 on trunk\n'));
+	commitFiles(dir, [LONG], 'trunk moved');
+	const worktree = path.join(dir, '..', `${path.basename(dir)}-reject`);
+	gitOk(['worktree', 'add', '-q', '--detach', worktree, 'HEAD'], dir);
+	// The fixture's own cleanup runs first and takes the repository with it,
+	// so the worktree is removed as a directory (read-only objects included,
+	// #381), not through Git.
+	t.after(() => removeRepo(worktree));
+	const patchFile = path.join(dir, '..', `${path.basename(dir)}.patch`);
+	fs.writeFileSync(patchFile, LONG_PATCH);
+	t.after(() => fs.rmSync(patchFile, { force: true }));
+
+	const reject = git(['apply', '--reject', '-v', patchFile], worktree);
+	assert.strictEqual(reject.status, 1, reject.stderr);
+	const rejected = [...reject.stderr.matchAll(/Rejected hunk #(\d+)\./g)].map((m) => Number(m[1]) - 1);
+	assert.deepStrictEqual(rejected, [1], 'the fixture rejects the middle hunk and nothing else');
+
+	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
+	assert.strictEqual(res.ok, false);
+	assert.strictEqual(res.failures.length, 1);
+	const [conflict] = res.conflicts;
+	assert.strictEqual(conflict.path, LONG);
+	assert.strictEqual(conflict.total, 3);
+	assert.deepStrictEqual(conflict.regions.map((r) => r.index), rejected, 'same hunks as Git');
+	assert.strictEqual(res.applied.length, 0, 'unlike --reject, nothing was written');
+});
+
+// Characterisation, not an invariant: `git apply` matches two ways, so an
+// edit on a neighbouring line (inside the hunk's three lines of context)
+// fails a patch that `git merge` would take cleanly. The app agrees with
+// `git apply --check` here, and disagrees with GitHub. That is the part of
+// #351 still open, and it changes with the engine, not with this test.
+test('applyPatchToDir: a neighbouring edit is refused the way git apply refuses it, though a merge would not (#351)', async (t) => {
+	const dir = makeRepo(t, { [LONG]: LONG_BODY });
+	// The patch changes line 15; trunk changed line 13, within its context.
+	fs.writeFileSync(path.join(dir, LONG), LONG_BODY.replace('line 13\n', 'line 13 on trunk\n'));
+	commitFiles(dir, [LONG], 'trunk moved');
+	const patch = `diff --git a/${LONG} b/${LONG}
+--- a/${LONG}
++++ b/${LONG}
+@@ -12,7 +12,7 @@
+ line 12
+ line 13
+ line 14
+-line 15
++LINE FIFTEEN
+ line 16
+ line 17
+ line 18
+`;
+	const patchFile = path.join(dir, '..', `${path.basename(dir)}.patch`);
+	fs.writeFileSync(patchFile, patch);
+	t.after(() => fs.rmSync(patchFile, { force: true }));
+
+	const check = git(['apply', '--check', patchFile], dir);
+	assert.strictEqual(check.status, 1, 'git apply refuses the neighbouring edit');
+	assert.match(check.stderr, /patch does not apply/);
+
+	const res = await applyPatchToDir({ dir, patchText: patch });
+	assert.strictEqual(res.ok, false, 'and so does the app');
+	assert.strictEqual(res.conflicts[0].regions[0].status, 'moved');
+	assert.strictEqual(fs.readFileSync(path.join(dir, LONG), 'utf8'), LONG_BODY.replace('line 13\n', 'line 13 on trunk\n'), 'nothing written');
 });

--- a/tests/unit/patch-apply.integration.test.cjs
+++ b/tests/unit/patch-apply.integration.test.cjs
@@ -995,9 +995,14 @@ test('applyPatchToDir: the regions it names are the hunks git apply --reject rej
 	fs.writeFileSync(patchFile, LONG_PATCH);
 	t.after(() => fs.rmSync(patchFile, { force: true }));
 
-	const reject = git(['apply', '--reject', '-v', patchFile], worktree);
+	const reject = git(['apply', '--reject', patchFile], worktree);
 	assert.strictEqual(reject.status, 1, reject.stderr);
-	const rejected = [...reject.stderr.matchAll(/Rejected hunk #(\d+)\./g)].map((m) => Number(m[1]) - 1);
+	// What Git rejected is in the `.rej` it writes beside the file: the
+	// rejected hunks in diff format. Matching their headers against the
+	// patch's own gives the index of each, with no diagnostic text read.
+	const hunkHeaders = (text) => text.split('\n').filter((line) => line.startsWith('@@ '));
+	const rejectedHeaders = hunkHeaders(fs.readFileSync(path.join(worktree, `${LONG}.rej`), 'utf8'));
+	const rejected = hunkHeaders(LONG_PATCH).map((header, index) => (rejectedHeaders.includes(header) ? index : -1)).filter((index) => index !== -1);
 	assert.deepStrictEqual(rejected, [1], 'the fixture rejects the middle hunk and nothing else');
 
 	const res = await applyPatchToDir({ dir, patchText: LONG_PATCH });
@@ -1007,7 +1012,7 @@ test('applyPatchToDir: the regions it names are the hunks git apply --reject rej
 	assert.strictEqual(conflict.path, LONG);
 	assert.strictEqual(conflict.total, 3);
 	assert.deepStrictEqual(conflict.regions.map((r) => r.index), rejected, 'same hunks as Git');
-	assert.strictEqual(res.applied.length, 0, 'unlike --reject, nothing was written');
+	assert.strictEqual(fs.readFileSync(path.join(dir, LONG), 'utf8'), LONG_BODY.replace('line 15\n', 'line 15 on trunk\n'), 'unlike --reject, nothing was written');
 });
 
 // Characterisation, not an invariant: `git apply` matches two ways, so an

--- a/tests/unit/ticket-branches.integration.test.cjs
+++ b/tests/unit/ticket-branches.integration.test.cjs
@@ -659,6 +659,7 @@ test('rebaseOntoTrunk refuses a conflict with the paths and moves nothing (issue
 	await assert.rejects(rebaseOntoTrunk(dir, ref, { baseOid }), (e) => {
 		assert.equal(e.code, 'rebase-conflict');
 		assert.deepEqual(e.conflicts, ['wp-login.php']);
+		assert.deepEqual(e.kinds, { 'wp-login.php': 'content' }, 'and which kind of conflict (#351)');
 		return true;
 	});
 

--- a/tests/unit/ticket-trunk-notice.test.cjs
+++ b/tests/unit/ticket-trunk-notice.test.cjs
@@ -19,9 +19,31 @@ test('rebaseRefusal names the files that clash and hands over the manual path (#
 	assert.match(sentence, /src\/wp-login\.php, src\/wp-admin\/about\.php/);
 	assert.match(sentence, /Nothing was moved/);
 	assert.match(sentence, /link #123 again/);
+	assert.match(rebaseRefusal({ code: 'rebase-conflict', ticketId: 123 }), /^Trunk and your work disagree\. Nothing was moved/);
 	assert.match(rebaseRefusal({ code: 'no-base', ticketId: 123 }), /which trunk #123 started from/);
 	assert.equal(rebaseRefusal({ code: 'legacy-site', error: 'the sentence' }), 'the sentence');
 	assert.equal(rebaseRefusal({}), 'Could not move the ticket onto the current trunk.');
+});
+
+// The conflicts Git reports are not all "the same lines": a file trunk
+// deleted, or one both sides created, is refused with the reason Git gives,
+// not a sentence that is false for it (#351).
+test('rebaseRefusal words each conflict by its kind, and a kind it has no words for generically (#351)', () => {
+	const kinds = { 'src/a.php': 'content', 'src/b.php': 'content', 'src/gone.php': 'modify/delete', 'src/new.php': 'add/add', 'src/odd.php': 'rename/delete' };
+	const sentence = rebaseRefusal({ code: 'rebase-conflict', conflicts: ['src/gone.php', 'src/a.php', 'src/new.php', 'src/odd.php', 'src/b.php'], kinds, ticketId: 123 });
+	assert.strictEqual(sentence,
+		'Trunk changed the same lines as your work in: src/a.php, src/b.php. '
+		+ 'Deleted on one side and changed on the other: src/gone.php. '
+		+ 'Trunk added a file your work also adds, with different content: src/new.php. '
+		+ 'Trunk and your work disagree in: src/odd.php. '
+		+ 'Nothing was moved. Save a copy of your work, unlink the ticket, delete its work from the site, then link #123 again and apply the copy.');
+	// Without kinds (an older main, or a path Git gave no record for) the
+	// path is still named, generically rather than as a clash it may not be.
+	assert.match(rebaseRefusal({ code: 'rebase-conflict', conflicts: ['src/x.php'], ticketId: 1 }), /^Trunk and your work disagree in: src\/x\.php\. Nothing was moved/);
+	assert.match(rebaseRefusal({ code: 'rebase-conflict', conflicts: ['src/x.php', 'src/y.php'], kinds: { 'src/x.php': 'modify/delete', 'src/y.php': 'modify/delete' }, ticketId: 1 }), /^Deleted on one side and changed on the other: src\/x\.php, src\/y\.php\./);
+	// A kind naming an inherited property is not a clause: the path stays in
+	// the sentence, generically, rather than vanishing from it.
+	assert.match(rebaseRefusal({ code: 'rebase-conflict', conflicts: ['src/x.php'], kinds: { 'src/x.php': 'constructor' }, ticketId: 1 }), /^Trunk and your work disagree in: src\/x\.php\./);
 });
 
 test('ticketTrunkNotice stays silent without a ticket or a known move (#305)', () => {


### PR DESCRIPTION
## Why

Under #350's contract the conflicts the app shows must be the conflicts Git would show, same files, same regions. #408 moved the ticket move onto `merge-tree --write-tree`, but nothing proved its verdicts against a real `git merge`, and its one refusal sentence, "Trunk changed the same lines as your work", is false when trunk deleted the file or both sides created it. The acceptance run for #351 (seven three-way fixtures against the bundled Git 2.53.0) found the verdicts match and the sentence does not.

## What changes

**Acceptance tests pin the match.** `tests/unit/git-read.integration.test.cjs` builds seven conflict shapes (same lines, same file far apart, adjacent lines, rename/modify, delete/modify, add/add, three regions with one clash), runs a real `git merge` in a throwaway worktree, and asserts `mergeTree` names the same files, the same marker regions in the tree it writes, and the same conflict kinds `git merge` prints. `tests/unit/patch-apply.integration.test.cjs` asserts the regions the app names for a patch are the hunks `git apply --reject` rejects, and records as a characterisation that a neighbouring edit is refused the way `git apply` refuses it, though a merge would take it.

**The refusal says what kind of conflict it is.** `parseMergeTreeZ` now reads the conflicted index entries `merge-tree -z` lists (`<mode> <oid> <stage>\t<path>`, so `--name-only` is gone) and classifies each path by its stages, the way `git status` and every merge tool do: all three stages is `content`, stages 2 and 3 with no base is `add/add`, a base with one side left is `modify/delete`. `mergeTree` returns that as `kinds`, `rebaseOntoTrunk` attaches it to the `rebase-conflict` error, main's branches handler forwards it, and `rebaseRefusal` groups the paths per kind with one clause each: "Trunk changed the same lines as your work in", "Deleted on one side and changed on the other" (one kind whichever side deleted, so the clause names no side), "Trunk added a file your work also adds, with different content", and a generic "Trunk and your work disagree in" for any other stage combination or when no kind arrived.

Deliberately not in this PR: the patch flow stays on two-way `git apply`. It agrees with `git apply` hunk for hunk, but `git apply` refuses adjacent edits and rename/modify that `git merge` and GitHub take cleanly. Closing that means a three-way apply, which leaves unmerged index entries in the checkout, and the app first has to recognise that state (#352).

## How to test this

Platforms: any. The unit and integration layers carry the verdict comparison; the manual steps cover the sentence.

**Starting state:** a site created by this build, a ticket linked (say #60001) with one edit in `src/wp-login.php`, then the ticket unlinked so the work is parked. Then move trunk under it by hand with the bundled Git from the site folder (macOS: `<app>/Contents/Resources/app.asar.unpacked/node_modules/dugite/git/bin/git`; Windows: `resources\app.asar.unpacked\node_modules\dugite\git\cmd\git.exe`, add `--no-pager`).

1. From the site folder: `git checkout trunk`, delete `src/wp-login.php`, `git commit -am "trunk deletes it"`. Link #60001 again. Expected: the ticket card shows **Trunk has moved since this ticket started.**
2. Click **Update this ticket to the current trunk**. Expected: the card says `Deleted on one side and changed on the other: src/wp-login.php. Nothing was moved.` followed by the manual path. Not "changed the same lines".
3. Repeat from the starting state, but instead of deleting, edit the same line of `src/wp-login.php` on trunk and commit. Expected after the click: `Trunk changed the same lines as your work in: src/wp-login.php. Nothing was moved.`
4. Repeat with a new file: on the ticket add `src/wp-includes/new.php`, park; on trunk add `src/wp-includes/new.php` with different content and commit. Expected after the click: `Trunk added a file your work also adds, with different content: src/wp-includes/new.php. Nothing was moved.`

**What must not have happened:** the ticket's parked work is still byte for byte what it was (`git show ticket/60001:src/wp-login.php`), the ticket's recorded base did not move (the notice is still shown after the refusal), and `git status` in the site is clean, no unmerged entries, no `MERGE_HEAD`.

The verdict comparison itself cannot be driven by hand any more precisely than the tests do: `node --test tests/unit/git-read.integration.test.cjs` runs the seven shapes against a real `git merge`, and breaking the "same files" assertion turns all seven red.

## Risks and limitations

- `kinds` is derived from index stages, porcelain-stable; nothing in this PR reads Git's human-facing conflict messages (an earlier revision did, and CodeRabbit rightly flagged it). Stage combinations the app has no words for (a rename tangle, a type change) keep no kind and read generically.
- Tests add a worktree beside the temporary repository and remove it with the helper's `removeRepo` (read-only objects handled, #381), because the fixture's own cleanup runs first.
- No manual Windows pass for this PR, on purpose. Nothing here touches paths, spawning, line endings or signing; what is platform-dependent (the merge and apply verdicts, the refusal reaching the card) runs in CI on windows-latest in the integration layer and in the existing ticket-rebase journey, and the two new sentences are pinned in the unit layer. The steps above are for a reviewer who wants to see it, not a gate.
- Self-review: 5 fix-here, all fixed; 1 follow-up applied as documentation (see the collapsed outcome).

## Related

Part of #351. Follow-up to #408. The two-way patch gap stays open in #351 and depends on #352 and #290.

---

<details>
<summary>Design decisions and alternatives considered</summary>

- Showing regions for the ticket move was considered and left out: the refusal happens before anything is written, and the regions are identical to `git merge`'s by construction (same tree). Naming the kind is what a mentor needs to recognise the merge; the line numbers are not.
- Making `conflicts` an array of objects instead of adding `kinds` was rejected: the paths array is the contract three tests and the renderer already pin, and a separate map degrades cleanly when absent.
- `git apply --3way` for patches was rejected here (see What changes). The acceptance script that settled this, seven fixtures with raw `git merge`, `merge-tree`, `apply --check`, `apply --reject` and `apply --3way`, is archived outside the repo.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

5 [fix here] · 1 [follow-up] — all 5 fixed, the follow-up applied as a JSDoc note.

Fixed: (1) the worktree cleanup in the new integration tests ran after the fixture's own cleanup and silently no-oped, leaking a checkout per test; both tests now remove the worktree with `removeRepo`, and the review standard gained a sentence about cleanup that is green while doing nothing. (2) The modify/delete clause named trunk as the deleting side, but Git uses the same kind when the ticket deleted; the clause now names no side, and the matrix gained the mirror shape. (3) `KIND_CLAUSES[kind]` and the parser's `kinds` map read through the prototype; own-property checks and a null-prototype map, with tests for `constructor` and `__proto__`. (4) Two parser branches (a CONFLICT message without a parenthesis, a malformed count) were unreached; both pinned. (5) The no-paths refusal still claimed "changed the same lines"; it now says "disagree", like the layer below.

Follow-up, superseded: the first revision read the kind from Git's `CONFLICT (…)` message and documented why; CodeRabbit flagged it against §1, and the parser now classifies by index stages instead, with the parser test on bytes captured from the bundled binary. CodeRabbit's other three findings (fixture bytes for the parser test, the `.rej` file instead of `Rejected hunk` stderr, a content assertion after the refused apply) are applied too.

Style notes taken: "for instance" in the guide's list of reasons; `strictEqual` on a count.

</details>

<details>
<summary>Implementation notes</summary>

- `merge-tree -z` lists one field per conflicted index entry before an empty field, then informational records (`<count>`, paths, type, message) that this parser never reads: the type field says `contents` for both a content clash and an add/add, so only the stages, or the human message, can tell them apart, and the stages are the porcelain.
- `git merge` leaves no markers for modify/delete (the modified side is left in the tree); the test treats "no markers on either side" as agreement.
- The journey `ticket-rebase.spec.js` is unchanged: its fixture is a content clash, whose sentence did not change.

</details>

<details>
<summary>Screenshots or recording</summary>

The only visible change is the refusal sentence on the ticket card for delete/modify and add/add conflicts; the manual steps above show the exact text. No recording.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Hnjh7DNJm6BB9FPjeWAjz
