### PR TITLE
[Remove] test-only external URL predicate

### DIFF
--- a/src/external-url.js
+++ b/src/external-url.js
@@ -51,10 +51,6 @@ function normalizeExternalUrl(url) {
 	return parsed.href;
 }
 
-function isAllowedExternalUrl(url) {
-	return normalizeExternalUrl(url) !== null;
-}
-
 // A refused address is attacker-influenced by hypothesis, and it is about to be
 // written into the file contributors attach to bug reports, so it has to stay on
 // one line and it has to be bounded. safe-log.js is where both live, and why.
@@ -80,7 +76,6 @@ async function openExternalUrl(url, { openExternal, onRefused } = {}) {
 module.exports = {
 	ALLOWED_URL_SCHEMES,
 	normalizeExternalUrl,
-	isAllowedExternalUrl,
 	describeRefusedUrl,
 	openExternalUrl
 };

--- a/tests/unit/external-url.test.cjs
+++ b/tests/unit/external-url.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { isAllowedExternalUrl, normalizeExternalUrl, describeRefusedUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
+const { normalizeExternalUrl, describeRefusedUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
 
 // Stands in for shell.openExternal, so "did this reach the OS?" is an assertion
 // rather than something the test has to take on trust.
@@ -102,10 +102,10 @@ test('junk input is refused rather than thrown', async () => {
 test('the scheme is read off the parsed URL, not the raw string', () => {
 	// Casing and leading whitespace are normalized by the URL parser before the
 	// comparison, so they are neither a false refusal nor a way past the guard.
-	assert.equal(isAllowedExternalUrl('HTTPS://example.com'), true);
-	assert.equal(isAllowedExternalUrl('  https://example.com'), true);
-	assert.equal(isAllowedExternalUrl('FILE:///etc/passwd'), false);
-	assert.equal(isAllowedExternalUrl('  file:///etc/passwd'), false);
+	assert.equal(normalizeExternalUrl('HTTPS://example.com'), 'https://example.com/');
+	assert.equal(normalizeExternalUrl('  https://example.com'), 'https://example.com/');
+	assert.equal(normalizeExternalUrl('FILE:///etc/passwd'), null);
+	assert.equal(normalizeExternalUrl('  file:///etc/passwd'), null);
 });
 
 test('the allow-list is only http and https', () => {


### PR DESCRIPTION
## Why

`isAllowedExternalUrl()` only restated whether `normalizeExternalUrl()` returned a value and existed solely for tests. Keeping that duplicate API made the tests assert an implementation wrapper instead of URL normalization behavior.

## What changes

Remove the test-only predicate from `src/external-url.js`. The former tests now assert `normalizeExternalUrl()`'s returned normalized URL or refusal directly, while existing opening coverage remains intact.

## How to test this

Platforms: any — this is a pure URL-normalization module with no platform-specific branch.

**Starting state:**

1. Check out this branch with dependencies installed.
2. Run `node --test tests/unit/external-url.test.cjs`.

**Expected result:** the focused suite passes, including parsed-scheme normalization and refused `file:` URLs.

**What must not have happened:** invalid or non-HTTP(S) input must not reach the `openExternal` recorder; normalized HTTP(S) URLs must still be the values handed to it.

No visible UI surface changed; the focused test command demonstrates this internal cleanup.

## Risks and limitations

The removed export was intentionally test-only; a downstream consumer importing it would now fail, but repository-wide search found none. Self-review: 0 findings across the five required dimensions.

## Related

Fixes #428.

---

<details>
<summary>Design decisions and alternatives considered</summary>

The assertions were folded into direct normalization checks rather than deleted wholesale, retaining coverage of the parser-derived protocol and output that callers actually use.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up] — no findings across architecture, security, performance, cross-platform behavior, or tests.

</details>

<details>
<summary>Implementation notes</summary>

Validation: `node --test tests/unit/external-url.test.cjs` (11 passing), `npm run lint`, and `npm test` (1,258 passing). The unrelated pre-existing `package-lock.json` modification was left uncommitted.

</details>
