### PR TITLE
[Remove] unused Git and logging exports

### DIFF
--- a/src/git-progress.cjs
+++ b/src/git-progress.cjs
@@ -80,4 +80,4 @@ function failureReason(stderr, signal = null) {
 	return lines.filter((line) => /^(fatal|error):/.test(line)).pop() || lines.pop() || (signal ? `killed by ${signal}` : 'no output');
 }
 
-module.exports = { PROGRESS_LINE, parseProgressLines, createProgressReader, failureReason };
+module.exports = { parseProgressLines, createProgressReader, failureReason };

--- a/src/safe-log.js
+++ b/src/safe-log.js
@@ -47,7 +47,5 @@ function describeRefused(value) {
 }
 
 module.exports = {
-	CONTROL_CHARACTERS,
-	MAX_DESCRIPTION_LENGTH,
 	describeRefused
 };


### PR DESCRIPTION
## Why

`git-progress.cjs` and `safe-log.js` exposed implementation constants that no caller imports. Keeping their public API limited to consumed helpers prevents consumers from depending on internal details without changing behavior.

## What changes

Removes `PROGRESS_LINE`, `CONTROL_CHARACTERS`, and `MAX_DESCRIPTION_LENGTH` from their respective CommonJS export objects. The constants remain module-private and the existing exported behavior, including `parseProgressLines`, is unchanged.

## How to test this

No user-visible surface changed; this is an API-surface cleanup, so manual app testing is not applicable.

**Starting state:** A checkout with dependencies installed.

1. Run `npm run lint`; it exits successfully.
2. Run `npm test`; all tests pass, including `tests/unit/git-progress.test.cjs` and logging refusal behavior exercised by the suite.

**What must not have happened:** Git progress parsing and bounded, one-line refusal logging must continue to behave identically; no production consumer may need the removed internal exports.

Platforms: any — this only narrows JavaScript module exports.

## Risks and limitations

Low risk: this is a deliberate breaking change only for unsupported, unconsumed exports. No user-facing behavior changed and no manual UI path applies.

## Related

Fixes #431

---

<details>
<summary>Design decisions and alternatives considered</summary>

Kept the constants in their original modules rather than deleting or inlining them, preserving implementation behavior and readability. Retained `parseProgressLines` because its dedicated unit test imports it.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up] — none found. The review checked architecture, security, performance, cross-platform behavior, and test coverage against the two-file diff; no invariants are affected.

</details>

<details>
<summary>Implementation notes</summary>

Validation: `node --test tests/unit/git-progress.test.cjs`, `npm run lint`, and `npm test` (1,258 passing). The worktree has a pre-existing unrelated `package-lock.json` modification, excluded from this commit and PR.

</details>
