### PR TITLE
[Docs] Commands name their directory and manual passes name their platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ Prefer the simplest fix for reproducible user-facing failures. Do not add defens
 
 When writing manual test instructions, inspect the current renderer flow first and distinguish actions that happen automatically after linking a ticket from controls used only to retry or refresh them. Do not tell a tester to click a control when the app already starts that operation.
 
+Every command you hand a person names the directory to run it from, or says that it does not matter. Every manual pass you ask for names the platform, Windows or macOS, or says that either works, and the exact build it runs against: the Buildkite build number and commit, or "the current head". A tester who has to ask either question has already lost the round trip the instructions were meant to save.
+
 When asked to add an existing pull request to an existing stack, preserve its commits and change its base to the head branch of the current top PR. Do not move commits into an earlier PR unless the user explicitly asks to rewrite the stack.
 
 ## Architecture notes (non-obvious)


### PR DESCRIPTION
## Why

Twice today a manual pass stalled on a question the instructions should have answered: which machine to run it on, and where to run a command from. Both are cheap to state and expensive to omit, because the person testing is usually switching between a Mac and a Windows VM and each question is a round trip.

## What changes

One paragraph in `AGENTS.md`, next to the existing rule on writing manual test instructions: every command an agent hands a person names its directory or says it does not matter; every manual pass names Windows or macOS or says either works, and the exact build it runs against (Buildkite number and commit, or the current head). The PR-description section already asks for platforms; this covers the same expectation everywhere else an agent talks to a tester.

## How to test this

Platforms: any. Documentation only, no user-visible surface. Read the added paragraph under "Commands" in `AGENTS.md` and check it does not contradict the "platforms it needs" bullet under "Every pull request says how to test it by hand", which it complements rather than restates.

## Risks and limitations

None beyond one more rule to keep in mind; it is phrased as an outcome rather than a format so it does not fight the PR template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tz2pgC4BHcG6YP9bDvidm