### PR TITLE
[Fix] Disabled ticket actions explain themselves to assistive technology, Fixes #409

### DIFF
--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -39,7 +39,7 @@ import { parsePrRef } from '../patch-sources.cjs';
 import { prStateBadge } from './pr-state.cjs';
 import { statusBadge } from '../trac-ticket-info.cjs';
 import { prDateLabel } from './pr-date-label.cjs';
-import { ticketUrl, attachUrl } from './trac-ticket.cjs';
+import { ticketUrl, attachUrl, parseTicketRef } from './trac-ticket.cjs';
 import { adminUrl, adminerUrl } from './site-urls.cjs';
 import { ticketBranchRows, ticketListCard } from './ticket-branch-list.cjs';
 import { ticketTrunkNotice, rebaseRefusal } from './ticket-trunk-notice.cjs';
@@ -78,19 +78,24 @@ const COPY_BUTTON_LABELS = {
 // the accessible way: still in the tab order, `aria-disabled` rather than
 // `disabled` so assistive technology reads it, the sentence as its
 // description and as a tooltip. `title` would do neither, since Chromium
-// shows no tooltip on a disabled control. Without a reason it is the plain
-// Button, `disabled` passed through for gates that need no sentence.
+// shows no tooltip on a disabled control.
+//
+// The Tooltip is rendered whether or not there is a reason, and with no text
+// it renders its anchor and no popover. The conditional version returned two
+// different element types at the same position, so React remounted the
+// button every time the gate flipped — which throws away exactly what
+// `accessibleWhenDisabled` buys, since a keyboard user who just activated
+// the control has the focused element destroyed under them and focus falls
+// back to the document. `disabled` is passed through for gates that need no
+// sentence (an empty input, not a blocked action).
 function ReasonedButton({ reason, disabled, children, ...props }) {
-  if (!reason) {
-    return <Button disabled={disabled} {...props}>{children}</Button>;
-  }
   return (
-    <Tooltip text={reason} placement="bottom">
+    <Tooltip text={reason || undefined} placement="bottom">
       <Button
         {...props}
-        disabled
-        accessibleWhenDisabled
-        description={reason}
+        disabled={reason ? true : disabled}
+        accessibleWhenDisabled={Boolean(reason)}
+        description={reason || undefined}
       >{children}</Button>
     </Tooltip>
   );
@@ -1832,13 +1837,17 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
         // error line over a set of choices would read as a fault, so the
         // message is kept for real failures only. `canCarry` is main's word
         // on whether the edits can ride into this ticket, and the count
-        // arrives only on the path that scanned before refusing.
+        // arrives only on the path that scanned before refusing. Only that
+        // path names the ticket too, so the other one reads it back off the
+        // ref the switch was asked for, rather than saying "the ticket" to
+        // someone who typed a number (#409).
         if (res?.code === 'dirty-trunk') {
+          const parsedRef = parseTicketRef(String(ref));
           setBlockedByTrunkWork({
             ref: String(ref),
             canCarry: Boolean(res.canCarry),
             files: typeof res.files === 'number' ? res.files : null,
-            ticket: res.ticket || null
+            ticket: res.ticket || (parsedRef.ok ? parsedRef.id : null)
           });
         } else {
           setTicketError(res?.error || 'Could not save the ticket.');

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -50,6 +50,7 @@ import { highlightDiff, hasDiffLines } from './diff-highlight.cjs';
 import { highlightLog } from './log-highlight.cjs';
 import { carryTestMode } from './github-account.cjs';
 import { changesNoteParts, discardOutcome, applyFeedbackAfterDiscard, noteAfterDiscard, noteAfterProbe, discardBlocked, discardDisabledReason, DISCARD_CONFIRM_MESSAGE } from './changes-note.cjs';
+import { ticketActionDisabledReason, rebaseDisabledReason, dirtyTrunkQuestion } from './ticket-actions.cjs';
 import { initialConfirmations, confirmationReducer, prConfirmationMessage, deleteFailureMessage } from './confirmations.cjs';
 
 const TERMINAL_ALLOWED_SCRIPTS = ['build', 'build:dev', 'dev', 'test', 'watch', 'grunt'];
@@ -73,26 +74,32 @@ const COPY_BUTTON_LABELS = {
   failed: 'Could not copy'
 };
 
-// One discard action, wherever it is offered. Keeping the disabled rendering
-// here means the ticket note cannot lose the explanation while the review
-// modal keeps it (or vice versa).
-function DiscardChangesLink({ label, onClick, reason, style }) {
+// A button that explains itself while disabled (#409). A reason disables it
+// the accessible way: still in the tab order, `aria-disabled` rather than
+// `disabled` so assistive technology reads it, the sentence as its
+// description and as a tooltip. `title` would do neither, since Chromium
+// shows no tooltip on a disabled control. Without a reason it is the plain
+// Button, `disabled` passed through for gates that need no sentence.
+function ReasonedButton({ reason, disabled, children, ...props }) {
   if (!reason) {
-    return <Button variant="link" isDestructive onClick={onClick} style={style}>{label}</Button>;
+    return <Button disabled={disabled} {...props}>{children}</Button>;
   }
   return (
     <Tooltip text={reason} placement="bottom">
       <Button
-        variant="link"
-        isDestructive
-        onClick={onClick}
+        {...props}
         disabled
         accessibleWhenDisabled
         description={reason}
-        style={style}
-      >{label}</Button>
+      >{children}</Button>
     </Tooltip>
   );
+}
+// One discard action, wherever it is offered. Keeping the disabled rendering
+// here means the ticket note cannot lose the explanation while the review
+// modal keeps it (or vice versa).
+function DiscardChangesLink({ label, onClick, reason, style }) {
+  return <ReasonedButton variant="link" isDestructive onClick={onClick} reason={reason} style={style}>{label}</ReasonedButton>;
 }
 // What the app is doing while a pull request is being opened (#167). Each step
 // is named because they take visibly different amounts of time — forking is the
@@ -2681,7 +2688,10 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       <span>{describeSwitchProgress(switchProgress)}</span>
     </div>
   ) : null;
-  const ticketActionsBlocked = ticketSaving || deletingBranch !== null || updateState !== 'idle' || installing || building;
+  // One gate for every ticket action, and the sentence that goes with it
+  // (#409): a control this disables says why, through ReasonedButton.
+  const ticketActionsReason = ticketActionDisabledReason({ ticketSaving, deletingBranch, updateState, installing, building });
+  const ticketActionsBlocked = Boolean(ticketActionsReason);
 
   // The one question both paths now ask (#234). Picking a ticket while trunk
   // has uncommitted edits used to do opposite things — carry them silently
@@ -2692,45 +2702,40 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
   // loose edits cannot ride into it. Rendered as a variable because two
   // views hold a "Link ticket" field, and a refusal with no panel under it
   // would be a dead end in the second one.
+  const dirtyQuestion = blockedByTrunkWork ? dirtyTrunkQuestion(blockedByTrunkWork) : null;
   const blockedPanel = blockedByTrunkWork ? (
     <div style={{ marginTop: 8, padding: '10px 12px', background: '#fcf9e8', border: '1px solid #dba617', borderRadius: 6, color: '#6e5406', fontSize: 12 }}>
-      <div>
-        {blockedByTrunkWork.files
-          ? `You have ${blockedByTrunkWork.files === 1 ? '1 uncommitted change' : `${blockedByTrunkWork.files} uncommitted changes`} on this site, not on any ticket yet.`
-          : 'You have uncommitted changes on this site, not on any ticket yet.'}
-        {' '}What should happen to them?
-        {blockedByTrunkWork.canCarry ? '' : ' This ticket already has its own work here, so these edits cannot come along into it.'}
-      </div>
+      <div>{dirtyQuestion.question}</div>
       {patchSavedTo ? (
         <div style={{ marginTop: 6, fontWeight: 600 }}>
           Saved to {patchSavedTo}. The edits are still in the working tree.
         </div>
       ) : null}
       <div style={{ marginTop: 6, display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-        {blockedByTrunkWork.canCarry ? (
-          <Button
+        {dirtyQuestion.carry ? (
+          <ReasonedButton
             variant="link"
             isBusy={ticketSaving}
-            disabled={ticketActionsBlocked}
+            reason={ticketActionsReason}
             onClick={() => saveTicket(blockedByTrunkWork.ref, { carryTrunkWork: true })}
             style={{ fontSize: 12 }}
-          >Take these edits into {blockedByTrunkWork.ticket ? `#${blockedByTrunkWork.ticket}` : 'the ticket'}</Button>
+          >{dirtyQuestion.carry}</ReasonedButton>
         ) : null}
-        <Button variant="link" disabled={ticketActionsBlocked} onClick={() => saveTrunkWorkThenStartClean(blockedByTrunkWork.ref)} style={{ fontSize: 12 }}>
-          Save them as a patch, then start clean…
-        </Button>
-        <Button
+        <ReasonedButton variant="link" reason={ticketActionsReason} onClick={() => saveTrunkWorkThenStartClean(blockedByTrunkWork.ref)} style={{ fontSize: 12 }}>
+          {dirtyQuestion.save}
+        </ReasonedButton>
+        <ReasonedButton
           variant="link"
           isDestructive
-          disabled={ticketActionsBlocked}
+          reason={ticketActionsReason}
           onClick={() => confirmAnd('Discard the uncommitted edits on trunk? This cannot be undone.', () => discardTrunkWorkAndSwitch(blockedByTrunkWork.ref))}
           style={{ fontSize: 12 }}
-        >Discard them and start clean</Button>
+        >{dirtyQuestion.discard}</ReasonedButton>
         {/* The way out that touches nothing — three consequential actions
             with no fourth door is its own trap (#234). */}
-        <Button variant="link" disabled={ticketActionsBlocked} onClick={() => { setBlockedByTrunkWork(null); setPatchSavedTo(''); }} style={{ fontSize: 12 }}>
-          Cancel
-        </Button>
+        <ReasonedButton variant="link" reason={ticketActionsReason} onClick={() => { setBlockedByTrunkWork(null); setPatchSavedTo(''); }} style={{ fontSize: 12 }}>
+          {dirtyQuestion.cancel}
+        </ReasonedButton>
       </div>
     </div>
   ) : null;
@@ -2759,22 +2764,22 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
           <div style={{ flex: '1 1 auto', minWidth: 0 }}>
             <span style={{ fontSize: 13, color: '#1d2327' }}>
               {linked ? <>You also have work on #{row.ticketId}{' — '}</> : null}
-              <Button variant="link" onClick={() => saveTicket(String(row.ticketId))} disabled={ticketActionsBlocked} style={{ fontSize: 13 }}>
+              <ReasonedButton variant="link" onClick={() => saveTicket(String(row.ticketId))} reason={ticketActionsReason} style={{ fontSize: 13 }}>
                 {linked ? 'switch' : `Continue working on #${row.ticketId}`}
-              </Button>
+              </ReasonedButton>
             </span>
             {row.timeLabel ? (
               <div style={{ marginTop: 2, fontSize: 11, color: '#6c6f72' }}>{row.timeLabel}</div>
             ) : null}
           </div>
-          <Button
+          <ReasonedButton
             variant="link"
             isDestructive
             isBusy={deletingBranch === row.ref}
-            disabled={ticketActionsBlocked}
+            reason={ticketActionsReason}
             onClick={() => confirmAnd(`Delete all work on #${row.ticketId} on this site? This cannot be undone.`, () => deleteTicketWork(row.ref))}
             style={{ fontSize: 12, flex: '0 0 auto' }}
-          >Delete this ticket&apos;s work</Button>
+          >Delete this ticket&apos;s work</ReasonedButton>
         </div>
       ))}
     </div>
@@ -4647,7 +4652,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   {tracAttachmentsLoading ? 'Reading ticket…' : 'Read details from Trac'}
                 </Button>
               ) : null}
-              <Button variant="link" isDestructive onClick={unlinkTicket} disabled={ticketActionsBlocked}>Unlink</Button>
+              <ReasonedButton variant="link" isDestructive onClick={unlinkTicket} reason={ticketActionsReason}>Unlink</ReasonedButton>
             </div>
 
             {staleTicketNotice ? (
@@ -4656,14 +4661,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                 <div style={{ marginTop: 4 }}>{staleTicketNotice.body}</div>
                 <div style={{ marginTop: 8 }}>
                   {/* Rewrites the tree when the ticket is checked out, so the
-                      same gate as a discard: nothing running over the files. */}
-                  <Button
+                      same gate as a discard: nothing running over the files.
+                      Every branch of that gate has a sentence (#409). */}
+                  <ReasonedButton
                     variant="secondary"
                     isBusy={ticketSaving}
-                    disabled={ticketActionsBlocked || layerExitBlocked}
-                    title={layerExitBlocked ? discardDisabledReason({ patchHasChanges: true, isUpdating, installing, building, devServerActive: isDevProcessActive, discarding }) : undefined}
+                    reason={rebaseDisabledReason({ ticketSaving, deletingBranch, updateState, installing, building, devServerActive: isDevProcessActive, discarding })}
                     onClick={rebaseTicket}
-                  >{staleTicketNotice.action}</Button>
+                  >{staleTicketNotice.action}</ReasonedButton>
                 </div>
               </div>
             ) : null}
@@ -4876,13 +4881,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                   aria-label="Trac ticket number or URL"
                 />
               </div>
-              <Button
+              <ReasonedButton
                 variant="secondary"
                 onClick={linkTicket}
                 isBusy={ticketSaving}
-                disabled={ticketActionsBlocked || !ticketInput.trim()}
+                reason={ticketActionsReason}
+                disabled={!ticketInput.trim()}
                 style={{ padding: '10px 16px', borderRadius: 10 }}
-              >Link ticket</Button>
+              >Link ticket</ReasonedButton>
             </div>
             {/* Expectation-setting, not the warning itself: since #234 the
                 app asks before moving or discarding anything, so this only
@@ -5559,13 +5565,14 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
                             placeholder="Ticket number or URL, e.g. 62281"
                             aria-label="Trac ticket number or URL"
                           />
-                          <Button
+                          <ReasonedButton
                             variant="secondary"
                             onClick={linkTicket}
                             isBusy={ticketSaving}
-                            disabled={ticketActionsBlocked || !ticketInput.trim()}
+                            reason={ticketActionsReason}
+                            disabled={!ticketInput.trim()}
                             style={{ justifyContent:'center' }}
-                          >Link ticket</Button>
+                          >Link ticket</ReasonedButton>
                           {ticketError ? <div role="alert" style={{ color:'#d63638', fontSize:12 }}>{ticketError}</div> : null}
                           {switchProgressLine}
                           {savedCleanNotice}

--- a/src/renderer/ticket-actions.cjs
+++ b/src/renderer/ticket-actions.cjs
@@ -8,9 +8,10 @@
  * discard's guards on top. Each branch that disables a control has a sentence
  * here, because a disabled control carrying its reason as `title` explains
  * nothing: Chromium shows no tooltip on a disabled element and assistive
- * technology skips one with the real `disabled` attribute. The component
- * renders the sentence through `Tooltip` + `accessibleWhenDisabled` +
- * `description`, the shape the discard link already uses.
+ * technology skips one with the real `disabled` attribute. `ReasonedButton`
+ * in `index.jsx` renders the sentence, and is the only sanctioned way to
+ * disable a ticket action: a bare `disabled=` on one of these controls is
+ * the bug this module exists to close.
  *
  * Ordered like `discardDisabledReason` in `changes-note.cjs`: the action
  * already underway first, then the processes the contributor can wait for or
@@ -41,9 +42,14 @@ function ticketActionDisabledReason({ ticketSaving, deletingBranch, updateState 
  * @return {string|null}
  */
 function rebaseDisabledReason(state = {}) {
+	// `discarding` leads, as it does in `discardDisabledReason`: a discard is
+	// already rewriting the tree, and reporting an install the contributor
+	// could wait out would name the wrong thing. The rest of the shared gate
+	// follows, then the dev server, which is the one the contributor has to
+	// act on rather than wait for.
+	if (state.discarding) return 'Wait for the discard to finish before updating the ticket.';
 	const shared = ticketActionDisabledReason(state);
 	if (shared) return shared;
-	if (state.discarding) return 'Wait for the discard to finish before updating the ticket.';
 	if (state.devServerActive) return 'Stop the dev server before updating the ticket.';
 	return null;
 }

--- a/src/renderer/ticket-actions.cjs
+++ b/src/renderer/ticket-actions.cjs
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * Why a ticket action is unavailable, and what the dirty-trunk question says
+ * (#409). Every ticket action on the card (link, switch, unlink, delete work,
+ * move onto trunk, the four answers to the dirty-trunk question) shares one
+ * gate; the move onto trunk rewrites the checked-out tree, so it adds the
+ * discard's guards on top. Each branch that disables a control has a sentence
+ * here, because a disabled control carrying its reason as `title` explains
+ * nothing: Chromium shows no tooltip on a disabled element and assistive
+ * technology skips one with the real `disabled` attribute. The component
+ * renders the sentence through `Tooltip` + `accessibleWhenDisabled` +
+ * `description`, the shape the discard link already uses.
+ *
+ * Ordered like `discardDisabledReason` in `changes-note.cjs`: the action
+ * already underway first, then the processes the contributor can wait for or
+ * stop, so a state with several guards true reports the one that will clear
+ * on its own.
+ *
+ * @param {{ticketSaving?: boolean, deletingBranch?: string|null, updateState?: string,
+ *          installing?: boolean, building?: boolean}} state
+ * @return {string|null} Null when nothing blocks the action.
+ */
+function ticketActionDisabledReason({ ticketSaving, deletingBranch, updateState = 'idle', installing, building } = {}) {
+	if (ticketSaving) return 'Wait for the current ticket change to finish.';
+	if (deletingBranch) return "Wait for the ticket's work to finish deleting.";
+	if (updateState !== 'idle') return 'Wait for the trunk update to finish.';
+	if (installing) return 'Wait for the installation to finish.';
+	if (building) return 'Wait for the build to finish.';
+	return null;
+}
+
+/**
+ * Why "Update this ticket to the current trunk" is unavailable: the shared
+ * gate, then the guards a tree rewrite needs (a running dev server, a discard
+ * in flight), the same ones the discard action checks.
+ *
+ * @param {{ticketSaving?: boolean, deletingBranch?: string|null, updateState?: string,
+ *          installing?: boolean, building?: boolean, devServerActive?: boolean,
+ *          discarding?: boolean}} state
+ * @return {string|null}
+ */
+function rebaseDisabledReason(state = {}) {
+	const shared = ticketActionDisabledReason(state);
+	if (shared) return shared;
+	if (state.discarding) return 'Wait for the discard to finish before updating the ticket.';
+	if (state.devServerActive) return 'Stop the dev server before updating the ticket.';
+	return null;
+}
+
+/**
+ * The dirty-trunk question (#234): trunk has uncommitted edits and the
+ * contributor picked a ticket. The three answers change with `canCarry`: a
+ * new ticket can take the edits along and otherwise starts clean, but an
+ * existing ticket has parked work that the switch restores, so nothing
+ * starts clean there and the answers say "continue on #N" instead.
+ *
+ * @param {Object}             root0
+ * @param {number}             [root0.files]    How many files are dirty, 0 when unknown.
+ * @param {boolean}            [root0.canCarry] Whether the edits can ride into the ticket.
+ * @param {string|number|null} [root0.ticket]   Ticket being picked, for the labels.
+ * @return {{question: string, carry: string|null, save: string, discard: string, cancel: string}}
+ */
+function dirtyTrunkQuestion({ files = 0, canCarry = false, ticket = null } = {}) {
+	const count = files
+		? `You have ${files === 1 ? '1 uncommitted change' : `${files} uncommitted changes`} on this site, not on any ticket yet.`
+		: 'You have uncommitted changes on this site, not on any ticket yet.';
+	const name = ticket ? `#${ticket}` : 'the ticket';
+	if (canCarry) {
+		return {
+			question: `${count} What should happen to them?`,
+			carry: `Take these edits into ${name}`,
+			save: 'Save them as a patch, then start clean…',
+			discard: 'Discard them and start clean',
+			cancel: 'Cancel'
+		};
+	}
+	return {
+		question: `${count} What should happen to them? This ticket already has its own work here, so these edits cannot come along into it.`,
+		carry: null,
+		save: `Save them as a patch, then continue on ${name}…`,
+		discard: `Discard them and continue on ${name}`,
+		cancel: 'Cancel'
+	};
+}
+
+module.exports = { ticketActionDisabledReason, rebaseDisabledReason, dirtyTrunkQuestion };

--- a/tests/unit/ticket-actions.test.cjs
+++ b/tests/unit/ticket-actions.test.cjs
@@ -1,0 +1,68 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { ticketActionDisabledReason, rebaseDisabledReason, dirtyTrunkQuestion } = require('../../src/renderer/ticket-actions.cjs');
+
+// A disabled control with no reason is the bug (#409): the ticketActionsBlocked
+// gate used to disable the card's buttons silently. Every branch of it has a
+// sentence, and an idle app has none.
+test('ticketActionDisabledReason has a sentence for every branch of the gate and none when idle (#409)', () => {
+	assert.equal(ticketActionDisabledReason(), null);
+	assert.equal(ticketActionDisabledReason({ ticketSaving: false, deletingBranch: null, updateState: 'idle', installing: false, building: false }), null);
+	assert.match(ticketActionDisabledReason({ ticketSaving: true }), /ticket change to finish/);
+	assert.match(ticketActionDisabledReason({ deletingBranch: 'refs/heads/ticket-1' }), /finish deleting/);
+	for (const updateState of ['fetching', 'installing', 'building']) {
+		assert.match(ticketActionDisabledReason({ updateState }), /trunk update to finish/, updateState);
+	}
+	assert.match(ticketActionDisabledReason({ installing: true }), /installation to finish/);
+	assert.match(ticketActionDisabledReason({ building: true }), /build to finish/);
+});
+
+// Several guards go true at once while state settles; the one already
+// underway wins so the sentence does not flicker between reasons.
+test('ticketActionDisabledReason reports the action underway before a process it could wait for', () => {
+	assert.match(ticketActionDisabledReason({ ticketSaving: true, updateState: 'fetching', installing: true }), /ticket change/);
+	assert.match(ticketActionDisabledReason({ deletingBranch: 'x', building: true }), /deleting/);
+	assert.match(ticketActionDisabledReason({ updateState: 'building', building: true }), /trunk update/);
+});
+
+// The move onto trunk rewrites the checked-out tree, so it is gated like a
+// discard on top of the shared gate. Both extra guards name the button.
+test('rebaseDisabledReason adds the tree-rewrite guards after the shared gate (#409)', () => {
+	assert.equal(rebaseDisabledReason(), null);
+	assert.equal(rebaseDisabledReason({ devServerActive: false, discarding: false }), null);
+	assert.equal(rebaseDisabledReason({ devServerActive: true }), 'Stop the dev server before updating the ticket.');
+	assert.equal(rebaseDisabledReason({ discarding: true }), 'Wait for the discard to finish before updating the ticket.');
+	// The shared gate still leads: a trunk update with the dev server running
+	// reports the update, which clears on its own.
+	assert.match(rebaseDisabledReason({ updateState: 'fetching', devServerActive: true }), /trunk update/);
+	assert.match(rebaseDisabledReason({ discarding: true, devServerActive: true }), /discard/);
+});
+
+test('dirtyTrunkQuestion counts the files and offers the carry for a new ticket (#234)', () => {
+	const one = dirtyTrunkQuestion({ files: 1, canCarry: true, ticket: 123 });
+	assert.equal(one.question, 'You have 1 uncommitted change on this site, not on any ticket yet. What should happen to them?');
+	assert.equal(one.carry, 'Take these edits into #123');
+	assert.equal(one.save, 'Save them as a patch, then start clean…');
+	assert.equal(one.discard, 'Discard them and start clean');
+	assert.equal(one.cancel, 'Cancel');
+	assert.match(dirtyTrunkQuestion({ files: 3, canCarry: true }).question, /^You have 3 uncommitted changes/);
+	assert.equal(dirtyTrunkQuestion({ canCarry: true }).carry, 'Take these edits into the ticket');
+	assert.match(dirtyTrunkQuestion({ canCarry: true }).question, /^You have uncommitted changes on this site/);
+});
+
+// An existing ticket has parked work that the switch restores, so "start
+// clean" is false for it: the answers say what actually happens (#409).
+test('dirtyTrunkQuestion says "continue on #N" and drops the carry when the ticket has parked work (#409)', () => {
+	const parked = dirtyTrunkQuestion({ files: 2, canCarry: false, ticket: 123 });
+	assert.equal(parked.carry, null);
+	assert.match(parked.question, /already has its own work here, so these edits cannot come along into it\.$/);
+	assert.equal(parked.save, 'Save them as a patch, then continue on #123…');
+	assert.equal(parked.discard, 'Discard them and continue on #123');
+	assert.equal(parked.cancel, 'Cancel');
+	assert.doesNotMatch(parked.save + parked.discard, /start clean/);
+	assert.equal(dirtyTrunkQuestion({ canCarry: false }).discard, 'Discard them and continue on the ticket');
+	// The default is the safe reading: no carry offered unless main said so.
+	assert.equal(dirtyTrunkQuestion({}).carry, null);
+});

--- a/tests/unit/ticket-actions.test.cjs
+++ b/tests/unit/ticket-actions.test.cjs
@@ -37,7 +37,15 @@ test('rebaseDisabledReason adds the tree-rewrite guards after the shared gate (#
 	// The shared gate still leads: a trunk update with the dev server running
 	// reports the update, which clears on its own.
 	assert.match(rebaseDisabledReason({ updateState: 'fetching', devServerActive: true }), /trunk update/);
+	// A discard is already rewriting the tree, so it leads over every process
+	// the contributor could otherwise wait out — the order the discard's own
+	// reason uses, which the old inline `title` on this button produced.
 	assert.match(rebaseDisabledReason({ discarding: true, devServerActive: true }), /discard/);
+	assert.match(rebaseDisabledReason({ discarding: true, installing: true, building: true }), /discard/);
+	assert.match(rebaseDisabledReason({ discarding: true, updateState: 'building' }), /discard/);
+	// Including over the shared gate's own first branch: a discard in flight
+	// is the tree rewrite that has to finish, whatever else is settling.
+	assert.match(rebaseDisabledReason({ discarding: true, ticketSaving: true }), /discard/);
 });
 
 test('dirtyTrunkQuestion counts the files and offers the carry for a new ticket (#234)', () => {


### PR DESCRIPTION
## Why

The ticket card disables its actions while a link, switch, delete, trunk update, install or build runs, and used to do so silently: one shared gate, no sentence. The one button that did explain itself, **Update this ticket to the current trunk**, carried its reason as `title`, which Chromium does not show on a disabled control and assistive technology skips because the control has the real `disabled` attribute. A contributor saw a dead button with no way to learn why. #409 has the full case.

The dirty-trunk question had a second, smaller wrong: **Discard them and start clean** and **Save them as a patch, then start clean…** are false when the ticket already has parked work, because the switch restores that work and nothing starts clean.

## What changes

- **`src/renderer/ticket-actions.cjs`** holds the reason for every branch of the shared gate (`ticketActionDisabledReason`), the two extra guards the move onto trunk adds because it rewrites the checked-out tree (`rebaseDisabledReason`, the dev server and a discard in flight), and the dirty-trunk question with both wordings (`dirtyTrunkQuestion`). Order follows `discardDisabledReason`: the action already underway first, then the process the contributor can wait for or stop.
- **`ReasonedButton`** in `index.jsx` is the house shape lifted out of `DiscardChangesLink`: `Tooltip` + `accessibleWhenDisabled` + `description={reason}` when there is a reason, the plain `Button` otherwise. `DiscardChangesLink` now builds on it. Every ticket action goes through it: Unlink, the branch rows (switch, delete work), the four dirty-trunk answers, Link ticket in both views, and the move onto trunk.
- **Link ticket** keeps a plain `disabled` for the empty field. That is not a blocked action, so it gets no sentence.
- When the ticket has parked work the answers read **Save them as a patch, then continue on #N…** and **Discard them and continue on #N**; the carry is not offered, as before.

Deliberately not in this PR: the button staying enabled after a rebase conflict (the third item in #409, needs state that outlives the refusal), the `TextControl` for the ticket number (a disabled text field has no tooltip shape in the component library), and `src/main.js` (untouched, another change owns it).

## How to test this

Platform: either, macOS or Windows. Build: the Buildkite artifact for this branch at head `1fb75e1`, or a local `npm start` from the repository root.

**Starting state:** a site with a linked ticket whose base predates trunk, so the card shows "Trunk has moved since this ticket started." A site cloned before trunk last moved, then **Update to latest trunk** on a second site, gets there; the journey below stages the same thing.

1. Click **Start dev server** (or **Install dependencies**). Expected: **Update this ticket to the current trunk** is greyed, still reachable with Tab, and hovering or focusing it shows "Stop the dev server before updating the ticket." (or "Wait for the installation to finish."). A screen reader reads the sentence as the button's description.
2. While the install runs, Tab to **Unlink**, **Link ticket** and, if the site has another ticket branch, **switch** and **Delete this ticket's work**. Expected: each is greyed and shows "Wait for the installation to finish."
3. Stop the server or let the install finish. Expected: every button is enabled again and the tooltip is gone.
4. Edit a file on trunk with no ticket linked, then link a ticket that already has work on this site. Expected: the yellow panel says "This ticket already has its own work here, so these edits cannot come along into it." and offers **Save them as a patch, then continue on #N…**, **Discard them and continue on #N** and **Cancel**. No "start clean" wording, no **Take these edits into #N**.
5. Same edit, link a new ticket. Expected: **Take these edits into #N**, **Save them as a patch, then start clean…**, **Discard them and start clean**, **Cancel**, unchanged from before.

**What must not have happened:** a button that is greyed with no tooltip and no description; a disabled button that still fires its action on click or Enter; the dirty-trunk panel losing an answer it offered before; the branch rows or the Unlink action disabled while the app is idle.

The layer-4 journey `tests/e2e/journeys/ticket-rebase.spec.js` clicks the move button by its accessible name on both platforms; run from the repository root with `npx playwright test --project=journeys tests/e2e/journeys/ticket-rebase.spec.js`. It covers the happy path, not the disabled state, so steps 1 to 3 are the manual pass. Unit coverage is `tests/unit/ticket-actions.test.cjs` (from the repository root: `node --test tests/unit/ticket-actions.test.cjs`). On the old code there is nothing to test: the gate was an inline boolean in `index.jsx` and the wording was inline JSX, which is the bug the test now pins.

## Risks and limitations

- **The self-review raised 2 🔵 [fix here] findings; both are fixed in `1fb75e1`, none deferred.** Everything below this line is what is deliberately not fixed here. See the review outcome for the full record.
- `accessibleWhenDisabled` keeps the button in the tab order and uses `aria-disabled`, so a Playwright `click()` on it waits for enabled as before, but a test that asserted the `disabled` attribute directly would need `toBeDisabled()`. No test in the repository does.
- The ticket number in the parked-work answers is read off the ref the switch was asked for, because only the new-ticket refusal in `src/main.js` carries `ticket` and `files`. That file is owned by another change, so the count stays absent on that path and the sentence reads "You have uncommitted changes on this site" rather than naming a number. Carrying both through the other refusal is the tidier fix and belongs wherever `src/main.js` next opens.
- The Link ticket field itself (`TextControl`) is still silently disabled by the gate; the button beside it explains.
- Unrelated finding from the same self-review that is not filed as an issue, recorded here: the `---`/`+++` header heuristic in `rewritePatchPaths` and `splitPatchSections` (`src/patch-plan.cjs`) is line-local, so a hunk that removes a line starting `-- ` right before one adding a line starting `++ ` reads as a file header and the patch is refused with a nonsense reason. Never a bad write, Git decides. Tracking hunk state (the `@@` counts) closes it.
- After a rebase conflict the move button stays enabled and a second click repeats the same refusal; harmless, left for a later change.

## Related

Fixes #409. Follow-up to #408 (which moved the ticket panel's feedback under the controls).

---

<details>
<summary>Design decisions and alternatives considered</summary>

- One wrapper (`ReasonedButton`) rather than a second copy of the Tooltip block per button. `DiscardChangesLink` keeps its signature and callers; it is now three lines over the wrapper.
- The reason for the move onto trunk is computed separately from the shared gate instead of reusing `discardDisabledReason`, because that function's first three branches (patch loading, load failed, no changes) do not apply to a tree rewrite that is not a discard, and its sentences end in "before discarding changes".
- `ticketActionsBlocked` stays as `Boolean(ticketActionsReason)` so the two `TextControl`s keep their gate without a second expression that could drift from the sentence.
- The dirty-trunk labels take `canCarry` from main's answer, as before; the module only words it. The "continue on #N" form is what the switch actually does, per #409.

</details>

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

**2 [fix here] · 3 [follow-up] — both `[fix here]` fixed in `1fb75e1`.**

Fixed:

- **Architecture 🔵** — `ReasonedButton` returned `<Button>` without a reason and `<Tooltip><Button></Tooltip>` with one, so React saw a different element type at the same position and remounted the `<button>` on every flip of the gate. That discards what `accessibleWhenDisabled` buys: the keyboard user who just activated the control loses the focused element and focus falls back to the document, and the busy animation restarts on the buttons that pair `isBusy` with the same flag. The Tooltip is now always rendered; with no text it renders its anchor and no popover (verified in `@wordpress/components` 28.13.0, `build/tooltip/index.js`).
- **Architecture 🔵** — `rebaseDisabledReason` checked `discarding` after the shared gate, so an install or build would be reported over a discard already rewriting the tree. `discardDisabledReason` puts it first, and so did this button's old inline `title`. It leads now, with the ordering pinned by the test.

Deferred, with reasons:

- **Tests 🔵 [follow-up]** — the `canCarry: false` question was asserted with a ticket number and a file count that the app could not produce, because only the new-ticket refusal in `src/main.js` attaches `ticket` and `files`. Rather than mark the wording unreachable, the renderer now derives the ticket from the ref it asked to switch to, so the `#N` form ships. The count still does not; carrying it through the other refusal needs `src/main.js`, which another change owns. Noted in Risks.
- **Architecture 🔵 [follow-up]** — the ticket-number `TextControl` beside "Link ticket" is still `disabled` with no reason. `TextControl` has no `accessibleWhenDisabled`, so it needs a different shape (a visible sentence in the row, or `readOnly` with `aria-describedby`) rather than this PR's wrapper. Noted in Risks.
- **Tests 🔵 [follow-up]** — none of the new tests could fail on the old code for the reported bug, because the bug was the wiring in `index.jsx`, which §1 of the review standard puts out of the suite's reach by construction. Taken as the repo's chosen trade-off; the module header now names `ReasonedButton` as the only sanctioned way to disable a ticket action, so a future review has something to point at.

Checked and clear in the review: `isBusy` with `accessibleWhenDisabled` (the no-op click handlers are spread after the caller's props, so a gated click cannot reach `saveTicket`); `Tooltip` inside the text span and the flex row (portalled popover, `VisuallyHidden` description, no layout or focus effect); the dirty-trunk question sentence byte-identical for both `canCarry` values; `Button` forwarding `description` and `accessibleWhenDisabled` on the installed 28.13.0; and the `ticket-rebase` journey's locator and auto-wait, since `description` does not enter the accessible name and Playwright's enabled check honours `aria-disabled`. Security, performance and cross-platform: nothing to report, a renderer string module with no IPC, spawn, path or persistence surface.

- **Review:** not run — CodeRabbit; its check reads `pass` but its message reads "Review rate limited", and an `@coderabbitai review` after the window it named was refused the same way. No CodeRabbit finding exists for this PR, at any severity.
- **Review:** completed — fresh agent context, no involvement in writing the change, against `.github/instructions/code-review.instructions.md`; reviewed head `909258d` / base `f31e5df`; `npm run lint` clean and `npm test` 1289 pass / 0 fail at that revision.
- **Since review:** `909258d` → `1fb75e1`, the two `[fix here]` findings plus the ticket-number fallback; lint clean, `npm test` 1289 pass / 0 fail, `npm run build:once` clean. Not re-reviewed in a fresh context.

</details>

<details>
<summary>Screenshots or recording</summary>

No screenshot. The visible change is a tooltip and a screen-reader description on buttons that were already greyed; the state that shows it needs a running install or dev server, which the manual pass above stages. The dirty-trunk panel's new labels are quoted in step 4.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJJSFQMq1ahmubgNNxJwqz
