### PR TITLE
Bump the version to 1.1.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-setup-wordpress-core",
-  "version": "1.0.1",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-setup-wordpress-core",
-      "version": "1.0.1",
+      "version": "1.1.0-beta.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-setup-wordpress-core",
   "author": "WordPress.org",
-  "version": "1.0.1",
+  "version": "1.1.0-beta.1",
   "private": true,
   "license": "GPL-2.0-or-later",
   "description": "Desktop app that sets up a WordPress core development environment with no prerequisites, applies the work already on a Trac ticket, and submits a contribution back",


### PR DESCRIPTION
## Why

`v1.0.1` shipped on 21 August. Trunk carries 45 commits since, and this is the **beta for 1.1.0**, published so contributors can test it before the stable tag. The headline is the bundled Git: the app ships its own Git binary and every checkout operation runs on it, so a contributor no longer needs Git installed (#401 to #411, #418, #420). It also ships the packaging allow-list (#450) and the fixes closed under the v1.1.0 milestone.

The version reaches two places a contributor sees, and both must carry the real build: electron-builder embeds it in the artifact names (`wordpress-contributor-toolkit-1.1.0-beta.1-*`), and `src/logging.js` writes `app <version>` as the log's first line, so a problem report names the build it came from. That is why the bump merges before the tag.

## What changes

Only the version. All three package-version fields in `package.json` and `package-lock.json` move together from `1.0.1` to `1.1.0-beta.1`. No dependency versions change, and there is no application behaviour change in this PR.

## How to test this

Platforms: any for the suite; macOS or Windows for the artifact check that follows the merge.

In the repository root:

1. `npm run lint` is clean and `npm test` passes.
2. `node -e "console.log(require('./package.json').version)"` prints `1.1.0-beta.1`.
3. `python3 -c "import json;d=json.load(open('package-lock.json'));print(d['version'], d['packages']['']['version'])"` prints `1.1.0-beta.1 1.1.0-beta.1`.

**What must not have happened:** no dependency version may change. `git diff trunk` shows exactly three changed lines, all of them the root package version.

After merge, the release build must produce artifacts named `wordpress-contributor-toolkit-1.1.0-beta.1-*`, and the first line of a fresh app log must read `app 1.1.0-beta.1`.

## Risks and limitations

No UI change. The risk is a mis-scoped edit in `package-lock.json`, where dependencies also carry `1.0.1`; the replacement was confined to the first 2000 bytes of the file, which holds the two root entries, and both files were re-parsed as JSON afterwards.

## Related

Same shape as #244 (v1.0.0-beta.1) and #397 (v1.0.1).

---

<details>
<summary>Review outcome (required — see AGENTS.md)</summary>

Version-only change, three lines. Verified locally on this branch: `npm run lint` clean, `npm test` 1316 pass, 0 fail; `git diff --stat` shows two files, three insertions, three deletions; both JSON files parse. Nothing to fix, nothing deferred.

</details>

<details>
<summary>Screenshots or recording</summary>

Nothing on screen changes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123opUnXoxs1CAN7YQ7q8KU
