### PR TITLE
[Refactor] centralize safe log formatter tests, Fixes #429

### DIFF
--- a/src/external-url.js
+++ b/src/external-url.js
@@ -51,10 +51,6 @@ function normalizeExternalUrl(url) {
 	return parsed.href;
 }
 
-function isAllowedExternalUrl(url) {
-	return normalizeExternalUrl(url) !== null;
-}
-
 // A refused address is attacker-influenced by hypothesis, and it is about to be
 // written into the file contributors attach to bug reports, so it has to stay on
 // one line and it has to be bounded. safe-log.js is where both live, and why.
@@ -80,7 +76,6 @@ async function openExternalUrl(url, { openExternal, onRefused } = {}) {
 module.exports = {
 	ALLOWED_URL_SCHEMES,
 	normalizeExternalUrl,
-	isAllowedExternalUrl,
 	describeRefusedUrl,
 	openExternalUrl
 };

--- a/src/external-url.js
+++ b/src/external-url.js
@@ -51,13 +51,6 @@ function normalizeExternalUrl(url) {
 	return parsed.href;
 }
 
-// A refused address is attacker-influenced by hypothesis, and it is about to be
-// written into the file contributors attach to bug reports, so it has to stay on
-// one line and it has to be bounded. safe-log.js is where both live, and why.
-function describeRefusedUrl(url) {
-	return describeRefused(url);
-}
-
 // The `url:open` handler's body, kept out of main.js so both sides of the guard
 // can be tested without an Electron process: `openExternal` is the real
 // `shell.openExternal` in the app and a recording stub in the tests.
@@ -65,7 +58,7 @@ async function openExternalUrl(url, { openExternal, onRefused } = {}) {
 	const target = normalizeExternalUrl(url);
 
 	if (target === null) {
-		if (typeof onRefused === 'function') onRefused(describeRefusedUrl(url));
+		if (typeof onRefused === 'function') onRefused(describeRefused(url));
 		return false;
 	}
 
@@ -76,6 +69,5 @@ async function openExternalUrl(url, { openExternal, onRefused } = {}) {
 module.exports = {
 	ALLOWED_URL_SCHEMES,
 	normalizeExternalUrl,
-	describeRefusedUrl,
 	openExternalUrl
 };

--- a/src/logging.js
+++ b/src/logging.js
@@ -109,8 +109,7 @@ function getLogFilePath() {
 // sequence or U+2028 begins a new line in one viewer or another, which is the
 // same forgery through a different reader.
 //
-// This is the same escaping as `describeRefusedUrl` (external-url.js) and
-// `describeRefusedSite` (site-registry.js). Those two describe a single value
+// This is the same escaping as `describeRefused` (safe-log.js), which describes a single value
 // for a caller; this one is the writer itself and bounds a whole line, so the
 // limits differ — a spawn message with a long path is legitimately longer than
 // a refused URL. Keeping the escape identical matters more than sharing it.

--- a/tests/unit/external-url.test.cjs
+++ b/tests/unit/external-url.test.cjs
@@ -3,6 +3,15 @@ const assert = require('node:assert/strict');
 
 const { normalizeExternalUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
 
+test('a refused URL reaches the log escaped and bounded', async () => {
+	const rec = recorder();
+	await openExternalUrl(`file:///tmp/\n${'x'.repeat(500)}`, rec.options);
+	assert.equal(rec.refused.length, 1);
+	assert.ok(rec.refused[0].startsWith('file:///tmp/\\x0a'));
+	assert.equal(rec.refused[0].length, 121);
+	assert.ok(rec.refused[0].endsWith('…'));
+});
+
 // Stands in for shell.openExternal, so "did this reach the OS?" is an assertion
 // rather than something the test has to take on trust.
 function recorder() {

--- a/tests/unit/external-url.test.cjs
+++ b/tests/unit/external-url.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { normalizeExternalUrl, describeRefusedUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
+const { normalizeExternalUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
 
 // Stands in for shell.openExternal, so "did this reach the OS?" is an assertion
 // rather than something the test has to take on trust.
@@ -112,51 +112,4 @@ test('the allow-list is only http and https', () => {
 	// A guard against widening it by accident: adding a scheme should be a
 	// deliberate change with a reason, and this test is where that shows up.
 	assert.deepEqual(ALLOWED_URL_SCHEMES, ['http:', 'https:']);
-});
-
-test('a refusal reports the address, truncated', async () => {
-	const rec = recorder();
-	const long = `file:///${'a'.repeat(500)}`;
-
-	await openExternalUrl(long, rec.options);
-
-	assert.equal(rec.refused.length, 1);
-	assert.ok(rec.refused[0].length < 200, 'the log line should not carry a 500-character address');
-	assert.ok(rec.refused[0].startsWith('file:///aaa'), 'enough of the address to diagnose the caller');
-});
-
-// The address is about to be written into the file contributors attach to bug
-// reports, and electron-log passes newlines through unchanged. Left as-is, a
-// refused address could close the log line and open another one in the app's own
-// timestamp-and-scope format — a log that describes events that never happened.
-test('a refused address cannot forge a second log line', async () => {
-	const rec = recorder();
-	const forged = 'file:///tmp/x\n[2026-08-06 10:00:00.000] [info]  (app) update completed successfully';
-
-	await openExternalUrl(forged, rec.options);
-
-	assert.equal(rec.refused.length, 1);
-	assert.ok(!rec.refused[0].includes('\n'), 'the description must stay on one line');
-	// Escaped, not dropped: the line still says what the caller actually sent.
-	assert.ok(rec.refused[0].includes('file:///tmp/x\\x0a[2026-08-06'));
-});
-
-test('every control character is escaped, not just newlines', () => {
-	// Carriage return alone ends a line in some viewers, and U+2028/U+2029 do it
-	// in others, so the whole class is escaped rather than the obvious member.
-	assert.equal(describeRefusedUrl('file:///a\rb'), 'file:///a\\x0db');
-	assert.equal(describeRefusedUrl('file:///a\tb'), 'file:///a\\x09b');
-	assert.equal(describeRefusedUrl('file:///a\u2028b'), 'file:///a\\u2028b');
-	assert.equal(describeRefusedUrl('file:///a\u0000b'), 'file:///a\\x00b');
-	// Ordinary addresses are untouched.
-	assert.equal(describeRefusedUrl('file:///etc/passwd'), 'file:///etc/passwd');
-});
-
-test('truncation is applied to the escaped form', () => {
-	// Escaping expands the string, so truncating first would let an address of
-	// control characters land in the log several times over the cap.
-	const description = describeRefusedUrl(`file:${'\n'.repeat(500)}`);
-
-	assert.ok(description.length <= 121, `escaped description was ${description.length} characters`);
-	assert.ok(!description.includes('\n'));
 });

--- a/tests/unit/external-url.test.cjs
+++ b/tests/unit/external-url.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { isAllowedExternalUrl, normalizeExternalUrl, describeRefusedUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
+const { normalizeExternalUrl, describeRefusedUrl, openExternalUrl, ALLOWED_URL_SCHEMES } = require('../../src/external-url.js');
 
 // Stands in for shell.openExternal, so "did this reach the OS?" is an assertion
 // rather than something the test has to take on trust.
@@ -102,10 +102,10 @@ test('junk input is refused rather than thrown', async () => {
 test('the scheme is read off the parsed URL, not the raw string', () => {
 	// Casing and leading whitespace are normalized by the URL parser before the
 	// comparison, so they are neither a false refusal nor a way past the guard.
-	assert.equal(isAllowedExternalUrl('HTTPS://example.com'), true);
-	assert.equal(isAllowedExternalUrl('  https://example.com'), true);
-	assert.equal(isAllowedExternalUrl('FILE:///etc/passwd'), false);
-	assert.equal(isAllowedExternalUrl('  file:///etc/passwd'), false);
+	assert.equal(normalizeExternalUrl('HTTPS://example.com'), 'https://example.com/');
+	assert.equal(normalizeExternalUrl('  https://example.com'), 'https://example.com/');
+	assert.equal(normalizeExternalUrl('FILE:///etc/passwd'), null);
+	assert.equal(normalizeExternalUrl('  file:///etc/passwd'), null);
 });
 
 test('the allow-list is only http and https', () => {

--- a/tests/unit/safe-log.test.cjs
+++ b/tests/unit/safe-log.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { describeRefused, MAX_DESCRIPTION_LENGTH } = require('../../src/safe-log.js');
+const { describeRefused } = require('../../src/safe-log.js');
 
 test('describeRefused escapes every log-breaking control character', () => {
 	assert.equal(describeRefused('file:///a\rb'), 'file:///a\\x0db');
@@ -22,7 +22,7 @@ test('describeRefused prevents a refused value from forging a second log entry',
 test('describeRefused escapes before bounding its output', () => {
 	const description = describeRefused(`file:${'\n'.repeat(500)}`);
 
-	assert.equal(description.length, MAX_DESCRIPTION_LENGTH + 1);
+	assert.equal(description.length, 121);
 	assert.ok(description.endsWith('…'));
 	assert.ok(!description.includes('\n'));
 });

--- a/tests/unit/safe-log.test.cjs
+++ b/tests/unit/safe-log.test.cjs
@@ -1,0 +1,35 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { describeRefused, MAX_DESCRIPTION_LENGTH } = require('../../src/safe-log.js');
+
+test('describeRefused escapes every log-breaking control character', () => {
+	assert.equal(describeRefused('file:///a\rb'), 'file:///a\\x0db');
+	assert.equal(describeRefused('file:///a\tb'), 'file:///a\\x09b');
+	assert.equal(describeRefused('file:///a\u2028b'), 'file:///a\\u2028b');
+	assert.equal(describeRefused('file:///a\u0000b'), 'file:///a\\x00b');
+	assert.equal(describeRefused('file:///etc/passwd'), 'file:///etc/passwd');
+});
+
+test('describeRefused prevents a refused value from forging a second log entry', () => {
+	const forged = 'file:///tmp/x\n[2026-08-06 10:00:00.000] [info]  (app) update completed successfully';
+	const description = describeRefused(forged);
+
+	assert.ok(!description.includes('\n'));
+	assert.ok(description.includes('file:///tmp/x\\x0a[2026-08-06'));
+});
+
+test('describeRefused escapes before bounding its output', () => {
+	const description = describeRefused(`file:${'\n'.repeat(500)}`);
+
+	assert.equal(description.length, MAX_DESCRIPTION_LENGTH + 1);
+	assert.ok(description.endsWith('…'));
+	assert.ok(!description.includes('\n'));
+});
+
+test('describeRefused describes non-string values by type', () => {
+	assert.equal(describeRefused(null), '<null>');
+	assert.equal(describeRefused(undefined), '<undefined>');
+	assert.equal(describeRefused(42), '<number>');
+	assert.equal(describeRefused({}), '<object>');
+});


### PR DESCRIPTION
## Why

`external-url` duplicated formatter-only coverage through `describeRefusedUrl()`, even though the shared `safe-log` module owns the one-line, bounded rendering contract.

## What changes

Removes the forwarding export and calls `describeRefused()` directly at the URL refusal boundary. Formatter coverage now exercises `safe-log` directly; `external-url` retains URL normalization and refusal-behavior coverage.

## How to test this

Platforms: any — this is a internal refactor with no visible UI change.

**Starting state:**

1. Check out this PR branch (targets `trunk`).
2. Install the repository dependencies.

1. Run `node --test tests/unit/external-url.test.cjs tests/unit/safe-log.test.cjs`.
2. Run `npm run lint` and `npm test`.

**What must not have happened:**

Refused `file:`, custom, malformed, and otherwise non-HTTP(S) URLs must still not reach `shell.openExternal`; refused values must remain one-line and bounded. The focused tests cover this directly, and the full suite covers the integration boundary.

## Risks and limitations

No user-visible behavior changed. Parent PR #436 is merged; this PR now targets trunk; the review found 0 [fix here] and 0 [follow-up] findings.

## Related

Fixes #429

---

<details>
<summary>Design decisions and alternatives considered</summary>

The formatter belongs to `safe-log`, where it is shared by URL, site, and editor refusal paths. Keeping a URL-specific wrapper would preserve a second public surface without adding behavior.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up] — no findings across architecture, security, performance, cross-platform, or tests. `npm run lint` and `npm test` passed (1,252 tests on Node 24.18.0).

</details>

<details>
<summary>Implementation notes</summary>

PR #436 already merged the test-only external URL predicate removal. Also fixes the integration with #439: the truncation test asserts the observable 121-character output instead of importing the removed constant. Before the fix it failed with 121 !== NaN; after the fix all 12 focused tests pass. The URL refusal callback remains covered for escaping and truncation, and the stale logging comment now names the shared formatter. Fresh independent self-review: no remaining findings.

</details>
