### PR TITLE
[Remove] brittle renderer source-text tests

### DIFF
--- a/tests/unit/changes-note.test.cjs
+++ b/tests/unit/changes-note.test.cjs
@@ -3,8 +3,6 @@
 // DOM; index.jsx only interleaves the parts with its two link buttons.
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
 
 const {
 	changesNoteParts,
@@ -191,10 +189,4 @@ test('discardDisabledReason reports the operation in progress before secondary b
 		discardDisabledReason({ patchLoading: true, patchHasChanges: false, discarding: true, devServerActive: true }),
 		'Changes are already being discarded.'
 	);
-});
-
-test('both visible discard links use the shared explanatory control', () => {
-	const source = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'renderer', 'index.jsx'), 'utf8');
-	const uses = source.match(/<DiscardChangesLink\b/g) || [];
-	assert.equal(uses.length, 2, 'the ticket note and review modal must share the tooltip-enabled discard link');
 });

--- a/tests/unit/pr-state.test.cjs
+++ b/tests/unit/pr-state.test.cjs
@@ -6,11 +6,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const fs = require('node:fs');
-const path = require('node:path');
 const { PR_STATE_BADGES, prStateBadge } = require('../../src/renderer/pr-state.cjs');
-
-const INDEX_JSX = path.join(__dirname, '..', '..', 'src', 'renderer', 'index.jsx');
 
 // The accessibility rule the design is built on: colour accompanies the word,
 // it never replaces it. A pill with a colour and no label tells a contributor
@@ -33,8 +29,6 @@ test('the three states are told apart by colour, all three of them (issue #227)'
 // wears GitHub's red, not the error pair the alert boxes are painted with.
 test('the closed pill is not the error styling used elsewhere (issue #227)', () => {
 	const closed = prStateBadge('closed');
-	const source = fs.readFileSync(INDEX_JSX, 'utf8');
-	assert.ok(source.includes('#fcf0f1'), 'the error banner background moved; this test no longer compares against the real one');
 	assert.notStrictEqual(closed.background, '#fcf0f1');
 	assert.notStrictEqual(closed.color, '#d63638');
 });
@@ -47,23 +41,4 @@ test('an unknown or missing state reads as open, the way the row has always beha
 	// GitHub answers in lower case, but a cached list should not lose its colour
 	// over capitalisation either.
 	assert.deepStrictEqual(prStateBadge('MERGED'), PR_STATE_BADGES.merged);
-});
-
-test('the row renders the state through the pill, not as grey text (issue #227)', () => {
-	const source = fs.readFileSync(INDEX_JSX, 'utf8');
-
-	// The words come from this module, so the row cannot say one thing while the
-	// tested mapping says another.
-	assert.ok(
-		!/pr\.state === 'closed' \? 'closed' : 'open'/.test(source),
-		'index.jsx still collapses the state to its own open/closed text instead of using prStateBadge'
-	);
-
-	// One call site: the single pull-request row. Counted as a call rather than
-	// as the bare name so a comment naming the helper is not a red suite.
-	assert.strictEqual(
-		source.split('prStatePill(').length - 1,
-		1,
-		'expected exactly one prStatePill( call: the linked pull request row'
-	);
 });

--- a/tests/unit/site-urls.test.cjs
+++ b/tests/unit/site-urls.test.cjs
@@ -2,13 +2,7 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
-const fs = require('node:fs');
-const path = require('node:path');
 const { siteUrl, adminUrl, adminerUrl } = require('../../src/renderer/site-urls.cjs');
-
-const INDEX_JSX = path.join(__dirname, '..', '..', 'src', 'renderer', 'index.jsx');
-
-const ADMINER_LINK = '>DB inspect (Adminer)</a>';
 
 // The shape server-runner.js actually produces: `http://127.0.0.1:${port}/`.
 const RUNNING = 'http://127.0.0.1:8881/';
@@ -68,90 +62,4 @@ test('siteUrl: an empty path yields the base with one trailing slash (issue #248
 // A port is part of the origin, and stripping it would point the link at :80.
 test('siteUrl: the port survives (issue #248)', () => {
 	assert.ok(adminUrl('http://127.0.0.1:39372/').startsWith('http://127.0.0.1:39372/'));
-});
-
-// No DOM here, so what is testable is that the renderer reads its URLs from
-// this module rather than restating them — as pr-state.test.cjs does.
-
-test('both places that show the site URL also link wp-admin (issue #248)', () => {
-	const source = fs.readFileSync(INDEX_JSX, 'utf8');
-
-	// The two the issue names: the setup checklist step and the site page.
-	assert.strictEqual(
-		source.split('>wp-admin</a>').length - 1,
-		2,
-		'expected exactly two wp-admin links: the setup checklist step and the site page'
-	);
-});
-
-test('the renderer derives both destinations here, not inline (issue #248)', () => {
-	const source = fs.readFileSync(INDEX_JSX, 'utf8');
-
-	// What made `…:8881adminer.php` possible was concatenating a path onto the
-	// base by hand, so the literals are the guard: without them there is nothing
-	// to concatenate. Searching for the old `.replace()` instead would only
-	// match one spelling of the same mistake.
-	for (const literal of ["'wp-admin", '"wp-admin', "'adminer.php'"]) {
-		assert.strictEqual(
-			source.split(literal).length - 1,
-			0,
-			`index.jsx hardcodes ${literal} instead of deriving it from site-urls.cjs`
-		);
-	}
-
-	// Counted as calls so a comment naming a helper is not a red suite. The href
-	// specifically, not the click handler: a link could otherwise open the right
-	// page while pointing somewhere else.
-assert.strictEqual(
-		source.split('href={adminUrl(').length - 1,
-		2,
-		'expected both wp-admin anchors to take their href from adminUrl'
-	);
-	assert.strictEqual(
-		source.split('e.preventDefault(); window.api.openExternal(adminUrl(').length - 1,
-		2,
-		'expected both wp-admin anchors to prevent in-app navigation and open adminUrl externally'
-	);
-
-	assert.strictEqual(
-		source.split('href={adminerUrl(').length - 1,
-		1,
-		'expected the Adminer link to take its href from adminerUrl'
-	);
-	assert.strictEqual(
-		source.split('e.preventDefault(); window.api.openExternal(adminerUrl(').length - 1,
-		1,
-		'expected the Adminer link to prevent in-app navigation and open adminerUrl externally'
-	);
-});
-
-// Adminer became an anchor here, so it needs the same preventDefault the other
-// two links have — as a Button it could not navigate the window at all.
-test('the running site reads as one row of destinations (issue #249)', () => {
-	const source = fs.readFileSync(INDEX_JSX, 'utf8');
-
-	assert.strictEqual(
-		source.split('Open Adminer').length - 1,
-		0,
-		'Open Adminer is still a button in the action row'
-	);
-
-	assert.strictEqual(
-		source.split(ADMINER_LINK).length - 1,
-		1,
-		'expected exactly one DB inspect (Adminer) link beside the site URL'
-	);
-
-	// Placement is the whole point of #249, and the assertions above pin only the
-	// widget: an anchor rendered back inside the action-button row passes all of
-	// them. Anchoring it between the site page's wp-admin link and the
-	// credentials line puts it in the row it was moved into. lastIndexOf,
-	// because the wizard step has a wp-admin link of its own, earlier.
-	const wpAdmin = source.lastIndexOf('>wp-admin</a>');
-	const adminer = source.indexOf(ADMINER_LINK);
-	const credentials = source.indexOf('Log in with <code>admin</code>');
-	assert.ok(
-		wpAdmin < adminer && adminer < credentials,
-		'expected the Adminer link on the links row, after wp-admin and above the credentials line'
-	);
 });


### PR DESCRIPTION
## Why

These tests inspect raw `src/renderer/index.jsx` text, so harmless JSX restructuring can fail the suite without changing user-facing behavior. Issue #426 keeps the directly testable renderer decisions covered through their pure modules instead.

## What changes

Remove source-text assertions from the site URL, changes note, and PR-state unit suites, along with imports used only by those assertions. Direct behavior tests for `site-urls.cjs`, `changes-note.cjs`, and `pr-state.cjs` remain; no production code changes.

## How to test this

Platforms: any — this changes unit-test coverage only and has no user-visible surface.

**Starting state:**

1. Check out this branch with dependencies installed.
2. Run `node --test tests/unit/site-urls.test.cjs tests/unit/changes-note.test.cjs tests/unit/pr-state.test.cjs`.
3. Run `npm run lint` and `npm test`.

**Expected result:**

The focused suite reports 34 passing tests, lint succeeds, and the full suite succeeds.

**What must not have happened:**

The pure-function behavior checks for URL construction, discard-note state, and PR badge state must not be removed. No application code or other test suites should change.

## Risks and limitations

No self-review findings. This intentionally stops checking `index.jsx` call-site structure and link/control placement by literal source text; the retained tests validate the pure renderer decisions those source-text checks duplicated. No manual UI test applies because there is no user-visible change.

## Related

Fixes #426

---

<details>
<summary>Design decisions and alternatives considered</summary>

Removed only the tests that read `index.jsx` as text (including literal counts, ordering, and regex checks). Kept tests that call pure helper functions directly, because they exercise behavior rather than implementation spelling or layout.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. Reviewed the deletion-only diff across architecture, security, performance, cross-platform behavior, and test coverage after `npm run lint` and `npm test`; no findings.

</details>

<details>
<summary>Implementation notes</summary>

Removed 125 lines across `tests/unit/site-urls.test.cjs`, `tests/unit/changes-note.test.cjs`, and `tests/unit/pr-state.test.cjs`. The branch commit is `73eb662`.

</details>
