### PR TITLE
[Remove] terminal-hint visibility wrapper

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -24,7 +24,7 @@ import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
 import { computeSetupStepState, setupStepStatuses, setupStepCopy, setupAutoStartDecision, setupStepLabel } from './setup-steps.cjs';
 import { deriveNextAction } from './next-action.cjs';
-import { shouldShowTerminalHints, computeTerminalBusy } from './terminal-hints.cjs';
+import { computeTerminalBusy } from './terminal-hints.cjs';
 import { planDevServerStart, formatElapsed, watchTabLabel } from './dev-server-command.cjs';
 import { appendBounded, countLines } from './debug-log.cjs';
 import { pathBasename } from './path-basename.cjs';
@@ -2851,7 +2851,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // Same three-stage shape as the update chain, and the same npm wrappers, so
   // exit codes and terminal streaming behave identically.
   const isApplying = applyState !== 'idle';
-  const showTerminalHints = shouldShowTerminalHints({ hasBuilt });
+  const showTerminalHints = Boolean(hasBuilt);
   const terminalBusy = computeTerminalBusy({
     terminalRunning, installing, building, starting, running, isUpdating, isApplying
   });

--- a/src/renderer/terminal-hints.cjs
+++ b/src/renderer/terminal-hints.cjs
@@ -1,36 +1,6 @@
 'use strict';
 
 /**
- * The two rules behind the command hints under the Terminal (#182): whether to
- * offer them at all, and whether the prompt is free to take one.
- *
- * Kept as a pure, dependency-free module so it can be unit tested without a
- * DOM: the renderer bundle imports it, `node --test` requires it directly
- * (same convention as setup-steps.cjs and dev-server-command.cjs).
- */
-
-/**
- * Whether the hints belong on screen yet.
- *
- * Both commands they name are things you do *again*, after a site is built and
- * you have started changing it. Before that they are not merely premature but
- * wrong: during the clone the terminal is streaming `Updating workdir n/6987`,
- * `npm install` has not run a first time, and there is no checkout to have
- * changed files in. A completed build is the point where re-running either one
- * becomes the normal thing to do, so it is the point where they appear.
- *
- * The checklist owns the first run of both commands and says so in its own
- * steps; these hints exist for everything after it.
- *
- * @param {Object}  flags
- * @param {boolean} [flags.hasBuilt] The site has a completed build on disk.
- * @return {boolean} True when the hints should be rendered.
- */
-function shouldShowTerminalHints(flags = {}) {
-	return Boolean(flags.hasBuilt);
-}
-
-/**
  * Whether the Terminal is occupied, and so cannot take a prefilled command.
  *
  * The hints offer to type `npm run build` / `npm install` at the prompt, which
@@ -78,4 +48,4 @@ function computeTerminalBusy(flags = {}) {
 	);
 }
 
-module.exports = { shouldShowTerminalHints, computeTerminalBusy };
+module.exports = { computeTerminalBusy };

--- a/tests/unit/terminal-hints.test.cjs
+++ b/tests/unit/terminal-hints.test.cjs
@@ -3,20 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { shouldShowTerminalHints, computeTerminalBusy } = require('../../src/renderer/terminal-hints.cjs');
-
-test('the hints stay hidden until a build has completed (issue #182)', () => {
-	// They were showing from the moment a site existed, so a contributor watched
-	// "Edited files in src/? Run npm run build" scroll past while the clone was
-	// still writing the checkout that would contain those files.
-	assert.strictEqual(shouldShowTerminalHints({ hasBuilt: false }), false);
-	assert.strictEqual(shouldShowTerminalHints({}), false, 'a site mid-clone must not show them');
-	assert.strictEqual(shouldShowTerminalHints(), false, 'no flags at all must not show them');
-});
-
-test('a completed build is what puts the hints on screen (issue #182)', () => {
-	assert.strictEqual(shouldShowTerminalHints({ hasBuilt: true }), true);
-});
+const { computeTerminalBusy } = require('../../src/renderer/terminal-hints.cjs');
 
 test('an idle terminal is free, so the hint links stay clickable (issue #182)', () => {
 	assert.strictEqual(computeTerminalBusy({}), false);


### PR DESCRIPTION
## Why

`shouldShowTerminalHints()` only wrapped `Boolean(hasBuilt)` at one renderer call site, creating a test-only abstraction rather than a reusable decision.

## What changes

- Inline the existing boolean conversion in the renderer.
- Remove the visibility wrapper and its truthiness-only tests.
- Keep `computeTerminalBusy()` and its multi-state coverage unchanged.

## How to test this

No user-visible surface changes. Run:

```sh
npm run lint
npm test
```

Expected: both commands pass; terminal hints remain hidden until a site has built.

## Risks and limitations

Low risk: this preserves the exact existing boolean conversion at its sole call site.

<details>
<summary>Review outcome</summary>

0 [fix here] · 0 [follow-up]. The branch passed `git diff --check`, `npm run lint`, and `npm test` (1,256 tests).
</details>

## Related

Fixes #427