### PR TITLE
[CI] Reject focused tests and retain Playwright reports

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,8 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright report
-        if: failure()
+        # Keep retry evidence even when the job ultimately passes.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-journeys-${{ matrix.os }}
@@ -126,7 +127,8 @@ jobs:
         run: npm run test:e2e:packaged
 
       - name: Upload Playwright report
-        if: failure()
+        # Keep retry evidence even when the job ultimately passes.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-packaged-${{ matrix.os }}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,6 +20,8 @@ module.exports = defineConfig({
 	// same packaged binary and, in the journeys, over the same fixture roots.
 	workers: 1,
 	fullyParallel: false,
+	// A focused test must not silently shrink the suite in CI.
+	forbidOnly: !!process.env.CI,
 	// Locally a retry hides a flake you want to see; in CI it stops one flake from
 	// blocking somebody else's pull request.
 	retries: process.env.CI ? 1 : 0,


### PR DESCRIPTION
## Why

A committed `.only` can silently reduce the Playwright suite in CI. A test that fails and passes on retry also leaves no downloadable report because uploads currently run only when the job fails.

## What changes

Reject focused tests in CI and upload both Playwright reports on non-cancelled runs, including successful retries. Local focusing and the existing retry policy remain available.

## How to test this

**Starting state:** This branch with its own dependencies installed. Platforms: macOS and Windows; no application UI change.

1. In a disposable checkout, temporarily mark an existing journey with `test.only` and run `CI=1 npm run test:e2e` from Bash. Expect a forbidden `.only` error. Remove the temporary edit afterwards. Local runs without `CI` should still allow focusing.
2. On this PR, open **Checks**, then the E2E workflow run. Once it passes, open the run's **Artifacts** section. Expect journeys and packaged reports for both platforms, retained for seven days.
3. If a test passes on retry, download its report and inspect the flaky result. Expect the failed attempt to remain visible despite the green job.

**What must not have happened:** CI must not silently pass a focused subset; a passing retry must not suppress report upload.

## Risks and limitations

Successful runs now consume artifact storage and upload time. Retention remains seven days. Cancelled runs skip uploads. If setup fails before a report exists, the existing artifact action may warn about missing files.

Local validation on `f448ceb`: lint and all 1,258 unit tests passed; CI/local configuration checks and parsed YAML checks passed. The CI `forbidOnly` assertion failed before the change and passes after it. All seven CI checks passed on that revision, and all four reports were verified uploaded after successful jobs in [E2E run 34560492869](https://github.com/WordPress/contributor-toolkit/actions/runs/34560492869). The focused-test command above and an actual flaky E2E run have not been exercised for this change. CI is rerunning after the trunk update.

## Related

Addresses finding 7 of the local guardrails audit (focused tests and retry evidence).

---

<details>
<summary>Design decisions and alternatives considered</summary>

Uploading all non-cancelled reports keeps the workflow simple and makes successful runs inspectable without adding custom flaky-result parsing.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

0 [fix here] · 0 [follow-up]. No findings across the five dimensions.

- **Review:** completed — fresh agent `/root/review_ci_evidence`; published head `f448ceba560f08ec8db17a97e36149aa44f0a2de`, base `a1a8e883ab1c63409796ae3203a8806ec4136a1a`; local independent judgment pass covered both full files and local changes. Lint and 1,258 tests passed in the main session.
- **Since review:** reviewed worktree on `a1a8e88` committed as `f448ceb`; both file hashes matched. Then `f448ceb` → `5e4ca9ec074e821f827d4eae06c197881d2073f0` integrated base `26067afd2d8111af63511c7be4a11f90cef9e455`. The main agent inspected the three incoming cleanup commits and confirmed the two-file PR diff, both full changed files, and dependency manifests are unchanged; no new findings. CI reruns validate the combined revision.

</details>
