### PR TITLE
Harden CI workflows with pinned actions and scoped checkout credentials

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,9 +48,11 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -68,7 +70,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-journeys-${{ matrix.os }}
           path: |
@@ -88,9 +90,11 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -123,7 +127,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-packaged-${{ matrix.os }}
           path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,14 +34,14 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # Keeps the job's GITHUB_TOKEN out of .git/config. The stakes are low — nothing
           # here reads the tree back out to an attacker-facing channel — but leaving a
           # token on disk that a later change could expose is not worth the one line saved.
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,9 +32,11 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
## Why

The lint, unit and E2E workflows use mutable action tags, so their executed code can change without a repository diff. Unit and E2E jobs also retain checkout authentication in Git configuration while installing and testing code, although they do not need authenticated Git operations after checkout.

## What changes

Pin checkout, setup-node and upload-artifact to the full commits currently referenced by their v4 tags, with version comments for readability. Disable checkout credential persistence in the unit job and both E2E jobs; lint already disables it. This changes three workflows without upgrading action major versions or changing their triggers, permissions, matrices or test commands.

## How to test this

**Starting state:** This PR is ready for review and GitHub Actions has started runs for its latest revision. There is no application UI change to exercise. Platforms: Ubuntu for lint, macOS and Windows for unit tests and E2E.

1. Open the PR's **Checks** tab and select **eslint**. Confirm checkout, dependency installation and ESLint complete successfully.
2. Open **unit (macos-latest)** and **unit (windows-latest)**. Confirm installation and both suite steps, system Node and Electron's bundled Node, pass without Git authentication errors.
3. Open both **Journeys** and both **Packaged smoke** jobs. Confirm checkout, installation, renderer build, journeys and unsigned packaging/smoke tests pass. Check that the run belongs to the current PR revision.
4. In **Files changed**, confirm every action reference in these three workflows uses a 40-character SHA and every checkout sets `persist-credentials: false`. Compare the pins with the upstream version tags listed in the implementation notes below.

**What must not have happened:** No jobs or platforms should disappear, the action major versions should not change, and no extra permissions or credentials should be needed to make the jobs pass. Application files and lockfiles should not change.

Local checks: `npm run lint`, `npm test` and `git diff --check origin/trunk...HEAD`. These pass, but local tests do not reproduce GitHub's checkout authentication; the Actions runs above are needed for that validation. Failure-only artifact upload remains configured; its execution is not demonstrated by a green run.

## Risks and limitations

An unnoticed dependency on authenticated Git operations after checkout would now fail in CI. The pins match the existing v4 tags, reducing version-change risk, but future action updates must update the SHA explicitly. Remote CI validation is pending when this PR is opened.

## Related

Repository guardrail audit: action pinning and checkout credential persistence. No issue is closed by this PR.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] / 0 [follow-up]. A fresh-context reviewer applied .github/instructions/code-review.instructions.md across all five dimensions and found no issues. The reviewer independently verified the upstream SHA tags and checked the workflows and invoked scripts for reliance on persisted checkout credentials. No findings needed fixing or deferring within this PR's scope.

Deterministic validation passed: repo-wide ESLint; all 1,254 tests with zero failures or skips; YAML parsing and a structured comparison confirming only action pins and checkout credential settings changed; whitespace validation with git diff --check. Actionlint was not available locally. No application tests were added for this configuration-only change.

</details>

<details>
<summary>Implementation notes</summary>

Resolved directly from upstream refs with git ls-remote:

- actions/checkout v4.4.0: 11d5960a326750d5838078e36cf38b85af677262
- actions/setup-node v4.4.0: 49933ea5288caeca8642d1e84afbd3f7d6820020
- actions/upload-artifact v4.6.2: ea165f8d65b6e75b540449e92b4886f43607fa02

</details>
