### PR TITLE
[Docs] A pull request you did not open belongs to its author

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,12 @@ Once the pull request is open and out of draft, read the CodeRabbit check's mess
 
 That file carries the procedure as well as the standard. Follow it rather than improvising a review.
 
+### A pull request you did not open belongs to its author
+
+Never push commits to, rebase, update, edit the description of, or merge a pull request that the person you are working for did not open. That holds even when the repository lets maintainers push to the branch, even when the fix is one line, and even when the author has been quiet for weeks. The author decides what lands on their branch and when it merges.
+
+What you may do on someone else's pull request is review it: read it, run it, run the review procedure against it, and leave the findings as a comment or a review, with enough detail that the author can apply them without guessing. A finding you could fix in a minute is still a finding you write down, with the diff if that helps. If a pull request is blocked on its author and the work is urgent, say so to the person you are working for and let them decide how to reach the author, rather than taking the branch over.
+
 ### The pull request description follows the template
 
 [`.github/pull_request_template.md`](.github/pull_request_template.md) is the shape, and GitHub loads it into every new pull request automatically — including ones opened with `gh pr create`, as long as you do not pass a `--body` that replaces it. Fill it in rather than writing your own structure.


### PR DESCRIPTION
## Why

An agent found two rebase breakages on an external contributor's pull request (#358): trunk had removed two exports the branch still imported. The repository allows maintainer edits on that branch and each fix was one line, so the agent pushed a merge and a fix commit to the contributor's fork. Nothing in `AGENTS.md` said not to.

That is the author's call, not the agent's. A contributor's branch is theirs: what lands on it, and when it merges, is decided by whoever opened the pull request. The right move on a pull request the person you work for did not open is a review with the findings written down.

## What changes

One section in `AGENTS.md`, under "Before opening a pull request": a pull request you did not open belongs to its author. No pushes, rebases, description edits or merges on it, whatever the branch permissions say and however small the fix. Reviewing it and leaving findings, with a diff where that helps, is what an agent may do. If the author is unresponsive and the work is urgent, the agent says so and lets the person decide how to reach them.

## How to test this

Platforms: any. Documentation only, nothing runs.

**Starting state:** any checkout of this branch.

1. Open `AGENTS.md` and find the section "A pull request you did not open belongs to its author". It sits between the CodeRabbit paragraphs and "The pull request description follows the template".
2. Read it as an agent about to act on a pull request someone else opened. Expected: it names every action that is off limits (push, rebase, update, edit description, merge) and the one that is allowed (review and leave findings).

**What must not have happened:** no other line of `AGENTS.md` changed. `git diff trunk --stat` lists one file with six added lines.

## Risks and limitations

None to the app. The rule constrains agents only; a human maintainer keeps whatever latitude the repository gives them.

## Related

Prompted by #358, where the rule was broken before it existed.

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Documentation change, six added lines in `AGENTS.md`, no code. Read once against the surrounding sections for tone and placement; `npm run lint` does not cover Markdown. Nothing to fix, nothing deferred.

</details>

<details>
<summary>Screenshots or recording</summary>

Nothing on screen changes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123opUnXoxs1CAN7YQ7q8KU
