### PR TITLE
[Fix] Reject a run that never started, instead of streaming to nobody

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2760,7 +2760,13 @@ const ENGINE_RETRY_NOTICE = '\n⚠ This site requires a newer Node.js than this 
 // installs that inherit this environment — wordpress-develop's Gruntfile calls
 // install-changed at load time, which execSync's its own `npm install` (#54).
 function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register, logScope, retryOnEngineMismatch = false, relaxEnginesFromStart = false }) {
-	const start = (relaxEngines) => {
+	// `initial` is the first start, the one that happens inside the IPC handler
+	// before it has returned a run id. Nothing is listening on the log and done
+	// channels yet — the renderer subscribes after the invoke resolves (#43) —
+	// so a failure there is thrown for the handler to reject with, and reaches
+	// the contributor through the caller's own catch. A retry's failure happens
+	// later, with the listeners in place, and streams as usual.
+	const start = (relaxEngines, initial = false) => {
 		// Logged before the spawn: a child that fails to start at all (EPERM on
 		// Windows) produces no output, so without this the log would show nothing
 		// where the failure was.
@@ -2773,15 +2779,12 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			});
 		} catch (err) {
 			// Synchronous, unlike a spawn failure: the shim directory refused to
-			// hand out shims without the compat preload (#275). Same surface as
-			// the 'error' path below, and settled a turn later for the same
-			// reason: the handler has not stored the run yet.
+			// hand out shims without the compat preload (#275).
 			logError(logScope, `could not start: ${String(err)}`);
+			if (initial) throw err;
+			logEvent(logScope, 'never started; shims not written');
 			onLog('stderr', `\nFailed to start: ${err && err.message ? err.message : String(err)}\n`);
-			setTimeout(() => {
-				logEvent(logScope, 'never started; shims not written');
-				onDone(null);
-			}, 0);
+			setTimeout(() => onDone(null), 0);
 			return;
 		}
 		register(child);
@@ -2854,7 +2857,7 @@ function runNpmWithEngineRetry({ runnerPath, args, cwd, onLog, onDone, register,
 			settle(code);
 		});
 	};
-	start(relaxEnginesFromStart);
+	start(relaxEnginesFromStart, true);
 }
 
 ipcMain.handle('npm:install', async (event, directoryPath) => {

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -2002,6 +2002,13 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onSit
       if (code === 0) { try { await window.api.markSiteInitialized(sitePath); } catch {} onInitialized(sitePath); }
       try { await loadStatus(); } catch {}
       if (onDone) onDone({ code });
+    }).catch((error) => {
+      // A start that never got as far as a run id, so no done event is coming
+      // for it (#43): without this the button stays spinning on a run that does
+      // not exist. Same shape as runScript's catch.
+      appendNpm(`\nFailed to start npm install: ${error && error.message ? error.message : String(error)}\n`);
+      setInstalling(false);
+      if (onDone) onDone({ code: -1 });
     });
   }, [appendNpm, ensureStick, loadStatus, onInitialized, sitePath]);
 

--- a/tests/unit/ipc-wiring.test.cjs
+++ b/tests/unit/ipc-wiring.test.cjs
@@ -1939,7 +1939,7 @@ test('npm:run-script spawns the script runner through npm-runner too', async () 
 // in practice is the source file missing from the packaged bundle (a packaging
 // allow-list that forgot it), so it is the copy that fails here, not the temp
 // directory, which is why the shim writes would otherwise have gone ahead.
-test('npm:run-script refuses to start when the compat preload cannot be installed (#275)', async () => {
+test('npm:run-script refuses to start when the compat preload cannot be installed (#275, #43)', async () => {
 	const shimDir = path.join(os.tmpdir(), `electron-node-shims-${process.pid}`);
 	// A previous test in this file may have written a good set; the assertion
 	// below is about what this load writes.
@@ -1961,23 +1961,50 @@ test('npm:run-script refuses to start when the compat preload cannot be installe
 	});
 	const event = createIpcEvent();
 
-	await main.invokeWith('npm:run-script', event, '/sites/wp', 'build');
-	// The refusal is reported a turn later, like a spawn failure, so the handler
-	// has finished its bookkeeping before it is told the run is over.
-	await new Promise((resolve) => setTimeout(resolve, 0));
+	// Rejected, not streamed. The renderer subscribes to the log and done
+	// channels only after this invoke resolves (#43), so a failure reported
+	// through them before the run id exists reaches nobody, and the terminal
+	// waits for a completion event that was sent to no listener.
+	await assert.rejects(
+		main.invokeWith('npm:run-script', event, '/sites/wp', 'build'),
+		/preload/,
+		'the refusal did not reach the caller, or did not name the preload'
+	);
 
 	assert.equal(cp.spawned.length, 0, 'the runner was started into shims that carry no preload');
 	const shimName = process.platform === 'win32' ? 'node.cmd' : 'node';
 	assert.ok(!fs.existsSync(path.join(shimDir, shimName)), 'a node shim without the preload was written anyway');
-	const stderr = event.sent
-		.filter((m) => m.channel === 'npm:run-script:log' && m.payload.type === 'stderr')
-		.map((m) => m.payload.data)
-		.join('');
-	assert.match(stderr, /Failed to start/, 'the person who clicked the button was not told the run never started');
-	assert.match(stderr, /preload/, 'the reason does not name the preload');
-	const done = event.sent.find((m) => m.channel === 'npm:run-script:done');
-	assert.ok(done, 'the run was never settled, so the renderer waits forever');
-	assert.equal(done.payload.code, null);
+	assert.deepEqual(event.sent, [], 'a start that has no run id yet must not send correlated events');
+});
+
+// The install path reaches the same start, and a rejection there has its own
+// consequence: nothing sets `installing` back, so the wizard's button spins on
+// a run that does not exist. Asserted here because the renderer's catch cannot
+// be unit tested.
+test('npm:install refuses to start when the compat preload cannot be installed (#275, #43)', async () => {
+	fs.rmSync(path.join(os.tmpdir(), `electron-node-shims-${process.pid}`), { recursive: true, force: true });
+	const cp = stubbedSpawn();
+	const main = loadMain({
+		stubs: {
+			...silentLogging(),
+			...fakeSettingsStore().stubs,
+			'child_process': { spawn: cp.spawn },
+			'fs': {
+				copyFileSync(src, dest, ...rest) {
+					if (path.basename(src) === 'electron-node-compat.js') {
+						throw Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+					}
+					return fs.copyFileSync(src, dest, ...rest);
+				}
+			}
+		}
+	});
+	const event = createIpcEvent();
+
+	await assert.rejects(main.invokeWith('npm:install', event, '/sites/wp'), /preload/);
+
+	assert.equal(cp.spawned.length, 0);
+	assert.deepEqual(event.sent, [], 'a start that has no install id yet must not send correlated events');
 });
 
 test('npm:kill ends the script tree rather than signalling the runner alone', async (t) => {


### PR DESCRIPTION
## Why

#395 (merged this morning) made the runner refuse to start when the compat preload cannot be installed, which is right: shims without `--require` are the runaway state #275 describes. It reported that refusal the wrong way.

The report went out through `npm:run-script:log` and `npm:run-script:done`, from inside the IPC handler, **before the handler had returned the run id**. The renderer subscribes to those channels only after the invoke resolves, so:

- the `Failed to start:` line reached no listener at all, and
- the completion event raced the subscription. Lose it and the terminal sits in its running state forever, with no prompt, on a run that never existed.

This is the race #43 describes, in a path that can actually be reached: the preload copy fails when the file is missing from the packaged bundle, which is exactly what a packaging allow-list can cause (#399 is rewriting that rule now).

## What changes

The first start, the one inside the handler, throws instead of streaming. The handler rejects, the invoke rejects, and the caller's own catch reports it. `runScript` in the renderer already had that catch and already writes `Failed to start npm run <name>` and settles with code -1; `runInstall` did not, so it gains the same shape, without which the wizard's button spins on a run that does not exist.

A retry's failure keeps streaming, deliberately: by then the run id has been returned and the listeners are in place.

Not in this PR: the general contract #43 asks for, a renderer-generated correlation id and subscribe-before-start across every streaming channel. That is a larger change and #43 stays open for it.

## How to test this

Platforms: any. From the repository root:

1. `npm test` — `tests/unit/ipc-wiring.test.cjs` gains two tests, one per handler. Both are red on trunk: revert `src/main.js` and they fail on the rejection that never comes.
2. To see it by hand you need a build whose `electron-node-compat.js` is missing from the bundle, which no released artifact has. Skipped for that reason rather than described as done.

**What must not have happened:** a run id returned for a runner that was never spawned; a `Failed to start` line written into the terminal by the main process before the renderer could be listening; the install button left spinning after a refused start.

## Risks and limitations

- The two Playground handlers call `spawnRunner` directly and now reject rather than starting without the preload. That is the right outcome for a broken package, and their renderer paths already handle a rejected invoke.
- The renderer half (`runInstall`'s catch) is not unit tested: `index.jsx` is not a unit-testable surface in this repository, which is why the main-side test asserts that nothing correlated is sent at all. The wiring test is what would catch a regression.
- CodeRabbit reported "Review rate limited" on the two PRs before this one, so treat a green check as "did not run" unless the message says otherwise.

<details>
<summary>Review outcome (required, see AGENTS.md)</summary>

**0 `[fix here]` · 2 `[follow-up]`.** Self-review per `.github/instructions/code-review.instructions.md`, judgement pass by a fresh agent context with only the diff and the standard. Head `e008fcd`, base `origin/trunk` at `f31e5df`, working tree clean. Deterministic layer on the same head: lint clean, `npm test` 1285 pass / 2 skipped, `npm run test:electron` 1287 pass. CodeRabbit did not run on this PR ("Review rate limited"); this pass stands in for it.

Verified and not findings: the thrown error has exactly two callers, both async `ipcMain.handle`, so it can only become an invoke rejection; the retry path (`start(true)` from the `close` handler) keeps the streaming branch and cannot throw into the emit; both new tests fail on trunk (the handlers resolve there and send one `:log` and one `:done`) and assert observable outcomes; skipping `onDone` on the initial throw means `installFailed` is no longer persisted for an install that never started, which is right, since there is no partial `node_modules` for the flag to explain, and every in-session caller still branches on `code !== 0`.

Follow-ups, recorded here rather than filed:

- **Tests 🔵.** The streamed branch of the catch (a retry whose start fails) is no longer covered by any test. Close to unreachable, since `ensureNodeShimDir` retries the copy and the file would have to vanish between the two starts, but it is live code. A `copyFileSync` stub failing on the second call, driven through a `close` the engine-retry accepts, would reach it.
- **Architecture 🔵.** The new catch builds a user-facing sentence inline in `index.jsx`, mirroring the copy `runScript` already had. Both belong in one `src/renderer/*.cjs` helper with a test, which could also strip Electron's `Error invoking remote method` prefix from what the contributor reads.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tz2pgC4BHcG6YP9bDvidm
